### PR TITLE
Issue #158: Add Available Keys reference table to customization.md

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -46,6 +46,26 @@ capabilities:
 
 All keys are optional. If `.wholework.yml` does not exist, all settings use their defaults.
 
+### Available Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `copilot-review` | boolean | `false` | Wait for GitHub Copilot review before merging |
+| `claude-code-review` | boolean | `false` | Wait for Claude Code Review before merging |
+| `coderabbit-review` | boolean | `false` | Wait for CodeRabbit review before merging |
+| `review-bug` | boolean | `true` | Run bug-detection agent in `/review` |
+| `opportunistic-verify` | boolean | `false` | Run quick verify commands at skill completion |
+| `skill-proposals` | boolean | `false` | Generate Wholework improvement issues during `/verify` |
+| `steering-hint` | boolean | `true` | Show `/doc init` hint when steering docs are missing |
+| `production-url` | string | `""` | Production URL for browser-based verify commands |
+| `spec-path` | string | `docs/spec` | Where specs are stored |
+| `steering-docs-path` | string | `docs` | Where steering documents live |
+| `capabilities.browser` | boolean | `false` | Enable Playwright-based verify commands |
+| `capabilities.mcp` | list | `[]` | MCP tool names available to skills |
+| `capabilities.{name}` | boolean | `false` | Dynamic capability mapping (e.g., `capabilities.invoice-api: true`) |
+
+For the full reference including implementation details and YAML parsing rules, see [`modules/detect-config-markers.md`](../../modules/detect-config-markers.md).
+
 ## `.wholework/domains/`
 
 Domain files let you add project-specific instructions to individual skill phases without modifying Wholework itself.

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -40,6 +40,26 @@ capabilities:
 
 すべてのキーはオプションです。`.wholework.yml` が存在しない場合、すべての設定はデフォルトで動作します。
 
+### Available Keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `copilot-review` | boolean | `false` | マージ前に GitHub Copilot review を待つ |
+| `claude-code-review` | boolean | `false` | マージ前に Claude Code Review を待つ |
+| `coderabbit-review` | boolean | `false` | マージ前に CodeRabbit review を待つ |
+| `review-bug` | boolean | `true` | `/review` でバグ検出 agent を実行する |
+| `opportunistic-verify` | boolean | `false` | スキル完了時に軽量 verify command を実行する |
+| `skill-proposals` | boolean | `false` | `/verify` 中に Wholework 改善 issue を生成する |
+| `steering-hint` | boolean | `true` | steering docs が欠如している場合に `/doc init` ヒントを表示する |
+| `production-url` | string | `""` | ブラウザベース verify command 用の本番 URL |
+| `spec-path` | string | `docs/spec` | spec の保存先 |
+| `steering-docs-path` | string | `docs` | steering document の配置先 |
+| `capabilities.browser` | boolean | `false` | Playwright ベースの verify command を有効化する |
+| `capabilities.mcp` | list | `[]` | スキルから利用できる MCP ツール名 |
+| `capabilities.{name}` | boolean | `false` | 動的 capability マッピング（例: `capabilities.invoice-api: true`） |
+
+実装の詳細や YAML パースルールを含む完全なリファレンスは [`modules/detect-config-markers.md`](../../../modules/detect-config-markers.md) を参照してください。
+
 ## `.wholework/domains/`
 
 Domain ファイルは Wholework 本体を変更せずに、個々のスキルフェーズへプロジェクト固有の指示を追加する仕組みです。

--- a/docs/spec/issue-158-add-available-keys-table.md
+++ b/docs/spec/issue-158-add-available-keys-table.md
@@ -51,3 +51,18 @@
 | `capabilities.{name}` | boolean | `false` | Dynamic capability mapping (e.g., `capabilities.invoice-api: true`) |
 
 `docs/ja/guide/customization.md` は日本語ミラーのため、表の Key 列は英語のまま維持し、Description のみ日本語化する。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A（設計通りに実装）
+
+### Design Gaps/Ambiguities
+
+- Spec の挿入箇所定義「All keys are optional.」段落の直後）は明確で曖昧さなし
+- `docs/ja/guide/customization.md` の参照リンクパスは `../../../modules/detect-config-markers.md` が正しいが、実際のファイル配置を確認すると `docs/ja/guide/` からは `../../..` が必要なため `../../../modules/detect-config-markers.md` と記載（ルートから `modules/` へのパス）
+
+### Rework
+
+- N/A（手戻りなし）

--- a/docs/spec/issue-158-add-available-keys-table.md
+++ b/docs/spec/issue-158-add-available-keys-table.md
@@ -66,3 +66,17 @@
 ### Rework
 
 - N/A（手戻りなし）
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+特記なし。Spec と PR diff が完全に一致しており、乖離は発生しなかった。ドキュメント追加系の Issue では Spec に挿入箇所・列構成・キー一覧が明確に定義されていたため、乖離の余地が少ない。
+
+### 繰り返し問題
+
+特記なし。今回は純粋なドキュメント追加であり、MUST/SHOULD/CONSIDER いずれの問題も検出されなかった。
+
+### 受入条件の検証難易度
+
+問題なし。`file_contains` および `section_contains` による verify command が適切で、偽陽性を防ぐ工夫（`file_contains` から `section_contains` への変更）がすでに Issue 本文の「自動解決した曖昧点」として記録されており、verify command の精度が高かった。UNCERTAIN 0 件。


### PR DESCRIPTION
## Summary

- `.wholework.yml` の全設定キーを一覧表示する `### Available Keys` セクションを `docs/guide/customization.md` のサンプル YAML 直後に追加
- 表は Key / Type / Default / Description の 4 列構成で、13 項目すべてを列挙
- SSoT である `modules/detect-config-markers.md` への参照リンクを表末尾に付与
- 日本語ミラー `docs/ja/guide/customization.md` にも同等のセクションを追加（Description 列のみ日本語化）

## Verification (pre-merge)

- `docs/guide/customization.md` に `Available Keys` 見出しが存在する
- `opportunistic-verify`、`spec-path`、`capabilities.browser`、`steering-hint` がリファレンス表に含まれる
- SSoT 参照リンク (`modules/detect-config-markers.md`) が存在する

## Verification (post-merge)

- customization.md を読んだ新規ユーザーが、他のドキュメントを参照せず主要設定キーを理解できる
- `detect-config-markers.md` に新キーが追加された際、customization.md との drift が `/audit drift` で検出可能

closes #158