### PR TITLE
Issue #281: Add shallow bats tests for core modules

### DIFF
--- a/docs/spec/issue-281-core-module-shallow-tests.md
+++ b/docs/spec/issue-281-core-module-shallow-tests.md
@@ -50,6 +50,17 @@
 - **`command` hint の UNCERTAIN 扱い**: AC 5 の `command "bats ..."` は safe モード(`/review`)で UNCERTAIN を返すが、CI 反映(AC 6 の `github_check`)で担保される
 - **Issue との整合**: Issue 本文の AC 7 項目と本 Spec Verification > Pre-merge の 7 項目は 1:1 対応
 
+## Code Retrospective
+
+### Deviations from Design
+- N/A（設計通り実装）
+
+### Design Gaps/Ambiguities
+- `domain-loader.bats` の discovery 契約テストで `-i` フラグを追加（`grep -qiE`）。"Glob" は大文字、"Discover" は大文字、"load" は小文字と混在するため、case-insensitive にした方が将来変更に頑健と判断。Spec では `grep -qiE "Glob|Discover|load"` という形は明示されていなかったが意図に合致。
+
+### Rework
+- N/A
+
 ## Verify Retrospective
 
 ### Phase-by-Phase Review

--- a/docs/spec/issue-281-core-module-shallow-tests.md
+++ b/docs/spec/issue-281-core-module-shallow-tests.md
@@ -61,6 +61,20 @@
 ### Rework
 - N/A
 
+## Review Retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note. 実装はSpec の4モジュール・7 AC と完全一致。granular test function 化（Specの「3カテゴリ」を6テストに展開）はSprit内での詳細化であり逸脱ではない。
+
+### Recurring issues
+
+Nothing to note. MUST/SHOULD/CONSIDER ゼロ件。指摘パターンの蓄積なし。
+
+### Acceptance criteria verification difficulty
+
+`command "bats ..."` は safe モードで UNCERTAIN になるが、CI fallback（`github_check "gh pr checks" "Run bats tests"`）が隣接条件として用意されており、AC 5 は CI SUCCESS で代替 PASS となった。この2条件の組み合わせ設計（ローカル確認用 + CI確認用）は適切で、UNCERTAIN 残存は発生しなかった。
+
 ## Verify Retrospective
 
 ### Phase-by-Phase Review

--- a/tests/adapter-resolver.bats
+++ b/tests/adapter-resolver.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+# Shallow tests for adapter-resolver module documentation.
+# LLM responses are not mocked; tests confirm that required sections and
+# contract terms are present in modules/adapter-resolver.md.
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+ADAPTER_RESOLVER="$PROJECT_ROOT/modules/adapter-resolver.md"
+
+@test "adapter-resolver: ## Purpose section exists" {
+    grep -q "## Purpose" "$ADAPTER_RESOLVER"
+}
+
+@test "adapter-resolver: ## Input section exists" {
+    grep -q "## Input" "$ADAPTER_RESOLVER"
+}
+
+@test "adapter-resolver: ## Processing Steps section exists" {
+    grep -q "## Processing Steps" "$ADAPTER_RESOLVER"
+}
+
+@test "adapter-resolver: ## Output section exists" {
+    grep -q "## Output" "$ADAPTER_RESOLVER"
+}
+
+@test "adapter-resolver: capability contract term is documented" {
+    grep -q "capability" "$ADAPTER_RESOLVER"
+}
+
+@test "adapter-resolver: 3-layer or resolution order contract term is documented" {
+    grep -qE "3-layer|resolution order" "$ADAPTER_RESOLVER"
+}

--- a/tests/doc-checker.bats
+++ b/tests/doc-checker.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+# Shallow tests for doc-checker module documentation.
+# LLM responses are not mocked; tests confirm that document references and
+# contract terms are present in modules/doc-checker.md.
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+DOC_CHECKER="$PROJECT_ROOT/modules/doc-checker.md"
+
+@test "doc-checker: README.md, CLAUDE.md, and workflow.md are referenced" {
+    grep -q "README.md" "$DOC_CHECKER"
+    grep -q "CLAUDE.md" "$DOC_CHECKER"
+    grep -q "workflow.md" "$DOC_CHECKER"
+}
+
+@test "doc-checker: missed updates contract term is documented" {
+    grep -q "missed updates" "$DOC_CHECKER"
+}
+
+@test "doc-checker: command example contract term is documented" {
+    grep -q "command example" "$DOC_CHECKER"
+}

--- a/tests/domain-loader.bats
+++ b/tests/domain-loader.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+# Shallow tests for domain-loader module documentation.
+# LLM responses are not mocked; tests confirm that discovery/loading contract
+# terms are present in modules/domain-loader.md.
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+DOMAIN_LOADER="$PROJECT_ROOT/modules/domain-loader.md"
+
+@test "domain-loader: .wholework/domains/ path is documented" {
+    grep -q "\.wholework/domains/" "$DOMAIN_LOADER"
+}
+
+@test "domain-loader: Markdown file type is documented" {
+    grep -q "Markdown" "$DOMAIN_LOADER"
+}
+
+@test "domain-loader: discovery contract term is documented (Glob, Discover, or load)" {
+    grep -qiE "Glob|Discover|load" "$DOMAIN_LOADER"
+}

--- a/tests/size-workflow-table.bats
+++ b/tests/size-workflow-table.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+# Shallow tests for size-workflow-table module documentation.
+# LLM responses are not mocked; tests confirm that Size judgment criteria
+# and workflow route terms are present in modules/size-workflow-table.md.
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SIZE_WORKFLOW_TABLE="$PROJECT_ROOT/modules/size-workflow-table.md"
+
+@test "size-workflow-table: 2 axes term is documented" {
+    grep -q "2 axes" "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: XS table row exists" {
+    grep -qE "^\| XS" "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: S table row exists (distinct from XS)" {
+    grep -qE "^\| S " "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: M table row exists" {
+    grep -qE "^\| M " "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: L table row exists (distinct from XL)" {
+    grep -qE "^\| L " "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: XL table row exists" {
+    grep -qE "^\| XL" "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: patch workflow route is documented" {
+    grep -q "patch" "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: pr workflow route is documented" {
+    grep -q "pr" "$SIZE_WORKFLOW_TABLE"
+}


### PR DESCRIPTION
## Summary

4つの core module（adapter-resolver / size-workflow-table / domain-loader / doc-checker）に対して、`tests/verify-rubric.bats` (#271) / `tests/review-rubric-safe.bats` (#275) と同じ shallow grep 方針の bats テストを追加。

- `tests/adapter-resolver.bats`: 4 section 存在 + "capability" / "3-layer" 文言（6テスト）
- `tests/size-workflow-table.bats`: "2 axes" + XS/S/M/L/XL 5行 + patch/pr route 文言（8テスト）
- `tests/domain-loader.bats`: `.wholework/domains/` path + Markdown + Glob 文言（3テスト）
- `tests/doc-checker.bats`: README.md/CLAUDE.md/workflow.md 参照 + "missed updates" + "command example" 文言（3テスト）

LLM 応答は mock せず、文書存在・section 構造・契約文言の存在のみを grep で shallow 確認。

## Verification (pre-merge)

- `tests/adapter-resolver.bats` 新規作成済み
- `tests/size-workflow-table.bats` 新規作成済み
- `tests/domain-loader.bats` 新規作成済み
- `tests/doc-checker.bats` 新規作成済み
- ローカル bats 実行: 20/20 PASS
- CI: `Run bats tests` ジョブで確認予定
- shallow test 方針（LLM mock 禁止）維持確認済み

## Verification (post-merge)

- (なし)

closes #281