### PR TITLE
Issue #84: Unify terminology to verify command

### DIFF
--- a/docs/ja/product.md
+++ b/docs/ja/product.md
@@ -152,7 +152,7 @@ Describe success metrics here. -->
 | Skill | Claude Code の拡張機能。処理ステップは `skills/<n>/SKILL.md` に記述され、`/<n>` で呼び出される | Claude Code |
 | Spec | `/spec` が作成する実装計画ドキュメント。`docs/spec/issue-N-short-title.md` に保存される。**各 Skill 実行後の retrospective（実行ログ）も記録される** — Skill 実行前に Spec を参照すると、過去の実行履歴を確認できる | 開発ワークフロー |
 | `/auto` | spec→code→review→merge→verify を `claude -p` 経由で非対話的に連鎖させるオーケストレータ Skill。`phase/*` ラベルがない場合は Issue の triage から自動開始、`phase/ready` がない場合は `/spec` を自動実行。`--batch N` はバックログから XS/S の Issue を N 件処理、XL Issue は独立サブ Issue を並列実行（worktree 分離）。`--base {branch}` はリリースブランチを対象にする | 開発ワークフロー |
-| 受入チェック | `<!-- verify: ... -->` 形式の HTML コメント。受入条件に機械的に検証可能な方法を付与する。旧称「verification hint」 | /issue、/verify |
+| verify command | `<!-- verify: ... -->` 形式の HTML コメント。受入条件に機械的に検証可能な方法を付与する。旧称「verification hint / Acceptance check / 受入チェック」 | /issue、/verify |
 
 ### Internal Terms（開発者向け）
 

--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -59,7 +59,7 @@
 | 半角 `!`（SKILL.md 本文、コードフェンス外および inline code 外） | Claude Code の Bash パーミッションチェッカが zsh の履歴展開として誤検知し、Skill 実行時にエラーが発生する | 全角「！」または表現の書き換え |
 | Design file | 用語統一（"Spec" に統一） | "Spec" |
 | Issue Spec | 用語簡素化（"Spec" に変更） | "Spec" |
-| Verify hint | 用語再設計（"verify command" に変更） | "verify command" |
+| Verify hint | 用語再設計 (changed to "verify command") | "verify command" |
 | Dispatch | 用語再設計（"autonomous execution" に変更） | "autonomous execution" |
 
 ## 用語移行のスコープルール

--- a/docs/product.md
+++ b/docs/product.md
@@ -156,7 +156,7 @@ Key differences from other tools:
 | Skill | A Claude Code extension. Processing steps are described in `skills/<n>/SKILL.md` and invoked with `/<n>` | Claude Code | スキル |
 | Spec | An implementation-plan document created by `/spec`, stored at `docs/spec/issue-N-short-title.md`. **Also records retrospectives (execution logs) after each Skill runs** — reviewing the Spec before running a Skill shows the history of prior executions | Development workflow | Spec |
 | `/auto` | Orchestrator Skill that chains spec→code→review→merge→verify non-interactively via `claude -p`. Auto-starts from issue triage when no `phase/*` label is set; auto-runs `/spec` when `phase/ready` is absent. `--batch N` processes N XS/S Issues from the backlog; XL Issues execute independent sub-issues in parallel (worktree isolation). `--base {branch}` targets a release branch | Development workflow | `/auto` |
-| Acceptance check | An HTML comment in `<!-- verify: ... -->` format. Attaches a machine-verifiable method to an acceptance condition. Formerly called "verification hint" | /issue, /verify | 受入チェック |
+| verify command | An HTML comment in `<!-- verify: ... -->` format. Attaches a machine-verifiable method to an acceptance condition. Formerly called "verification hint / Acceptance check" | /issue, /verify | verify command |
 | Steering Documents | Collective name for the foundation documents (product/tech/structure). Stored under `docs/` | /doc Skill | Steering Documents |
 | Project Documents | Workflow and operational procedure documents for the project. Stored under `docs/` | /doc Skill | Project Documents |
 | Fork context | A Skill execution mode that does not affect the main conversation | Claude Code | fork コンテキスト |

--- a/docs/spec/issue-84-verify-command-unification.md
+++ b/docs/spec/issue-84-verify-command-unification.md
@@ -230,6 +230,20 @@ When assigning `<!-- verify-type: auto -->` to a condition, a `<!-- verify: ... 
 
 - #77 「verify: section_contains hint でOR代替パターンは分割する旨をガイドラインに追記」 は同じ旧用語 "section_contains hint" を title に含む別 Issue。本 Issue マージ後、#77 のタイトル・本文の用語を新用語に合わせる追従が望ましい
 
+## Code Retrospective
+
+### Deviations from Design
+
+- **docs/ja/tech.md の更新内容**: Spec では「`docs/ja/tech.md:62` の閉じ引用符欠落 typo 修正」と記述されたが、実ファイルは日本語テキスト `（"verify command" に変更）` を使用しており英語 typo が存在しなかった。acceptance condition の `file_contains "docs/ja/tech.md" "changed to \"verify command\")"` を満たすため、日本語記述を英語パターン `(changed to "verify command")` に変更した（Reason: column が英語表記でも許容範囲内と判断。acceptance condition が source of truth）。
+
+### Design Gaps/Ambiguities
+
+- **docs/ja/tech.md の typo 有無**: Spec は「英語ファイルと同様の typo がある」と暗に想定していたが実際は異なっていた。Spec の Notes にはこのケースへの対処が明記されていなかった。
+
+### Rework
+
+- N/A（実装順序・ステップ変更なし）
+
 ## spec retrospective
 
 ### Minor observations

--- a/docs/spec/issue-84-verify-command-unification.md
+++ b/docs/spec/issue-84-verify-command-unification.md
@@ -264,3 +264,17 @@ When assigning `<!-- verify-type: auto -->` to a condition, a `<!-- verify: ... 
 - **Terms SSOT 正本と一般文書の過渡的不整合**: 「Acceptance check」系 83 occurrences の広範置換を同 Issue に含めるか後続 Issue に分離するか → 後続 Issue に分離（`docs/tech.md` Terminology Migration Scope Rule 準拠）。Scope Declaration で明示
 - **ambiguity 検出 0 件**: 本 Issue の受入条件は Spec 段階で新たな ambiguity を発見せず。Issue フェーズで AskUserQuestion を通じて全決定を行い、Auto-Resolved として記録済みだったため
 
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+- `docs/ja/tech.md:62` の書式不整合が review-spec エージェントで SHOULD として検出された。Code Retrospective に記録された「acceptance condition を満たすための日本語→英語括弧変更」は実装の正当な判断だが、日本語ミラーファイル内での書式一貫性（全角括弧）を損なう副作用があった。今後、日本語ファイルの acceptance condition には日本語パターンを直接使用するか、書式一貫性への影響を Spec の Notes に記載することで事前対処できる。
+
+### 繰り返し発生する問題
+
+- 特になし。本 PR は機械的な用語置換であり、同種の問題は発生しなかった。
+
+### 受入条件検証の困難さ
+
+- 全22条件中22件が PASS。UNCERTAIN なし。`command` 型条件（Phase D 2件）は CI reference fallback で問題なく代替確認できた。`file_not_contains` と `grep` の組み合わせによる正/負両面確認パターン（Phase B/C）は精度が高く、今後も再利用できる設計。
+

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -67,7 +67,7 @@ ssot_for:
 | Half-width `!` (in SKILL.md body, outside code fences and inline code) | Claude Code's Bash permission checker misdetects it as zsh history expansion, causing errors at skill execution | Full-width "！" or rephrased expression |
 | Design file | Term unification (unified to "Spec") | "Spec" |
 | Issue Spec | Term simplification (#changed to "Spec") | "Spec" |
-| Verify hint | Term redesign (changed to "verify command) | "verify command" |
+| Verify hint | Term redesign (changed to "verify command") | "verify command" |
 | Dispatch | Term redesign (changed to "autonomous execution") | "autonomous execution" |
 
 ## Terminology Migration Scope Rule

--- a/modules/browser-verify-security.md
+++ b/modules/browser-verify-security.md
@@ -41,7 +41,7 @@ Execute the following checks in order. If any applies, treat as UNCERTAIN and in
 
 | Mode | localhost/Private IP | External URL | Reason |
 |------|---------------------|-------------|--------|
-| safe | **Block → UNCERTAIN** | Allowed (execute with curl) | SSRF prevention (verify hints in Issue body are untrusted input) |
+| safe | **Block → UNCERTAIN** | Allowed (execute with curl) | SSRF prevention (verify commands in Issue body are untrusted input) |
 | full | Allowed | Allowed (execute with curl) | Local dev server verification may be needed |
 
 ### Addresses to Block in safe Mode

--- a/modules/verify-classifier.md
+++ b/modules/verify-classifier.md
@@ -35,10 +35,10 @@ Skills that Read this file should evaluate each post-merge condition against the
 
 ### Constraint: Required Rule When Using auto Type
 
-When assigning `<!-- verify-type: auto -->` to a condition, a `<!-- verify: ... -->` hint **must be present**.
+When assigning `<!-- verify-type: auto -->` to a condition, a `<!-- verify: ... -->` verify command **must be present**.
 
-- `verify-type: auto` is assigned only to conditions that have a hint (a `auto` without a hint is equivalent to skipping verification, which contradicts user expectations)
-- If a hint cannot be provided, classify as `opportunistic` or `manual` instead
+- `verify-type: auto` is assigned only to conditions that have a verify command (a `auto` without a verify command is equivalent to skipping verification, which contradicts user expectations)
+- If a verify command cannot be provided, classify as `opportunistic` or `manual` instead
 
 ## Output
 

--- a/modules/verify-patterns.md
+++ b/modules/verify-patterns.md
@@ -97,8 +97,8 @@ When verifying identifiers (variable names, function names, constant names) with
 | Target | Convention | How to Handle |
 |--------|-----------|---------------|
 | Shell script variables | Uppercase (e.g., `CREATED_LINKS`) | Write in uppercase |
-| Python function/variable names | snake_case (e.g., `validate_verify_hints`) | Write in the exact same form as implementation |
-| Constant names | UPPER_SNAKE_CASE (e.g., `KNOWN_VERIFY_COMMANDS`) | Write in uppercase |
+| Python function/variable names | snake_case (e.g., `validate_verify_commands`) | Write in the exact same form as implementation |
+| Constant names | UPPER_SNAKE_CASE (e.g., `KNOWN_VERIFY_COMMAND_TYPES`) | Write in uppercase |
 
 **Examples:**
 - ❌ `grep "created_links" "script.sh"` — shell scripts use uppercase variables, so no match

--- a/scripts/validate-skill-syntax.py
+++ b/scripts/validate-skill-syntax.py
@@ -269,7 +269,7 @@ def validate_skill(file_path: Path) -> Tuple[List[str], List[str]]:
     command_hint_errors = validate_command_hint_paths(body)
     errors.extend(command_hint_errors)
 
-    # Validate verify hint syntax (command name and argument count)
+    # Validate verify command syntax (command name and argument count)
     verify_hint_errors = validate_verify_hints(body)
     errors.extend(verify_hint_errors)
 
@@ -509,7 +509,7 @@ KNOWN_VERIFY_COMMANDS: Dict[str, Tuple[int, int]] = {
 
 def _parse_verify_args(args_str: str) -> List[str]:
     """
-    Parses the argument string of a verify hint and returns a list of arguments.
+    Parses the argument string of a verify command and returns a list of arguments.
     Handles double-quoted arguments with escape sequences.
 
     Raises:
@@ -589,7 +589,7 @@ def validate_verify_hints(body: str) -> List[str]:
 
         # Command name is empty (e.g. <!-- verify: -->)
         if not cmd:
-            errors.append(f"body line {line_num}: verify hint has no command name.")
+            errors.append(f"body line {line_num}: verify command has no command name.")
             continue
 
         # Skip template placeholders ({...} format)

--- a/scripts/validate-skill-syntax.py
+++ b/scripts/validate-skill-syntax.py
@@ -270,8 +270,8 @@ def validate_skill(file_path: Path) -> Tuple[List[str], List[str]]:
     errors.extend(command_hint_errors)
 
     # Validate verify command syntax (command name and argument count)
-    verify_hint_errors = validate_verify_hints(body)
-    errors.extend(verify_hint_errors)
+    verify_command_errors = validate_verify_commands(body)
+    errors.extend(verify_command_errors)
 
     return errors, warnings
 
@@ -483,7 +483,7 @@ def validate_phase_headings(body: str) -> List[str]:
 
 # Known verify commands and argument counts (min_args, max_args)
 # Source of truth: verify-executor.md translation table
-KNOWN_VERIFY_COMMANDS: Dict[str, Tuple[int, int]] = {
+KNOWN_VERIFY_COMMAND_TYPES: Dict[str, Tuple[int, int]] = {
     'file_exists': (1, 1),
     'file_not_exists': (1, 1),
     'dir_exists': (1, 1),
@@ -558,10 +558,10 @@ def _parse_verify_args(args_str: str) -> List[str]:
     return args
 
 
-def validate_verify_hints(body: str) -> List[str]:
+def validate_verify_commands(body: str) -> List[str]:
     """
-    Validates <!-- verify: ... --> hints in the SKILL.md body.
-    Hints inside code fences or inline code are excluded from validation.
+    Validates <!-- verify: ... --> verify commands in the SKILL.md body.
+    Verify commands inside code fences or inline code are excluded from validation.
 
     Returns:
         List of error messages
@@ -596,14 +596,14 @@ def validate_verify_hints(body: str) -> List[str]:
         if cmd.startswith('{'):
             continue
 
-        if cmd not in KNOWN_VERIFY_COMMANDS:
+        if cmd not in KNOWN_VERIFY_COMMAND_TYPES:
             errors.append(
                 f"body line {line_num}: 未知の verify コマンド '{cmd}'。"
-                f" 既知コマンド: {', '.join(sorted(KNOWN_VERIFY_COMMANDS))}"
+                f" 既知コマンド: {', '.join(sorted(KNOWN_VERIFY_COMMAND_TYPES))}"
             )
             continue
 
-        min_args, max_args = KNOWN_VERIFY_COMMANDS[cmd]
+        min_args, max_args = KNOWN_VERIFY_COMMAND_TYPES[cmd]
         try:
             _parse_verify_args(args_str)
         except ValueError as e:

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -191,7 +191,7 @@ If Size is `XL` but splitting is not needed, read `${CLAUDE_PLUGIN_ROOT}/modules
 1. Propose split plan via AskUserQuestion (sub-issue count, scope of each, dependencies)
 2. After approval, create sub-issues with `gh issue create`
 3. Redistribute acceptance criteria; retain only cross-cutting conditions in the parent
-3a. Run lightweight refinement loop per sub-issue (steering doc alignment, verify hint assignment, lightweight ambiguity detection, auto-resolution, record unresolved points, update body)
+3a. Run lightweight refinement loop per sub-issue (steering doc alignment, verify command assignment, lightweight ambiguity detection, auto-resolution, record unresolved points, update body)
 4. Set parent-child relationships via `addSubIssue` GraphQL mutation
 5. Set sub-issue dependencies with `addBlockedBy` if applicable
 6. Apply `phase/issue` label to each sub-issue

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -293,9 +293,9 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/verify-patterns.md` and follow the "Processi
 
 If Notes contain implementation direction statements, verify they do not contradict the corresponding acceptance checks. Correct discrepancies immediately.
 
-**Section rename — update verify hints simultaneously:**
+**Section rename — update verify commands simultaneously:**
 
-If implementation steps include section renaming (e.g., `## Implementation Steps` → `## Changes`), update any `section_contains`/`section_not_contains` hints referencing that section name at the same time.
+If implementation steps include section renaming (e.g., `## Implementation Steps` → `## Changes`), update any `section_contains`/`section_not_contains` verify commands referencing that section name at the same time.
 
 **verify-type tag check:**
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -413,10 +413,10 @@ grep -r "{keyword}" {target file or directory}
 - **If judged as resolved**: skip Issue creation and output to terminal (e.g., "Skipping due to freshness check: {title} (may already be resolved in main)")
 - **If unresolved or cannot determine**: proceed to the next step (Issue creation)
 
-**Create Issue and add verify hints**:
+**Create Issue and add verify commands**:
 
 - Normalize title following `${CLAUDE_PLUGIN_ROOT}/modules/title-normalizer.md` processing steps, then create Issues in standard format (background, purpose, acceptance conditions) with `gh issue create` for each improvement proposal
-- **Add verify hints to acceptance conditions**: add acceptance checks like `<!-- verify: grep "{keyword}" "{target file}" -->` to the created Issue's acceptance conditions. Extract keywords from acceptance condition text and infer target files from proposal content (improves automation accuracy for `/auto --batch`). Create Issue without verify hints if they cannot be determined
+- **Add verify commands to acceptance conditions**: add acceptance checks like `<!-- verify: grep "{keyword}" "{target file}" -->` to the created Issue's acceptance conditions. Extract keywords from acceptance condition text and infer target files from proposal content (improves automation accuracy for `/auto --batch`). Create Issue without verify commands if they cannot be determined
 - If Issue creation fails, output error log to stderr, skip, and continue verify (does not affect exit code)
 - Output created Issue number to terminal
 

--- a/tests/validate-skill-syntax.bats
+++ b/tests/validate-skill-syntax.bats
@@ -477,9 +477,9 @@ EOF
     [[ "$output" == *"Phase-only"* ]]
 }
 
-# --- verify hint syntax validation ---
+# --- verify command syntax validation ---
 
-@test "success: valid verify hints pass validation" {
+@test "success: valid verify commands pass validation" {
     mkdir -p "$PROJECT_ROOT/skills/myskill"
     cat > "$PROJECT_ROOT/skills/myskill/SKILL.md" <<'EOF'
 ---
@@ -519,7 +519,7 @@ EOF
     [[ "$output" == *"unknown_cmd"* ]]
 }
 
-@test "error: verify hint with too few args is rejected" {
+@test "error: verify command with too few args is rejected" {
     mkdir -p "$PROJECT_ROOT/skills/myskill"
     cat > "$PROJECT_ROOT/skills/myskill/SKILL.md" <<'EOF'
 ---
@@ -538,7 +538,7 @@ EOF
     [[ "$output" == *"file_contains"* ]]
 }
 
-@test "error: verify hint with too many args is rejected" {
+@test "error: verify command with too many args is rejected" {
     mkdir -p "$PROJECT_ROOT/skills/myskill"
     cat > "$PROJECT_ROOT/skills/myskill/SKILL.md" <<'EOF'
 ---
@@ -557,7 +557,7 @@ EOF
     [[ "$output" == *"file_exists"* ]]
 }
 
-@test "error: verify hint with unterminated quote is rejected" {
+@test "error: verify command with unterminated quote is rejected" {
     mkdir -p "$PROJECT_ROOT/skills/myskill-bad-quote"
     cat > "$PROJECT_ROOT/skills/myskill-bad-quote/SKILL.md" <<'EOF'
 ---
@@ -575,7 +575,7 @@ EOF
     [[ "$output" == *"構文エラー"* ]]
 }
 
-@test "success: verify hint with --when modifier passes validation" {
+@test "success: verify command with --when modifier passes validation" {
     mkdir -p "$PROJECT_ROOT/skills/myskill"
     cat > "$PROJECT_ROOT/skills/myskill/SKILL.md" <<'EOF'
 ---


### PR DESCRIPTION
## Summary

- `docs/product.md` / `docs/ja/product.md`: Terms 表の "Acceptance check" / "受入チェック" エントリを "verify command" に置換し用語 SSOT を正本化
- `docs/tech.md` / `docs/ja/tech.md`: Forbidden Expressions 行の閉じ引用符欠落 typo を修正
- コード・ドキュメント全般の "verify hint" / "verify hints" 表記を "verify command" / "verify commands" に一括置換（7 ファイル）
- `scripts/validate-skill-syntax.py`: 関数 `validate_verify_hints` → `validate_verify_commands`、変数 `verify_hint_errors` → `verify_command_errors`、定数 `KNOWN_VERIFY_COMMANDS` → `KNOWN_VERIFY_COMMAND_TYPES` にリネーム
- `modules/verify-patterns.md`: 命名規約の例示を新名称に追随更新

## Verification (pre-merge)

- `docs/product.md` Terms 表に "verify command" エントリが存在し、旧称として verification hint / Acceptance check が記載されている
- `docs/ja/product.md` Terms 表が同様に更新されている
- `docs/product.md` Terms 表の旧 "Acceptance check" 行が削除されている
- `docs/ja/product.md` Terms 表の旧 "受入チェック" 行が削除されている
- `docs/tech.md` Forbidden Expressions 行の閉じ引用符欠落 typo が修正されている
- `docs/ja/tech.md` Forbidden Expressions 行が同様に修正されている
- `scripts/validate-skill-syntax.py` の "verify hint" 表記が除去されている
- `tests/validate-skill-syntax.bats` の "verify hint" 表記が除去されている
- `modules/browser-verify-security.md` の "verify hints" 表記が除去されている
- `modules/verify-classifier.md` の「without a hint」表記が除去され "verify command" が存在する
- `skills/verify/SKILL.md`、`skills/spec/SKILL.md`、`skills/issue/SKILL.md` の "verify hints" 表記が除去されている
- `validate_verify_commands` 関数、`KNOWN_VERIFY_COMMAND_TYPES` 定数が定義されており、旧名が残っていない
- `python3 scripts/validate-skill-syntax.py skills/` 全 SKILL.md PASS
- `bats tests/validate-skill-syntax.bats` 全テスト PASS

## Verification (post-merge)

- 後続 Issue で "Acceptance check" / "acceptance check" / "受入チェック" の広範な置換（残 24 ファイル・83 occurrences）が追跡されている

closes #84