### PR TITLE
Issue #49: Resolve doc sync drift from /doc sync --deep

### DIFF
--- a/docs/structure.md
+++ b/docs/structure.md
@@ -30,7 +30,7 @@ wholework/
 │   └── workflows/
 │       ├── test.yml             # CI: bats tests and skill syntax validation
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
-├── tests/               # Bats test files for scripts (27 files)
+├── tests/               # Bats test files for scripts (25 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -39,8 +39,8 @@ wholework/
 │   ├── tech.md          # Tech stack, architecture decisions, forbidden expressions (steering)
 │   ├── workflow.md      # Development workflow phases and label transitions (project)
 │   ├── figma-best-practices.md # Figma MCP UI design guidelines (project)
-│   ├── migration-notes.md # Interface change records per migration issue
-│   ├── environment-adaptation.md # Environment adaptation architecture (4-layer)
+│   ├── migration-notes.md # Interface change records per migration issue (project)
+│   ├── environment-adaptation.md # Environment adaptation architecture (4-layer) (project)
 │   └── spec/            # Issue specifications
 ├── LICENSE              # Apache License 2.0
 ├── README.md            # Project overview

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -185,13 +185,11 @@ Document structure:
 - `docs/tech.md` — Tech stack, coding conventions, Forbidden Expressions
 - `docs/structure.md` — Directory structure, agent infrastructure
 
-**Rule**: When making changes that affect the workflow — such as adding, modifying, or removing skills — also update `docs/workflow.md`, `README.md`, and `.github/copilot-instructions.md`.
+**Rule**: When making changes that affect the workflow — such as adding, modifying, or removing skills — also update `docs/workflow.md` and `README.md`.
 
-Reason: To keep implementation and documentation always in sync and maintain an accurate overall view of the workflow. The 3 files each target different audiences (human / Claude Code / GitHub Copilot) so all must be kept in sync.
+Reason: To keep implementation and documentation always in sync and maintain an accurate overall view of the workflow. The 2 files target different audiences (human / Claude Code) so both must be kept in sync.
 
 **Key Files table sync rule**: When the role or description of files listed in the Key Files table in `docs/structure.md` changes, or when files are added, removed, or renamed, also update the Key Files table in `docs/structure.md`.
-
-**copilot-instructions.md self-containment**: Do not replace descriptions in `.github/copilot-instructions.md` with reference links to Steering Documents or other files. Since GitHub Copilot Agent cannot guarantee it will reference repository files other than `copilot-instructions.md`, maintain self-contained descriptions even if duplicated. Even in `/doc sync` normalization proposals, copilot-instructions.md is excluded from referencing targets.
 
 ## Related Documents
 

--- a/modules/doc-checker.md
+++ b/modules/doc-checker.md
@@ -14,7 +14,7 @@ The following information is passed from the caller:
 - **Documents to check**: List of document file paths to verify (defaults to the following when omitted):
   - **Steering documents**: Get `docs/*.md` with Glob, and dynamically identify files with frontmatter `type: steering`
   - **Project documents**: Get `docs/*.md` with Glob, and dynamically identify files with frontmatter `type: project`
-  - **Fixed root documents**: `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md`
+  - **Fixed root documents**: `README.md`, `CLAUDE.md`
   - Files under `docs/spec/` and `docs/reports/` are excluded from search
 - **Check perspectives**: Points to focus on
   - Completeness: Are all necessary items included?
@@ -30,9 +30,9 @@ When changes fall into any of the following categories, include the correspondin
 
 | Change Type | Affected Documents |
 |------------|-------------------|
-| Skill addition, change, or deletion | `README.md` (skill list), `docs/workflow.md` (skill list, phase descriptions), `CLAUDE.md` (skill list, dev flow), `.github/copilot-instructions.md` (skill list, dev flow) |
+| Skill addition, change, or deletion | `README.md` (skill list), `docs/workflow.md` (skill list, phase descriptions), `CLAUDE.md` (skill list, dev flow) |
 | Agent/shared module addition, change, or deletion | `docs/workflow.md` (modules/agents list table), `README.md` (if applicable) |
-| Workflow phase changes | `docs/workflow.md`, `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md` |
+| Workflow phase changes | `docs/workflow.md`, `README.md`, `CLAUDE.md` |
 | Project structure changes (directory/file placement) | `README.md` (project structure), `docs/workflow.md` (if applicable), `docs/structure.md` (Directory Layout / Key Files) |
 | Script addition, change, or deletion | `README.md` (setup instructions, script descriptions), `docs/workflow.md` (if applicable) |
 
@@ -50,11 +50,11 @@ When changes fall into any of the following categories, include the correspondin
 2. Dynamically identify candidate document files using Glob:
    - Get `docs/*.md` with Glob to create a Steering / Project document candidate list (do not Read at this stage)
    - Exclude files under `docs/spec/` and `docs/reports/` from candidates
-   - Always include `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md` as fixed targets
+   - Always include `README.md`, `CLAUDE.md` as fixed targets
 3. Read each document and parse the frontmatter at the top to determine the type (Read only once per file):
    - Treat files with frontmatter `type: steering` as Steering documents
    - Treat files with frontmatter `type: project` as Project documents
-   - Exclude `docs/*.md` files without `type` defined in frontmatter from subsequent checks (always check the fixed list: `README.md`, `CLAUDE.md`, `.github/copilot-instructions.md`)
+   - Exclude `docs/*.md` files without `type` defined in frontmatter from subsequent checks (always check the fixed list: `README.md`, `CLAUDE.md`)
 4. Extract only the base names (without extensions) of changed files as search keywords, and grep across all target documents identified in steps 2-3 (purpose: additional detection of affected document candidates):
    - Additionally detect documents that mention base names as "affected document candidates"
 5. For each document, grep for multiple keywords related to the change (base name plus full path, command names, feature names, etc.) and identify lines with suspected inconsistencies

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -194,7 +194,7 @@ This is equivalent to the CI `validate-syntax` job and detects invalid `allowed-
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-checker.md` and follow the "Impact assessment criteria" section to determine whether documentation sync updates are needed for files changed during implementation.
 
-If sync is required, update the target documents (`README.md`, `docs/workflow.md`, `.github/copilot-instructions.md`, etc.) before committing.
+If sync is required, update the target documents (`README.md`, `docs/workflow.md`, etc.) before committing.
 
 ### Step 10: Acceptance Check Consistency
 

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -278,7 +278,7 @@ Search for the following files in the project root with Glob (deduplicate files 
 - `README.*` (README files regardless of extension. Supplements non-Markdown formats like .rst, .txt)
 - `package.json`, `Gemfile`, `requirements.txt`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `tsconfig.json`, `Makefile`
 - `CLAUDE.md`
-- `.github/*.md`, `.github/**/*.md` (PR/Issue templates, copilot-instructions.md etc.)
+- `.github/*.md`, `.github/**/*.md` (PR/Issue templates etc.)
 - `.github/workflows/*.yml` (CI/CD configuration)
 - `docs/**/*.md` (all Markdown including subdirectories. But skip files with a `type` field in frontmatter. After retrieving with Glob, check for `type` field by reading the beginning of each file. If many matches, prioritize files directly under `docs/` and limit to 15)
 - `Dockerfile`, `docker-compose.yml`, `.env.example` (infrastructure configuration)
@@ -302,7 +302,7 @@ If `--deep` flag is enabled, in addition to codebase analysis, run **existing .m
 
 Search with Glob `**/*.md` and skip files matching these exclusion conditions:
 
-- **Protected files**: CLAUDE.md, README.md, .github/copilot-instructions.md (skip; not targets for content absorption/movement/deletion)
+- **Protected files**: CLAUDE.md, README.md (skip; not targets for content absorption/movement/deletion)
 - **Existing managed targets**: files with `type: steering` or `type: project` in frontmatter (read beginning to check `type` field; skip if present)
 - **Spec documents**: files under `docs/spec/`
 - **Package management directories**: files under `node_modules/`, `.git/`, `vendor/`
@@ -444,7 +444,7 @@ If `scripts/validate-skill-syntax.py` exists, Read `${CLAUDE_PLUGIN_ROOT}/module
 
 **Content classification based on dynamic SSoT mapping:**
 
-Based on the constructed SSoT mapping, determine the "source of truth (Single Source of Truth)" for each section/description. Detect references by dynamically searching other files (README.md, CLAUDE.md, copilot-instructions.md etc.) with Grep for information corresponding to each SSoT file's `ssot_for` category.
+Based on the constructed SSoT mapping, determine the "source of truth (Single Source of Truth)" for each section/description. Detect references by dynamically searching other files (README.md, CLAUDE.md etc.) with Grep for information corresponding to each SSoT file's `ssot_for` category.
 
 Classification of each section/description:
 - **Duplicate**: same information exists in multiple places (both SSoT side and reference side have substantive descriptions)
@@ -466,8 +466,6 @@ Based on Step 6 classification results, propose one of 3 actions for each item:
 - **Absorb**: incorporate descriptions from analysis source/implementation code into Steering Documents and replace original descriptions with reference links. Check for duplicate content in Steering Documents before executing
 - **Reference**: replace duplicate descriptions in analysis source/implementation code with reference links to Steering Documents (when Steering Documents already have the information). Treat Steering Documents as the source of truth; other files hold references to them
 - **Drift report**: report drift between implementation code and Steering Documents (no auto-fix, ask for user judgment)
-
-**Exclude copilot-instructions.md**: `.github/copilot-instructions.md` is the only instruction file that GitHub Copilot Agent is guaranteed to read, and replacing descriptions with references to external files risks losing information. Exclude copilot-instructions.md descriptions from "reference" and "absorb" targets; maintain self-contained descriptions even if there are duplicates. Include items related to copilot-instructions.md only as "drift report" proposals.
 
 If `--deep` flag is enabled and Step 2's .md integration scan results exist, add integration proposals for Pattern 2–4 unintegrated .md files to the existing proposal table:
 
@@ -502,7 +500,6 @@ If integration operations (absorb/move/delete) occurred, Grep the following file
 
 - CLAUDE.md (protected but update reference links)
 - README.md (protected but update reference links)
-- .github/copilot-instructions.md
 - `skills/*/SKILL.md`
 - `docs/spec/*.md` (best effort)
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -279,7 +279,7 @@ SHOULD constraints (best practices, manual check — examples):
 
 When defining acceptance criteria, explicitly consider:
 - Documentation additions (README.md, CLAUDE.md, docs/workflow.md, etc.)
-- Workflow-impacting doc sync (docs/workflow.md, README.md, .github/copilot-instructions.md — for workflow phase/skill behavior/routing changes)
+- Workflow-impacting doc sync (docs/workflow.md, README.md — for workflow phase/skill behavior/routing changes)
 - Config marker additions (.wholework.yml)
 - Reference updates in existing files (tables, links, etc.)
 - For new modules: include docs/structure.md module table and Mermaid graph updates in changed-files list


### PR DESCRIPTION
## Summary

`/doc sync --deep` で検出した Steering Documents と実装・ファイルシステムのドリフトを修正する。

### 主な変更

1. **`docs/structure.md` — tests ファイル数修正**: `27 files` → `25 files`（実際の .bats ファイル数に一致）
2. **`docs/structure.md` — project 注記統一**: `migration-notes.md` と `environment-adaptation.md` に `(project)` 注記を追加
3. **`.github/copilot-instructions.md` への stale 参照を全削除**:
   - `docs/workflow.md`（同期更新ルール + self-containment 注記）
   - `modules/doc-checker.md`（Fixed root documents / 変更タイプ表 / 走査ロジック）
   - `skills/doc/SKILL.md`（分析ソース / 保護ファイル / SSoT 検索 / 例外ルール / 参照更新リスト）
   - `skills/code/SKILL.md`（doc sync 対象リスト）
   - `skills/spec/SKILL.md`（workflow-impacting doc sync ターゲット）

wholework は self-hosting 構成（2026-04-08〜）で `.github/copilot-instructions.md` を持っていないため、これらは参照切れ（stale drift）となっていた。

### スコープ外

- グローバル `~/.claude/CLAUDE.md` の同期ルール記述（ユーザーのグローバル設定のため）

## Verification (pre-merge)

- `docs/structure.md` の tests ファイル数が 25 に修正されている
- `docs/structure.md` から "27 files" 表記が削除されている（scripts は 27 のまま OK）
- 変更対象 5 ファイル（`docs/workflow.md`, `modules/doc-checker.md`, `skills/doc/SKILL.md`, `skills/code/SKILL.md`, `skills/spec/SKILL.md`）から `copilot-instructions` 文字列が消えている
- `migration-notes.md` と `environment-adaptation.md` に `(project)` 注記が追加されている
- `python3 scripts/validate-skill-syntax.py skills/` が PASS する

## Verification (post-merge)

- `/doc sync --deep` を再実行して検出 drift が 0 件になる

closes #49
