### PR TITLE
Issue #227: Migrate run-*.sh model specs from pinned IDs to CLI aliases

### DIFF
--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -55,25 +55,27 @@
   - **軸 2 — Adaptive Thinking**（`--effort`）: `claude -p` は `low/medium/high/max` レベルをサポート（`claude --help` で確認済み）。`run-*.sh` でフェーズごとの effort レベルを実装済み（下記マトリクス参照）。medium effort と Opus advisor を組み合わせると、Sonnet のデフォルト effort 相当の品質をより低コストで達成（Anthropic ベンチマーク準拠）
   - **軸 3 — Advisor 戦略**（`advisor_20260301`）: Anthropic API ベータ機能（`advisor-tool-2026-03-01` ヘッダが必要）。`--betas` フラグで有効化 — API キー利用者のみ、OAuth/サブスクリプション認証（`run-*.sh` のデフォルト）では利用不可。性能向上: Sonnet + Opus advisor で SWE-bench +2.7 pp、コスト −11.9%（Sonnet 単独比）、Haiku + Opus advisor で BrowseComp 41.2%（単独 19.7%）、コスト −85%（Sonnet 比）。`run-*.sh` 実装はフォローアップ Issue
 
-  **フェーズ別モデル・effort マトリクス**（`ssot_for: model-effort-matrix`）:
+### フェーズ別モデル・effort マトリクス
 
-  | コンポーネント | フェーズ | モデル | Effort | 根拠 |
-  |-----------|-------|-------|--------|-----------|
-  | run-spec.sh | spec | Sonnet（L では `--opus` で Opus） | max | 設計品質が重要、spec のエラーは後続全フェーズに波及する。`/auto` は L サイズのみ `--opus` を渡す（XL は spec 前に分割済み） |
-  | run-code.sh | code | Sonnet | high | 実装には徹底した推論が必要 |
-  | run-review.sh | review | Sonnet | high | レビューのオーケストレーション、深い分析はサブエージェントが担う |
-  | run-issue.sh | issue | Sonnet | high | L/XL のスコープ分析とサブ issue 分割には徹底したオーケストレーションが必要 |
-  | run-verify.sh | verify | Sonnet | medium | 構造化された受入テスト、中程度の複雑度 |
-  | run-merge.sh | merge | Sonnet | low | 機械的なマージ操作、推論は最小限でよい |
-  | review-bug | review | Opus | — | バグ検出は最高精度が必要（サブエージェント、effort は親から継承） |
-  | review-spec | review | Opus | — | Spec 逸脱は高精度が必要（サブエージェント、effort は親から継承） |
-  | review-light | review | Sonnet | — | 軽量統合レビュー（サブエージェント、effort は親から継承） |
-  | issue-scope | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。スコープ特定精度はサブ issue 境界判断に直結 |
-  | issue-risk | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。リスク評価精度が受入条件品質を高める |
-  | issue-precedent | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。前例抽出が受入条件品質を高める |
-  | triage（skill） | triage | Sonnet | — | メタデータ付与、Sonnet で十分。インライン実行（`run-*.sh` ラッパーなし）— `/auto` が未ラベル issue に triage を連鎖させる場合も含む — のため effort は設定しない |
+(`ssot_for: model-effort-matrix`)
 
-  SSoT 備考: このマトリクスがすべてのモデル・effort 設定の唯一の真実。`run-*.sh`、agents、skills でモデル/effort を変更する際は、まずこの表を更新すること
+| コンポーネント | フェーズ | モデル | Effort | 根拠 |
+|-----------|-------|-------|--------|-----------|
+| run-spec.sh | spec | Sonnet（L では `--opus` で Opus） | max | 設計品質が重要、spec のエラーは後続全フェーズに波及する。`/auto` は L サイズのみ `--opus` を渡す（XL は spec 前に分割済み） |
+| run-code.sh | code | Sonnet | high | 実装には徹底した推論が必要 |
+| run-review.sh | review | Sonnet | high | レビューのオーケストレーション、深い分析はサブエージェントが担う |
+| run-issue.sh | issue | Sonnet | high | L/XL のスコープ分析とサブ issue 分割には徹底したオーケストレーションが必要 |
+| run-verify.sh | verify | Sonnet | medium | 構造化された受入テスト、中程度の複雑度 |
+| run-merge.sh | merge | Sonnet | low | 機械的なマージ操作、推論は最小限でよい |
+| review-bug | review | Opus | — | バグ検出は最高精度が必要（サブエージェント、effort は親から継承） |
+| review-spec | review | Opus | — | Spec 逸脱は高精度が必要（サブエージェント、effort は親から継承） |
+| review-light | review | Sonnet | — | 軽量統合レビュー（サブエージェント、effort は親から継承） |
+| issue-scope | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。スコープ特定精度はサブ issue 境界判断に直結 |
+| issue-risk | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。リスク評価精度が受入条件品質を高める |
+| issue-precedent | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。前例抽出が受入条件品質を高める |
+| triage（skill） | triage | Sonnet | — | メタデータ付与、Sonnet で十分。インライン実行（`run-*.sh` ラッパーなし）— `/auto` が未ラベル issue に triage を連鎖させる場合も含む — のため effort は設定しない |
+
+SSoT 備考: run-*.sh のモデル値は CLI エイリアス（sonnet/opus）を使用する。run-*.sh、agents、skills でモデル/effort を変更する際はこの表を更新すること。
 
 ## Wholework ラベル管理
 

--- a/docs/spec/issue-195-bats-run-spec-auto-sub.md
+++ b/docs/spec/issue-195-bats-run-spec-auto-sub.md
@@ -47,7 +47,7 @@
 - <!-- verify: file_exists "tests/run-spec.bats" --> `tests/run-spec.bats` が存在する
 - <!-- verify: file_exists "tests/run-auto-sub.bats" --> `tests/run-auto-sub.bats` が存在する
 - <!-- verify: file_contains "tests/run-spec.bats" "frontmatter" --> `tests/run-spec.bats` に SKILL.md frontmatter parsing 関連のテストが含まれている
-- <!-- verify: file_contains "tests/run-spec.bats" "claude-sonnet-4-6" --> `tests/run-spec.bats` に Sonnet モデル指定の検証が含まれている
+- <!-- verify: file_contains "tests/run-spec.bats" "sonnet" --> `tests/run-spec.bats` に Sonnet モデル指定の検証が含まれている（Issue #227 により alias 形式に更新済み）
 - <!-- verify: file_contains "tests/run-auto-sub.bats" "Size XS" --> `tests/run-auto-sub.bats` に Size XS 分岐テストが含まれている
 - <!-- verify: file_contains "tests/run-auto-sub.bats" "Size L" --> `tests/run-auto-sub.bats` に Size L 分岐テストが含まれている
 - <!-- verify: file_contains "tests/run-auto-sub.bats" "PATCH_LOCK" --> `tests/run-auto-sub.bats` に patch lock 機構のテストが含まれている

--- a/docs/spec/issue-227-run-scripts-alias.md
+++ b/docs/spec/issue-227-run-scripts-alias.md
@@ -59,6 +59,20 @@
 - 参照 Issue で `/auto N` を実行し、CLI ログで alias 表示（`Model: sonnet` / `Model: opus`）を確認
 - ベンチマーク #226 実施手順に「一時的に pin へ戻す」注意書きが追加されている
 
+## Code Retrospective
+
+### Deviations from Design
+
+- なし
+
+### Design Gaps/Ambiguities
+
+- `run-verify.bats` のモックは `echo "$@"` で全引数をログするため `grep -q -- "--model sonnet"` の形式で検証可能（run-spec.bats とは異なるモック構造）。Spec には記載がなかったが、テスト更新時に確認して対処した。
+
+### Rework
+
+- なし
+
 ## Notes
 
 ### run-spec.sh の verify 対応

--- a/docs/spec/issue-227-run-scripts-alias.md
+++ b/docs/spec/issue-227-run-scripts-alias.md
@@ -86,3 +86,17 @@
 ### patch route: github_check 変換
 
 Issue body の `github_check "gh pr checks" "Run bats tests"` は PR ルート用。Size=S のパッチルートでは PR が存在しないため、`github_check "gh run list --workflow=test.yml --limit=1 --json conclusion --jq '.[0].conclusion'"` に変換した（ワークフローファイルが複数あるため `--workflow=test.yml` を付与）。
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+記録なし。スクリプト・テスト・docs/tech.md のすべての変更が Spec 通りに実装されていた。
+
+### 繰り返し発生する問題
+
+英語版ドキュメントを更新した際に日本語版（`docs/ja/`）の同期が漏れるパターンが発生した（docs/ja/tech.md の見出し昇格と SSoT note 更新が未反映）。今後は英語版を変更する際に `docs/ja/` の対応ファイルを必ずチェックリストに含めるべき。
+
+### 受け入れ基準の検証難易度
+
+記録なし（UNCERTAIN ゼロ、verify コマンドはすべて正確）。ただし過去 Issue（#195）の Spec で verify 条件のターゲット文字列が安定しない値（`claude-sonnet-4-6`）に依存していたため、エイリアス移行後に条件が無効化されていた。今後 verify 条件記述時は、参照先文字列が将来変更される可能性があるか（定数か変数か）を意識する。

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -65,25 +65,27 @@ English | [日本語](ja/tech.md)
   - **Axis 2 — Adaptive Thinking** (`--effort`): `claude -p` supports `low/medium/high/max` levels (confirmed via `claude --help`). Implemented in `run-*.sh` with phase-specific effort levels (see matrix below). Combining medium effort with an Opus advisor achieves quality comparable to default-effort Sonnet at lower cost (per Anthropic benchmarks).
   - **Axis 3 — Advisor strategy** (`advisor_20260301`): Anthropic API beta feature (`advisor-tool-2026-03-01` header required). Enabled via the `--betas` flag — API key users only; not available with OAuth/subscription auth (the `run-*.sh` default). Performance gains: Sonnet + Opus advisor achieves SWE-bench +2.7 pp and cost −11.9% vs. Sonnet alone; Haiku + Opus advisor achieves BrowseComp 41.2% (vs. 19.7% solo) and cost −85% vs. Sonnet. Implementation in `run-*.sh` is a follow-up Issue.
 
-  **Phase-specific model and effort matrix** (`ssot_for: model-effort-matrix`):
+### Phase-specific model and effort matrix
 
-  | Component | Phase | Model | Effort | Rationale |
-  |-----------|-------|-------|--------|-----------|
-  | run-spec.sh | spec | Sonnet (Opus via `--opus` for L) | max | Design quality is critical; spec errors propagate to all subsequent phases. `/auto` passes `--opus` for L-size only (XL is split before spec) |
-  | run-code.sh | code | Sonnet | high | Implementation requires thorough reasoning |
-  | run-review.sh | review | Sonnet | high | Review orchestration; sub-agents handle deep analysis |
-  | run-issue.sh | issue | Sonnet | high | L/XL scope analysis and sub-issue splitting require thorough orchestration |
-  | run-verify.sh | verify | Sonnet | medium | Structured acceptance testing; moderate complexity |
-  | run-merge.sh | merge | Sonnet | low | Mechanical merge operation; minimal reasoning needed |
-  | review-bug | review | Opus | — | Bug detection requires highest accuracy (sub-agent, effort inherited from parent) |
-  | review-spec | review | Opus | — | Spec deviation requires high accuracy (sub-agent, effort inherited from parent) |
-  | review-light | review | Sonnet | — | Lightweight integrated review (sub-agent, effort inherited from parent) |
-  | issue-scope | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Scope identification accuracy is critical for sub-issue boundary decisions |
-  | issue-risk | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Risk assessment accuracy improves acceptance criteria quality |
-  | issue-precedent | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Precedent extraction improves acceptance criteria quality |
-  | triage (skill) | triage | Sonnet | — | Metadata assignment; Sonnet sufficient. Invoked inline (no `run-*.sh` wrapper) — including when `/auto` chains triage for unlabeled issues — so effort is not set |
+(`ssot_for: model-effort-matrix`)
 
-  SSoT note: This matrix is the single source of truth for all model and effort settings. When changing model/effort in run-*.sh, agents, or skills, update this table first.
+| Component | Phase | Model | Effort | Rationale |
+|-----------|-------|-------|--------|-----------|
+| run-spec.sh | spec | Sonnet (Opus via `--opus` for L) | max | Design quality is critical; spec errors propagate to all subsequent phases. `/auto` passes `--opus` for L-size only (XL is split before spec) |
+| run-code.sh | code | Sonnet | high | Implementation requires thorough reasoning |
+| run-review.sh | review | Sonnet | high | Review orchestration; sub-agents handle deep analysis |
+| run-issue.sh | issue | Sonnet | high | L/XL scope analysis and sub-issue splitting require thorough orchestration |
+| run-verify.sh | verify | Sonnet | medium | Structured acceptance testing; moderate complexity |
+| run-merge.sh | merge | Sonnet | low | Mechanical merge operation; minimal reasoning needed |
+| review-bug | review | Opus | — | Bug detection requires highest accuracy (sub-agent, effort inherited from parent) |
+| review-spec | review | Opus | — | Spec deviation requires high accuracy (sub-agent, effort inherited from parent) |
+| review-light | review | Sonnet | — | Lightweight integrated review (sub-agent, effort inherited from parent) |
+| issue-scope | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Scope identification accuracy is critical for sub-issue boundary decisions |
+| issue-risk | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Risk assessment accuracy improves acceptance criteria quality |
+| issue-precedent | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Precedent extraction improves acceptance criteria quality |
+| triage (skill) | triage | Sonnet | — | Metadata assignment; Sonnet sufficient. Invoked inline (no `run-*.sh` wrapper) — including when `/auto` chains triage for unlabeled issues — so effort is not set |
+
+SSoT note: Model values in run-*.sh use CLI aliases (sonnet/opus); update this table when changing model/effort in run-*.sh, agents, or skills.
 
 ## Wholework Label Management
 

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -133,9 +133,9 @@ fi
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
 set +e
-ANTHROPIC_MODEL=claude-sonnet-4-6 \
+ANTHROPIC_MODEL=sonnet \
   env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
-    --model claude-sonnet-4-6 \
+    --model sonnet \
     --effort high \
     --dangerously-skip-permissions
 EXIT_CODE=$?

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -57,9 +57,9 @@ ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
 set +e
-ANTHROPIC_MODEL=claude-sonnet-4-6 \
+ANTHROPIC_MODEL=sonnet \
   env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
-    --model claude-sonnet-4-6 \
+    --model sonnet \
     --effort high \
     --dangerously-skip-permissions
 EXIT_CODE=$?

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -49,9 +49,9 @@ ARGUMENTS: ${PR_NUMBER} --non-interactive"
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
 set +e
-ANTHROPIC_MODEL=claude-sonnet-4-6 \
+ANTHROPIC_MODEL=sonnet \
   env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
-    --model claude-sonnet-4-6 \
+    --model sonnet \
     --effort low \
     --dangerously-skip-permissions
 EXIT_CODE=$?

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -58,9 +58,9 @@ ARGUMENTS: ${ARGUMENTS}"
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
 set +e
-ANTHROPIC_MODEL=claude-sonnet-4-6 \
+ANTHROPIC_MODEL=sonnet \
   env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
-    --model claude-sonnet-4-6 \
+    --model sonnet \
     --effort high \
     --dangerously-skip-permissions
 EXIT_CODE=$?

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -7,11 +7,12 @@ ISSUE_NUMBER="${1:?Usage: run-spec.sh <issue-number> [--opus]}"
 shift
 
 # Parse options
-MODEL="claude-sonnet-4-6"
+# Default: --model sonnet (override: --model opus with --opus flag)
+MODEL="sonnet"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --opus)
-      MODEL="claude-opus-4-7"
+      MODEL="opus"
       shift
       ;;
     *)

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -86,9 +86,9 @@ fi
 # See: https://github.com/anthropics/claude-code/issues/22362
 VERIFY_TMPOUT=$(mktemp)
 set +e
-ANTHROPIC_MODEL=claude-sonnet-4-6 \
+ANTHROPIC_MODEL=sonnet \
   env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
-    --model claude-sonnet-4-6 \
+    --model sonnet \
     --effort medium \
     --dangerously-skip-permissions 2>&1 | tee "$VERIFY_TMPOUT"
 EXIT_CODE=$?

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -93,7 +93,7 @@ teardown() {
     grep -q "ARGUMENTS: 123 --non-interactive" "$CLAUDE_CALL_LOG"
 
     # Verify ANTHROPIC_MODEL environment variable was set
-    grep -q "ANTHROPIC_MODEL=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: --patch option calls claude with --patch --non-interactive" {

--- a/tests/run-issue.bats
+++ b/tests/run-issue.bats
@@ -101,7 +101,7 @@ teardown() {
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
 
-    grep -q "ANTHROPIC_MODEL=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: CLAUDECODE env var is not inherited by claude subprocess" {

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -92,7 +92,7 @@ teardown() {
     grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
 
     # Verify ANTHROPIC_MODEL environment variable was set
-    grep -q "ANTHROPIC_MODEL=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: ARGUMENTS contains --non-interactive flag" {

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -92,7 +92,7 @@ teardown() {
     grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
 
     # Verify ANTHROPIC_MODEL environment variable was set
-    grep -q "ANTHROPIC_MODEL=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: ARGUMENTS contains --non-interactive flag" {

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -124,11 +124,11 @@ teardown() {
     [[ "$output" == *"Error: Invalid option: --unknown"* ]]
 }
 
-@test "success: default model is claude-sonnet-4-6" {
+@test "success: default model is sonnet" {
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
-    grep -q "MODEL_VALUE=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
-    grep -q "ANTHROPIC_MODEL=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "MODEL_VALUE=sonnet" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: default effort is max" {
@@ -143,11 +143,11 @@ teardown() {
     grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
 }
 
-@test "success: --opus switches model to claude-opus-4-7" {
+@test "success: --opus switches model to opus" {
     run bash "$SCRIPT" 123 --opus
     [ "$status" -eq 0 ]
-    grep -q "MODEL_VALUE=claude-opus-4-7" "$CLAUDE_CALL_LOG"
-    grep -q "ANTHROPIC_MODEL=claude-opus-4-7" "$CLAUDE_CALL_LOG"
+    grep -q "MODEL_VALUE=opus" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=opus" "$CLAUDE_CALL_LOG"
 }
 
 @test "error: SKILL.md not found when file is absent" {

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -78,13 +78,13 @@ teardown() {
     # Verify claude was called with correct arguments
     # Direct SKILL.md body mode: prompt contains ARGUMENTS: 123
     grep -q "ARGUMENTS: 123" "$CLAUDE_CALL_LOG"
-    grep -q -- "--model claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q -- "--model sonnet" "$CLAUDE_CALL_LOG"
     grep -q -- "--dangerously-skip-permissions" "$CLAUDE_CALL_LOG"
     # Should use direct prompt, not skill invocation (/verify 123)
     ! grep -q -- "-p /verify 123" "$CLAUDE_CALL_LOG"
 
     # Verify ANTHROPIC_MODEL environment variable was set
-    grep -q "ANTHROPIC_MODEL=claude-sonnet-4-6" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: output shows start and finish messages" {


### PR DESCRIPTION
## Summary

- `run-spec.sh`: `MODEL="claude-sonnet-4-6"` / `MODEL="claude-opus-4-7"` を `MODEL="sonnet"` / `MODEL="opus"` に変更し、verify コマンド向けのリテラルコメントを追加
- `run-code.sh`, `run-review.sh`, `run-issue.sh`, `run-verify.sh`, `run-merge.sh`: `ANTHROPIC_MODEL=claude-sonnet-4-6` / `--model claude-sonnet-4-6` を `ANTHROPIC_MODEL=sonnet` / `--model sonnet` に変更（計 10 文字列）
- `tests/run-*.bats` (6 ファイル): model assertion を alias 形式に更新（計 8 箇所）
- `docs/tech.md`: `**Phase-specific model and effort matrix**` 見出しを `###` 形式に変更し、SSoT note に alias 採用方針を追記

## Verification (pre-merge)

- `run-spec.sh` から `claude-sonnet-4-6` / `claude-opus-*` 直書きが除去されている
- `run-code.sh`, `run-review.sh`, `run-issue.sh`, `run-verify.sh`, `run-merge.sh` から `claude-sonnet-4-6` 直書きが除去されている
- `run-spec.sh` が `--model sonnet` / `--model opus` alias を使用
- matrix に alias 採用方針が記載されている（`section_contains` PASS）
- bats テスト 70 件がすべてパス（ローカル確認済み）

## Verification (post-merge)

- 参照 Issue で `/auto N` を実行し、CLI ログで alias 表示（`Model: sonnet` / `Model: opus`）を確認

closes #227