### PR TITLE
Issue #195: Add bats tests for run-spec.sh and run-auto-sub.sh

### DIFF
--- a/docs/spec/issue-195-bats-run-spec-auto-sub.md
+++ b/docs/spec/issue-195-bats-run-spec-auto-sub.md
@@ -48,8 +48,8 @@
 - <!-- verify: file_exists "tests/run-auto-sub.bats" --> `tests/run-auto-sub.bats` が存在する
 - <!-- verify: file_contains "tests/run-spec.bats" "frontmatter" --> `tests/run-spec.bats` に SKILL.md frontmatter parsing 関連のテストが含まれている
 - <!-- verify: file_contains "tests/run-spec.bats" "claude-sonnet-4-6" --> `tests/run-spec.bats` に Sonnet モデル指定の検証が含まれている
-- <!-- verify: file_contains "tests/run-auto-sub.bats" "Size: XS" --> `tests/run-auto-sub.bats` に Size XS 分岐テストが含まれている
-- <!-- verify: file_contains "tests/run-auto-sub.bats" "Size: L" --> `tests/run-auto-sub.bats` に Size L 分岐テストが含まれている
+- <!-- verify: file_contains "tests/run-auto-sub.bats" "Size XS" --> `tests/run-auto-sub.bats` に Size XS 分岐テストが含まれている
+- <!-- verify: file_contains "tests/run-auto-sub.bats" "Size L" --> `tests/run-auto-sub.bats` に Size L 分岐テストが含まれている
 - <!-- verify: file_contains "tests/run-auto-sub.bats" "PATCH_LOCK" --> `tests/run-auto-sub.bats` に patch lock 機構のテストが含まれている
 - <!-- verify: file_contains "tests/run-auto-sub.bats" "phase/ready" --> `tests/run-auto-sub.bats` に phase/ready ラベル検出による spec skip テストが含まれている
 - <!-- verify: github_check "gh run list --workflow=test.yml --limit=1 --json conclusion --jq '.[0].conclusion'" "success" --> bats テスト CI が PASS する

--- a/docs/spec/issue-195-bats-run-spec-auto-sub.md
+++ b/docs/spec/issue-195-bats-run-spec-auto-sub.md
@@ -92,3 +92,17 @@ run-spec.sh は `SKILL_FILE="${SCRIPT_DIR}/../skills/spec/SKILL.md"` で SKILL.m
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note. All Spec-specified test cases were implemented as described. The verify hint correction (`"Size: XS"` → `"Size XS"`) was pre-identified and documented in Code Retrospective before review, demonstrating good self-correction during implementation.
+
+### Recurring issues
+
+Nothing to note. No repeated issue patterns were observed across the two test files.
+
+### Acceptance criteria verification difficulty
+
+The `github_check` condition (bats test CI PASS) was PENDING at review time because CI was still running. This is expected behavior for a test-addition PR. Consider adding a note in future Specs that CI-dependent verify conditions may be PENDING on first review attempt — this is acceptable and `/merge` should wait for CI completion before proceeding.

--- a/docs/spec/issue-195-bats-run-spec-auto-sub.md
+++ b/docs/spec/issue-195-bats-run-spec-auto-sub.md
@@ -78,3 +78,17 @@ run-spec.sh は `SKILL_FILE="${SCRIPT_DIR}/../skills/spec/SKILL.md"` で SKILL.m
 ### patch lock テストの範囲
 
 `acquire_patch_lock` の成功 (mkdir + PATCH_LOCK_DIR の存在確認) と `release_patch_lock` の成功 (rmdir + 不在確認) をテストする。timeout (300s) シナリオは sleep mock の複雑性ゆえ scope 外。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A
+
+### Design Gaps/Ambiguities
+
+- verify コマンドの `file_contains "tests/run-auto-sub.bats" "Size: XS"` / `"Size: L"` が miscalibrated だった。Spec ではテスト名パターンを `"Size: XS"` と想定していたが、実際には bats の `@test` 名は `"Size XS:"` (コロン位置が異なる) になる。これは run-auto-sub.sh のログ出力 `echo "Size: ${SIZE}"` と混同した可能性がある。verify hint は `"Size XS"` / `"Size L"` に修正した。
+
+### Rework
+
+- N/A

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -1,0 +1,276 @@
+#!/usr/bin/env bats
+
+# Tests for run-auto-sub.sh
+# Mocks sibling scripts via WHOLEWORK_SCRIPT_DIR, and gh/git via PATH
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-auto-sub.sh"
+
+setup() {
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    # Call logs for sibling script invocations
+    export RUN_SPEC_LOG="$BATS_TEST_TMPDIR/run-spec.log"
+    export RUN_CODE_LOG="$BATS_TEST_TMPDIR/run-code.log"
+    export RUN_REVIEW_LOG="$BATS_TEST_TMPDIR/run-review.log"
+    export RUN_MERGE_LOG="$BATS_TEST_TMPDIR/run-merge.log"
+    export RUN_VERIFY_LOG="$BATS_TEST_TMPDIR/run-verify.log"
+
+    # Mock phase-banner.sh (sourced by run-auto-sub.sh)
+    cat > "$MOCK_DIR/phase-banner.sh" <<'MOCK'
+print_start_banner() { echo "Starting /$3 for issue #$2"; }
+print_end_banner() { echo "Finished /$3 for issue #$2"; }
+MOCK
+
+    # Mock get-issue-size.sh: default Size M
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "M"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    # Mock sibling run-*.sh scripts: log args and exit 0
+    cat > "$MOCK_DIR/run-spec.sh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$RUN_SPEC_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-spec.sh"
+
+    cat > "$MOCK_DIR/run-code.sh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$RUN_CODE_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+
+    cat > "$MOCK_DIR/run-review.sh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$RUN_REVIEW_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-review.sh"
+
+    cat > "$MOCK_DIR/run-merge.sh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$RUN_MERGE_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-merge.sh"
+
+    cat > "$MOCK_DIR/run-verify.sh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$RUN_VERIFY_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-verify.sh"
+
+    # Mock git: rev-parse --show-toplevel returns /tmp/test-repo (for PATCH_LOCK_DIR computation)
+    # run-auto-sub.sh calls: git -C "${SCRIPT_DIR}/.." rev-parse --show-toplevel
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "-C" && "$3" == "rev-parse" && "$4" == "--show-toplevel" ]]; then
+    echo "/tmp/test-repo"
+    exit 0
+fi
+if [[ "$1" == "pull" ]]; then
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    # Mock gh: default phase/ready label present, pr list returns PR 99
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json labels"* ]]; then
+    echo "phase/ready"
+    echo "triaged"
+    exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
+    if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+        echo "test issue title"
+    elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+        echo "https://github.com/test/repo/issues/99"
+    fi
+    exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo "99"
+    exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+    # Clean up any leftover patch lock from the test repo hash
+    LOCK_HASH=$(echo "/tmp/test-repo" | cksum | awk '{print $1}')
+    rmdir "/tmp/claude-auto-patch-lock-${LOCK_HASH}" 2>/dev/null || true
+}
+
+@test "error: no arguments" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: run-auto-sub.sh <sub-issue-number>"* ]]
+}
+
+@test "error: non-numeric issue number" {
+    run bash "$SCRIPT" abc
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Issue number must be numeric: abc"* ]]
+}
+
+@test "error: --base without branch argument" {
+    run bash "$SCRIPT" 99 --base
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--base requires a branch name"* ]]
+}
+
+@test "error: unknown option is rejected" {
+    run bash "$SCRIPT" 99 --unknown
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Invalid option: --unknown"* ]]
+}
+
+@test "Size XS: run-code.sh --patch is called, run-review.sh and run-merge.sh are not called" {
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "42 --patch" "$RUN_CODE_LOG"
+    [ ! -f "$RUN_REVIEW_LOG" ]
+    [ ! -f "$RUN_MERGE_LOG" ]
+}
+
+@test "Size S: run-code.sh --patch is called, run-review.sh and run-merge.sh are not called" {
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "S"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "42 --patch" "$RUN_CODE_LOG"
+    [ ! -f "$RUN_REVIEW_LOG" ]
+    [ ! -f "$RUN_MERGE_LOG" ]
+}
+
+@test "Size M: run-code.sh --pr, run-review.sh --light, run-merge.sh, run-verify.sh are called" {
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "42 --pr" "$RUN_CODE_LOG"
+    grep -q -- "--light" "$RUN_REVIEW_LOG"
+    [ -f "$RUN_MERGE_LOG" ]
+    [ -f "$RUN_VERIFY_LOG" ]
+}
+
+@test "Size L: run-code.sh --pr, run-review.sh --full, run-merge.sh, run-verify.sh are called" {
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "L"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "42 --pr" "$RUN_CODE_LOG"
+    grep -q -- "--full" "$RUN_REVIEW_LOG"
+    [ -f "$RUN_MERGE_LOG" ]
+    [ -f "$RUN_VERIFY_LOG" ]
+}
+
+@test "Size XL: exits with error about sub-issue splitting" {
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XL"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Further sub-issue splitting is required"* ]]
+}
+
+@test "phase/ready present: run-spec.sh is not called" {
+    # Default gh mock has phase/ready
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    [ ! -f "$RUN_SPEC_LOG" ]
+}
+
+@test "phase/ready absent: run-spec.sh is called" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json labels"* ]]; then
+    echo "triaged"
+    exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo "99"
+    exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    [ -f "$RUN_SPEC_LOG" ]
+}
+
+@test "--base flag propagates to run-code.sh and run-verify.sh for Size M" {
+    run bash "$SCRIPT" 42 --base release/v1
+    [ "$status" -eq 0 ]
+    grep -q -- "--base release/v1" "$RUN_CODE_LOG"
+    grep -q -- "--base release/v1" "$RUN_VERIFY_LOG"
+}
+
+@test "PATCH_LOCK: lock dir is created during code execution and released after for Size XS" {
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    LOCK_CHECK_FILE="$BATS_TEST_TMPDIR/lock_existed.txt"
+    export LOCK_CHECK_FILE
+
+    # Override run-code.sh to verify lock dir exists during execution
+    cat > "$MOCK_DIR/run-code.sh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$RUN_CODE_LOG"
+ls /tmp/claude-auto-patch-lock-* 2>/dev/null && echo "LOCK_EXISTS" > "$LOCK_CHECK_FILE" || true
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+
+    # Lock existed during code phase
+    [ -f "$LOCK_CHECK_FILE" ]
+    grep -q "LOCK_EXISTS" "$LOCK_CHECK_FILE"
+
+    # Lock released after script completes
+    LOCK_HASH=$(echo "/tmp/test-repo" | cksum | awk '{print $1}')
+    [ ! -d "/tmp/claude-auto-patch-lock-${LOCK_HASH}" ]
+}

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+
+# Tests for run-spec.sh
+# Mocks: claude, claude-watchdog.sh, phase-banner.sh, gh (via MOCK_DIR + WHOLEWORK_SCRIPT_DIR)
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-spec.sh"
+
+setup() {
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    CLAUDE_CALL_LOG="$BATS_TEST_TMPDIR/claude_calls.log"
+    export CLAUDE_CALL_LOG
+
+    # Mock claude: log flags, model, effort, ANTHROPIC_MODEL, CLAUDECODE, ARGUMENTS
+    cat > "$MOCK_DIR/claude" <<'MOCK'
+#!/bin/bash
+echo "ARGS_COUNT=$#" >> "$CLAUDE_CALL_LOG"
+for arg in "$@"; do
+    case "$arg" in
+        -p) echo "FLAG_P=1" >> "$CLAUDE_CALL_LOG" ;;
+        --model) echo "FLAG_MODEL=1" >> "$CLAUDE_CALL_LOG" ;;
+        --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
+        --effort) echo "FLAG_EFFORT=1" >> "$CLAUDE_CALL_LOG" ;;
+    esac
+done
+echo "ANTHROPIC_MODEL=$ANTHROPIC_MODEL" >> "$CLAUDE_CALL_LOG"
+echo "CLAUDECODE=${CLAUDECODE:-__UNSET__}" >> "$CLAUDE_CALL_LOG"
+# Extract ARGUMENTS line from prompt (arg after -p)
+FOUND_P=0
+for arg in "$@"; do
+    if [[ $FOUND_P -eq 1 ]]; then
+        echo "PROMPT_CONTAINS_ARGUMENTS=$(echo "$arg" | grep -o 'ARGUMENTS:.*' | head -1)" >> "$CLAUDE_CALL_LOG"
+        break
+    fi
+    [[ "$arg" == "-p" ]] && FOUND_P=1
+done
+# Extract model value (arg after --model)
+FOUND_MODEL=0
+for arg in "$@"; do
+    if [[ $FOUND_MODEL -eq 1 ]]; then
+        echo "MODEL_VALUE=$arg" >> "$CLAUDE_CALL_LOG"
+        break
+    fi
+    [[ "$arg" == "--model" ]] && FOUND_MODEL=1
+done
+# Extract effort value (arg after --effort)
+FOUND_EFFORT=0
+for arg in "$@"; do
+    if [[ $FOUND_EFFORT -eq 1 ]]; then
+        echo "EFFORT_VALUE=$arg" >> "$CLAUDE_CALL_LOG"
+        break
+    fi
+    [[ "$arg" == "--effort" ]] && FOUND_EFFORT=1
+done
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+
+    # Mock claude-watchdog.sh: pass through to the real claude mock in PATH
+    cat > "$MOCK_DIR/claude-watchdog.sh" <<'MOCK'
+#!/bin/bash
+exec "$@"
+MOCK
+    chmod +x "$MOCK_DIR/claude-watchdog.sh"
+
+    # Mock phase-banner.sh (sourced by run-spec.sh)
+    cat > "$MOCK_DIR/phase-banner.sh" <<'MOCK'
+print_start_banner() { echo "Starting /$3 for issue #$2"; }
+print_end_banner() { echo "Finished /$3 for issue #$2"; }
+MOCK
+
+    # Mock gh for phase-banner title/url lookups
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
+    if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+        echo "test issue title"
+    elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+        echo "https://github.com/test/repo/issues/123"
+    fi
+    exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    # Create default SKILL.md with valid frontmatter at $BATS_TEST_TMPDIR/skills/spec/SKILL.md
+    # run-spec.sh resolves: SKILL_FILE="${SCRIPT_DIR}/../skills/spec/SKILL.md"
+    # With WHOLEWORK_SCRIPT_DIR=$MOCK_DIR, SCRIPT_DIR=$MOCK_DIR, so path is:
+    # $MOCK_DIR/../skills/spec/SKILL.md = $BATS_TEST_TMPDIR/skills/spec/SKILL.md
+    mkdir -p "$BATS_TEST_TMPDIR/skills/spec"
+    cat > "$BATS_TEST_TMPDIR/skills/spec/SKILL.md" <<'SKILL'
+---
+type: skill
+---
+# Spec Skill Body
+This is the skill body content used for testing.
+SKILL
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "error: no arguments" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: run-spec.sh <issue-number>"* ]]
+}
+
+@test "error: non-numeric issue number" {
+    run bash "$SCRIPT" abc
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Issue number must be numeric: abc"* ]]
+}
+
+@test "error: unknown option is rejected" {
+    run bash "$SCRIPT" 123 --unknown
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Invalid option: --unknown"* ]]
+}
+
+@test "success: default model is claude-sonnet-4-6" {
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    grep -q "MODEL_VALUE=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+}
+
+@test "success: default effort is max" {
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    grep -q "EFFORT_VALUE=max" "$CLAUDE_CALL_LOG"
+}
+
+@test "success: --dangerously-skip-permissions is passed" {
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
+}
+
+@test "success: --opus switches model to claude-opus-4-6" {
+    run bash "$SCRIPT" 123 --opus
+    [ "$status" -eq 0 ]
+    grep -q "MODEL_VALUE=claude-opus-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=claude-opus-4-6" "$CLAUDE_CALL_LOG"
+}
+
+@test "error: SKILL.md not found when file is absent" {
+    rm -f "$BATS_TEST_TMPDIR/skills/spec/SKILL.md"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"SKILL.md not found"* ]]
+}
+
+@test "error: frontmatter not found when SKILL.md has no --- delimiter" {
+    cat > "$BATS_TEST_TMPDIR/skills/spec/SKILL.md" <<'SKILL'
+# No frontmatter here
+Just a body with no frontmatter delimiter.
+SKILL
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"frontmatter not found"* ]]
+}
+
+@test "success: ARGUMENTS contains issue number with --non-interactive" {
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    grep -q "PROMPT_CONTAINS_ARGUMENTS=ARGUMENTS: 123 --non-interactive" "$CLAUDE_CALL_LOG"
+}
+
+@test "success: CLAUDECODE env var is unset for claude subprocess" {
+    export CLAUDECODE="parent-session-id"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    grep -q "CLAUDECODE=__UNSET__" "$CLAUDE_CALL_LOG"
+}


### PR DESCRIPTION
## Summary

- `tests/run-spec.bats` を新規作成: 引数バリデーション、claude 呼び出し引数 (model/effort/permissions)、`--opus` オプション、frontmatter parsing、CLAUDECODE env var unset を検証 (11 テストケース)
- `tests/run-auto-sub.bats` を新規作成: 引数バリデーション、Size 4 分岐 (XS/S/M/L)、XL エラー、phase/ready スキップ、patch lock 機構、`--base` フラグ伝播を検証 (13 テストケース)
- 既存 `run-*.bats` パターン (MOCK_DIR + PATH 注入 + `WHOLEWORK_SCRIPT_DIR` sibling mock) を踏襲

## Verification (pre-merge)

- `tests/run-spec.bats` が存在する
- `tests/run-auto-sub.bats` が存在する
- `tests/run-spec.bats` に SKILL.md frontmatter parsing 関連のテストが含まれている
- `tests/run-spec.bats` に Sonnet モデル指定の検証が含まれている
- `tests/run-auto-sub.bats` に Size XS 分岐テストが含まれている
- `tests/run-auto-sub.bats` に Size L 分岐テストが含まれている
- `tests/run-auto-sub.bats` に patch lock 機構のテストが含まれている
- `tests/run-auto-sub.bats` に phase/ready ラベル検出による spec skip テストが含まれている
- bats テスト CI が PASS する

## Verification (post-merge)

- 主要ケース (正常系・引数不正・外部コマンド失敗) が網羅されていることを次回関連 PR レビュー時に確認する

closes #195