### PR TITLE
Issue #325: Fix PR number filter to match #310 SSoT worktree-code+issue-N

### DIFF
--- a/docs/spec/issue-325-pr-filter-ssot-alignment.md
+++ b/docs/spec/issue-325-pr-filter-ssot-alignment.md
@@ -61,3 +61,17 @@
 - 旧命名 `worktree-issue-${N}-<short-description>` や `worktree-patch+issue-${N}` 等の旧形式への対応は追加しない（#310 の SSoT で廃止済み）
 - `tests/run-auto-sub.bats` setup() の default mock 変更は、tests 165 (Size M), 174 (Size L), 231 (--base flag) が PR 番号抽出を正しく完了するために必要
 - tests 253, 280 は `--patch` / no-route で guard が発動しないため mock 更新はテスト通過に不要だが、一貫性のため更新する
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `tests/run-auto-sub.bats` test 11 "phase/ready absent: run-spec.sh is called" も `echo "99"` を返す gh mock を持っており、JSON 形式への更新が必要だった。Spec では setup() default mock と `#311 regression` test のみ言及していたが、test 11 の独立 mock も同様に更新した。
+
+### Design Gaps/Ambiguities
+
+- Spec の「テスト強化」箇所に `tests/run-auto-sub.bats:238` と setup() のみ記載されていたが、同ファイル内のオーバーライド mock を持つ test 11 も影響を受けることが実装時に判明した。Spec に test 11 の mock 更新を追記しておくべきだった。
+
+### Rework
+
+- test 11 の mock 修正: 最初のテスト実行で test 11 が FAIL となり、1 回の修正（mock を JSON 形式に変更）で解決。

--- a/docs/spec/issue-325-pr-filter-ssot-alignment.md
+++ b/docs/spec/issue-325-pr-filter-ssot-alignment.md
@@ -75,3 +75,17 @@
 ### Rework
 
 - test 11 の mock 修正: 最初のテスト実行で test 11 が FAIL となり、1 回の修正（mock を JSON 形式に変更）で解決。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+特筆事項なし。実装は Spec の変更対象を全て網羅しており、逸脱（test 11 の mock 追加）は Code Retrospective セクションに正直に記録済み。Spec に test 11 のオーバーライド mock への言及がなかった点は `## Design Gaps/Ambiguities` で既に捕捉されている。
+
+### Recurring issues
+
+特筆事項なし。単発の issue であり、パターン的な繰り返しは見られない。
+
+### Acceptance criteria verification difficulty
+
+全条件 PASS。`bats` の `command` 型 verify は safe モードで CI reference fallback を使用しており問題なく解決できた。1 件の CONSIDER レベル指摘（negative test の欠如）あり。テスト内の positive case のみでの検証は今後の Issue で繰り返し発生しやすいパターンのため、verify rubric で「negative case の有無」を明示的に問うことを検討してもよい。

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -119,7 +119,7 @@ case "$SIZE" in
     echo "--- code phase (pr): issue #${SUB_NUMBER} ---"
     "$SCRIPT_DIR/run-code.sh" "$SUB_NUMBER" --pr ${BASE_FLAG:-}
 
-    PR_NUMBER=$(gh pr list --json number,headRefName --jq ".[] | select(.headRefName | contains(\"issue-${SUB_NUMBER}-\")) | .number" 2>/dev/null | head -1 || true)
+    PR_NUMBER=$(gh pr list --json number,headRefName 2>/dev/null | jq -r ".[] | select(.headRefName == \"worktree-code+issue-${SUB_NUMBER}\") | .number" | head -1 || true)
     if [[ -z "$PR_NUMBER" ]]; then
       echo "Error: Could not retrieve PR number for issue #${SUB_NUMBER}" >&2
       exit 1
@@ -139,7 +139,7 @@ case "$SIZE" in
     echo "--- code phase (pr): issue #${SUB_NUMBER} ---"
     "$SCRIPT_DIR/run-code.sh" "$SUB_NUMBER" --pr ${BASE_FLAG:-}
 
-    PR_NUMBER=$(gh pr list --json number,headRefName --jq ".[] | select(.headRefName | contains(\"issue-${SUB_NUMBER}-\")) | .number" 2>/dev/null | head -1 || true)
+    PR_NUMBER=$(gh pr list --json number,headRefName 2>/dev/null | jq -r ".[] | select(.headRefName == \"worktree-code+issue-${SUB_NUMBER}\") | .number" | head -1 || true)
     if [[ -z "$PR_NUMBER" ]]; then
       echo "Error: Could not retrieve PR number for issue #${SUB_NUMBER}" >&2
       exit 1

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -75,7 +75,7 @@ echo "---"
 
 # Idempotency guard: skip if open PR already exists for this issue
 if [[ "$ROUTE_FLAG" == "--pr" ]]; then
-  EXISTING_PR=$(gh pr list --state open --json number,headRefName --jq ".[] | select(.headRefName | contains(\"issue-${ISSUE_NUMBER}-\")) | .number" 2>/dev/null | head -1 || true)
+  EXISTING_PR=$(gh pr list --state open --json number,headRefName 2>/dev/null | jq -r ".[] | select(.headRefName == \"worktree-code+issue-${ISSUE_NUMBER}\") | .number" | head -1 || true)
   if [[ -n "$EXISTING_PR" ]]; then
     echo "=== run-code.sh: Existing PR #${EXISTING_PR} detected for issue #${ISSUE_NUMBER}, skipping /code ==="
     echo "PR: $(gh pr view ${EXISTING_PR} --json url -q '.url')"

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -162,7 +162,7 @@ Phase transition output format: output `[N/M] phase_name` before each phase, and
 
 1. Output `[1/4] code`, then run `${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh $NUMBER --pr [--base {branch}]` via Bash (timeout: 600000); on success output `[1/4] code → done (PR #N)`
 2. If code fails: go to Step 6
-3. Extract PR number via client-side filter (handles worktree branch names like `worktree-issue-*`): `gh pr list --json number,headRefName --jq ".[] | select(.headRefName | contains(\"issue-$NUMBER-\")) | .number" | head -1`
+3. Extract PR number via exact-match filter (matches SSoT branch name worktree-code+issue-N established by #310): `gh pr list --json number,headRefName | jq -r ".[] | select(.headRefName == \"worktree-code+issue-$NUMBER\") | .number" | head -1`
 4. If PR number cannot be fetched: report error and go to Step 6
 5. Output `[2/4] review`, then run `${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh $PR_NUMBER [--light|--full]` via Bash (timeout: 600000) (M→`--light`, L→`--full`); on success output `[2/4] review → done`
 6. If review fails: go to Step 6

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -95,7 +95,7 @@ if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
     exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
-    echo "99"
+    echo '[{"headRefName":"worktree-code+issue-42","number":99}]'
     exit 0
 fi
 echo ""
@@ -215,7 +215,7 @@ if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json labels"* ]]; then
     exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
-    echo "99"
+    echo '[{"headRefName":"worktree-code+issue-42","number":99}]'
     exit 0
 fi
 echo ""
@@ -235,11 +235,8 @@ MOCK
     grep -q -- "--base release/v1" "$RUN_VERIFY_LOG"
 }
 
-@test "PR extraction: uses client-side headRefName filter (#311 regression)" {
-    GH_PR_ARGS_LOG="$BATS_TEST_TMPDIR/gh-pr-args.log"
-    export GH_PR_ARGS_LOG
-
-    # Override gh mock: log pr list args; respond only to the client-side filter form
+@test "PR extraction: exact-match SSoT filter matches worktree-code+issue-N (#311 regression, #325 fix)" {
+    # Override gh mock: return JSON array with SSoT branch name so jq filter drives extraction
     cat > "$MOCK_DIR/gh" <<MOCK
 #!/bin/bash
 if [[ "\$1" == "issue" && "\$2" == "view" && "\$*" == *"--json labels"* ]]; then
@@ -251,10 +248,7 @@ if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
     exit 0
 fi
 if [[ "\$1" == "pr" && "\$2" == "list" ]]; then
-    echo "\$*" >> "${GH_PR_ARGS_LOG}"
-    if [[ "\$*" == *"--json number,headRefName"* ]]; then
-        echo "99"
-    fi
+    echo '[{"headRefName":"worktree-code+issue-42","number":99}]'
     exit 0
 fi
 echo ""
@@ -265,15 +259,8 @@ MOCK
     run bash "$SCRIPT" 42
     [ "$status" -eq 0 ]
 
-    # glob pattern must NOT have been passed to gh
-    run grep -- '--head' "$GH_PR_ARGS_LOG"
-    [ "$status" -ne 0 ]
-
-    # client-side filter form must have been used
-    run grep -- '--json number,headRefName' "$GH_PR_ARGS_LOG"
-    [ "$status" -eq 0 ]
-
     # PR 99 was successfully propagated to review and merge
+    # (proves jq filter matched worktree-code+issue-42 and extracted the number)
     grep -q "99" "$RUN_REVIEW_LOG"
     grep -q "99" "$RUN_MERGE_LOG"
 }

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -219,7 +219,7 @@ MOCK
 }
 
 @test "idempotency guard: --pr with existing PR skips claude and exits 0" {
-    # Override gh mock to return existing PR number for pr list
+    # Override gh mock to return JSON for pr list so jq filter drives extraction
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
 if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
@@ -231,7 +231,7 @@ if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
-  echo "456"
+  echo '[{"headRefName":"worktree-code+issue-123","number":456}]'
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
@@ -251,7 +251,7 @@ MOCK
 }
 
 @test "idempotency guard: --patch with existing PR calls claude normally" {
-    # Override gh mock to return existing PR number
+    # Override gh mock to return JSON for pr list (guard is skipped for --patch)
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
 if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
@@ -263,7 +263,7 @@ if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
-  echo "456"
+  echo '[{"headRefName":"worktree-code+issue-123","number":456}]'
   exit 0
 fi
 echo ""
@@ -278,7 +278,7 @@ MOCK
 }
 
 @test "idempotency guard: no route flag with existing PR calls claude normally" {
-    # Override gh mock to return existing PR number
+    # Override gh mock to return JSON for pr list (guard is skipped when no route flag)
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
 if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
@@ -290,7 +290,7 @@ if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
-  echo "456"
+  echo '[{"headRefName":"worktree-code+issue-123","number":456}]'
   exit 0
 fi
 echo ""


### PR DESCRIPTION
## Summary

- `scripts/run-auto-sub.sh` (Size M/L cases) の PR 番号抽出を `contains("issue-N-")` から `== "worktree-code+issue-N"` 完全一致に変更 (`| jq -r` パイプ形式)
- `scripts/run-code.sh` の idempotency guard を同様に変更
- `skills/auto/SKILL.md` の instruction text を exact-match 形式に更新
- `tests/run-auto-sub.bats` の `#311 regression` テストを JSON mock 形式に強化し、jq filter が実際に branch 名をマッチすることを検証
- `tests/run-code.bats` の idempotency guard テスト mock を JSON 形式に更新

## Verification (pre-merge)

- 3 ファイルすべてで PR 番号抽出が `worktree-code+issue-N` への完全一致に揃っている
- `skills/auto/SKILL.md`、`scripts/run-auto-sub.sh`、`scripts/run-code.sh` から旧 substring match 形式 `contains("issue-N-")` が除去されている
- `tests/run-auto-sub.bats` の regression テストが `worktree-code+issue-N` を含む JSON mock を使い jq filter の動作を検証している
- `bats tests/run-auto-sub.bats` 全テスト PASS
- `bats tests/run-code.bats` 全テスト PASS

## Verification (post-merge)

- 実際に pr route で `/auto N` を実行し、`worktree-code+issue-N` ブランチで PR 番号抽出が成功することを確認

closes #325