### PR TITLE
Issue #188: Unify SCRIPT_DIR env var override and BATS mock strategy

### DIFF
--- a/docs/spec/issue-188-script-dir-env-override.md
+++ b/docs/spec/issue-188-script-dir-env-override.md
@@ -143,6 +143,20 @@ Issue body の初版には `command "test $(grep -lF '$SCRIPT_DIR/' scripts/*.sh
 
 Size L: 17 scripts の一斉適用 (6-10 files を超える) + CI-sensitive (+1) + 新規規約導入 (+1) = L 相当 (XL への昇格は single-purpose refactor のため不要)
 
+## Code Retrospective
+
+### Deviations from Design
+
+- `docs/tech.md` の Environment Variables テーブルへの `WHOLEWORK_SCRIPT_DIR` 追加は Spec に明示されていなかったが、`WHOLEWORK_CI_TIMEOUT_SEC` との整合性と Notes の記述（「`WHOLEWORK_CI_TIMEOUT_SEC` と整合」）から追加が適切と判断した
+
+### Design Gaps/Ambiguities
+
+- macOS の BSD sed は複雑なシェル展開パターンを含む文字列の置換に非対応（`-i` の区切り文字エスケープ問題）。Spec は実装手法を明示していなかったため Python で代替した。Linux 環境の GNU sed では問題ないが、macOS での開発時は Python スクリプトが確実
+
+### Rework
+
+- N/A（設計通りに実装完了）
+
 ## spec retrospective
 
 ### Minor observations

--- a/docs/spec/issue-188-script-dir-env-override.md
+++ b/docs/spec/issue-188-script-dir-env-override.md
@@ -157,6 +157,20 @@ Size L: 17 scripts の一斉適用 (6-10 files を超える) + CI-sensitive (+1)
 
 - N/A（設計通りに実装完了）
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- `docs/tech.md` の Environment Variables テーブルへの `WHOLEWORK_SCRIPT_DIR` 追加はSpecに明示されていなかったが、Code Retrospectiveで「`WHOLEWORK_CI_TIMEOUT_SEC` との整合性から追加が適切と判断」と記録されており、適切なドキュメント整備として評価。Spec段階でEnvironment Variablesテーブルへの追記を明示しておくと、レビュー時の確認漏れを防げた。
+
+### Recurring issues
+
+- 特記なし。17スクリプトへの同一パターン適用という性質上、個別の問題は発生しなかった。
+
+### Acceptance criteria verification difficulty
+
+- 条件1〜7はすべてfile_contains/section_containsでPASSと判定できた。条件8（CI PASS）のみIN_PROGRESSでUNCERTAIN。`github_check "gh run list ..."` はsafeモードのallowlistに含まれないため、CIの完了まで待機する必要があった。今後、batsテストのCI PASSを事前条件とするIssueでは、CIが完了したタイミングで`/review`を実行するか、`gh pr checks`のallowlist内コマンドを活用するverify commandにすることで、より確実な自動判定が可能。
+
 ## spec retrospective
 
 ### Minor observations

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -131,6 +131,15 @@ This rule prevents drift between label references in code and the SSoT definitio
 | **validate-skill-syntax.py** | SKILL.md syntax validation (half-width `!` detection, frontmatter validation) | Pre-merge |
 | **Verify commands** (`<!-- verify: ... -->`) | Mechanical verification of acceptance criteria (file existence, text content, command execution) | At `/verify` skill execution |
 
+### BATS Mocking Convention
+
+Scripts under `scripts/` resolve sibling helpers through `SCRIPT_DIR`, which is
+overridable via the `WHOLEWORK_SCRIPT_DIR` environment variable. BATS tests set
+`export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` and place mock helpers (e.g.
+`$MOCK_DIR/gh-graphql.sh`) under the mock directory. This allows per-test
+substitution of arbitrary sibling scripts without falling back to mocking
+lower-level tools such as `gh api graphql`.
+
 ## Forbidden Expressions
 
 | Expression | Reason | Alternative |
@@ -164,6 +173,7 @@ In gradual migration, there is a period where deprecated terms remain in the sam
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `WHOLEWORK_CI_TIMEOUT_SEC` | `1200` | Maximum wait time in seconds for `wait-ci-checks.sh`. Set to a lower value (e.g., `60`) to test timeout behavior. |
+| `WHOLEWORK_SCRIPT_DIR` | *(auto-resolved)* | Override the `SCRIPT_DIR` used by `scripts/*.sh` when resolving sibling helpers. Used in BATS tests to redirect calls to a mock directory. In production, leave unset (auto-resolves to the script's own directory). |
 
 ## Gotchas
 

--- a/scripts/check-file-overlap.sh
+++ b/scripts/check-file-overlap.sh
@@ -32,7 +32,7 @@ if ! [[ "$PARENT_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Get sub-issue list (OPEN sub-issues only)

--- a/scripts/get-issue-priority.sh
+++ b/scripts/get-issue-priority.sh
@@ -27,7 +27,7 @@ if ! [[ "$NUMBER" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 # Phase 1: Get from Project field
 GQL_QUERY='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:10){nodes{fieldValues(first:20){nodes{... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2SingleSelectField{name}}value:name}}}}}}}}'

--- a/scripts/get-issue-size.sh
+++ b/scripts/get-issue-size.sh
@@ -27,7 +27,7 @@ if ! [[ "$NUMBER" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 # Phase 1: Get from Project field
 GQL_QUERY='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:10){nodes{fieldValues(first:20){nodes{... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2SingleSelectField{name}}value:name}}}}}}}}'

--- a/scripts/get-issue-type.sh
+++ b/scripts/get-issue-type.sh
@@ -36,7 +36,7 @@ if ! [[ "$NUMBER" =~ ^[0-9]+$ ]]; then
     exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 # Phase 1: Get from Issue Types GraphQL API
 GQL_QUERY='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){issueType{name}}}}'

--- a/scripts/get-sub-issue-graph.sh
+++ b/scripts/get-sub-issue-graph.sh
@@ -22,7 +22,7 @@ if ! [[ "$PARENT_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 # Fetch sub-issues + blockedBy in a single GraphQL call
 RAW_JSON=$("$SCRIPT_DIR/gh-graphql.sh" --query get-sub-issues -F "num=$PARENT_NUMBER")

--- a/scripts/gh-check-blocking.sh
+++ b/scripts/gh-check-blocking.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 usage() {
     echo "Usage: $(basename "$0") <issue-number> [--dry-run]"

--- a/scripts/gh-label-transition.sh
+++ b/scripts/gh-label-transition.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 PHASE_LABELS="phase/issue phase/spec phase/ready phase/code phase/review phase/verify phase/done"
 
 if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -35,7 +35,7 @@ if ! [[ "$SUB_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 # Process lock (prevents main branch conflicts on patch route)
 # Generate project-specific lock directory by hashing the repository root path

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -44,7 +44,7 @@ if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 echo "=== run-code.sh: Starting /code for issue #${ISSUE_NUMBER} ==="
 source "$SCRIPT_DIR/phase-banner.sh"

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -19,7 +19,7 @@ if [[ $# -gt 0 ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 echo "=== run-issue.sh: Starting /issue for issue #${ISSUE_NUMBER} ==="
 source "$SCRIPT_DIR/phase-banner.sh"

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -11,7 +11,7 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 echo "=== run-merge.sh: Starting /merge for PR #${PR_NUMBER} ==="
 source "$SCRIPT_DIR/phase-banner.sh"

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -13,7 +13,7 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 echo "=== run-review.sh: Starting /review for PR #${PR_NUMBER} ==="
 source "$SCRIPT_DIR/phase-banner.sh"

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -28,7 +28,7 @@ if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 echo "=== run-spec.sh: Starting /spec for issue #${ISSUE_NUMBER} ==="
 source "$SCRIPT_DIR/phase-banner.sh"

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 echo "=== run-verify.sh: Starting /verify for Issue #${ISSUE_NUMBER} ==="
 source "$SCRIPT_DIR/phase-banner.sh"

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
 # Parse flags
 FORCE=false

--- a/scripts/test-skills.sh
+++ b/scripts/test-skills.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 echo "=== Skills syntax validation ==="

--- a/scripts/validate-permissions.sh
+++ b/scripts/validate-permissions.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 errors=0

--- a/tests/setup-labels.bats
+++ b/tests/setup-labels.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 
 # Tests for setup-labels.sh
-# Mocks the gh command by placing it at the front of PATH.
-# gh-graphql.sh (called via absolute SCRIPT_DIR path) internally calls "gh api graphql",
-# so environment detection is controlled by how the mock gh handles "api graphql" calls.
+# Uses WHOLEWORK_SCRIPT_DIR to redirect gh-graphql.sh calls to a mock directory.
+# The gh mock handles label operations only; environment detection is controlled
+# by placing a gh-graphql.sh mock under MOCK_DIR.
 
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/setup-labels.sh"
 
@@ -11,20 +11,21 @@ setup() {
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
     GH_CALL_LOG="$BATS_TEST_TMPDIR/gh_calls.log"
     export GH_CALL_LOG
 
-    # Default gh mock:
-    # - "api graphql": returns "1" (simulates all GitHub features available)
-    # - "label list": returns empty (no existing labels)
-    # - everything else: logs and succeeds
+    # Default gh-graphql.sh mock: returns 1 (all GitHub features available)
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
+#!/bin/bash
+echo "1"
+MOCK
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    # Default gh mock: handles label list and create operations (no api graphql handling)
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "1"
-    exit 0
-fi
 echo "$@" >> "$GH_CALL_LOG"
 if [ "$1" = "label" ] && [ "$2" = "list" ]; then
     echo ""
@@ -96,19 +97,11 @@ label_created() {
 # All 11 always + 17 fallback = 28 labels
 
 @test "env=none: all 28 labels created when no features available" {
-    cat > "$MOCK_DIR/gh" <<'MOCK'
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "0"
-    exit 0
-fi
-echo "$@" >> "$GH_CALL_LOG"
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-    echo ""
-fi
-exit 0
+echo "0"
 MOCK
-    chmod +x "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
 
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -116,19 +109,11 @@ MOCK
 }
 
 @test "env=none: fallback type/* labels created when Issue Types unavailable" {
-    cat > "$MOCK_DIR/gh" <<'MOCK'
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "0"
-    exit 0
-fi
-echo "$@" >> "$GH_CALL_LOG"
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-    echo ""
-fi
-exit 0
+echo "0"
 MOCK
-    chmod +x "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
 
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -138,19 +123,11 @@ MOCK
 }
 
 @test "env=none: fallback size/* labels created when Size field unavailable" {
-    cat > "$MOCK_DIR/gh" <<'MOCK'
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "0"
-    exit 0
-fi
-echo "$@" >> "$GH_CALL_LOG"
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-    echo ""
-fi
-exit 0
+echo "0"
 MOCK
-    chmod +x "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
 
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -162,19 +139,11 @@ MOCK
 }
 
 @test "env=none: fallback value/* labels created when Value field unavailable" {
-    cat > "$MOCK_DIR/gh" <<'MOCK'
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "0"
-    exit 0
-fi
-echo "$@" >> "$GH_CALL_LOG"
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-    echo ""
-fi
-exit 0
+echo "0"
 MOCK
-    chmod +x "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
 
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -183,19 +152,11 @@ MOCK
 }
 
 @test "env=none: fallback priority/* labels created when Priority field unavailable" {
-    cat > "$MOCK_DIR/gh" <<'MOCK'
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "0"
-    exit 0
-fi
-echo "$@" >> "$GH_CALL_LOG"
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-    echo ""
-fi
-exit 0
+echo "0"
 MOCK
-    chmod +x "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
 
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -210,10 +171,6 @@ MOCK
 @test "idempotent: existing label is skipped without --force" {
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "1"
-    exit 0
-fi
 echo "$@" >> "$GH_CALL_LOG"
 if [ "$1" = "label" ] && [ "$2" = "list" ]; then
     echo "phase/issue"
@@ -232,10 +189,6 @@ MOCK
 @test "idempotent: non-existing label is created even when others exist" {
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "1"
-    exit 0
-fi
 echo "$@" >> "$GH_CALL_LOG"
 if [ "$1" = "label" ] && [ "$2" = "list" ]; then
     echo "phase/issue"
@@ -254,10 +207,6 @@ MOCK
 @test "--force: existing labels are created with --force flag" {
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "1"
-    exit 0
-fi
 echo "$@" >> "$GH_CALL_LOG"
 if [ "$1" = "label" ] && [ "$2" = "list" ]; then
     echo "phase/issue"
@@ -293,19 +242,11 @@ MOCK
 # --- --no-fallback flag ---
 
 @test "--no-fallback: only always-group labels created even when features unavailable" {
-    cat > "$MOCK_DIR/gh" <<'MOCK'
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "0"
-    exit 0
-fi
-echo "$@" >> "$GH_CALL_LOG"
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-    echo ""
-fi
-exit 0
+echo "0"
 MOCK
-    chmod +x "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
 
     run bash "$SCRIPT" --no-fallback
     [ "$status" -eq 0 ]
@@ -314,21 +255,14 @@ MOCK
     [ "$status" -ne 0 ]
 }
 
-# --- gh api graphql (detection) failure handling ---
+# --- gh-graphql.sh (detection) failure handling ---
 
-@test "env-detect-fail: api graphql failure treated as unavailable (fallback created)" {
-    cat > "$MOCK_DIR/gh" <<'MOCK'
+@test "env-detect-fail: gh-graphql.sh failure treated as unavailable (fallback created)" {
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    exit 1
-fi
-echo "$@" >> "$GH_CALL_LOG"
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-    echo ""
-fi
-exit 0
+exit 1
 MOCK
-    chmod +x "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
 
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
@@ -342,10 +276,6 @@ MOCK
 @test "error: gh label create failure propagates" {
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
-if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
-    echo "1"
-    exit 0
-fi
 if [ "$1" = "label" ] && [ "$2" = "list" ]; then
     echo ""
     exit 0


### PR DESCRIPTION
## Summary

- `scripts/*.sh` の `SCRIPT_DIR=` 初期化 17 ファイルを `SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"` に統一
- `tests/setup-labels.bats` を `WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` を export する新モック戦略で書き直し（`gh-graphql.sh` モックを `MOCK_DIR` 配下に配置; `gh` モックから `api graphql` 特殊処理を除去）
- `docs/tech.md` の Testing Strategy セクションに BATS モック規約を追加; Environment Variables テーブルに `WHOLEWORK_SCRIPT_DIR` を追加

## Verification (pre-merge)

- `scripts/setup-labels.sh` が `WHOLEWORK_SCRIPT_DIR` に対応
- `scripts/gh-label-transition.sh` が同じパターンに対応
- `scripts/run-auto-sub.sh` が同じパターンに対応
- `scripts/gh-check-blocking.sh` が同じパターンに対応
- `tests/setup-labels.bats` が `WHOLEWORK_SCRIPT_DIR` を利用したモック戦略で書き直し済み
- `tests/setup-labels.bats` が `MOCK_DIR` を用いたモックディレクトリを設定
- `docs/tech.md` の Testing Strategy セクションに `WHOLEWORK_SCRIPT_DIR` の規約記載
- bats テスト CI PASS（PR マージ後確認）

## Verification (post-merge)

- 新しく BATS テストを追加する際に `WHOLEWORK_SCRIPT_DIR` を利用したモック戦略が機能することを opportunistic に確認する

closes #188