### PR TITLE
Issue #124: Add custom verify command handler registration mechanism

### DIFF
--- a/docs/environment-adaptation.md
+++ b/docs/environment-adaptation.md
@@ -143,6 +143,75 @@ Adapters are valuable when multiple implementation choices must be abstracted �
 
 If pre/post processing customization is needed in the future (e.g., argument transformation, result normalization), it should be added as a hook mechanism (e.g., `.wholework/hooks/mcp-pre.sh`) rather than an adapter. This is outside the current implementation scope.
 
+### Custom Verify Command Handlers
+
+A mechanism for adding project-local custom verification commands. Place a Markdown handler file at `.wholework/verify-commands/{name}.md` to register a custom verify command named `{name}`.
+
+#### Declaration Path
+
+```
+.wholework/verify-commands/{name}.md
+```
+
+No capability declaration is required. Placing the file is sufficient to activate the handler.
+
+#### Dispatch Convention
+
+The command name in `<!-- verify: {name} "arg" -->` is matched against the handler filename (without extension). Example: `<!-- verify: api-contract "endpoint" -->` dispatches to `.wholework/verify-commands/api-contract.md`.
+
+**Built-in priority**: If `{name}` matches a built-in command (e.g., `file_exists`, `grep`), the built-in is always used and the handler file is ignored with a warning.
+
+#### Handler Contract
+
+Custom handler files follow a four-section Markdown structure (same as adapter contracts):
+
+```markdown
+# {name} verify command handler
+
+**Safe mode:** compatible   ← or "uncertain" (see below)
+
+## Purpose
+
+{Description of what this handler verifies}
+
+## Input
+
+- **Arguments**: {arguments accepted by this command}
+
+## Processing Steps
+
+{Step-by-step verification logic — executed by the LLM when dispatched}
+
+## Output
+
+- **Result**: PASS / FAIL / UNCERTAIN
+- **Detail**: Description of verification result
+```
+
+#### Result Format
+
+Custom handlers must return one of:
+
+- **PASS**: Verification condition satisfied
+- **FAIL**: Verification condition not satisfied (include detailed reason)
+- **UNCERTAIN**: Cannot be determined automatically (include detailed reason)
+
+#### Safe Mode Self-Declaration
+
+Each handler self-declares its safe-mode compatibility near the top of the file:
+
+| Declaration | Behavior |
+|-------------|----------|
+| `**Safe mode:** compatible` | Handler executes in both safe and full modes |
+| `**Safe mode:** uncertain` | Handler returns UNCERTAIN in safe mode; executes only in full mode |
+| (not declared) | Treated as `uncertain` — returns UNCERTAIN in safe mode |
+
+Use `compatible` only for side-effect-free checks (file reads, static analysis, etc.). Use `uncertain` for any handler that calls external services or executes shell commands.
+
+#### Relationship to Adapter Pattern
+
+Custom verify command handlers differ from adapters in a key way: handlers are designed for a single implementation with no tool-selection branching. The adapter pattern (see `### Adapter Pattern` below) adds value when multiple tool implementations must be abstracted. Handlers are simpler — one handler file, one verification approach — and do not require the 3-layer resolution order that adapters use.
+
 ### Adapter Contract Template
 
 Adapters follow a unified contract. Users can create custom adapters by following this template and placing them at the project-local or user-global path above.
@@ -296,6 +365,7 @@ While Layers 1–3 control "which parts of a skill to load," `--when` provides e
 ToolSearch (Layer 2) ─→ dynamic MCP tool detection (fallback when not declared)
 command -v (Layer 2) ─→ CLI tool availability check (inside adapters, inside --when)
 --when (Layer 4) ────→ per-acceptance-condition environment gate (planned)
+verify-executor (Layer 4) ─→ .wholework/verify-commands/*.md (project-local custom handlers)
 ```
 
 ## Extension Guide

--- a/docs/spec/issue-124-custom-verify-command-handlers.md
+++ b/docs/spec/issue-124-custom-verify-command-handlers.md
@@ -74,3 +74,17 @@ Issue で確定した設計方針:
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+- verify-executor.md の Step e（名前衝突警告）が到達不能ロジックになっていた。設計意図（「ビルトイン名と衝突するハンドラファイルが存在する場合に警告を出す」）は Issue Design Decisions に明記されていたが、実装では Step a の早期リターンにより Step e に到達できなかった。Spec（`docs/environment-adaptation.md`）に「警告が出る」と記述されていたため乖離として検出できた。今後の同種 Issue では「早期リターンするステップの後続に検出ロジックを置くパターン」を到達可能性の視点でレビューすること。
+
+### 繰り返しイシューの有無
+
+- 今回の SHOULD イシュー1件のみ。繰り返しパターンは検出されず。
+
+### 受入条件検証の難易度
+
+- 全5条件が `section_contains` / `file_contains` で記述されており、すべて PASS で確認できた。verify command の選定は適切。UNCERTAIN なし。

--- a/docs/spec/issue-124-custom-verify-command-handlers.md
+++ b/docs/spec/issue-124-custom-verify-command-handlers.md
@@ -60,3 +60,17 @@ Issue で確定した設計方針:
 - **`docs/ja/environment-adaptation.md`** および **`docs/ja/structure.md`** は翻訳出力ファイル（`/doc translate ja` 生成）のため実装対象外。
 - **ビルトイン衝突時の警告出力先**: verify-executor の出力結果テーブルの Details 列に警告文言を含める（新規ログ機構の導入は不要）。
 - **Glob scan のタイミング**: verify-executor が呼び出されるたびに Glob scan を行う（キャッシュ不要、ファイル数は実用上小規模を想定）。#122 domain-loader と同方式。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A
+
+### Design Gaps/Ambiguities
+
+- `section_contains` の境界判定において、コードブロック内に `## Purpose` 等の h2 見出しが存在する場合、テキスト検索で誤って境界として検出される可能性がある。verify-executor の LLM 実装はコードブロック内の擬似見出しを無視するため実運用に問題はないが、機械的な境界検出を行う場合（テスト等）は注意が必要。
+
+### Rework
+
+- N/A

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -49,6 +49,7 @@ wholework/
 │   └── spec/            # Issue specifications
 ├── .wholework/          # Project-local Wholework configuration (user-managed, not tracked in wholework repo)
 │   ├── adapters/        # Verification adapter overrides
+│   ├── verify-commands/ # Project-local custom verify command handlers
 │   └── domains/         # Project-local Domain files
 │       ├── spec/        # Domain files for /spec
 │       ├── code/        # Domain files for /code

--- a/modules/verify-executor.md
+++ b/modules/verify-executor.md
@@ -33,7 +33,23 @@ The following information is passed from the caller:
 
    When no `--when` modifier is present, proceed to Step 3 as before.
 
-3. Execute verification according to the translation table below:
+3. **Resolve custom verify command handlers**: Before looking up the translation table, check whether the command name is a custom handler:
+
+   a. **Built-in priority check**: If the command name matches a built-in command in the translation table below (e.g., `file_exists`, `grep`, `section_contains`), use the built-in processing directly. Skip custom handler lookup.
+
+   b. **Custom handler lookup** (only for non-built-in command names): Glob `.wholework/verify-commands/{name}.md` where `{name}` is the command name from the verify comment. Perform this scan on each verify-executor invocation (no caching).
+
+   c. **Handler found**: Read the handler Markdown file. Check for a safe-mode declaration in the handler (a line near the top of the file in the form `**Safe mode:** compatible` or `**Safe mode:** uncertain`):
+      - Declared `compatible` → execute in both safe and full modes following the handler's Processing Steps
+      - Declared `uncertain` or not declared → in safe mode, return UNCERTAIN; in full mode, execute following the handler's Processing Steps
+
+   d. **Handler not found**: Return UNCERTAIN (no built-in match and no custom handler file found).
+
+   e. **Name collision warning**: If a custom handler file exists but its name matches a built-in command name, output a warning in the Details column of the result table (e.g., "Warning: custom handler `file_exists.md` ignored — built-in takes priority") and use the built-in.
+
+   f. **Result format**: Custom handlers must return one of PASS, FAIL, or UNCERTAIN. The handler's Processing Steps describe the verification logic; execute them and map the outcome to these three values.
+
+4. Execute verification according to the translation table below:
 
 | Verification Command | Processing |
 |---------------------|-----------|
@@ -61,13 +77,13 @@ The following information is passed from the caller:
 | `mcp_call "tool_name" "description"` | **Mode-dependent**: `safe` → return UNCERTAIN (to prevent external API calls). `full` → Use ToolSearch with `select:<tool_name>` (tool_name in `server_name__tool_name` fully qualified format, no spaces) to find the tool, and **only** call MCP tools clearly identified as read-only verification. Do not call tools with any possibility of writes, deletions, or external transmissions; return UNCERTAIN (with reason). Also return UNCERTAIN if ToolSearch is unavailable or tool call is blocked by permissions (include detailed reason). Evaluate result against description using AI judgment for PASS/FAIL. Return UNCERTAIN if tool not found (include detailed reason). Best-effort due to subjective elements. For the rationale of using ToolSearch directly (bypassing the adapter layer), see the Adapter Pattern section in `docs/environment-adaptation.md` |
 | `github_check "gh_command" "expected_value"` | **Mode-dependent**: In safe mode, use allowlist approach. Allowlist: `gh issue view`, `gh pr view`, `gh pr checks`, `gh api` (no `--method` or `--method GET`). If allowlist matches → run `gh_command` in Bash and confirm output contains `expected_value` (if `expected_value` is omitted, confirm output is non-empty). If not in allowlist → return UNCERTAIN. `full` → no restrictions; run `gh_command` in Bash (timeout: 30 seconds) |
 
-4. Treat syntax errors (unknown command names, missing arguments, etc.) as UNCERTAIN
-5. Classify each condition's verification result:
+5. Treat syntax errors (unknown command names, missing arguments, etc.) as UNCERTAIN
+6. Classify each condition's verification result:
    - **PASS**: Condition is met
    - **FAIL**: Condition is not met
    - **UNCERTAIN**: Cannot be automatically determined (safe mode command, syntax error, etc.)
    - **SKIPPED**: Environment condition (`--when`) was not met; skipped execution
-6. Organize results according to the output format
+7. Organize results according to the output format
 
 ### Basic Authentication Support
 

--- a/modules/verify-executor.md
+++ b/modules/verify-executor.md
@@ -35,7 +35,7 @@ The following information is passed from the caller:
 
 3. **Resolve custom verify command handlers**: Before looking up the translation table, check whether the command name is a custom handler:
 
-   a. **Built-in priority check**: If the command name matches a built-in command in the translation table below (e.g., `file_exists`, `grep`, `section_contains`), use the built-in processing directly. Skip custom handler lookup.
+   a. **Built-in priority check**: If the command name matches a built-in command in the translation table below (e.g., `file_exists`, `grep`, `section_contains`), also Glob `.wholework/verify-commands/{name}.md`; if a shadowing handler file is found, output a warning in the Details column (e.g., "Warning: custom handler `file_exists.md` ignored — built-in takes priority"). Then use the built-in processing directly. Skip custom handler lookup in step b.
 
    b. **Custom handler lookup** (only for non-built-in command names): Glob `.wholework/verify-commands/{name}.md` where `{name}` is the command name from the verify comment. Perform this scan on each verify-executor invocation (no caching).
 
@@ -45,7 +45,7 @@ The following information is passed from the caller:
 
    d. **Handler not found**: Return UNCERTAIN (no built-in match and no custom handler file found).
 
-   e. **Name collision warning**: If a custom handler file exists but its name matches a built-in command name, output a warning in the Details column of the result table (e.g., "Warning: custom handler `file_exists.md` ignored — built-in takes priority") and use the built-in.
+   e. *(Collision warning is handled in step a above.)*
 
    f. **Result format**: Custom handlers must return one of PASS, FAIL, or UNCERTAIN. The handler's Processing Steps describe the verification logic; execute them and map the outcome to these three values.
 

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -108,6 +108,14 @@ When using `file_contains` or `section_contains` with a compound string like `"k
 
 When MCP tools are available, use ToolSearch with `select:<tool_name>` to confirm existence and read-only nature before proposing `mcp_call` hints.
 
+**Custom verify command handlers (project-local):**
+
+Projects can extend the built-in command set by placing handler Markdown files at `.wholework/verify-commands/{name}.md`. Once placed, the custom command is available as `<!-- verify: {name} "arg" -->` in Issue acceptance criteria — no capability declaration is required.
+
+- To add a custom command, place `.wholework/verify-commands/{name}.md` following the handler contract in `docs/environment-adaptation.md` Layer 4
+- Use `<!-- verify: {name} "arg" --> condition description` in acceptance criteria the same way as built-in commands
+- For full handler contract details and the safe-mode self-declaration spec, see the "Custom Verify Command Handlers" section in `docs/environment-adaptation.md`
+
 **`--when` modifier (conditional verification):**
 
 Append `--when="shell_condition"` to any check to skip it when the condition is not met (returns SKIPPED):


### PR DESCRIPTION
## Summary

- `modules/verify-executor.md` の Processing Steps に、`.wholework/verify-commands/{name}.md` を発見・ディスパッチするカスタム verify command ハンドラ機構を追加（Step 3 として挿入、ビルトイン優先・Glob scan・safe-mode 自己宣言・名前衝突警告を規定）
- `docs/environment-adaptation.md` の Layer 4 に `### Custom Verify Command Handlers` セクションを追加（宣言パス・ディスパッチ規約・ハンドラ契約テンプレート・結果フォーマット PASS/FAIL/UNCERTAIN・safe-mode 自己宣言仕様・adapter パターンとの差異）
- `skills/issue/SKILL.md` の "Supported commands (exhaustive)" 表直後に `**Custom verify command handlers (project-local):**` ブロックを追加
- `docs/structure.md` の `.wholework/` エントリに `verify-commands/` サブディレクトリを追加

## Verification (pre-merge)

- `modules/verify-executor.md` の Processing Steps に `verify-commands` の Glob scan・コマンド名マッピング・ビルトイン優先・未解決 UNCERTAIN の仕様が追加されている
- `docs/environment-adaptation.md` Layer 4 にカスタム verify command 機構の仕様（宣言パス・ハンドラ契約・結果フォーマット）が追加されている
- カスタムコマンドの結果フォーマット（PASS/FAIL/UNCERTAIN）が `docs/environment-adaptation.md` Layer 4 に記載されている
- カスタムハンドラの safe-mode 自己宣言仕様（未宣言時は UNCERTAIN）が `docs/environment-adaptation.md` に文書化されている
- `skills/issue/SKILL.md` の verify command セクションにプロジェクトローカルのカスタム verify command タイプへの言及が追加されている

## Verification (post-merge)

- `.wholework/verify-commands/{name}.md` にテストハンドラを配置し、対応する `<!-- verify: {name} ... -->` 条件を `/verify` で実行したときカスタムハンドラが検出・ディスパッチされることを確認

closes #124