### PR TITLE
Issue #53: Add commit/push guide module for /doc subcommands

### DIFF
--- a/docs/spec/issue-53-doc-commit-push-guide.md
+++ b/docs/spec/issue-53-doc-commit-push-guide.md
@@ -74,3 +74,18 @@
 - **`sync Bidirectional Normalization` の 2 出口**: reverse-generation (Steps 2–5) と normalization (Steps 6–9) の両フローで commit/push 機会があるため、それぞれの完了点に Read 指示を置く必要がある。どちらか一方の出口からは必ず commit/push ガイドを通過する設計。
 - **`git add -A` vs 変更パス限定**: モジュール側で `git add -A` を使用（呼び出し側の変更が docs/ 以下に限定される前提で安全）。ユースケース拡張で限定が必要になった場合は Input を拡張できる余地を残す。
 - **`AskUserQuestion` の挙動**: Claude Code 環境下でのみ動作。`claude -p --dangerously-skip-permissions` では自動的に「最初の選択肢」が選ばれる前提（既存 translate-phase.md と同方針）。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `sync Bidirectional Normalization` の reverse-generation 完了点（Step 5 末尾）への追加は、Spec の「新規 `### Step N: Commit and Push Guide` を追加し」という形式ではなく、Step 5 の末尾にインライン追記する形を採用した。理由: Step 5（reverse-generation exit）と Step 6（normalization の開始）の間に新規ステップ番号を挿入すると既存の Steps 6–9 を全て繰り上げ変更する必要があり、変更範囲が大きくなるため。Notes 節の「Step 5 末尾に Read 指示を追加する」という表現がこのインライン方式を支持していると判断した。
+- `init Wizard` の Step 5 の「and exit」を「and proceed to Step 6」に変更した上で Step 6 を追加した。Spec の「最終 Step の直後に追加」では既存 Step 5 の exit 記述と矛盾が生じるため、Step 5 も合わせて修正した。
+
+### Design Gaps/Ambiguities
+
+- Spec の「追加形式: 新規 `### Step N: Commit and Push Guide` を追加し」という指示と「Step 5 末尾（reverse-generation 完了時）と Step 9 末尾（normalization 完了時）の両方に Read 指示を追加する」という Notes 節の記述が若干矛盾していた（前者は新規ステップ、後者は既存ステップへの追記を示唆）。`sync Bidirectional Normalization` のケースで判断が必要だった。
+
+### Rework
+
+- 特になし

--- a/docs/spec/issue-53-doc-commit-push-guide.md
+++ b/docs/spec/issue-53-doc-commit-push-guide.md
@@ -89,3 +89,17 @@
 ### Rework
 
 - 特になし
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+`sync Bidirectional Normalization` の reverse-generation 出口において、Spec の「新規 `### Step N: Commit and Push Guide` を追加」指示と Notes 節の「Step 5 末尾にインライン追記」指示が矛盾していた。実装者は Notes 節の記述を優先してインライン方式を採用し、その理由をCode Retrospectiveに記録した。この種の Spec 内矛盾は、将来のSpec作成時に「既存ステップ番号への影響」を明示的に検討する設計ポイントとして意識するとよい。
+
+### 繰り返し問題
+
+特になし。
+
+### 受入条件検証難易度
+
+全5条件が `file_exists`, `section_contains`, `file_contains`, `grep` の静的コマンドで構成されており、safe mode での自動検証が完全に可能だった。UNCERTAINが0件で、verify commandの設計が適切だった。Post-merge条件は `opportunistic` タイプで適切に分類されている。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -81,6 +81,7 @@ Key modules:
 - `modules/adapter-resolver.md` — 3-layer adapter resolution (project-local → user-global → bundled)
 - `modules/opportunistic-verify.md` — opportunistic verification at skill completion
 - `modules/doc-checker.md` — documentation consistency checker
+- `modules/doc-commit-push.md` — commit/push guide for /doc subcommand outputs
 - `modules/domain-loader.md` — project-local domain file discovery and loading
 - `modules/skill-help.md` — shared `--help` output formatter for skills
 - `modules/skill-dev-checks.md` — cross-skill consistency validation

--- a/modules/doc-commit-push.md
+++ b/modules/doc-commit-push.md
@@ -1,0 +1,35 @@
+# doc-commit-push
+
+## Purpose
+
+Confirm with the user and execute commit/push for file changes written out by `/doc` subcommands.
+Runs `git status --porcelain` first; if there are no changes, exits silently without prompting.
+
+## Input
+
+- `SUMMARY`: Summary string for the commit message body (set by the caller, e.g., `"sync (reverse-generation)"`). Placeholders (`{doc}`, `{path}`, `{name}`) are expanded by the caller at the point of invocation.
+
+## Processing Steps
+
+1. Run `git status --porcelain`. If the output is empty (no changes), exit silently (no AskUserQuestion prompt).
+2. Display the change summary with `git status --short` to show what will be committed.
+3. Ask with AskUserQuestion:
+   ```
+   Commit and push these changes?
+   - Yes, commit and push
+   - No, skip
+   ```
+4. If "No, skip" is selected: display "Changes left uncommitted. Run `git status` to review, or re-run the /doc command later." and exit.
+5. If "Yes, commit and push" is selected:
+   ```bash
+   git add -A
+   git commit -m "docs: ${SUMMARY}
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   git push origin HEAD
+   ```
+6. Display the commit hash and push result to confirm completion.
+
+## Output
+
+Side effects only (commit and push). No return value.

--- a/skills/doc/SKILL.md
+++ b/skills/doc/SKILL.md
@@ -236,6 +236,10 @@ Which section do you want to update? Please describe the update content.
 
 Apply the update content specified in Step 8 with Edit.
 
+### Step 10: Commit and Push Guide
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-commit-push.md` and follow the "Processing Steps" section with `SUMMARY="update {doc}"`. This step is reached from both the new creation flow (after Step 6) and the update flow (after Step 9).
+
 ---
 
 ## init Wizard
@@ -277,7 +281,11 @@ After creation, check remaining uncreated files.
 
 If uncreated files remain, return to Step 3.
 
-When all are created, display "All steering documents have been created." and exit.
+When all are created, display "All steering documents have been created." and proceed to Step 6.
+
+### Step 6: Commit and Push Guide
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-commit-push.md` and follow the "Processing Steps" section with `SUMMARY="init steering documents"`.
 
 ---
 
@@ -426,6 +434,8 @@ Regardless of the number of files saved, display the following message to comple
 sync (reverse-generation) complete.
 To normalize Steering Documents and project files, run `/doc sync` again.
 ```
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-commit-push.md` and follow the "Processing Steps" section with `SUMMARY="sync (reverse-generation)"`.
 
 ### Step 6: Content Classification
 
@@ -582,6 +592,10 @@ If integration operations (absorb/move/delete) occurred, Grep the following file
 
 If references are found, display before/after diff then update. Skip if no references found. After updating, display the list of updated files and change count.
 
+### Step 10: Commit and Push Guide
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-commit-push.md` and follow the "Processing Steps" section with `SUMMARY="sync (normalization)"`.
+
 ---
 
 ## sync Individual Reverse-Generation
@@ -601,6 +615,8 @@ After completion, display:
 sync individual reverse-generation complete.
 To bidirectionally normalize all documents, run `/doc sync` without arguments.
 ```
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-commit-push.md` and follow the "Processing Steps" section with `SUMMARY="sync {doc} (reverse-generation)"`.
 
 ---
 
@@ -681,6 +697,10 @@ Display the following message to complete:
 Run `/doc` to check registration status.
 Run `/doc sync` to reflect in SSoT mapping.
 ```
+
+### Step 6: Commit and Push Guide
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-commit-push.md` and follow the "Processing Steps" section with `SUMMARY="register {path} as project document"`.
 
 ---
 
@@ -787,6 +807,10 @@ docs/{name}.md has been created.
 Run `/doc` to check registration status.
 Run `/doc sync` to reflect in SSoT mapping.
 ```
+
+### Step 7: Commit and Push Guide
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/doc-commit-push.md` and follow the "Processing Steps" section with `SUMMARY="create project document {name}"`.
 
 ---
 


### PR DESCRIPTION
## Summary

- 共有モジュール `modules/doc-commit-push.md` を新規作成。`git status --porcelain` で変更なしの場合はサイレント終了、変更ありの場合は AskUserQuestion で Yes/No 確認後に commit/push を実行する
- `/doc` 系のファイル書き出し 9 サブコマンド（`init`, `product`, `tech`, `structure`, `sync`, `sync --deep`, `sync {doc}`, `add`, `project`）の末尾に `modules/doc-commit-push.md` の Read 指示を追加
- `docs/structure.md` の Modules リストに `modules/doc-commit-push.md` を追記

## Verification (pre-merge)

- `modules/doc-commit-push.md` が作成されている
- `modules/doc-commit-push.md` の Processing Steps に AskUserQuestion による commit/push 確認フロー（Yes/No 選択肢）が記載されている
- `modules/doc-commit-push.md` に `git status` → `git add` → `git commit` → `git push` の実行手順が含まれている
- `skills/doc/SKILL.md` から `modules/doc-commit-push.md` を参照する Read 指示が追加されている
- `docs/structure.md` の Modules リストに `modules/doc-commit-push.md` が追記されている

## Verification (post-merge)

- `/doc sync --deep` 実行後に commit/push 確認の AskUserQuestion が表示されることを確認
- `/doc add {path}`, `/doc project`, `/doc tech` 等でも同様に確認が表示されることを確認

closes #53