### PR TITLE
Issue #113: Add phase-banner shared module for phase identification display

### DIFF
--- a/docs/spec/issue-113-phase-banner-module.md
+++ b/docs/spec/issue-113-phase-banner-module.md
@@ -279,3 +279,17 @@
 
 ### Rework
 - N/A
+
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+`modules/phase-banner.md` の Processing Steps に記述されたバナーフォーマット（`--- /SKILL_NAME #N ---` / `TITLE` / `URL` / `---`）と、`scripts/phase-banner.sh` の `print_start_banner` が実際に出力するフォーマット（`Issue: #N TITLE` / `URL: URL`）が異なる。これは Spec の Notes に「SKILL.md は start banner のみ」「run-*.sh は start + end 両方」という意図的な2-layer設計として明記されているが、モジュール内の記述が run-*.sh フォーマットを参照していないため、将来 LLM が phase-banner.md を読む際に誤解する可能性がある。モジュールに「run-*.sh の出力フォーマットは `phase-banner.sh` を参照」という注記を追加することを検討する。
+
+### Recurring Issues
+
+- 特筆事項なし
+
+### Acceptance Criteria Verification Difficulty
+
+- 全8条件が `file_exists` / `grep` / `file_contains` / `github_check` の verify command で機械的に検証可能であり、UNCERTAIN は0件。verify command の設計が適切で自動検証効率が高かった。

--- a/docs/spec/issue-113-phase-banner-module.md
+++ b/docs/spec/issue-113-phase-banner-module.md
@@ -268,3 +268,14 @@
 
 ### Uncertainty resolution
 - Nothing to note
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A
+
+### Design Gaps/Ambiguities
+- Spec の Implementation Steps で「SCRIPT_DIR を=== 行の前に移動する必要があるスクリプト」として run-issue.sh, run-spec.sh, run-review.sh, run-merge.sh が挙げられていたが、実際には run-code.sh と run-verify.sh も同じ状況（SCRIPT_DIR がStarting行より後に定義）であり、全6スクリプトで前方移動が必要だった。run-auto-sub.sh のみ既に前方に定義されていた点は Spec と一致。
+
+### Rework
+- N/A

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -23,11 +23,11 @@ wholework/
 │   └── <skill-name>/
 │       ├── SKILL.md     # Skill definition (required)
 │       └── *.md         # Auxiliary phase/guideline files (optional)
-├── modules/             # Shared modules referenced by skills (23 files)
+├── modules/             # Shared modules referenced by skills (24 files)
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (6 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (27 files)
+├── scripts/             # Utility scripts used by skills and agents (28 files)
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   └── workflows/
@@ -85,6 +85,7 @@ Key modules:
 - `modules/lighthouse-adapter.md` — Lighthouse performance audit adapter
 - `modules/measurement-scope.md` — measurement scope definition
 - `modules/next-action-guide.md` — unified next action guidance for all skills
+- `modules/phase-banner.md` — phase identification banner display for skills
 
 ### Agents
 
@@ -98,6 +99,9 @@ Key modules:
 | precedent-agent | `agents/precedent-agent.md` | Precedent investigation from similar issues |
 
 ### Scripts
+
+**Phase banner:**
+- `scripts/phase-banner.sh` — sourceable helper providing `print_start_banner` / `print_end_banner` functions for run-*.sh scripts
 
 **GitHub API utilities:**
 - `scripts/gh-graphql.sh` — GraphQL query executor with caching

--- a/modules/phase-banner.md
+++ b/modules/phase-banner.md
@@ -1,0 +1,27 @@
+# phase-banner
+
+Standardized phase identification banner for skill start.
+
+## Purpose
+Display Issue/PR title and URL at skill start for identification.
+
+## Input
+- ENTITY_TYPE: "issue" or "pr"
+- ENTITY_NUMBER: Issue or PR number (extracted by calling skill)
+- SKILL_NAME: name of the skill (e.g., "issue", "spec", "review")
+
+## Processing Steps
+1. Fetch title and URL:
+   - Issue: `gh issue view $N --json title,url`
+   - PR: `gh pr view $N --json title,url`
+2. Output banner format (at skill start, after number extraction):
+   ```
+   --- /SKILL_NAME #N ---
+   TITLE
+   URL
+   ---
+   ```
+3. If `gh` command fails, output banner without title/URL (skip silently)
+
+## Output
+Phase identification banner displayed to terminal.

--- a/scripts/phase-banner.sh
+++ b/scripts/phase-banner.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# phase-banner.sh — sourceable helper for run-*.sh phase banner display
+# Usage: source this file, then call print_start_banner / print_end_banner
+
+# Fetch and cache title/URL for the given entity
+# Args: entity_type ("issue"|"pr"), entity_number
+_fetch_entity_info() {
+  local entity_type="$1" entity_number="$2"
+  if [[ "$entity_type" == "pr" ]]; then
+    _ENTITY_TITLE=$(gh pr view "$entity_number" --json title -q '.title' 2>/dev/null || echo "")
+    _ENTITY_URL=$(gh pr view "$entity_number" --json url -q '.url' 2>/dev/null || echo "")
+  else
+    _ENTITY_TITLE=$(gh issue view "$entity_number" --json title -q '.title' 2>/dev/null || echo "")
+    _ENTITY_URL=$(gh issue view "$entity_number" --json url -q '.url' 2>/dev/null || echo "")
+  fi
+}
+
+# Print start banner with title/URL
+# Args: entity_type ("issue"|"pr"), entity_number
+print_start_banner() {
+  local entity_type="$1" entity_number="$2"
+  _fetch_entity_info "$entity_type" "$entity_number"
+  local label; [[ "$entity_type" == "pr" ]] && label="PR" || label="Issue"
+  echo "${label}: #${entity_number} ${_ENTITY_TITLE}"
+  echo "URL: ${_ENTITY_URL}"
+}
+
+# Print end banner with cached title/URL
+# Args: entity_type ("issue"|"pr"), entity_number
+print_end_banner() {
+  local entity_type="$1" entity_number="$2"
+  local label; [[ "$entity_type" == "pr" ]] && label="PR" || label="Issue"
+  echo "${label}: #${entity_number} ${_ENTITY_TITLE}"
+  echo "URL: ${_ENTITY_URL}"
+}

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -88,6 +88,8 @@ run_verify_with_retry() {
 }
 
 echo "=== run-auto-sub.sh: Starting sub-issue #${SUB_NUMBER} ==="
+source "$SCRIPT_DIR/phase-banner.sh"
+print_start_banner "issue" "$SUB_NUMBER"
 echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 if [[ -n "$BASE_BRANCH" ]]; then
   echo "Base branch: ${BASE_BRANCH}"
@@ -194,5 +196,6 @@ esac
 
 echo "---"
 echo "=== run-auto-sub.sh: Completed sub-issue #${SUB_NUMBER} ==="
+print_end_banner "issue" "$SUB_NUMBER"
 echo "Finished at: $(date '+%Y-%m-%d %H:%M:%S')"
 exit 0

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -44,7 +44,11 @@ if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "=== run-code.sh: Starting /code for issue #${ISSUE_NUMBER} ==="
+source "$SCRIPT_DIR/phase-banner.sh"
+print_start_banner "issue" "$ISSUE_NUMBER"
 echo "Model: sonnet"
 echo "Effort: high"
 echo "Permissions: skip (autonomous mode)"
@@ -63,7 +67,6 @@ echo "---"
 # /code has context: fork, so calling it via claude -p "/code N" prevents
 # --dangerously-skip-permissions from propagating to the fork sub-agent (#284)
 # By passing SKILL.md body directly, we bypass frontmatter interpretation
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_FILE="${SCRIPT_DIR}/../skills/code/SKILL.md"
 
 if [[ ! -f "$SKILL_FILE" ]]; then
@@ -112,6 +115,7 @@ set -e
 
 echo "---"
 echo "=== run-code.sh: Finished /code for issue #${ISSUE_NUMBER} ==="
+print_end_banner "issue" "$ISSUE_NUMBER"
 echo "Exit code: ${EXIT_CODE}"
 echo "Finished at: $(date '+%Y-%m-%d %H:%M:%S')"
 exit $EXIT_CODE

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -19,7 +19,11 @@ if [[ $# -gt 0 ]]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "=== run-issue.sh: Starting /issue for issue #${ISSUE_NUMBER} ==="
+source "$SCRIPT_DIR/phase-banner.sh"
+print_start_banner "issue" "$ISSUE_NUMBER"
 echo "Model: sonnet"
 echo "Effort: high"
 echo "Permissions: skip (autonomous mode)"
@@ -30,7 +34,6 @@ echo "---"
 # /issue has context: fork, so calling it via claude -p "/issue N" prevents
 # --dangerously-skip-permissions from propagating to the fork sub-agent (#284)
 # By passing SKILL.md body directly, we bypass frontmatter interpretation
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_FILE="${SCRIPT_DIR}/../skills/issue/SKILL.md"
 
 if [[ ! -f "$SKILL_FILE" ]]; then
@@ -64,6 +67,7 @@ set -e
 
 echo "---"
 echo "=== run-issue.sh: Finished /issue for issue #${ISSUE_NUMBER} ==="
+print_end_banner "issue" "$ISSUE_NUMBER"
 echo "Exit code: ${EXIT_CODE}"
 echo "Finished at: $(date '+%Y-%m-%d %H:%M:%S')"
 exit $EXIT_CODE

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -11,7 +11,11 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "=== run-merge.sh: Starting /merge for PR #${PR_NUMBER} ==="
+source "$SCRIPT_DIR/phase-banner.sh"
+print_start_banner "pr" "$PR_NUMBER"
 echo "Model: sonnet"
 echo "Effort: low"
 echo "Permissions: skip (autonomous mode)"
@@ -21,7 +25,6 @@ echo "---"
 # Pass SKILL.md body directly as prompt (same pattern as run-review.sh)
 # /merge has no context: fork, but uses the same approach for consistency
 # See: #284 (context: fork permission non-propagation issue)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_FILE="${SCRIPT_DIR}/../skills/merge/SKILL.md"
 
 if [[ ! -f "$SKILL_FILE" ]]; then
@@ -53,6 +56,7 @@ set -e
 
 echo "---"
 echo "=== run-merge.sh: Finished /merge for PR #${PR_NUMBER} ==="
+print_end_banner "pr" "$PR_NUMBER"
 echo "Exit code: ${EXIT_CODE}"
 echo "Finished at: $(date '+%Y-%m-%d %H:%M:%S')"
 exit $EXIT_CODE

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -13,7 +13,11 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "=== run-review.sh: Starting /review for PR #${PR_NUMBER} ==="
+source "$SCRIPT_DIR/phase-banner.sh"
+print_start_banner "pr" "$PR_NUMBER"
 echo "Model: sonnet"
 echo "Effort: high"
 echo "Permissions: skip (autonomous mode)"
@@ -24,7 +28,6 @@ echo "---"
 # /review has context: fork, so calling it via claude -p "/review N" prevents
 # --dangerously-skip-permissions from propagating to the fork sub-agent (#284)
 # By passing SKILL.md body directly, we bypass frontmatter interpretation
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_FILE="${SCRIPT_DIR}/../skills/review/SKILL.md"
 
 if [[ ! -f "$SKILL_FILE" ]]; then
@@ -61,6 +64,7 @@ set -e
 
 echo "---"
 echo "=== run-review.sh: Finished /review for PR #${PR_NUMBER} ==="
+print_end_banner "pr" "$PR_NUMBER"
 echo "Exit code: ${EXIT_CODE}"
 echo "Finished at: $(date '+%Y-%m-%d %H:%M:%S')"
 exit $EXIT_CODE

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -28,7 +28,11 @@ if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "=== run-spec.sh: Starting /spec for issue #${ISSUE_NUMBER} ==="
+source "$SCRIPT_DIR/phase-banner.sh"
+print_start_banner "issue" "$ISSUE_NUMBER"
 echo "Model: ${MODEL}"
 echo "Effort: max"
 echo "Permissions: skip (autonomous mode)"
@@ -36,7 +40,6 @@ echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
 
 # Pass SKILL.md body directly as prompt (avoids context: fork issue)
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_FILE="${SCRIPT_DIR}/../skills/spec/SKILL.md"
 
 if [[ ! -f "$SKILL_FILE" ]]; then
@@ -69,6 +72,7 @@ set -e
 
 echo "---"
 echo "=== run-spec.sh: Finished /spec for issue #${ISSUE_NUMBER} ==="
+print_end_banner "issue" "$ISSUE_NUMBER"
 echo "Exit code: ${EXIT_CODE}"
 echo "Finished at: $(date '+%Y-%m-%d %H:%M:%S')"
 exit $EXIT_CODE

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -32,7 +32,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "=== run-verify.sh: Starting /verify for Issue #${ISSUE_NUMBER} ==="
+source "$SCRIPT_DIR/phase-banner.sh"
+print_start_banner "issue" "$ISSUE_NUMBER"
 echo "Model: sonnet"
 echo "Effort: medium"
 echo "Permissions: skip (autonomous mode)"
@@ -43,7 +47,6 @@ echo "---"
 # /verify has context: fork, so calling it via claude -p "/verify N" prevents
 # --dangerously-skip-permissions from propagating to the fork sub-agent (#284)
 # By passing SKILL.md body directly, we bypass frontmatter interpretation
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILL_FILE="${SCRIPT_DIR}/../skills/verify/SKILL.md"
 
 if [[ ! -f "$SKILL_FILE" ]]; then
@@ -92,6 +95,7 @@ rm -f "$VERIFY_TMPOUT"
 
 echo "---"
 echo "=== run-verify.sh: Finished /verify for Issue #${ISSUE_NUMBER} ==="
+print_end_banner "issue" "$ISSUE_NUMBER"
 echo "Exit code: ${EXIT_CODE}"
 echo "Finished at: $(date '+%Y-%m-%d %H:%M:%S')"
 exit $EXIT_CODE

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -29,6 +29,8 @@ Extract the Issue number from ARGUMENTS. Examples: `ARGUMENTS = "279"` → `NUMB
 
 If `--batch N` flag is present (e.g., `ARGUMENTS = "--batch 5"`): record `BATCH_SIZE = 5` and branch to the "Batch Mode (--batch N)" section (**skip Steps 2–6**). No Issue number needed.
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="issue", ENTITY_NUMBER=$NUMBER, SKILL_NAME="auto".
+
 ### Step 2: Route Detection and Base Branch
 
 Detect `--patch`/`--pr`, `--review=full`/`--review=light`, and `--base {branch}` flags from ARGUMENTS.

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -59,6 +59,8 @@ In `--non-interactive` mode (invoked via `run-code.sh` with `claude -p`), AskUse
 
 Determine the route based on Size (Project field preferred → label fallback) and option flags.
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="issue", ENTITY_NUMBER=$NUMBER, SKILL_NAME="code".
+
 First, fetch Size (run before route detection):
 
 ```bash

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -243,6 +243,8 @@ gh issue view $NUMBER --json body,title,labels
 gh issue view $NUMBER --json comments
 ```
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="issue", ENTITY_NUMBER=$NUMBER, SKILL_NAME="issue".
+
 Detect embedded links in body and comments; fetch GitHub-hosted attachments via WebFetch or Read. Use attachment content and all comments as context for subsequent steps.
 
 ### Step 2: Auto-chain to triage (if `triaged` label is absent)

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -62,6 +62,8 @@ Note: Always wrap `$NUMBER` in double quotes.
   - User selects "Abort": Stop processing (do not proceed to subsequent steps)
   - User selects "Treat as conflict": Proceed to Step 2 (Resolve Conflicts)
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="pr", ENTITY_NUMBER=$NUMBER, SKILL_NAME="merge".
+
 ### Step 2: Worktree Entry
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Entry section" to create a worktree.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -64,6 +64,8 @@ Run `${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh $ISSUE_NUMBER` and store th
 
 If Issue number cannot be extracted, set `TYPE=` (empty string).
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="pr", ENTITY_NUMBER=$NUMBER, SKILL_NAME="review".
+
 ### Step 2: Worktree Entry
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Entry" section.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -40,6 +40,8 @@ Parse ARGUMENTS to extract the Issue number and mode options:
 gh issue view $NUMBER --json title,body,labels
 ```
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="issue", ENTITY_NUMBER=$NUMBER, SKILL_NAME="spec".
+
 Run `${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh $NUMBER` and store the result in `ISSUE_TYPE`:
 - Value (`Bug`/`Feature`/`Task`) stored as-is
 - Empty string: `ISSUE_TYPE=unset`

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -72,6 +72,8 @@ gh issue view 123 --json number,title,body,labels && echo "---" && gh issue view
 gh issue view $NUMBER --json title,body,labels
 ```
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="issue", ENTITY_NUMBER=$NUMBER, SKILL_NAME="triage".
+
 - If the `triaged` label is already present, skip and notify the user
 
 ### Step 2: Duplicate Candidate Detection

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -65,6 +65,8 @@ git status
   "Error: Cannot run verify because there are uncommitted changes. Run `git stash` or `git commit`, then re-run `/verify $NUMBER`."
 - **Clean** → continue
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="issue", ENTITY_NUMBER=$NUMBER, SKILL_NAME="verify".
+
 ### Step 2: Detect and Update Base Branch
 
 If ARGUMENTS contains `--base {branch}`, use that as `BASE_BRANCH`. Otherwise, search for a merged PR linked to the Issue and fetch `baseRefName`:

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -41,6 +41,21 @@ done
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/claude"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test issue title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/issues/123"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
 }
 
 teardown() {

--- a/tests/run-issue.bats
+++ b/tests/run-issue.bats
@@ -41,6 +41,21 @@ done
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/claude"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test issue title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/issues/123"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
 }
 
 teardown() {

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -22,6 +22,21 @@ echo "CLAUDECODE=${CLAUDECODE:-__UNSET__}" >> "$CLAUDE_CALL_LOG"
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/claude"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
 }
 
 teardown() {

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -22,6 +22,21 @@ echo "CLAUDECODE=${CLAUDECODE:-__UNSET__}" >> "$CLAUDE_CALL_LOG"
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/claude"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
 }
 
 teardown() {

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -22,6 +22,21 @@ echo "CLAUDECODE=${CLAUDECODE:-__UNSET__}" >> "$CLAUDE_CALL_LOG"
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/claude"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test issue title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/issues/123"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

- `scripts/phase-banner.sh` を新規作成し、`print_start_banner` / `print_end_banner` 関数を提供するsourceable helperを追加
- `modules/phase-banner.md` shared module を新規作成し、SKILL.md向けにバナーフォーマットと処理手順を定義
- 7本の `run-*.sh` スクリプトを更新し、Starting/Finished 両方でタイトル・URL を表示
- 8本の `SKILL.md` スキルを更新し、スキル開始時にバナーを表示するよう指示を追加
- 5本の bats テストに `gh` モックを追加して phase-banner.sh の呼び出しをサポート
- `docs/structure.md` のモジュール数（23→24）・スクリプト数（27→28）を更新

## Verification (pre-merge)
- `modules/phase-banner.md` shared module が作成されている
- `scripts/phase-banner.sh` shell helper が作成されている
- run-*.sh スクリプトが shell helper を参照している（run-code.sh で代表検証）
- SKILL.md スキルが shared module を参照している（/issue で代表検証）
- PR-based スキルも shared module を参照している（/review で代表検証）
- shell helper が Issue/PR タイトルを取得する
- shell helper が URL 表示フォーマットを含む
- 全 bats テストが PASS する

## Verification (post-merge)
- `/issue N` 実行時にスキル開始出力に Issue タイトルと URL が表示される
- `/auto N` 実行時に各フェーズの Starting/Finished 出力に Issue/PR タイトルと URL が表示される

closes #113