### PR TITLE
Issue #151: Integrate marketplace and plugin update into install.sh

### DIFF
--- a/docs/spec/issue-151-install-plugin-update.md
+++ b/docs/spec/issue-151-install-plugin-update.md
@@ -68,3 +68,17 @@
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Nothing to note. All 4 implementation steps in the Spec matched the PR diff exactly. The Code Retrospective also confirms no deviations.
+
+### Recurring Issues
+
+- Nothing to note. No repeated issue patterns observed. The change was a single-file shell script addition with clean separation of argument parsing and execution logic.
+
+### Acceptance Criteria Verification Difficulty
+
+- Nothing to note. All 6 pre-merge conditions used `file_contains` verify commands and resolved to PASS automatically. Verify command quality was high — no UNCERTAIN results occurred.

--- a/docs/spec/issue-151-install-plugin-update.md
+++ b/docs/spec/issue-151-install-plugin-update.md
@@ -54,3 +54,17 @@
 - `--marketplace NAME` のデフォルト値 `saitoco-wholework` は、Issue body の Auto-Resolved Ambiguity Points で確定済み
 - plugin update 後の再起動は自動化しない（Issue body の Auto-Resolved: restart の自動化は行わず、メッセージで案内する方針）
 - `docs/structure.md` の "Why `./install.sh`?" 節（line 188）は新機能について追記する（既存の `${HOME}` 展開説明は保持）
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A（Spec の実装手順をそのまま実施）
+
+### Design Gaps/Ambiguities
+
+- N/A
+
+### Rework
+
+- N/A

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -55,7 +55,7 @@ wholework/
 │       ├── spec/        # Domain files for /spec
 │       ├── code/        # Domain files for /code
 │       └── review/      # Domain files for /review
-├── install.sh           # Generate .claude/settings.json from template (run after clone)
+├── install.sh           # Sync settings.json, marketplace, and plugin (run after clone or pull)
 ├── CONTRIBUTING.md      # Contribution guide (DCO sign-off instructions)
 ├── LICENSE              # Apache License 2.0
 ├── README.md            # Project overview
@@ -186,6 +186,8 @@ claude --plugin-dir <path-to-wholework>
 Skills are discovered as `wholework:<skill-name>`. Claude Code sets `${CLAUDE_PLUGIN_ROOT}` to the plugin directory at runtime, which skills and modules use to reference scripts and modules.
 
 **Why `./install.sh`?** `.claude/settings.json` is generated from `.claude/settings.json.template` with the user's actual `$HOME` substituted for `${HOME}`. Claude Code does not expand `${HOME}` or `~/` inside `permissions.allow`, so each developer must materialize the template locally. The generated `.claude/settings.json` is gitignored. Run `./install.sh` once after clone, and again after `git pull` whenever `.claude/settings.json.template` has changed.
+
+`./install.sh` also runs `claude plugin marketplace update` and `claude plugin update` to keep the local plugin in sync with the latest version in the repository. Use `--no-plugin` to skip the plugin update steps (settings.json regeneration only). Use `--marketplace NAME` to override the marketplace name (default: `saitoco-wholework`).
 
 <!-- ## Module Dependencies（Optional）
 

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,47 @@
 #!/bin/bash
-# install.sh — Generate .claude/settings.json from template with ${HOME} substitution.
+# install.sh — Sync .claude/settings.json, marketplace, and plugin (run after clone or pull).
 #
 # Wholework's permission patterns require absolute paths (Claude Code does not
 # expand ${HOME} or ~/ inside permissions.allow), so each user must materialize
 # the template with their actual $HOME. Run this script once after `git clone`
 # and again whenever .claude/settings.json.template changes.
 #
-# Usage: ./install.sh
+# Usage: ./install.sh [--no-plugin] [--marketplace NAME]
+#
+#   --no-plugin          Skip marketplace and plugin update steps (settings.json only)
+#   --marketplace NAME   Override marketplace name (default: saitoco-wholework)
 
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPLATE="${SCRIPT_DIR}/.claude/settings.json.template"
 OUTPUT="${SCRIPT_DIR}/.claude/settings.json"
+
+# Argument parser
+MARKETPLACE="saitoco-wholework"
+NO_PLUGIN=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-plugin)
+      NO_PLUGIN=true
+      shift
+      ;;
+    --marketplace)
+      if [ $# -lt 2 ]; then
+        echo "Error: --marketplace requires a NAME argument" >&2
+        exit 1
+      fi
+      MARKETPLACE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown option: $1" >&2
+      echo "Usage: ./install.sh [--no-plugin] [--marketplace NAME]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 if [ ! -f "$TEMPLATE" ]; then
   echo "Error: template not found at $TEMPLATE" >&2
@@ -38,3 +67,18 @@ mv "$TMP_OUTPUT" "$OUTPUT"
 
 echo "Generated $OUTPUT from $TEMPLATE"
 echo "HOME substituted as: $HOME"
+
+# Plugin update (skipped when --no-plugin is specified)
+if [ "$NO_PLUGIN" = false ]; then
+  if command -v claude > /dev/null 2>&1; then
+    echo "Updating marketplace: $MARKETPLACE"
+    claude plugin marketplace update "$MARKETPLACE" || echo "Warning: marketplace update failed (continuing)"
+    echo "Updating plugin: wholework@${MARKETPLACE}"
+    claude plugin update "wholework@${MARKETPLACE}" || echo "Warning: plugin update failed (continuing)"
+  else
+    echo "Warning: 'claude' CLI not found — skipping marketplace and plugin update"
+  fi
+fi
+
+echo ""
+echo "Done. Restart Claude Code to apply the updated plugin."


### PR DESCRIPTION
## Summary

- `install.sh` に `claude plugin marketplace update` と `claude plugin update` を統合し、1 コマンドで settings.json 生成 + plugin 更新を実行可能にした
- `--no-plugin` オプション追加（plugin 更新をスキップし settings.json 再生成のみ実行）
- `--marketplace NAME` オプション追加（marketplace 名を差し替え可能、デフォルト: `saitoco-wholework`）
- `command -v claude` チェックにより `claude` CLI 不在時は warning 付きで graceful skip
- 完了時に "Restart Claude Code" 再起動案内を出力
- `docs/structure.md` の `install.sh` 説明と "Why `./install.sh`?" 節を新機能に合わせて更新

## Verification (pre-merge)

- `install.sh` が `claude plugin marketplace update` を実行するロジックを含む
- `install.sh` が `claude plugin update` を実行するロジックを含む
- `install.sh` が `--no-plugin` オプションをサポートしている
- `install.sh` が `--marketplace NAME` オプションで marketplace 名を差し替え可能
- `install.sh` が `claude` CLI 不在時に plugin 更新を graceful に skip する
- `install.sh` 完了時に Claude Code 再起動必須の案内を出力する

## Verification (post-merge)

- wholework リポジトリで `./install.sh` を実行し、marketplace 更新 + plugin 更新 + settings.json 再生成がこの順序で完了することを確認
- `./install.sh --no-plugin` で plugin 更新がスキップされ settings.json のみ再生成されることを確認
- `claude` CLI をパス外にした状態で `./install.sh` を実行し、settings.json 再生成は成功、plugin 更新は warning 付きで skip されることを確認

closes #151