### PR TITLE
Issue #108: Add phase-specific model/effort matrix and implement --effort in run-*.sh

### DIFF
--- a/agents/precedent-agent.md
+++ b/agents/precedent-agent.md
@@ -2,7 +2,7 @@
 name: precedent-agent
 description: Precedent Investigation: extract learnings from similar Issue/Spec retrospectives (for L/XL Issue parallel investigation)
 tools: Read, Glob, Grep
-model: sonnet
+model: opus
 ---
 
 # Precedent Investigation Agent

--- a/agents/risk-agent.md
+++ b/agents/risk-agent.md
@@ -2,7 +2,7 @@
 name: risk-agent
 description: Risk Investigation: assess test impact, verify command effects, and breaking change potential (for L/XL Issue parallel investigation)
 tools: Read, Glob, Grep
-model: sonnet
+model: opus
 ---
 
 # Risk Investigation Agent

--- a/agents/scope-agent.md
+++ b/agents/scope-agent.md
@@ -2,7 +2,7 @@
 name: scope-agent
 description: Scope Investigation: identify change targets and impact scope (for L/XL Issue parallel investigation)
 tools: Read, Glob, Grep, Bash(git log:*, git diff:*)
-model: sonnet
+model: opus
 ---
 
 # Scope Investigation Agent

--- a/docs/spec/issue-108-effort-matrix.md
+++ b/docs/spec/issue-108-effort-matrix.md
@@ -133,3 +133,18 @@ Nothing to note（初回作成のため変更なし）
 ### Uncertainty resolution
 
 - `--effort` が sub-agents に継承されるかどうかは Claude Code の内部動作に依存するが、Anthropic のドキュメントから推定。実装後に run-review.sh + review-bug の動作で間接的に確認可能
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A（Spec の実装ステップに従い、設計通りに実装完了）
+
+### Design Gaps/Ambiguities
+
+- Spec の `run-verify.sh` 行番号指定（L76-80）は実際のファイルと一致（`tee` を使ったパイプ構造の claude コマンド部分）。ただし `--effort` の挿入位置は `--dangerously-skip-permissions` の直前であり、Spec の「L76-80 に追加」という記述は行番号変動リスクがある。次回から行番号ではなくコンテキストで指定するとよい
+- echo 出力の "Effort: X" を追加する位置について Spec では「echo 出力に追加」と記述されており、具体的な挿入箇所が「Model: sonnet」の直後であることは自明だったが、明示するとより良い
+
+### Rework
+
+- N/A（全ステップ一発で完了、rework なし）

--- a/docs/spec/issue-108-effort-matrix.md
+++ b/docs/spec/issue-108-effort-matrix.md
@@ -148,3 +148,17 @@ Nothing to note（初回作成のため変更なし）
 ### Rework
 
 - N/A（全ステップ一発で完了、rework なし）
+
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Nothing to note — review-specエージェントが全実装ステップを確認し、Specとの乖離は検出されなかった。受入条件10件全てPASSで、追加の修正は不要だった。
+
+### Recurring Issues
+
+Nothing to note — review-bug×2エージェントとも問題を検出せず、ドキュメント一貫性も問題なし。フォルスポジティブは2件除外（run-verify.shのteeパイプはdiff外の既存挙動、Specファイル日本語はCLAUDE.md準拠）。
+
+### Acceptance Criteria Verification Difficulty
+
+Nothing to note — 全10件がgrep/section_contains等の静的コマンドで確認でき、UNCERTAIN・POST-MERGEはゼロ。verify命令の設計が適切で、自動検証の精度が高かった。

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -4,6 +4,7 @@ ssot_for:
   - tech-stack
   - forbidden-expressions
   - gotchas
+  - model-effort-matrix
 ---
 
 English | [日本語](ja/tech.md)
@@ -56,9 +57,29 @@ English | [日本語](ja/tech.md)
     | File existence | Specific file presence | `review/skill-dev-recheck.md` (read when `scripts/validate-skill-syntax.py` exists) |
 
 - **Effort optimization strategy (3 axes)**: Three axes for controlling execution cost and quality in `claude -p` invocations. CLI support status and Wholework adoption policy per axis:
-  - **Axis 1 — Model selection** (`--model`): Already implemented. Sonnet is the default; `run-spec.sh --opus` switches to Opus for L-size specs. No further action needed.
-  - **Axis 2 — Adaptive Thinking** (`--effort`): `claude -p` supports `low/medium/high/max` levels (confirmed via `claude --help`). Not yet used in `run-*.sh`. Combining medium effort with an Opus advisor achieves quality comparable to default-effort Sonnet at lower cost (per Anthropic benchmarks). Implementation in `run-*.sh` is a follow-up Issue.
+  - **Axis 1 — Model selection** (`--model`): Already implemented. Sonnet is the default; `run-spec.sh --opus` switches to Opus for L-size specs. Reviewed and confirmed.
+  - **Axis 2 — Adaptive Thinking** (`--effort`): `claude -p` supports `low/medium/high/max` levels (confirmed via `claude --help`). Implemented in `run-*.sh` with phase-specific effort levels (see matrix below). Combining medium effort with an Opus advisor achieves quality comparable to default-effort Sonnet at lower cost (per Anthropic benchmarks).
   - **Axis 3 — Advisor strategy** (`advisor_20260301`): Anthropic API beta feature (`advisor-tool-2026-03-01` header required). Enabled via the `--betas` flag — API key users only; not available with OAuth/subscription auth (the `run-*.sh` default). Performance gains: Sonnet + Opus advisor achieves SWE-bench +2.7 pp and cost −11.9% vs. Sonnet alone; Haiku + Opus advisor achieves BrowseComp 41.2% (vs. 19.7% solo) and cost −85% vs. Sonnet. Implementation in `run-*.sh` is a follow-up Issue.
+
+  **Phase-specific model and effort matrix** (`ssot_for: model-effort-matrix`):
+
+  | Component | Phase | Model | Effort | Rationale |
+  |-----------|-------|-------|--------|-----------|
+  | run-spec.sh | spec | Sonnet (Opus via `--opus` for L) | max | Design quality is critical; spec errors propagate to all subsequent phases. `/auto` passes `--opus` for L-size only (XL is split before spec) |
+  | run-code.sh | code | Sonnet | high | Implementation requires thorough reasoning |
+  | run-review.sh | review | Sonnet | high | Review orchestration; sub-agents handle deep analysis |
+  | run-issue.sh | issue | Sonnet | high | L/XL scope analysis and sub-issue splitting require thorough orchestration |
+  | run-verify.sh | verify | Sonnet | medium | Structured acceptance testing; moderate complexity |
+  | run-merge.sh | merge | Sonnet | low | Mechanical merge operation; minimal reasoning needed |
+  | review-bug | review | Opus | — | Bug detection requires highest accuracy (sub-agent, effort inherited from parent) |
+  | review-spec | review | Opus | — | Spec deviation requires high accuracy (sub-agent, effort inherited from parent) |
+  | review-light | review | Sonnet | — | Lightweight integrated review (sub-agent, effort inherited from parent) |
+  | scope-agent | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Scope identification accuracy is critical for sub-issue boundary decisions |
+  | risk-agent | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Risk assessment accuracy improves acceptance criteria quality |
+  | precedent-agent | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Precedent extraction improves acceptance criteria quality |
+  | triage (skill) | triage | Sonnet | — | Metadata assignment; Sonnet sufficient (direct invocation, effort not set) |
+
+  SSoT note: This matrix is the single source of truth for all model and effort settings. When changing model/effort in run-*.sh, agents, or skills, update this table first.
 
 ## Testing Strategy
 

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -46,6 +46,7 @@ fi
 
 echo "=== run-code.sh: Starting /code for issue #${ISSUE_NUMBER} ==="
 echo "Model: sonnet"
+echo "Effort: high"
 echo "Permissions: skip (autonomous mode)"
 if [[ "$ROUTE_FLAG" == "--patch" ]]; then
   echo "Route: patch (${BASE_BRANCH:-main} direct commit)"
@@ -104,6 +105,7 @@ set +e
 ANTHROPIC_MODEL=claude-sonnet-4-6 \
   env -u CLAUDECODE claude -p "$PROMPT" \
     --model claude-sonnet-4-6 \
+    --effort high \
     --dangerously-skip-permissions
 EXIT_CODE=$?
 set -e

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -21,6 +21,7 @@ fi
 
 echo "=== run-issue.sh: Starting /issue for issue #${ISSUE_NUMBER} ==="
 echo "Model: sonnet"
+echo "Effort: high"
 echo "Permissions: skip (autonomous mode)"
 echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
@@ -56,6 +57,7 @@ set +e
 ANTHROPIC_MODEL=claude-sonnet-4-6 \
   env -u CLAUDECODE claude -p "$PROMPT" \
     --model claude-sonnet-4-6 \
+    --effort high \
     --dangerously-skip-permissions
 EXIT_CODE=$?
 set -e

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -13,6 +13,7 @@ fi
 
 echo "=== run-merge.sh: Starting /merge for PR #${PR_NUMBER} ==="
 echo "Model: sonnet"
+echo "Effort: low"
 echo "Permissions: skip (autonomous mode)"
 echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
@@ -45,6 +46,7 @@ set +e
 ANTHROPIC_MODEL=claude-sonnet-4-6 \
   env -u CLAUDECODE claude -p "$PROMPT" \
     --model claude-sonnet-4-6 \
+    --effort low \
     --dangerously-skip-permissions
 EXIT_CODE=$?
 set -e

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -15,6 +15,7 @@ fi
 
 echo "=== run-review.sh: Starting /review for PR #${PR_NUMBER} ==="
 echo "Model: sonnet"
+echo "Effort: high"
 echo "Permissions: skip (autonomous mode)"
 echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
@@ -53,6 +54,7 @@ set +e
 ANTHROPIC_MODEL=claude-sonnet-4-6 \
   env -u CLAUDECODE claude -p "$PROMPT" \
     --model claude-sonnet-4-6 \
+    --effort high \
     --dangerously-skip-permissions
 EXIT_CODE=$?
 set -e

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -30,6 +30,7 @@ fi
 
 echo "=== run-spec.sh: Starting /spec for issue #${ISSUE_NUMBER} ==="
 echo "Model: ${MODEL}"
+echo "Effort: max"
 echo "Permissions: skip (autonomous mode)"
 echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
@@ -61,6 +62,7 @@ set +e
 ANTHROPIC_MODEL="${MODEL}" \
   env -u CLAUDECODE claude -p "$PROMPT" \
     --model "${MODEL}" \
+    --effort max \
     --dangerously-skip-permissions
 EXIT_CODE=$?
 set -e

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -34,6 +34,7 @@ done
 
 echo "=== run-verify.sh: Starting /verify for Issue #${ISSUE_NUMBER} ==="
 echo "Model: sonnet"
+echo "Effort: medium"
 echo "Permissions: skip (autonomous mode)"
 echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
@@ -77,6 +78,7 @@ set +e
 ANTHROPIC_MODEL=claude-sonnet-4-6 \
   env -u CLAUDECODE claude -p "$PROMPT" \
     --model claude-sonnet-4-6 \
+    --effort medium \
     --dangerously-skip-permissions 2>&1 | tee "$VERIFY_TMPOUT"
 EXIT_CODE=$?
 set -e


### PR DESCRIPTION
## Summary

- `docs/tech.md` の Architecture Decisions に phase 別 model・effort マトリクスを追加。`ssot_for: model-effort-matrix` を設定し、SSoT として管理
- 全 `run-*.sh` に phase ごとの `--effort` パラメータを追加（spec: max, code/review/issue: high, verify: medium, merge: low）
- investigation agents（scope-agent, risk-agent, precedent-agent）の model を `sonnet` → `opus` に変更

## Verification (pre-merge)

- `docs/tech.md` の Architecture Decisions に phase 別 model・effort マトリクスを記載（`ssot_for: model-effort-matrix` 追加済み）
- `scripts/run-spec.sh` の `claude -p` 呼び出しに `--effort max` を追加
- `scripts/run-code.sh` の `claude -p` 呼び出しに `--effort high` を追加
- `scripts/run-review.sh` の `claude -p` 呼び出しに `--effort high` を追加
- `scripts/run-issue.sh` の `claude -p` 呼び出しに `--effort high` を追加
- `scripts/run-merge.sh` の `claude -p` 呼び出しに `--effort low` を追加
- `scripts/run-verify.sh` の `claude -p` 呼び出しに `--effort medium` を追加
- investigation agents（scope-agent, risk-agent, precedent-agent）の model frontmatter が `opus` に変更済み
- triage skill の変更不要根拠を docs/tech.md に記載済み
- `docs/tech.md` の `ssot_for` frontmatter に `model-effort-matrix` を追加

## Verification (post-merge)

- `/auto` で実行されるフェーズが各 run-*.sh の effort 設定を反映して動作すること

closes #108