### PR TITLE
Issue #165: Remove auto error recovery (watchdog retry, UNCERTAIN reopen, fix-cycle)

### DIFF
--- a/docs/guide/workflow.md
+++ b/docs/guide/workflow.md
@@ -184,9 +184,9 @@ Run periodically — for example, after a sprint or milestone — to keep docs, 
 | Reviewing a PR someone else created | `/review PR_NUMBER` |
 | Bulk-process small backlog issues | `/auto --batch 10` |
 
-## Fix Cycle
+## Fixing After Verify Fails
 
-If `/verify` fails, Wholework reopens the issue and adds a `fix-cycle` label. Running `/auto N` or `/code N` again detects this label and routes through patch regardless of size — keeping fix cycles fast.
+If `/verify` fails, Wholework reopens the issue and removes all `phase/*` labels. Run `/code --patch N` to apply a small fix with a direct commit to main (Size unchanged), or `/code --pr N` for a larger fix with a new branch and PR. For cases requiring design changes, run `/spec N` to revisit the spec first.
 
 ## Further Reading
 

--- a/docs/product.md
+++ b/docs/product.md
@@ -153,7 +153,6 @@ Key differences from other tools:
 | auto-verify | The automated verification process run by `/verify`. Executes verify commands for each acceptance condition, checks off passing conditions, and reopens the Issue on failure | /verify Skill | 自動検証 |
 | Domain file | Auxiliary Markdown loaded conditionally by a Skill via marker detection, file existence, or directory scan — supplements the SKILL.md core with environment- or project-specific logic while keeping the core lightweight. Project-local customization is supported through `.wholework/domains/{skill}/` | Skill development | Domain file |
 | Drift | Semantic divergence between documented specifications (Steering Documents or Specs) and actual code implementation. Detected by `/audit drift` | /audit Skill | ドリフト |
-| Fix cycle | A post-verify modification cycle for an Issue marked with the `fix-cycle` label. Preserves the original Size metadata and routes through patch to avoid polluting Size-based throughput analysis | `/verify`, `/code` | Fix cycle |
 | Fork context | A Skill execution mode that does not affect the main conversation | Claude Code | fork コンテキスト |
 | Patch route | Workflow path for XS/S-sized Issues; commits directly to the main branch without creating a Pull Request | Development workflow | パッチ経路 |
 | Phase label | A `phase/*` GitHub label (e.g., `phase/issue`, `phase/spec`, `phase/ready`, `phase/code`) indicating the current workflow stage of an Issue | Development workflow | フェーズラベル |

--- a/docs/spec/issue-165-remove-auto-recovery.md
+++ b/docs/spec/issue-165-remove-auto-recovery.md
@@ -173,6 +173,17 @@
 | Size | L (13 files、pr route + full review) |
 | Value | 4 (信頼性向上 + 維持コスト削減、全 Issue に波及) |
 
+## Code Retrospective
+
+### Deviations from Design
+- N/A（全ステップを Spec の Implementation Steps どおりに実施）
+
+### Design Gaps/Ambiguities
+- `tests/setup-labels.bats` の `--force` 件数チェック（Spec では「--force の 11 回期待も 10 に変更」と記載）は、既存テストコードを確認したところ `@test "success: each label uses --force flag"` のコメント内にのみ件数が記載されていたため、その記述も 10 に変更した。Spec の記述は実態に沿っており問題なし。
+
+### Rework
+- N/A
+
 ## spec retrospective
 
 ### Minor observations

--- a/docs/spec/issue-165-remove-auto-recovery.md
+++ b/docs/spec/issue-165-remove-auto-recovery.md
@@ -202,3 +202,17 @@
 
 - **設計時の未解決**: なし。Issue 本文の Auto-Resolved 5 項目で主要な選択肢は事前確定。codebase 調査で追加発見した論点（`_watchdog_killed` 扱い、OPEN path の guidance 対応範囲、docs/ja の同期可否）はいずれも Notes で記録済み
 - **検証方針**: Size L の `/code --patch` 動作は既存機能のため新規検証不要。実装時は Step 4 の guidance 文面と Step 3 の UNCERTAIN-only 分岐挙動を Post-merge 観測で確認（verify command では section_contains のみ、挙動は manual）
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+なし。Spec の implementation steps と差分は完全に整合。13 ファイルの変更はすべて Spec 記載通りに実施されており、Code Retrospective にも「N/A」と記録されている。
+
+### 繰り返し問題
+
+なし。SHOULD issue が 2 件検出されたが、いずれも Spec の Judgment rationale に設計上の意図的省略として記録済みのケースだった。レビュー時に Spec の judgment rationale を事前に参照することで false positive を効率的に識別できた。
+
+### 受入条件検証の難易度
+
+受入条件 18 件中 17 件は `file_not_contains` / `file_contains` / `section_contains` で PASS、1 件（bats tests CI）は IN_PROGRESS のため UNCERTAIN。CI 完了後に `/verify 165` で確認が必要。`file_not_contains` を複数ファイルに対して繰り返す verify command は冗長だが、各ファイルへの言及が独立しているため集約の実益は小さい。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -144,7 +144,6 @@ Setup: Create labels with `scripts/setup-labels.sh`.
 | `phase/verify` | Acceptance test phase | `/merge` | `/verify` |
 | `phase/done` | Complete | `/verify` (no post-merge conditions) | — |
 | (no label) | Backlog / not started | — | `/verify` (on FAIL) |
-| `fix-cycle` | Post-verify fix cycle marker | `/verify` (on FAIL) | (manual / future cleanup) |
 
 ### XL Parent Issue Phase Management
 
@@ -173,18 +172,17 @@ Adding `closes #N` to PR body auto-closes the Issue on merge (GitHub standard fe
   - FAIL → gh issue reopen + remove all phase/* → return to fix cycle
 ```
 
-### Post-verify Fix Cycle
+### Verify Fail Flow
 
-When `/verify` detects a FAIL among auto-verification targets, it reopens the Issue and attaches the `fix-cycle` label (alongside removing all `phase/*` labels). This triggers the post-verify fix cycle:
+When `/verify` detects a FAIL among auto-verification targets, it reopens the Issue and removes all `phase/*` labels. The user then selects the next action manually:
 
 ```
-/verify FAIL → gh issue reopen + add fix-cycle label + remove phase/*
+/verify FAIL → gh issue reopen + remove all phase/*
   ↓
-/code N  (or /auto N)
-  └─ Detects fix-cycle label + OPEN state
-  └─ Forces patch route regardless of original Size
-  └─ Bypasses XL guard, phase/ready check, and Size-based routing
-  └─ Appends ## Post-verify fix section to Spec (preserves fix context as cross-phase memory)
+User selects:
+  - /code --patch N  — fix with direct commit to main (small fix, Size unchanged)
+  - /code --pr N     — fix with new branch + PR (larger fix, Size L)
+  - /spec N          — revisit design (when root cause requires redesign)
   ↓
 /verify N  (re-verify after fix)
 ```

--- a/modules/next-action-guide.md
+++ b/modules/next-action-guide.md
@@ -54,7 +54,7 @@ Use the table below as guidance. Contextual factors (e.g., whether acceptance cr
 | `review`   | success | any                                 | `/merge {PR_NUMBER}`     | `/auto {ISSUE_NUMBER}`         |
 | `merge`    | success | any                                 | `/verify {ISSUE_NUMBER}` | `/auto {ISSUE_NUMBER}`         |
 | `verify`   | success (PASS) | any                          | (no guidance)            | —                              |
-| `verify`   | fail    | any                                 | `/code {ISSUE_NUMBER}`   | `/auto {ISSUE_NUMBER}`         | <!-- fix-cycle label auto-applied by /verify; /code and /auto detect it and force patch route -->
+| `verify`   | fail    | any                                 | `/code {ISSUE_NUMBER}`   | `/auto {ISSUE_NUMBER}`         |
 | `auto`     | success | any                                 | (no guidance)            | —                              |
 | `auto`     | fail    | any                                 | `/code {ISSUE_NUMBER}`   | manual investigation           |
 

--- a/modules/size-workflow-table.md
+++ b/modules/size-workflow-table.md
@@ -51,16 +51,6 @@ Factors to **decrease** size by one step:
 | L    | pr        | Branch + PR, full review | Required | Yes |
 | XL   | split guidance | Guide to split into sub-issues | Required | — |
 
-### Fix-cycle Override
-
-When an Issue has the `fix-cycle` label and is OPEN, the route resolves to `patch` regardless of Size. This override is scoped to post-verify fix cycles and does not affect XL split guidance for new work.
-
-| Condition | Route | Notes |
-|-----------|-------|-------|
-| `fix-cycle` label present + state OPEN | patch | Bypasses Size routing, XL guard, and `phase/ready` check |
-| `--patch`/`--pr` flag explicitly set | (flag takes precedence) | fix-cycle detection is skipped |
-| No `fix-cycle` label | normal Size-based routing | — |
-
 ### Phase-Level Light/Full Mapping
 
 | Phase | patch (XS/S) | pr (M/L) |

--- a/scripts/claude-watchdog.sh
+++ b/scripts/claude-watchdog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # claude-watchdog.sh - Watchdog wrapper for claude -p invocations
-# Detects hangs (no output for WATCHDOG_TIMEOUT seconds) and kills + retries once.
+# Detects hangs (no output for WATCHDOG_TIMEOUT seconds) and kills the process.
 # Usage: claude-watchdog.sh <command> [args...]
 #
 # Environment variables:
@@ -14,7 +14,7 @@ WATCHDOG_HEARTBEAT_INTERVAL="${WATCHDOG_HEARTBEAT_INTERVAL:-60}"
 # Check interval is min(WATCHDOG_TIMEOUT, 10) to keep tests fast with small timeouts
 _CHECK_INTERVAL=$(( WATCHDOG_TIMEOUT < 10 ? WATCHDOG_TIMEOUT : 10 ))
 
-# Global flag: set to true when watchdog triggers a kill (used to decide retry)
+# Global flag: set to true when watchdog triggers a kill
 _watchdog_killed=false
 
 _run_with_watchdog() {
@@ -78,15 +78,11 @@ if [[ $# -eq 0 ]]; then
   exit 1
 fi
 
-# Run with 1 retry on watchdog-triggered kill
 _run_with_watchdog "$@"
 _final_exit=$?
 
 if [[ "$_watchdog_killed" == "true" ]]; then
-  echo "watchdog: retrying once..." >&2
-  # retry
-  _run_with_watchdog "$@"
-  _final_exit=$?
+  echo "watchdog: retrying disabled; please re-run the skill manually" >&2
 fi
 
 exit "$_final_exit"

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -21,7 +21,6 @@ LABELS=(
     "type/bug|#D73A4A|Type: bug"
     "type/feature|#0075CA|Type: feature"
     "type/task|#E4E669|Type: task"
-    "fix-cycle|#c5def5|Post-verify fix cycle marker — preserves original Size while routing through patch"
 )
 
 for entry in "${LABELS[@]}"; do

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -54,21 +54,6 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh "$NUMBER" 2>/dev/null
 
 ### Step 3: `phase/ready` Label Check
 
-**Fix-cycle Pre-check (run before phase/* label evaluation):**
-
-If ARGUMENTS does NOT contain `--patch` or `--pr`:
-
-```bash
-gh issue view "$NUMBER" --json state,labels -q '{state: .state, labels: [.labels[].name]}'
-```
-
-If state == "OPEN" and labels contains "fix-cycle":
-- Set `ROUTE=patch` (fix-cycle detected — bypass phase/* state machine and XL sub-issue graph)
-- Run: `${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh $NUMBER --patch` (plus `--base {BASE_BRANCH}` if set)
-- After the script completes, proceed to Step 5 (completion report) — skip the rest of Step 3 and Step 4
-
-If ARGUMENTS contains `--patch` or `--pr`, skip fix-cycle detection (explicit user intent takes precedence).
-
 Fetch labels with `gh issue view $NUMBER --json labels -q '.labels[].name'` and branch based on label state:
 
 - **`phase/ready` label present**: proceed to the next step
@@ -103,8 +88,6 @@ Run each phase via `run-*.sh`. Each script launches an independent process with 
 ---
 
 **XL route: sub-issue dependency graph with parallel execution (`run-auto-sub.sh` checks each sub-issue's `phase/ready` and auto-runs spec if not set):**
-
-**Defensive fix-cycle check before sub-issue graph expansion**: before calling `get-sub-issue-graph.sh`, verify fix-cycle label is not present. If detected (state==OPEN and fix-cycle label), redirect to patch route via `run-code.sh $NUMBER --patch` and skip the XL graph expansion entirely. This guards against edge cases where the pre-check in Step 3 was bypassed.
 
 1. **Fetch dependency graph**:
    ```bash

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -73,20 +73,6 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh "$NUMBER" 2>/dev/null
 
 If ARGUMENTS contains `--base {branch}`, use that value as `BASE_BRANCH`. If `--base` is not specified, default to `BASE_BRANCH=main` (backward compatibility).
 
-**Fix-cycle Detection (run before flag/size evaluation):**
-
-If ARGUMENTS does NOT contain `--patch` or `--pr`:
-
-```bash
-gh issue view "$NUMBER" --json state,labels -q '{state: .state, labels: [.labels[].name]}'
-```
-
-If state == "OPEN" and labels contains "fix-cycle":
-- Set `ROUTE=patch` (fix-cycle detected — bypass Size routing, XL guard, and `phase/ready` check)
-- Skip the Flag precedence and Size auto-detection blocks below; proceed directly to Step 1
-
-If ARGUMENTS contains `--patch` or `--pr`, skip fix-cycle detection (explicit user intent takes precedence).
-
 **Flag precedence (explicit flag > Size auto-detection)**:
 - ARGUMENTS contains `--patch` → **patch route** (direct commit to BASE_BRANCH, no PR). Even if Size is `XL`, `--patch` takes precedence — skip the XL check and run as patch route
 - ARGUMENTS contains `--pr` → **pr route** (branch + PR flow)
@@ -381,24 +367,6 @@ If there are items under "Deviations from Design" (reordering of implementation 
 
 - No deviations: no need to update Spec implementation steps
 - Deviations exist: revise Spec implementation steps to match actual implementation and include in the same commit
-
-**Post-verify fix append (run only when fix-cycle was detected in Step 0):**
-
-When ROUTE=patch was set because fix-cycle label was detected (not because of `--patch` flag), append a `## Post-verify fix` section to the Spec before committing the retrospective:
-
-1. Check if Spec exists (`$SPEC_PATH/issue-$NUMBER-*.md`). If not, output a warning and skip.
-2. Check for existing section:
-   ```bash
-   grep -q "^## Post-verify fix" "$SPEC_PATH/issue-$NUMBER-*.md"
-   ```
-   - If section does not exist: append new `## Post-verify fix` section with `### Fix Cycle 1` subsection
-   - If section exists: count existing `### Fix Cycle N` subsections and append `### Fix Cycle N+1`
-3. Content to record (4 fixed items):
-   - `- **対象 AC**:` — the failed acceptance condition(s) that triggered this fix
-   - `- **修正内容**:` — summary of the fix applied
-   - `- **コミット**: <sha>` — the commit hash of the fix (use `git rev-parse --short HEAD`)
-   - `- **判断根拠**:` — reasoning behind the approach taken
-4. Stage and commit together with the retrospective in the commit below
 
 **Steps:**
 1. If no retrospective information, write "N/A"

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -492,16 +492,6 @@ Keep implementation step count and pre-merge verification item count within the 
 
 ## Notes
 (if applicable)
-
-## Post-verify fix
-
-**(Appended by `/code` after each fix-cycle run. Do not include in initial Spec draft.)**
-
-### Fix Cycle 1
-- **対象 AC**: (the failed acceptance condition that triggered this fix)
-- **修正内容**: (summary of the fix applied)
-- **コミット**: <sha>
-- **判断根拠**: (reasoning behind the approach taken)
 ```
 
 **Self-review (internal consistency check) (SPEC_DEPTH=full only):**

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -302,15 +302,25 @@ Judgment:
     ```
   - Confirm the Issue is closed. If not closed, close with `gh issue close "$NUMBER"` (handles cases like XL parent Issues not auto-closed by PR's `closes #N`)
   - **Even if post-merge conditions without hints are unchecked, do not reopen the Issue** (present user verification guide only)
-- **Auto-verification targets include FAIL or UNCERTAIN**:
-  - Reopen Issue and attach `fix-cycle` label (idempotent), then remove all `phase/*` labels:
+- **Auto-verification targets include FAIL**:
+  - Reopen Issue and remove all `phase/*` labels:
     ```bash
     gh issue reopen "$NUMBER"
-    gh label list --search fix-cycle | grep -q '^fix-cycle' || gh label create fix-cycle --color c5def5 --description "Post-verify fix cycle marker — preserves original Size while routing through patch"
-    gh issue edit "$NUMBER" --add-label "fix-cycle"
     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER"
     ```
-  - User selects the next action (`/code`, `/spec`, or `/issue`) to return to the fix cycle
+  - Output guidance for the user:
+    ```
+    Issue #N を再オープンしました。以下のいずれかで修正してください:
+    - `/code --patch N` — Size を変えずに main 直コミットで修正（小さな修正）
+    - `/code --pr N` — 新規ブランチ + PR で修正（Size L の大きな修正）
+    - `/spec N` — Spec から見直し（根本的な設計変更が必要な場合）
+    ```
+- **UNCERTAIN のみ（FAIL なし、UNCERTAIN ≥1）**:
+  - Assign `phase/verify` label without reopening the Issue:
+    ```bash
+    ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" verify
+    ```
+  - Notify user: "Auto-verification contains UNCERTAIN items. Please manually re-verify the flagged conditions, then re-run `/verify $NUMBER` to complete."
 
 #### When Issue is OPEN (auto-close disabled)
 
@@ -331,12 +341,18 @@ Judgment:
     gh issue close "$NUMBER"
     ```
   - **Even if post-merge conditions without hints are unchecked, do not close the Issue** (present user verification guide only)
-- **Auto-verification targets include FAIL or UNCERTAIN**:
+- **Auto-verification targets include FAIL**:
   - Remove all `phase/*` labels (Issue is already OPEN; no reopen needed):
     ```bash
     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER"
     ```
   - User selects the next action (`/code`, `/spec`, or `/issue`) to return to the fix cycle
+- **UNCERTAIN のみ（FAIL なし、UNCERTAIN ≥1）**:
+  - Assign `phase/verify` label (Issue remains OPEN):
+    ```bash
+    ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" verify
+    ```
+  - Notify user: "Auto-verification contains UNCERTAIN items. Please manually re-verify the flagged conditions, then re-run `/verify $NUMBER` to complete."
 
 ### Step 10: Retrospective (Full Workflow Review)
 

--- a/tests/claude-watchdog.bats
+++ b/tests/claude-watchdog.bats
@@ -61,39 +61,11 @@ MOCK
     chmod +x "$MOCK_DIR/cmd.sh"
 
     run env WATCHDOG_TIMEOUT=2 bash "$SCRIPT" bash "$MOCK_DIR/cmd.sh"
-    # Should be non-zero (killed by watchdog, then retry also killed)
+    # Should be non-zero (killed by watchdog)
     [ "$status" -ne 0 ]
     [[ "$output" == *"watchdog: no output for 2s, killing process"* ]]
 }
 
-@test "retry: second invocation occurs after watchdog kill" {
-    COUNTER_FILE="$BATS_TEST_TMPDIR/invocation_count"
-    echo "0" > "$COUNTER_FILE"
-
-    cat > "$MOCK_DIR/cmd.sh" <<MOCK
-#!/bin/bash
-count=\$(cat "$COUNTER_FILE")
-count=\$((count + 1))
-echo \$count > "$COUNTER_FILE"
-if [[ \$count -eq 1 ]]; then
-    # First invocation: produce no output and hang — trigger watchdog
-    sleep 60
-else
-    # Second invocation (retry): succeed normally
-    echo "retry succeeded"
-    exit 0
-fi
-MOCK
-    chmod +x "$MOCK_DIR/cmd.sh"
-
-    run env WATCHDOG_TIMEOUT=2 bash "$SCRIPT" bash "$MOCK_DIR/cmd.sh"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"watchdog: retrying once..."* ]]
-    [[ "$output" == *"retry succeeded"* ]]
-
-    # Verify exactly 2 invocations occurred
-    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
-}
 
 @test "WATCHDOG_TIMEOUT env var: custom value takes effect" {
     cat > "$MOCK_DIR/cmd.sh" <<'MOCK'
@@ -125,7 +97,7 @@ MOCK
     [[ "$output" == *"watchdog: still waiting"* ]]
 }
 
-@test "no retry: watchdog fires only once on second hang" {
+@test "no retry: watchdog kills and does not retry" {
     COUNTER_FILE="$BATS_TEST_TMPDIR/invocation_count"
     echo "0" > "$COUNTER_FILE"
 
@@ -134,14 +106,15 @@ MOCK
 count=\$(cat "$COUNTER_FILE")
 count=\$((count + 1))
 echo \$count > "$COUNTER_FILE"
-# Both invocations hang — watchdog fires twice but only retries once
+# Hang to trigger watchdog kill
 sleep 60
 MOCK
     chmod +x "$MOCK_DIR/cmd.sh"
 
     run env WATCHDOG_TIMEOUT=2 bash "$SCRIPT" bash "$MOCK_DIR/cmd.sh"
     [ "$status" -ne 0 ]
+    [[ "$output" == *"retrying disabled"* ]]
 
-    # Verify exactly 2 invocations (original + 1 retry), no more
-    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
+    # Verify command was invoked exactly once (no retry)
+    [ "$(cat "$COUNTER_FILE")" -eq 1 ]
 }

--- a/tests/setup-labels.bats
+++ b/tests/setup-labels.bats
@@ -25,20 +25,20 @@ teardown() {
     rm -rf "$MOCK_DIR"
 }
 
-@test "success: creates 11 labels" {
+@test "success: creates 10 labels" {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    # gh label create must be called 11 times (6 phase/* + triaged + 3 type/* + fix-cycle)
-    [ "$(grep -c 'label create' "$GH_CALL_LOG")" -eq 11 ]
+    # gh label create must be called 10 times (6 phase/* + triaged + 3 type/*)
+    [ "$(grep -c 'label create' "$GH_CALL_LOG")" -eq 10 ]
 }
 
 @test "success: each label uses --force flag" {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [ -s "$GH_CALL_LOG" ]
-    # All 11 calls must include --force
+    # All 10 calls must include --force
     force_count=$(grep -c -- '--force' "$GH_CALL_LOG")
-    [ "$force_count" -eq 11 ]
+    [ "$force_count" -eq 10 ]
 }
 
 @test "success: correct label names" {
@@ -54,7 +54,6 @@ teardown() {
     grep -q 'label create type/bug' "$GH_CALL_LOG"
     grep -q 'label create type/feature' "$GH_CALL_LOG"
     grep -q 'label create type/task' "$GH_CALL_LOG"
-    grep -q 'label create fix-cycle' "$GH_CALL_LOG"
 }
 
 @test "success: correct colors (without # prefix)" {
@@ -71,7 +70,7 @@ teardown() {
 @test "success: completion message includes label count" {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"11"* ]]
+    [[ "$output" == *"10"* ]]
 }
 
 @test "error: gh command failure propagates" {


### PR DESCRIPTION
## Summary

- Remove watchdog auto-retry on kill; output "retrying disabled" message instead
- Split verify FAIL/UNCERTAIN handling: FAIL reopens issue, UNCERTAIN-only sets phase/verify label without reopening
- Remove `fix-cycle` label creation, assignment, and all references (13 files)
- Add `/code --patch N` guidance in verify reopen message as replacement for fix-cycle auto-routing
- Update docs/workflow.md and docs/guide/workflow.md to reflect manual intervention flow

## Verification (pre-merge)

- watchdog の retry メッセージが削除されている
- kill 時の新メッセージ (retrying disabled) が実装されている
- verify SKILL.md で fix-cycle ラベル付与が削除されている
- UNCERTAIN のみの場合の reopen 回避ロジックが追加されている
- auto SKILL.md から fix-cycle pre-check セクションが削除されている
- code/spec/modules/scripts/docs から fix-cycle 参照がすべて削除されている
- reopen 時の案内に /code --patch が含まれている

## Verification (post-merge)

- watchdog kill 後に再実行を促すメッセージが出力され、自動 spawn が発生しないことを観測
- verify で UNCERTAIN のみ含む結果の場合、Issue が reopen されないことを観測
- verify で FAIL を含む場合、Issue が reopen されるが fix-cycle ラベルは付与されないことを観測

closes #165