### PR TITLE
Issue #289: Fix verify CLOSED path to always transition to phase/done

### DIFF
--- a/docs/ja/workflow.md
+++ b/docs/ja/workflow.md
@@ -159,7 +159,7 @@ bash scripts/check-translation-sync.sh
 | `phase/code` | 実装フェーズ | `/code` | `/review` |
 | `phase/review` | レビューフェーズ | `/review` | `/merge` |
 | `phase/verify` | 受入テストフェーズ | `/merge` | `/verify` |
-| `phase/done` | 完了 | `/verify`（マージ後条件なしの場合） | — |
+| `phase/done` | 完了 | `/verify`（全 auto-verify PASS/SKIPPED 時） | — |
 | （ラベルなし） | バックログ / 未着手 | — | `/verify`（FAIL 時） |
 
 ### XL 親 Issue のフェーズ管理
@@ -185,7 +185,7 @@ PR 本文に `closes #N` を追加すると、マージ時に Issue が自動ク
 /merge: マージ → Issue 自動クローズ
   ↓
 /verify: クローズ済み Issue を検証
-  - PASS → 完了（phase/verify ラベルを除去）
+  - 全 auto-verify PASS/SKIPPED → phase/done（opportunistic/manual 条件は完了をブロックしない）
   - FAIL → gh issue reopen + 全 phase/* 除去 → fix サイクルへ戻る
 ```
 

--- a/docs/spec/issue-289-fix-phase-done-transition.md
+++ b/docs/spec/issue-289-fix-phase-done-transition.md
@@ -69,3 +69,17 @@
 - **既存 60 件のバックフィルは対象外**: Issue の Non-Goals に明記済み
 - **bats テストが LLM 経路を直接検証できない制約**: `/verify` SKILL.md の判定ロジックは LLM 解釈のため bats で直接再現できない。代わりに (a) pre-merge の `rubric` verify command で SKILL.md への修正反映を意味レベルで検証、(b) bats 回帰テストで下位 script (`gh-label-transition.sh`) の `phase/verify` 除去が不変であることを保証
 - **参考先行例**: #39 (patch route の phase/done ラベル遷移), #132 (gh-label-transition: target ラベル消失バグ)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- なし。実装ステップ 1〜4 をすべて Spec 通りに実施した。
+
+### Design Gaps/Ambiguities
+
+- Spec の Changed Files には `docs/workflow.md` の L168-169 「必要であれば明確化」と記載されていたが、実際に読んでみると phase/done の Assigned by 列「/verify (no post-merge conditions)」が旧挙動を示していたため、明確化ではなく修正（「/verify (on all auto-verify PASS/SKIPPED)」）が必要だった。
+
+### Rework
+
+- なし。

--- a/docs/spec/issue-289-fix-phase-done-transition.md
+++ b/docs/spec/issue-289-fix-phase-done-transition.md
@@ -83,3 +83,17 @@
 ### Rework
 
 - なし。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+特記なし。Spec の実装ステップ 1〜4 が PR diff と完全に対応しており、構造的な乖離は検出されなかった。
+
+### Recurring issues
+
+特記なし。4つの観点（Spec乖離・バグ/ロジック・steering document整合性・ドキュメント整合性）すべてで問題は検出されなかった。同種の問題の繰り返しはなし。
+
+### Acceptance criteria verification difficulty
+
+特記なし。`rubric` verify command は Spec 記載内容と diff を照合して問題なく判定できた。`github_check` は CI ステータス直接確認で明確に PASS。UNCERTAIN 判定はゼロ。verify command の精度は良好。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -166,7 +166,7 @@ Setup: Wholework automatically creates the labels it needs on first run. Manual 
 | `phase/code` | Implementation phase | `/code` | `/review` |
 | `phase/review` | Review phase | `/review` | `/merge` |
 | `phase/verify` | Acceptance test phase | `/merge` | `/verify` |
-| `phase/done` | Complete | `/verify` (no post-merge conditions) | — |
+| `phase/done` | Complete | `/verify` (on all auto-verify PASS/SKIPPED) | — |
 | (no label) | Backlog / not started | — | `/verify` (on FAIL) |
 
 ### XL Parent Issue Phase Management
@@ -192,7 +192,7 @@ Adding `closes #N` to PR body auto-closes the Issue on merge (GitHub standard fe
 /merge: Merge → Issue auto-closes
   ↓
 /verify: Verify closed Issue
-  - PASS → Complete (remove phase/verify label)
+  - All auto-verify PASS/SKIPPED → phase/done (opportunistic/manual conditions don't block)
   - FAIL → gh issue reopen + remove all phase/* → return to fix cycle
 ```
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -346,12 +346,7 @@ Branch on Issue state:
 Judgment:
 
 - **All auto-verification target conditions are PASS or SKIPPED (0 FAIL/UNCERTAIN among auto-verification targets; SKIPPED is ignored as environment conditions were unmet)**:
-  - Check if any unchecked (`- [ ]`) `<!-- verify-type: opportunistic -->` or `<!-- verify-type: manual -->` conditions remain in the post-merge section of the Issue body
-  - **If unchecked opportunistic or manual conditions remain**: assign `phase/verify` label and remove all other `phase/*` labels:
-    ```bash
-    ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" verify
-    ```
-  - **If no unchecked opportunistic or manual conditions remain**: remove all `phase/*` labels and assign `phase/done` (also handles cases where `phase/code` persists in patch route):
+  - Remove all `phase/*` labels and assign `phase/done` (also handles cases where `phase/code` persists in patch route). Opportunistic conditions are checked post-hoc by `modules/opportunistic-verify.md`; manual conditions are informational only and do not block completion:
     ```bash
     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" done
     ```

--- a/tests/gh-label-transition.bats
+++ b/tests/gh-label-transition.bats
@@ -85,6 +85,13 @@ teardown() {
     grep -q "\-\-remove-label phase/issue" "$GH_CALL_LOG"
 }
 
+@test "regression (#289): transition to done removes phase/verify" {
+    run bash "$SCRIPT" 289 done
+    [ "$status" -eq 0 ]
+    grep -q "\-\-add-label phase/done" "$GH_CALL_LOG"
+    grep -q "\-\-remove-label phase/verify" "$GH_CALL_LOG"
+}
+
 @test "success: remove all phase labels without adding (no target-phase)" {
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- `skills/verify/SKILL.md` の CLOSED 経路判定を修正: 全 auto-verification target が PASS/SKIPPED の場合に opportunistic/manual 未チェック条件の有無に関わらず常に `phase/done` へ遷移するよう単純化
- `docs/workflow.md` / `docs/ja/workflow.md` を新挙動に同期
- `tests/gh-label-transition.bats` に regression test を追加: `done` 遷移時に `phase/verify` が明示的に除去されることを確認

## Verification (pre-merge)

- [x] CLOSED 経路の root cause（SKILL.md の opportunistic/manual 条件分岐）が特定され、`skills/verify/SKILL.md` に phase/done 遷移を確実化する修正が反映されている（rubric PASS）
- [ ] CI の bats ジョブが PASS（`gh pr checks` で確認）

## Verification (post-merge)

- 本 Issue マージ後 1 週間以内に新規 CLOSED された Issue について、`/audit stats` を実行して `phase/done` 到達率が 95% 以上に改善していることを確認

closes #289