### PR TITLE
Issue #304: Restore post-merge gate in verify CLOSED path

### DIFF
--- a/docs/ja/workflow.md
+++ b/docs/ja/workflow.md
@@ -159,7 +159,7 @@ bash scripts/check-translation-sync.sh
 | `phase/code` | 実装フェーズ | `/code` | `/review` |
 | `phase/review` | レビューフェーズ | `/review` | `/merge` |
 | `phase/verify` | 受入テストフェーズ | `/merge` | `/verify` |
-| `phase/done` | 完了 | `/verify`（全 auto-verify PASS/SKIPPED 時） | — |
+| `phase/done` | 完了 | `/verify`（全 auto-verify PASS + 全 post-merge 条件 checked 時） | — |
 | （ラベルなし） | バックログ / 未着手 | — | `/verify`（FAIL 時） |
 
 ### XL 親 Issue のフェーズ管理
@@ -185,7 +185,8 @@ PR 本文に `closes #N` を追加すると、マージ時に Issue が自動ク
 /merge: マージ → Issue 自動クローズ
   ↓
 /verify: クローズ済み Issue を検証
-  - 全 auto-verify PASS/SKIPPED → phase/done（opportunistic/manual 条件は完了をブロックしない）
+  - 全 auto-verify PASS + 全 post-merge 条件 checked → phase/done
+  - 全 auto-verify PASS + opportunistic/manual 未チェックあり → phase/verify（Issue は CLOSED のまま）
   - FAIL → gh issue reopen + 全 phase/* 除去 → fix サイクルへ戻る
 ```
 

--- a/docs/spec/issue-304-restore-closed-path-post-merge-gate.md
+++ b/docs/spec/issue-304-restore-closed-path-post-merge-gate.md
@@ -73,6 +73,20 @@
 
 - なし。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+なし。CLOSED 経路への OPEN 経路同型ロジックの移植は Spec 記載の実装ステップと完全に一致しており、構造的な乖離は見られなかった。
+
+### Recurring issues
+
+なし。単一の CLOSED/OPEN 経路不整合を修正する明確なスコープで、同種の指摘が重複する箇所はなかった。
+
+### Acceptance criteria verification difficulty
+
+なし。`rubric` verify がセマンティックな検証を担い、`github_check` が CI 状態を確認する 2 段構えにより、3 条件すべてが PASS と判定できた。UNCERTAIN 発生もなく、verify コマンドの精度は適切だった。
+
 ## Notes
 
 - **bats テストが LLM 経路を直接検証できない制約**: SKILL.md の CLOSED/OPEN 経路判定は LLM 解釈のため bats で直接再現できない。代わりに (a) pre-merge の `rubric` verify で SKILL.md 修正の意味的検証、(b) bats 回帰テストで下位 script (`gh-label-transition.sh`) の `--remove-label phase/done` 挙動を保証する二段構え。#289 Spec Notes の設計方針を踏襲

--- a/docs/spec/issue-304-restore-closed-path-post-merge-gate.md
+++ b/docs/spec/issue-304-restore-closed-path-post-merge-gate.md
@@ -58,6 +58,21 @@
 
 - 本 Issue マージ後 1 週間以内に、新規 CLOSED され Post-merge に未チェックの opportunistic/manual 条件が残る Issue が `phase/verify` に留まることを 1 件以上実例で確認
 
+## Code Retrospective
+
+### Deviations from Design
+
+- なし。Spec の実装ステップを順序通りに実行した。
+
+### Design Gaps/Ambiguities
+
+- CLOSED 経路の「Even if post-merge conditions without hints are unchecked, do not reopen the Issue」の注記を (a-2) 全 checked ブロック内に配置した。Spec は「(a-2) 内に残置」と記載しており整合している。
+- Step 10 の verify コマンド整合性チェックで `github_check "gh pr checks"` が PR 未作成のため UNCERTAIN となったが、これは pr route では通常の挙動（PR 作成後に CI が実行される）。
+
+### Rework
+
+- なし。
+
 ## Notes
 
 - **bats テストが LLM 経路を直接検証できない制約**: SKILL.md の CLOSED/OPEN 経路判定は LLM 解釈のため bats で直接再現できない。代わりに (a) pre-merge の `rubric` verify で SKILL.md 修正の意味的検証、(b) bats 回帰テストで下位 script (`gh-label-transition.sh`) の `--remove-label phase/done` 挙動を保証する二段構え。#289 Spec Notes の設計方針を踏襲

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -166,7 +166,7 @@ Setup: Wholework automatically creates the labels it needs on first run. Manual 
 | `phase/code` | Implementation phase | `/code` | `/review` |
 | `phase/review` | Review phase | `/review` | `/merge` |
 | `phase/verify` | Acceptance test phase | `/merge` | `/verify` |
-| `phase/done` | Complete | `/verify` (on all auto-verify PASS/SKIPPED) | — |
+| `phase/done` | Complete | `/verify` (on all auto-verify PASS + all post-merge conditions checked) | — |
 | (no label) | Backlog / not started | — | `/verify` (on FAIL) |
 
 ### XL Parent Issue Phase Management
@@ -192,7 +192,8 @@ Adding `closes #N` to PR body auto-closes the Issue on merge (GitHub standard fe
 /merge: Merge → Issue auto-closes
   ↓
 /verify: Verify closed Issue
-  - All auto-verify PASS/SKIPPED → phase/done (opportunistic/manual conditions don't block)
+  - All auto-verify PASS + all post-merge conditions checked → phase/done
+  - All auto-verify PASS + opportunistic/manual unchecked → phase/verify (Issue stays CLOSED)
   - FAIL → gh issue reopen + remove all phase/* → return to fix cycle
 ```
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -346,11 +346,16 @@ Branch on Issue state:
 Judgment:
 
 - **All auto-verification target conditions are PASS or SKIPPED (0 FAIL/UNCERTAIN among auto-verification targets; SKIPPED is ignored as environment conditions were unmet)**:
-  - Remove all `phase/*` labels and assign `phase/done` (also handles cases where `phase/code` persists in patch route). Opportunistic conditions are checked post-hoc by `modules/opportunistic-verify.md`; manual conditions are informational only and do not block completion:
+  - Check if any unchecked (`- [ ]`) `<!-- verify-type: opportunistic -->` or `<!-- verify-type: manual -->` conditions remain in the post-merge section of the Issue body
+  - **If unchecked opportunistic or manual conditions remain**: assign `phase/verify` (Issue remains CLOSED; do not reopen):
+    ```bash
+    ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" verify
+    ```
+    Inform the user: "Manually check the remaining opportunistic/manual conditions, then re-run `/verify $NUMBER` to complete."
+  - **If all conditions are checked**: assign `phase/done`. Confirm the Issue is closed. If not closed, close with `gh issue close "$NUMBER"` (handles cases like XL parent Issues not auto-closed by PR's `closes #N`):
     ```bash
     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" done
     ```
-  - Confirm the Issue is closed. If not closed, close with `gh issue close "$NUMBER"` (handles cases like XL parent Issues not auto-closed by PR's `closes #N`)
   - **Even if post-merge conditions without hints are unchecked, do not reopen the Issue** (present user verification guide only)
 - **Auto-verification targets include FAIL**:
   - Check iteration counter before reopening:

--- a/tests/gh-label-transition.bats
+++ b/tests/gh-label-transition.bats
@@ -92,6 +92,13 @@ teardown() {
     grep -q "\-\-remove-label phase/verify" "$GH_CALL_LOG"
 }
 
+@test "regression (#304): transition to verify removes phase/done" {
+    run bash "$SCRIPT" 304 verify
+    [ "$status" -eq 0 ]
+    grep -q "\-\-add-label phase/verify" "$GH_CALL_LOG"
+    grep -q "\-\-remove-label phase/done" "$GH_CALL_LOG"
+}
+
 @test "success: remove all phase labels without adding (no target-phase)" {
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

`skills/verify/SKILL.md` の CLOSED 経路（`When Issue is CLOSED`）で、auto-verification 全 PASS の場合でも Post-merge に未チェックの opportunistic/manual 条件が残ると `phase/done` に遷移してしまう回帰を修正。OPEN 経路と同型の条件分岐を移植し、「未チェック opportunistic/manual が残れば `phase/verify` 維持、全 checked で `phase/done`」に統一した。

- `skills/verify/SKILL.md`: CLOSED 経路に OPEN 経路と同型の Post-merge 未チェック判定を追加
- `tests/gh-label-transition.bats`: `regression (#304)` 回帰テストを追加
- `docs/workflow.md`, `docs/ja/workflow.md`: `phase/done` 付与条件の記述を新挙動に同期

## Verification (pre-merge)

- CLOSED 経路の判定が「全 auto-verification PASS + 全 Post-merge 条件 checked → `phase/done`」「Post-merge 条件に unchecked あり → `phase/verify` 維持」に修正され、OPEN 経路と整合している
- CLOSED + 未チェック opportunistic/manual → `phase/verify` 維持を検証する bats 回帰テストが追加されている
- CI の `Run bats tests` ジョブが PASS

## Verification (post-merge)

- 本 Issue マージ後 1 週間以内に、新規 CLOSED され Post-merge に未チェックの opportunistic/manual 条件が残る Issue が `phase/verify` に留まることを 1 件以上実例で確認

closes #304