### PR TITLE
Issue #310: Unify code worktree naming to code/issue-N SSoT

### DIFF
--- a/docs/spec/issue-310-worktree-naming-ssot.md
+++ b/docs/spec/issue-310-worktree-naming-ssot.md
@@ -54,3 +54,17 @@
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Spec と実装の乖離なし。`tests/watchdog-reconcile.bats` のコメント更新（実行パス非影響）は Code Retrospective で既に記録済み。
+
+### Recurring Issues
+
+- 特記事項なし。
+
+### Acceptance Criteria Verification Difficulty
+
+- 4条件すべて自動検証可能。`github_check` 条件は CI SUCCESS により PASS。UNCERTAIN ゼロ、verify コマンドの精度は高い。

--- a/docs/spec/issue-310-worktree-naming-ssot.md
+++ b/docs/spec/issue-310-worktree-naming-ssot.md
@@ -40,3 +40,17 @@
 - **`gh pr list --head` 挙動**: 現行コード `--head "code+issue-${ISSUE_NUMBER}"` は実ブランチ名 `worktree-code+issue-${ISSUE_NUMBER}` と prefix 不一致により無マッチが懸念される。Step 3 では実ブランチ名ベース（例: `--head "worktree-code+issue-${ISSUE_NUMBER}"`）に揃えることで、Stage 1 の PR 存在判定を実運用と整合させる。
 - **Auto-Resolve Log（Issue 側で確定済み）**: SSoT 配置先は `skills/code/SKILL.md` Step 2（AC rubric 「どちらか一方に SSoT が明記」と整合）。`_find_code_worktree` の 2段階探索は単一パターンに簡素化（workaround 除去、wholework の no-backwards-compat-shims 方針と整合）。
 - **"No change needed" pre-verification 結果**: `scripts/run-code.sh` / `tests/run-code.bats` / `tests/watchdog-reconcile.bats` の無変更判断は grep で実検証済み（Step 6 codebase investigation 時）。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `tests/watchdog-reconcile.bats` に変更なしの予定だったが、mock コメント（`# gh pr list --head "issue-N-*" ...`）が旧パターンを参照していたため、新 SSoT パターン（`worktree-code+issue-N`）に更新した。Spec の "変更なし（grep 検証済み）" は実行パスに影響するコードに限定した判断であり、コメント更新は追加スコープとして受容。
+
+### Design Gaps/Ambiguities
+
+- N/A
+
+### Rework
+
+- N/A

--- a/scripts/watchdog-reconcile.sh
+++ b/scripts/watchdog-reconcile.sh
@@ -10,7 +10,7 @@
 #   issue       triaged label exists on the issue
 #   spec        spec file exists under spec-path + phase/ready or later label
 #   code-patch  origin/main has a commit matching "closes #<issue_number>"
-#   code-pr     an open PR for issue-<issue_number>-* branch exists
+#   code-pr     an open PR for worktree-code+issue-<issue_number> branch exists
 #   review      PR has a comment containing "## Review Summary"
 #   merge       PR state is MERGED
 #   verify      issue is CLOSED or has phase/verify or phase/done label
@@ -99,36 +99,21 @@ _find_code_worktree() {
   repo_root=$(cd "$SCRIPT_DIR/.." && pwd)
   local worktree_base="$repo_root/.claude/worktrees"
 
-  # Primary: code+issue-N (run-code.sh managed)
   if [[ -d "$worktree_base/code+issue-${ISSUE_NUMBER}" ]]; then
     echo "$worktree_base/code+issue-${ISSUE_NUMBER}"
     return 0
   fi
 
-  # Fallback: issue-N-* (SKILL.md pr-route naming convention)
-  local dir
-  for dir in "$worktree_base/issue-${ISSUE_NUMBER}-"*; do
-    if [[ -d "$dir" ]]; then
-      echo "$dir"
-      return 0
-    fi
-  done
-
   return 1
 }
 
 _reconcile_code_pr() {
-  # Stage 1: open PR exists (check both naming patterns used by SKILL.md and run-code.sh)
+  # Stage 1: open PR exists for the SSoT branch name
   local pr_count
-  pr_count=$(gh pr list --head "issue-${ISSUE_NUMBER}-*" --state open --json number -q 'length' 2>/dev/null) || {
+  pr_count=$(gh pr list --head "worktree-code+issue-${ISSUE_NUMBER}" --state open --json number -q 'length' 2>/dev/null) || {
     echo "watchdog-reconcile: gh pr list failed for issue #$ISSUE_NUMBER" >&2
     exit 2
   }
-  if [[ "${pr_count:-0}" -eq 0 ]]; then
-    local pr_count2
-    pr_count2=$(gh pr list --head "code+issue-${ISSUE_NUMBER}" --state open --json number -q 'length' 2>/dev/null) || true
-    pr_count="${pr_count2:-0}"
-  fi
   if [[ "${pr_count:-0}" -gt 0 ]]; then
     return 0
   fi

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -99,8 +99,14 @@ Generate a short description from the title (e.g., "add-implement-skill").
 Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Entry section" to create a worktree.
 
 **Worktree naming convention (by route):**
-- **patch route**: `patch/issue-$NUMBER`
-- **pr route**: `issue-$NUMBER-<short-description>` (same as branch name)
+
+> **SSoT**: This section is the single source of truth for worktree naming in `/code`. All scripts and modules must derive their naming from this section.
+
+Both patch and pr routes use the same name: `code/issue-$NUMBER`
+
+EnterWorktree converts `/` to `+`, resulting in:
+- Worktree dir: `.claude/worktrees/code+issue-$NUMBER`
+- Branch: `worktree-code+issue-$NUMBER`
 
 Record the `ENTERED_WORKTREE` variable for use in subsequent steps.
 

--- a/tests/watchdog-reconcile.bats
+++ b/tests/watchdog-reconcile.bats
@@ -235,7 +235,7 @@ MOCK_EOF
 @test "code-pr: open PR exists -> exit 0" {
     cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
 #!/bin/bash
-# gh pr list --head "issue-N-*" --state open --json number -q 'length'
+# gh pr list --head "worktree-code+issue-N" --state open --json number -q 'length'
 echo "1"
 exit 0
 MOCK_EOF


### PR DESCRIPTION
## Summary

`skills/code/SKILL.md` / `scripts/watchdog-reconcile.sh` の worktree 命名規則を `code/issue-{N}` に統一し、SKILL.md Step 2 を命名規則の SSoT として確立する。

- `skills/code/SKILL.md` Step 2: patch/pr 両ルートの命名を `code/issue-$NUMBER` に統一、SSoT 宣言を追記
- `scripts/watchdog-reconcile.sh`: `_find_code_worktree` の2段階探索（`code+issue-{N}` primary + `issue-{N}-*` fallback）を単一パターンに簡素化、`_reconcile_code_pr` Stage 1 の `gh pr list --head` を実ブランチ名 `worktree-code+issue-{N}` に差し替え
- `tests/watchdog-reconcile.bats`: mock コメントを新 SSoT パターンに更新

## Verification (pre-merge)

- `skills/code/SKILL.md` Step 2 に `code/issue-{N}` 命名規則が SSoT として記載されている
- `skills/code/SKILL.md` から旧命名（`patch/issue-N`、`issue-N-<short-description>`）が除去されている
- `watchdog-reconcile.sh` の worktree/branch 探索ロジックが新 SSoT `code+issue-{N}` 単一パターンに簡素化され、Stage 1 も整合している
- 既存 bats テスト（`tests/watchdog-reconcile.bats`、`tests/run-code.bats` 含む）が通過している

## Verification (post-merge)

- `/auto {issue-number}` を pr route で実行し、worktree dir `.claude/worktrees/code+issue-{N}` とブランチ `worktree-code+issue-{N}` が作成され、/code → /review → /merge → /verify が正常完走することを手動確認

closes #310