### PR TITLE
Issue #62: Add next-action-guide module and unify completion guidance

### DIFF
--- a/docs/spec/issue-62-unify-next-action-guide.md
+++ b/docs/spec/issue-62-unify-next-action-guide.md
@@ -188,6 +188,21 @@
 - **モジュール標準構造**: 新規モジュール `next-action-guide.md` は `worktree-lifecycle.md` などの 4 セクション（Purpose / Input / Processing Steps / Output）を踏襲する。`docs/tech.md` の Coding Conventions「新規コンポーネントの入力インターフェース」に準拠。
 - **Read 指示の書式**: 抽出されたモジュール参照は `read ${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md and follow the "Processing Steps" section` 形式で記述する（#716 のパターン、tech.md 準拠）。
 
+## Code Retrospective
+
+### Deviations from Design
+
+- なし。Spec の Implementation Steps に記載された順序・内容通りに実装完了。Step 1（モジュール作成）→ Step 2〜9（8 skill 更新、並列実施）→ Step 10（docs/structure.md 更新）の順序を維持。
+
+### Design Gaps/Ambiguities
+
+- `skills/review/SKILL.md` の早期終了（XS/S patch route）メッセージ箇所は Spec で「108〜111 行目」と記載されていたが、実際は 104〜111 行目が該当ブロック。行番号のズレは軽微で内容は一致しており問題なし。
+- Spec で「既存の `"need to run a review explicitly"` / `"main branch protection"` 言及はそのまま保持」と指示されていた通り、既存文言を削除せずに `next-action-guide.md` 参照指示を後ろに追加する形で実装した。
+
+### Rework
+
+- なし。各 SKILL.md の Completion Report セクションを 1 回で確定できた。バリデーションも 0 errors で一発通過。
+
 ## spec retrospective
 
 - **Spec 作成の所感**: 8 skill の Completion Report セクションを Grep で一括特定し、各セクションの出力パターンを比較することで、統一モジュールに必要な入力インターフェース（SKILL_NAME / RESULT / ISSUE_NUMBER / PR_NUMBER / SIZE / ROUTE / BLOCKED_BY_OPEN）を抽出できた。`/spec` Step 18 の ROUTE ベース 2 択ロジックが既存の参照実装として機能しており、そこから一般化する形で設計できた。

--- a/docs/spec/issue-62-unify-next-action-guide.md
+++ b/docs/spec/issue-62-unify-next-action-guide.md
@@ -210,3 +210,19 @@
 - **スコープ確定のポイント**: `docs/ja/structure.md` は `/doc translate` で自動生成されるため対象外、`docs/structure.md` の Modules セクションとカウント (22 → 23) のみが更新対象であることを特定した。これにより対象ファイルを 10 件に確定。
 - **想定リスク**: `/verify` および `/auto --batch` での PASS 時の次アクション案内抑制ルールをモジュール側で扱う必要があり、判定テーブルで `RESULT=success AND SKILL_NAME IN (verify, auto-batch)` のケースを明示する必要がある。実装時に見落とすと「何もしない」動作が崩れる。
 - **検証計画**: 16 件の pre-merge acceptance check と 5 件の post-merge acceptance check で、モジュール作成・8 skill 更新・structure.md 同期を網羅。`grep` と `section_contains` で機械的に検証可能にした。
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+- Spec に「Step 6（On Failure）も同様に参照」と明示されていたにもかかわらず、コード実装時に漏れが生じた。`{success|fail}` という曖昧な値を Step 5 に残したことで、実装者が「Step 5 で両方カバーできる」と誤解しやすくなっていた。Spec でフェーズ別に独立した指示をする場合は、ステップ単位で明示的に分けた記述が有効。
+- `$PR_NUMBER` と `$NUMBER` の変数名不一致は横断的変更（8 skill）で起きやすい典型的な誤り。次回の横断修正時は、PRe-existing の変数名を Spec の実装ステップに明記するか、完了後に変数名の一貫性チェックを追加する。
+
+### 繰り返し課題
+
+- 今回は1件のみ（Step 6 漏れ）で同種の繰り返しなし。review-bug×2 エージェントは偽陽性を多く排除し、実際の課題を1件正確に特定できた（HIGH SIGNAL フィルタが適切に機能）。
+
+### 受け入れ条件の検証難易度
+
+- pre-merge 16 件はすべて `file_exists`/`grep`/`section_contains`/`command`(CI fallback) で機械的に検証可能だった。UNCERTAIN が0件で、今後の Issue 設計の参考になる。
+- 検証が難しい post-merge 条件（opportunistic verify）は適切に分離されており、今回のレビューフェーズでの過検証（UNCERTAIN 多発）を防げた。

--- a/docs/spec/issue-62-unify-next-action-guide.md
+++ b/docs/spec/issue-62-unify-next-action-guide.md
@@ -192,7 +192,7 @@
 
 ### Deviations from Design
 
-- なし。Spec の Implementation Steps に記載された順序・内容通りに実装完了。Step 1（モジュール作成）→ Step 2〜9（8 skill 更新、並列実施）→ Step 10（docs/structure.md 更新）の順序を維持。
+- `skills/auto/SKILL.md` の Step 6（On Failure）への next-action-guide 参照が初回実装で漏れていた。Spec Implementation Step 9 に「Step 6（On Failure）も同様に `RESULT=fail` で参照」と明記されていたが、Step 5 の `RESULT={success|fail}` で十分と誤判断。レビューフィードバックを受けて同 PR 内で追加修正した。また `skills/review/SKILL.md` 早期終了パスで `PR_NUMBER=$PR_NUMBER`（未定義変数）を `PR_NUMBER=$NUMBER` に修正した。
 
 ### Design Gaps/Ambiguities
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -20,7 +20,7 @@ wholework/
 │   └── <skill-name>/
 │       ├── SKILL.md     # Skill definition (required)
 │       └── *.md         # Auxiliary phase/guideline files (optional)
-├── modules/             # Shared modules referenced by skills (22 files)
+├── modules/             # Shared modules referenced by skills (23 files)
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (6 files)
 │   └── <agent-name>.md
@@ -80,6 +80,7 @@ Key modules:
 - `modules/browser-verify-security.md` — browser verification security checks
 - `modules/lighthouse-adapter.md` — Lighthouse performance audit adapter
 - `modules/measurement-scope.md` — measurement scope definition
+- `modules/next-action-guide.md` — unified next action guidance for all skills
 
 ### Agents
 

--- a/modules/next-action-guide.md
+++ b/modules/next-action-guide.md
@@ -1,0 +1,93 @@
+# next-action-guide module
+
+## Purpose
+
+Generates a unified next action guide at the completion of each skill. Provides users with context-aware guidance — a recommended action and an alternative — so they know what to do next without having to re-learn the workflow for each skill.
+
+Called by: `issue`, `spec`, `code`, `review`, `merge`, `verify`, `triage`, `auto`
+
+## Input
+
+Variables passed by the calling skill:
+
+- `SKILL_NAME` (string, required): Name of the completed skill. One of: `issue` / `spec` / `code` / `review` / `merge` / `verify` / `triage` / `auto`
+- `RESULT` (string, optional, default `success`): Outcome of the skill. One of: `success` / `fail` / `blocked`
+- `ISSUE_NUMBER` (int, optional): Issue number. Pass when available
+- `PR_NUMBER` (int, optional): PR number. Pass when available (primarily for `code`, `review`, `merge`)
+- `SIZE` (string, optional): Issue size. One of: `XS` / `S` / `M` / `L` / `XL` / empty string
+- `ROUTE` (string, optional): Workflow route. One of: `patch` / `pr` / `sub_issue`. When omitted, derived from SIZE using `modules/size-workflow-table.md`
+- `BLOCKED_BY_OPEN` (bool, optional, default `false`): Whether open blocked-by relationships exist
+
+## Processing Steps
+
+Use contextual understanding to determine the appropriate guidance. This is a judgment task — do not mechanically apply rules, but interpret the situation and select the most helpful recommendation.
+
+### Step 1: Check RESULT
+
+- `blocked` → Skip Steps 2–3 and go to Step 4 (blocker guidance)
+- `fail` → Proceed to Step 3, selecting the fail row for the skill
+- `success` → Proceed to Step 2
+
+### Step 2: Derive ROUTE from SIZE (when ROUTE is not provided)
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` to derive ROUTE from SIZE:
+- `XS` or `S` → `patch`
+- `M` or `L` → `pr`
+- `XL` → `sub_issue`
+- SIZE empty → treat as unknown; omit route-specific reasoning
+
+### Step 3: Select recommendation using judgment table
+
+Use the table below as guidance. Contextual factors (e.g., whether acceptance criteria are clearly defined, whether blockers exist) may shift the recommendation — apply LLM judgment rather than strict pattern matching.
+
+| SKILL_NAME | RESULT  | Situation                           | Recommended              | Alternative                    |
+|------------|---------|-------------------------------------|--------------------------|--------------------------------|
+| `triage`   | success | any                                 | `/issue {ISSUE_NUMBER}`  | `/auto {ISSUE_NUMBER}`         |
+| `issue`    | success | XS/S and acceptance criteria clear  | `/auto {ISSUE_NUMBER}`   | `/spec {ISSUE_NUMBER}`         |
+| `issue`    | success | M/L                                 | `/spec {ISSUE_NUMBER}`   | `/auto {ISSUE_NUMBER}`         |
+| `issue`    | success | XL (sub-issue split recommended)    | `/issue {ISSUE_NUMBER}` (split) | —                         |
+| `spec`     | success | patch (XS/S)                        | `/auto {ISSUE_NUMBER}`   | `/code {ISSUE_NUMBER}`         |
+| `spec`     | success | pr (M/L)                            | `/auto {ISSUE_NUMBER}`   | `/code {ISSUE_NUMBER}`         |
+| `spec`     | success | sub_issue (XL)                      | `/issue {ISSUE_NUMBER}` (split) | —                         |
+| `code`     | success | patch                               | `/verify {ISSUE_NUMBER}` | `/auto {ISSUE_NUMBER}`         |
+| `code`     | success | pr                                  | `/review {PR_NUMBER}`    | `/auto {ISSUE_NUMBER}`         |
+| `review`   | success | any                                 | `/merge {PR_NUMBER}`     | `/auto {ISSUE_NUMBER}`         |
+| `merge`    | success | any                                 | `/verify {ISSUE_NUMBER}` | `/auto {ISSUE_NUMBER}`         |
+| `verify`   | success (PASS) | any                          | (no guidance)            | —                              |
+| `verify`   | fail    | any                                 | `/code {ISSUE_NUMBER}`   | `/auto {ISSUE_NUMBER}`         |
+| `auto`     | success | any                                 | (no guidance)            | —                              |
+| `auto`     | fail    | any                                 | `/code {ISSUE_NUMBER}`   | manual investigation           |
+
+**Batch/bulk completion (ISSUE_NUMBER not provided)**: When `SKILL_NAME` is `triage`, `auto`, or similar and `ISSUE_NUMBER` is not passed (multi-issue batch run), omit the next action guide entirely.
+
+### Step 4: Blocker guidance (when BLOCKED_BY_OPEN=true or RESULT=blocked)
+
+Do not show a recommended next action. Instead, inform the user to wait for the blocker to be resolved:
+
+```
+次のアクション:
+- ブロッカー Issue を解消してから `/code {ISSUE_NUMBER}` または `/auto {ISSUE_NUMBER}` を実行してください
+```
+
+## Output
+
+Output to terminal in Japanese. Follow CLAUDE.md convention: "Skill output (terminal): Japanese".
+
+**Pattern 1 — Recommendation available:**
+
+```
+次のアクション:
+- **`{recommended command}`** （推奨） — {one-line reason}
+- `{alternative command}` — {one-line purpose}
+```
+
+**Pattern 2 — No guidance (verify PASS, auto success, batch completion):**
+
+Output nothing. The calling skill's completion message is sufficient.
+
+**Pattern 3 — Blocked:**
+
+```
+次のアクション:
+- ブロッカー Issue を解消してから `/code {ISSUE_NUMBER}` または `/auto {ISSUE_NUMBER}` を実行してください
+```

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -248,6 +248,11 @@ Determine the close flow for the parent Issue based on all sub-issue execution r
 
 If all phases succeeded, report completion. **For XL routes, also output "Auto retrospective recorded in Spec".**
 
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=auto`
+- `ISSUE_NUMBER=$NUMBER`
+- `RESULT={success|fail}`
+
 ### Step 6: On Failure: Stop and Report Error
 
 If any phase exits with a non-zero exit code, stop processing and report the error to the user. Do not invoke subsequent phases.
@@ -285,6 +290,11 @@ Process the selected N Issues **sequentially** (serially):
 ### Batch Completion Report
 
 After all N Issues are processed, report results (success/skip/failure) for each Issue.
+
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=auto`
+- `RESULT=success`
+- (omit `ISSUE_NUMBER` — batch run with multiple issues, guide will be omitted per module logic)
 
 ## Notes
 

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -251,7 +251,7 @@ If all phases succeeded, report completion. **For XL routes, also output "Auto r
 Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
 - `SKILL_NAME=auto`
 - `ISSUE_NUMBER=$NUMBER`
-- `RESULT={success|fail}`
+- `RESULT=success`
 
 ### Step 6: On Failure: Stop and Report Error
 
@@ -261,6 +261,11 @@ If any phase exits with a non-zero exit code, stop processing and report the err
 - review phase failure: review wait timeout, fix failure, retry limit reached
 - merge phase failure: invalid PR state (not approved, CI failure), conflict resolution failure
 - verify phase failure: acceptance condition FAIL, Issue reopened
+
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=auto`
+- `ISSUE_NUMBER=$NUMBER`
+- `RESULT=fail`
 
 ## Batch Mode (--batch N)
 

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -367,9 +367,17 @@ Only if `.wholework.yml` in the project has `opportunistic-verify: true`, Read `
 
 ## Completion Report
 
-**Completion report (always use this format):**
-- **patch route**: "Direct commit and push to main complete. Run `/verify {Issue number}` next."
-- **pr route**: "PR creation complete. Run `/review {PR number}` next."
+Output the route-specific prefix, then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section.
+
+- **patch route prefix**: "Direct commit and push to main complete."
+- **pr route prefix**: "PR creation complete."
+
+Parameters to pass to next-action-guide:
+- `SKILL_NAME=code`
+- `ISSUE_NUMBER=$NUMBER`
+- `PR_NUMBER={PR number if pr route}`
+- `ROUTE={patch|pr}`
+- `RESULT=success`
 
 ## Notes
 

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -387,15 +387,20 @@ Good:
 
 ## Completion Report
 
-After opportunistic verification, get Size with `get-issue-size.sh $NUMBER` and guide the next action.
+After opportunistic verification, get Size with `get-issue-size.sh $NUMBER`.
 
 **For XL issues (after sub-issue splitting)**: list sub-issues with unresolved "Needs Refinement" points and recommend running `/issue N` for each. Do not list sub-issues without needs-refinement points.
 
-- **Size is XS only**: transition to `phase/ready`, then guide "Run `/auto $NUMBER`":
-  ```bash
-  ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh $NUMBER ready
-  ```
-- **All other cases (S/M/L/XL/unset)**: guide "Run `/spec $NUMBER`."
+**For XS issues only**: transition to `phase/ready` first:
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh $NUMBER ready
+```
+
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=issue`
+- `ISSUE_NUMBER=$NUMBER`
+- `SIZE={fetched size}`
+- `RESULT={success|blocked}`
 
 ---
 

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -200,15 +200,17 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Exit:
 
 ## Completion Report
 
-Extract the related Issue number from the PR body and report in the following format.
+Extract the related Issue number from the PR body.
 
 **Issue number extraction steps:**
 1. Run `gh pr view "$NUMBER" --json title,body` to get PR info
 2. Search the PR body for `closes #N`, `Related to #N`, or `Issue #N`
 3. If not found, search the PR title for `Issue #N`
 
-**Completion report (always use this format):**
-"Merge complete. Run `/verify {Issue number}` next."
+Output "Merge complete." as a fixed prefix, then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=merge`
+- `ISSUE_NUMBER=$ISSUE_NUMBER`
+- `RESULT=success`
 
 ## Notes
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -110,7 +110,7 @@ Patch route — review is not needed. Proceed with `/merge $PR_NUMBER`.
 If you need to run a review explicitly (e.g., main branch protection required PR route), run `/review $PR_NUMBER --light`.
 ```
 
-Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with `SKILL_NAME=review, PR_NUMBER=$PR_NUMBER, ISSUE_NUMBER=$ISSUE_NUMBER, RESULT=success`.
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with `SKILL_NAME=review, PR_NUMBER=$NUMBER, ISSUE_NUMBER=$ISSUE_NUMBER, RESULT=success`.
 
 Get Size (Project field first, label fallback):
 ```bash

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -110,6 +110,8 @@ Patch route — review is not needed. Proceed with `/merge $PR_NUMBER`.
 If you need to run a review explicitly (e.g., main branch protection required PR route), run `/review $PR_NUMBER --light`.
 ```
 
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with `SKILL_NAME=review, PR_NUMBER=$PR_NUMBER, ISSUE_NUMBER=$ISSUE_NUMBER, RESULT=success`.
+
 Get Size (Project field first, label fallback):
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh "$ISSUE_NUMBER" 2>/dev/null
@@ -711,7 +713,7 @@ If `opportunistic-verify: true` is set in `.wholework.yml`, read `${CLAUDE_PLUGI
 
 **Completion report (always use this format):**
 
-After posting the Step 14 summary, output a review response summary to the terminal and a completion report in the following format (do not abbreviate or modify):
+After posting the Step 14 summary, output a review response summary to the terminal in the following format (do not abbreviate or modify):
 
 ```
 ## Review Complete
@@ -719,8 +721,6 @@ After posting the Step 14 summary, output a review response summary to the termi
 - Copilot review response: {response count} resolved, {skip count} skipped
 - Claude review response: {response count} resolved, {skip count} skipped
 - Lightweight re-check: {result}
-
-Next: run `/merge $NUMBER`.
 ```
 
 **If Copilot/Claude response was skipped (including Step 7 skip due to settings)**: omit the corresponding line.
@@ -728,6 +728,12 @@ Next: run `/merge $NUMBER`.
 **When Step 10 was entirely skipped**: replace "Claude review response" line with "Step 10: skipped (Issue number not extractable)".
 
 **In light mode (`REVIEW_DEPTH=light`)**: replace "Claude review response" line with "Step 10 (lightweight integrated review): review-light agent ran all 4 aspects".
+
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=review`
+- `PR_NUMBER=$NUMBER`
+- `ISSUE_NUMBER=$ISSUE_NUMBER`
+- `RESULT=success`
 
 ---
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -606,58 +606,15 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` and re-evaluate Size
 
 ### Step 18: Completion Message
 
-Output a completion message based on `ROUTE` and blocked-by status:
+Output "Design complete. Spec created, committed, pushed, and Issue comment posted." as a fixed prefix.
 
-**If open blocked-by Issues were detected** (`HAS_OPEN_BLOCKING=true`):
-
-```
-Design complete. Spec created, committed, pushed, and Issue comment posted.
-
-This Issue is blocked. Start implementation after the blocking issue is resolved.
-
-Next actions:
-- After resolving blockers, run `/code $NUMBER` or `/auto $NUMBER`
-```
-
-**No blockers (or all closed):**
-
-- **`ROUTE=patch` (XS/S: patch route recommended):**
-```
-Design complete. Spec created, committed, pushed, and Issue comment posted.
-
-Next actions:
-- `/auto $NUMBER` — autonomous execution (recommended: implementation through verification, patch route)
-- `/code $NUMBER` — patch route (direct commit to main, no PR)
-```
-
-- **`ROUTE=pr` (M: pr route, review=light recommended):**
-```
-Design complete. Spec created, committed, pushed, and Issue comment posted.
-
-Next actions:
-- `/auto $NUMBER` — autonomous execution (recommended: implementation through merge and verification, pr route, review=light)
-- `/code $NUMBER` — branch + PR implementation
-```
-
-- **`ROUTE=pr` (L: pr route, review=full recommended):**
-```
-Design complete. Spec created, committed, pushed, and Issue comment posted.
-
-Next actions:
-- `/auto $NUMBER` — autonomous execution (recommended: implementation through merge and verification, pr route, review=full)
-- `/code $NUMBER` — branch + PR implementation
-```
-
-- **`ROUTE=sub_issue` (XL: sub-issue splitting required):**
-```
-Design complete. Spec created.
-
-Size XL change — sub-issue splitting is recommended.
-
-Next actions:
-- `/issue $NUMBER` — consider sub-issue splitting (recommended)
-- After splitting, run `/auto $NUMBER` or `/code $NUMBER` for each sub-issue
-```
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=spec`
+- `ISSUE_NUMBER=$NUMBER`
+- `ROUTE=$ROUTE`
+- `SIZE={fetched size}`
+- `RESULT=success`
+- `BLOCKED_BY_OPEN=$HAS_OPEN_BLOCKING`
 
 ---
 

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -238,6 +238,12 @@ Output a summary of the processing results to the user:
 - Dependency check: no dependencies (or "resolved dependency (#200 is CLOSED)")
 ```
 
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=triage`
+- `ISSUE_NUMBER=$NUMBER`
+- `SIZE={triaged size}`
+- `RESULT=success`
+
 ---
 
 ## Bulk Execution (`/triage`)
@@ -382,6 +388,11 @@ After processing all issues, output a results summary:
 | #102 | unchanged | Bug | — | M | 2 | none | ✅ |
 | #103 | — | — | — | — | — | — | ❌ API error |
 ```
+
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=triage`
+- `RESULT=success`
+- (omit `ISSUE_NUMBER` — bulk run with multiple issues, guide will be omitted per module logic)
 
 ---
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -441,6 +441,11 @@ After each Issue is created successfully, assign the `retro/verify` label. This 
 - All conditions PASS: "Acceptance test complete. Issue #$NUMBER is closed."
 - Partial PASS: "Acceptance test found unchecked conditions. Issue #$NUMBER has been reopened."
 
+Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
+- `SKILL_NAME=verify`
+- `ISSUE_NUMBER=$NUMBER`
+- `RESULT={success if PASS, fail if partial PASS}`
+
 ---
 
 ## Notes


### PR DESCRIPTION
## Summary

- `modules/next-action-guide.md` を新規作成。全 skill の完了時次アクション案内を統一フォーマット（推奨 + 代替）で生成する共有モジュール
- 全 8 skill（issue, spec, code, review, merge, verify, triage, auto）の Completion Report セクションを書き換え、既存の固定文言を廃止して `next-action-guide.md` 参照に統一
- `docs/structure.md` のモジュールファイル数を 22 → 23 に更新し、新モジュールをリストに追加

## Verification (pre-merge)

- `modules/next-action-guide.md` 新規作成（Purpose/Input/Processing Steps/Output 4セクション）
- `size-workflow-table.md` 参照を含む
- 全 8 skill の SKILL.md が `next-action-guide` を参照
- `docs/structure.md` にモジュール追加
- `validate-skill-syntax.py` 0 errors

## Verification (post-merge)

- `/verify` フェーズで pre-merge 受入チェック全件 PASS を確認

closes #62