### PR TITLE
Issue #63: Add change tracking comment steps to /code and /review

### DIFF
--- a/docs/spec/issue-63-change-tracking-comments.md
+++ b/docs/spec/issue-63-change-tracking-comments.md
@@ -45,3 +45,17 @@
 ### Rework
 
 - verify command パターン修正のため、Issue body・Spec の両方を追加コミットで更新する必要が生じた（実装コミットとは別に `fix:` コミットが発生）
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+- Spec の Implementation Step 1 が「Step 11 末尾」と記述しているが、実装は Step 12 直前の独立したポストステップとして挿入されている。意味的には合理的な配置だが、Spec 文言との乖離が生じた。verify command に依存しない記述的な配置指定（「Step N の末尾」）は、実装後に Spec が追認する形で修正されることが多い。Spec には配置の意図（「PR 作成後のポストステップ」）を記述する方が、文言の揺れを防ぎやすい。
+
+### 繰り返し指摘パターン
+
+- 特になし（CONSIDER 指摘のみ、MUST/SHOULD なし）
+
+### 受け入れ条件検証の難易度
+
+- Pre-merge 条件 2件はいずれも `grep` verify command で明確に検証可能（PASS）。Post-merge 条件は `opportunistic` タグ付きで `/verify` フェーズに委ねる設計になっており、UNCERTAIN なし。verify command の設計として問題なし。

--- a/docs/spec/issue-63-change-tracking-comments.md
+++ b/docs/spec/issue-63-change-tracking-comments.md
@@ -18,8 +18,8 @@
 
 ### Pre-merge
 
-- <!-- verify: grep "change.track" "skills/code/SKILL.md" --> `/code` スキルに change tracking comment 投稿ステップが追加されている
-- <!-- verify: grep "change.track" "skills/review/SKILL.md" --> `/review` スキルに change tracking 用語が追加されている
+- <!-- verify: grep "Change.Track" "skills/code/SKILL.md" --> `/code` スキルに change tracking comment 投稿ステップが追加されている
+- <!-- verify: grep "Change.Track" "skills/review/SKILL.md" --> `/review` スキルに change tracking 用語が追加されている
 
 ### Post-merge
 

--- a/docs/spec/issue-63-change-tracking-comments.md
+++ b/docs/spec/issue-63-change-tracking-comments.md
@@ -31,3 +31,17 @@
 - `/review` Step 13.3 は既に policy change 検出時にコメントを投稿する仕組みを持っている。本 Issue の実装はこの既存機構に change tracking の用語を追加し、明示的に位置づけるもの。新たなロジックの追加は不要。
 - `/code` Step 10 の case 1（全 PASS、チェックボックス更新のみ）は仕様変更に該当しないため、change tracking の対象外とする。case 2（verify command 書き換え）と Step 11 の auto-append のみが対象。
 - コメント投稿は条件付き：Issue body/Spec に実際の変更がなかった場合はスキップする。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- verify command パターン `change.track` が実装後のテキスト（`Change Tracking`、大文字始まり）にマッチしないことが verify 実行時に判明し、パターンを `Change.Track` に修正した。Spec では実装前の想定パターンを記載していたが、実装後の実際のテキストと不一致になった。設計フェーズでの verify command 記述時にコンテンツの大文字小文字を事前確認する必要がある
+
+### Design Gaps/Ambiguities
+
+- N/A
+
+### Rework
+
+- verify command パターン修正のため、Issue body・Spec の両方を追加コミットで更新する必要が生じた（実装コミットとは別に `fix:` コミットが発生）

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -299,6 +299,34 @@ closes #$NUMBER
 
 When creating a PR, compare the Spec verification methods against the Issue acceptance conditions. If the Issue acceptance conditions are missing verification items, fetch the current Issue body with `gh issue view $NUMBER --json body`, build the updated body with the missing items appended, pre-create the directory with `mkdir -p .tmp`, write the updated body to `.tmp/issue-body-$NUMBER.md` with Write tool, update with `${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh $NUMBER .tmp/issue-body-$NUMBER.md`. After update, delete the temp file with `rm -f .tmp/issue-body-$NUMBER.md`.
 
+**Change tracking comment (post-PR):**
+
+After creating the PR, if any of the following changes occurred during Step 10 or Step 11, post a change tracking comment to the Issue:
+
+- Step 10 case 2: verify command was rewritten (FAIL → corrected hint)
+- Step 10 Spec sync: Spec verify commands were updated to match Issue body
+- Step 11 auto-append: acceptance conditions were appended to the Issue body
+
+If none of the above changes occurred, skip this step.
+
+When changes occurred, write the comment body to `.tmp/change-tracking-$NUMBER.md` with the Write tool, then post:
+
+```bash
+mkdir -p .tmp
+${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh $NUMBER .tmp/change-tracking-$NUMBER.md
+rm -f .tmp/change-tracking-$NUMBER.md
+```
+
+Comment format:
+
+```markdown
+## Change Tracking (by /code)
+
+### Changes Made
+- {change summary 1 — what was changed and why}
+- {change summary 2}
+```
+
 ### Step 12: Code Retrospective
 
 Append retrospective information to the Spec and commit.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -588,11 +588,11 @@ Assess whether any changes contradict the acceptance criteria (verify command te
 4. Write to `.tmp/issue-body-$ISSUE_NUMBER.md`
 5. `${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh "$ISSUE_NUMBER" .tmp/issue-body-$ISSUE_NUMBER.md`
 
-### 13.3. Post Change Reason Comment (only on policy change detection)
+### 13.3. Post Change Tracking Comment (only on policy change detection)
 
 Format:
 ```markdown
-## Acceptance Criteria Update
+## Change Tracking (by /review)
 
 ### Change Reason
 - Review issue ({Copilot/Claude}) led to {change summary}


### PR DESCRIPTION
## Summary

後続スキル（`/code`、`/review`）が Issue body や Spec を修正した際に、変更サマリーを新規 Issue コメントとして自動投稿する仕組みを追加します。

- `/code` SKILL.md の Step 11 末尾に `Change Tracking (by /code)` コメント投稿ステップを追加。verify command 書き換え（FAIL→修正）・Spec sync・acceptance condition 自動追加のいずれかが発生した場合に `gh-issue-comment.sh` で Issue へコメントを投稿する
- `/review` SKILL.md の Step 13.3 セクションタイトルを `Post Change Reason Comment` から `Post Change Tracking Comment` に変更し、コメント見出しも `## Acceptance Criteria Update` から `## Change Tracking (by /review)` に統一する

## Verification (pre-merge)

- `/code` スキルに `Change Tracking (by /code)` 見出しの change tracking comment 投稿ステップが追加されている
- `/review` スキルに `Change Tracking (by /review)` 見出しの change tracking comment セクションが追加されている

## Verification (post-merge)

- `/code` 実行時に Issue body/Spec が変更された場合、スキル名・変更概要・変更理由を含む変更追跡コメントが Issue に投稿される
- `/review` 実行時に Issue body が変更された場合、スキル名・変更概要・変更理由を含む変更追跡コメントが Issue に投稿される

closes #63