### PR TITLE
Issue #88: Add title drift check to /issue and /spec skills

### DIFF
--- a/docs/spec/issue-88-title-drift-check.md
+++ b/docs/spec/issue-88-title-drift-check.md
@@ -70,3 +70,17 @@
 
 ### Rework
 - N/A
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+`modules/title-normalizer.md` の `## Output` セクションは「呼び出し元が `gh issue edit` を実行する」設計を前提としているが、新設した「Title Drift Check」サブセクションはモジュール内部で直接 `gh issue edit` を実行する。この2パターンが同一モジュール内に混在し、モジュールの責任境界が不明瞭になっている（SHOULD）。将来 Output セクションを2パートに分割して責任境界を明記することで改善できる。
+
+### Recurring issues
+
+今回の変更規模（SKILL.md のステップ挿入とリナンバリング）としてはレビューイシューが最小限に抑えられており、繰り返しパターンは特になし。
+
+### Acceptance criteria verification difficulty
+
+Pre-merge 条件3件はすべて `section_contains` / `grep` ヒントが整備されており PASS 判定が容易だった。Post-merge 条件はいずれも `verify-type: opportunistic` で適切にマークされており、UNCERTAIN 対応が不要だった。

--- a/docs/spec/issue-88-title-drift-check.md
+++ b/docs/spec/issue-88-title-drift-check.md
@@ -48,3 +48,25 @@
   - `/spec` での drift 検出ソースは Issue body のみ（`docs/product.md` の `/issue` (What) vs `/spec` (How) 境界に沿う）
   - drift 検出後の再生成は既存の naming convention をそのまま適用
 - `docs/structure.md` のモジュール一覧の description は "issue title normalization" のままで更新不要（drift check は normalization の拡張であり範囲内）
+
+## Spec Retrospective
+
+### Minor observations
+- Nothing to note
+
+### Judgment rationale
+- Nothing to note
+
+### Uncertainty resolution
+- Nothing to note
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A

--- a/modules/title-normalizer.md
+++ b/modules/title-normalizer.md
@@ -38,6 +38,35 @@ Normalize the Issue title following the naming convention below.
 - `bug: login fails` → `auth: Fix authentication error on login`
 - `design: Add noun-ending rule` (already ends without verb) → `design: Add noun-ending rule`
 
+### Title Drift Check
+
+After updating the Issue body, check for semantic drift between the current title and the updated body.
+
+**Input:**
+- **Current Issue title**: the title before any body update
+- **Updated Issue body**: the full body content after update
+
+**Processing:**
+
+1. Read the current Issue title and the updated Issue body
+2. Assess whether the body's scope, purpose, or target has changed significantly from what the title describes
+3. **Drift criteria** — classify as drift when any of the following apply:
+   - The body describes a clearly broader or narrower scope than the title
+   - The body's primary subject or component differs from the title
+   - The body's goal or purpose has changed substantially
+4. **If drift is detected:**
+   - Generate a new title following the naming convention: `component: concise description starting with a verb`
+   - Apply the same component determination criteria as the normalization rules above
+   - Update the title via:
+     ```bash
+     gh issue edit "$NUMBER" --title "$new_title"
+     ```
+   - Output the before/after in skill output:
+     ```
+     Title updated: "{old_title}" → "{new_title}"
+     ```
+5. **If no drift detected**: do nothing (no output)
+
 ## Output
 
 Normalized title string. The caller applies it as the `--title` argument to `gh issue edit`.

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -275,7 +275,11 @@ After confirming auto-resolved items, record them in an "Auto-Resolved Ambiguity
 
 > **Note**: Always use the Write tool for temp files. Shell redirects trigger confirmation prompts.
 
-### Step 9: Set Blocked-by Dependencies
+### Step 9: Title Drift Check
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/title-normalizer.md` and follow the "Title Drift Check" section. Detect semantic drift between the current title and the updated Issue body, and update the title if drift is found.
+
+### Step 10: Set Blocked-by Dependencies
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh $NUMBER
@@ -283,13 +287,13 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh $NUMBER
 
 Exit code 0: no open blockers. Exit code 2: open blockers (relationship set, continue). Exit code 1: error (warn and continue).
 
-### Step 10: Scope Assessment (sub-issue splitting)
+### Step 11: Scope Assessment (sub-issue splitting)
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md`.
 
-**For L/XL issues: run parallel investigation (Step 10a → 10b → 10c).**
+**For L/XL issues: run parallel investigation (Step 11a → 11b → 11c).**
 
-#### Step 10a: Parallel Investigation (Scope / Risk / Precedent Agents)
+#### Step 11a: Parallel Investigation (Scope / Risk / Precedent Agents)
 
 Get steering doc paths with Glob. Launch 3 agents in parallel:
 
@@ -306,11 +310,11 @@ Task(subagent_type="precedent-agent", description="Precedent investigation",
 
 On failure: fall back to standard scope assessment.
 
-#### Step 10b: Split Proposal (integrate results)
+#### Step 11b: Split Proposal (integrate results)
 
 Integrate outputs into a structured split proposal: sub-issue boundaries (from scope + risk data), size estimates, parallelization groups, key design decisions (from precedent data). Present via AskUserQuestion.
 
-#### Step 10c: Create sub-issues (after approval)
+#### Step 11c: Create sub-issues (after approval)
 
 Run the standard sub-issue creation flow (New Issue Creation Step 8, procedures 2–8).
 
@@ -318,11 +322,11 @@ Run the standard sub-issue creation flow (New Issue Creation Step 8, procedures 
 
 (For non-L/XL or fallback: run standard split assessment. Size XL → L change applies when no split is needed.)
 
-### Step 11: Issue Retrospective
+### Step 12: Issue Retrospective
 
 Same as New Issue Creation Step 9.
 
-### Step 12: Opportunistic Verification
+### Step 13: Opportunistic Verification
 
 Same as New Issue Creation Step 10.
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -72,7 +72,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh $NUMBER --dry-run
 - Exit code 2: open blockers present → `HAS_OPEN_BLOCKING=true`
 - Exit code 1: error → warn and set `HAS_OPEN_BLOCKING=false`
 
-**Retain the result**: if any open blocked-by Issues exist (exit code 2), set `HAS_OPEN_BLOCKING=true` and retain through Step 18.
+**Retain the result**: if any open blocked-by Issues exist (exit code 2), set `HAS_OPEN_BLOCKING=true` and retain through Step 19.
 
 ### Step 5: Reference Steering Documents (if present)
 
@@ -485,16 +485,20 @@ Before committing the Spec, verify internal consistency:
   - If mismatched, auto-update Issue body (use Spec's `## Verification > Pre-merge` as source of truth)
 - **Post-merge skill name alignment**: if `## Verification > Post-merge` mentions a target skill name (`/foo`), verify it matches the target skill in the Issue purpose
 
-### Step 11: Commit Spec
+### Step 11: Title Drift Check
 
-Commit the Spec (push is done in Step 13 Worktree Exit):
+Read `${CLAUDE_PLUGIN_ROOT}/modules/title-normalizer.md` and follow the "Title Drift Check" section. Detect semantic drift between the current title and the updated Issue body (drift detection source: Issue body only — do not include Spec content). Update the title if drift is found.
+
+### Step 12: Commit Spec
+
+Commit the Spec (push is done in Step 14 Worktree Exit):
 
 ```bash
 git add docs/spec/issue-$NUMBER-short-title.md
 git commit -m "Add design for issue #$NUMBER"
 ```
 
-### Step 12: Spec Retrospective
+### Step 13: Spec Retrospective
 
 **SPEC_DEPTH=full only. Skip if SPEC_DEPTH=light.**
 
@@ -539,13 +543,13 @@ Reflect on the specification phase and present improvement suggestions to the us
 1. Write "Nothing to note" in each section if nothing to record
 2. If issue retrospective found, transfer it first (Edit tool to prepend to Spec)
 3. Edit tool to append spec retrospective to Spec end
-4. Additional commit (push in Step 13 Worktree Exit):
+4. Additional commit (push in Step 14 Worktree Exit):
    ```bash
    git add docs/spec/issue-$NUMBER-short-title.md
    git commit -m "Add retrospective notes for issue #$NUMBER"
    ```
 
-### Step 13: Worktree Exit (merge-to-main)
+### Step 14: Worktree Exit (merge-to-main)
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Exit: merge-to-main" section.
 
@@ -553,7 +557,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Exit:
 - `ENTERED_WORKTREE=true`: ExitWorktree("keep") → merge → push → cleanup
 - `ENTERED_WORKTREE=false`: run `git push origin main` directly
 
-### Step 14: Issue Comment
+### Step 15: Issue Comment
 
 Post a design summary comment to the target Issue.
 
@@ -574,17 +578,17 @@ Template:
 - `### Implementation Steps` — numbered list with dependencies and acceptance criteria mapping
 - Spec link: `[issue-$NUMBER-short-title.md](https://github.com/{REPO}/blob/main/docs/spec/issue-$NUMBER-short-title.md)`
 
-### Step 15: Label Transition (design complete)
+### Step 16: Label Transition (design complete)
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh $NUMBER ready
 ```
 
-### Step 16: Opportunistic Verification
+### Step 17: Opportunistic Verification
 
 If `opportunistic-verify: true` is set in `.wholework.yml`, read `${CLAUDE_PLUGIN_ROOT}/modules/opportunistic-verify.md` and follow "Processing Steps". Skill name: `/spec`. Skip if not set.
 
-### Step 17: Size-to-Workflow Determination (for Step 18)
+### Step 18: Size-to-Workflow Determination (for Step 19)
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` and re-evaluate Size using the 2-axis method.
 
@@ -604,7 +608,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` and re-evaluate Size
    - `M` or `L` → `pr`
    - `XL` → `sub_issue`
 
-### Step 18: Completion Message
+### Step 19: Completion Message
 
 Output "Design complete. Spec created, committed, pushed, and Issue comment posted." as a fixed prefix.
 
@@ -622,5 +626,5 @@ Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "P
 
 - This skill covers Spec creation, commit, push, and Issue comment only
 - Implementation is not performed here
-- After Step 11 commit → Step 12 retrospective → Step 13 Worktree Exit+push → Step 14 Issue comment → Step 16 opportunistic verification → Step 18 completion message
+- After Step 12 commit → Step 13 retrospective → Step 14 Worktree Exit+push → Step 15 Issue comment → Step 17 opportunistic verification → Step 19 completion message
 - Always use the Write tool for temp files. Shell redirects trigger confirmation prompts


### PR DESCRIPTION
## Summary

`/issue` の既存 Issue 精査フローと `/spec` の Spec 作成フローに、Issue body と title の意味的乖離（drift）を自動検出して title を更新する「Title Drift Check」ステップを追加する。

- `modules/title-normalizer.md` の `## Processing Steps` セクションに `### Title Drift Check` サブセクションを追加
- `skills/issue/SKILL.md` の Existing Issue Refinement フローに Step 9 として Title Drift Check を挿入（旧 Step 9〜12 を Step 10〜13 にリナンバリング）
- `skills/spec/SKILL.md` に Step 11 として Title Drift Check を挿入（旧 Step 11〜18 を Step 12〜19 にリナンバリング）

## Verification (pre-merge)

- `modules/title-normalizer.md` の `## Processing Steps` セクションに「Title Drift Check」手順が追加されている
- `/issue` SKILL.md の Existing Issue Refinement フローに title drift check ステップが追加されている
- `/spec` SKILL.md に title drift check ステップが追加されている

## Verification (post-merge)

- `/issue N` の精査実行で body のスコープが大きく変わった場合、title が自動更新されスキル出力に更新前後が表示される
- `/spec N` の Spec 作成後にスコープ変更が検出された場合、title が自動更新されスキル出力に更新前後が表示される

closes #88