### PR TITLE
Issue #355: Fix patch route CI wait to use branch-based PR lookup

### DIFF
--- a/docs/spec/issue-355-verify-patch-route-ci-wait.md
+++ b/docs/spec/issue-355-verify-patch-route-ci-wait.md
@@ -89,3 +89,17 @@ VERIFY_PR_NUMBER=$(gh pr list --search "is:merged linked:issue:$ISSUE_NUMBER" --
 - `WHOLEWORK_CI_TIMEOUT_SEC` を patch route の main branch CI wait にも適用（`wait-ci-checks.sh` 内と同じ変数で統一）
 - `skills/verify/SKILL.md` の PR lookup (line 79, `closes #$ISSUE_NUMBER`) はテキスト検索で正しく動作しており、修正対象外
 - `gh run watch` が存在しない環境（非常に古い gh CLI）での自動解決: `2>/dev/null || true` でエラーを吸収し、後続の LLM 実行で判断させる（既存の `wait-ci-checks.sh` の `|| true` と同じ戦略）
+
+## Code Retrospective
+
+### Deviations from Design
+
+- なし。Spec の実装ステップを忠実に実施した。
+
+### Design Gaps/Ambiguities
+
+- regression test の `WHOLEWORK_SCRIPT_DIR` オーバーライドアプローチが問題: `WHOLEWORK_SCRIPT_DIR` を設定すると `claude-watchdog.sh` など他のスクリプトも mock dir から探されてしまい、テストが失敗した。Spec では言及されていなかった制約。回避策として `WHOLEWORK_SCRIPT_DIR` オーバーライドを削除し、PATH 上の mock `gh` だけで検証する方法に変更した。
+
+### Rework
+
+- regression test を 1 回修正: `WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` を使ってサイドチャネル検証（`wait-ci-checks.sh` 呼び出しログ）を試みたが、他のスクリプト（`claude-watchdog.sh` 等）が mock dir に存在せずスクリプトがエラー終了した。オーバーライドを削除し、出力メッセージの有無で検証する方式に変更した。

--- a/docs/spec/issue-355-verify-patch-route-ci-wait.md
+++ b/docs/spec/issue-355-verify-patch-route-ci-wait.md
@@ -103,3 +103,18 @@ VERIFY_PR_NUMBER=$(gh pr list --search "is:merged linked:issue:$ISSUE_NUMBER" --
 ### Rework
 
 - regression test を 1 回修正: `WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` を使ってサイドチャネル検証（`wait-ci-checks.sh` 呼び出しログ）を試みたが、他のスクリプト（`claude-watchdog.sh` 等）が mock dir に存在せずスクリプトがエラー終了した。オーバーライドを削除し、出力メッセージの有無で検証する方式に変更した。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+なし。Spec の設計ステップ・実装メモに沿った実装で、review phase での Spec 乖離は確認されなかった。
+
+### Recurring issues
+
+- `gh run list --json X --jq '.[0].X'` の jq null 問題: 空配列 `[]` に対して `.[0].X` は `null` を返すが、`if [[ -n "$_RUN_ID" ]]` チェックは `"null"` を non-empty と判定する。今回は `// empty` で修正したが、同パターンが他スクリプトにも存在する可能性がある。今後 `gh ... --json X --jq '...'` を使う際は `// empty` をデフォルトで付与するか、`!= "null"` チェックを追加する規約を検討する価値がある。
+- テストモックが `echo ""` を使っているが実際の `gh run list` は `null`（jq literal）を返す点が乖離していた。mock 設計時に jq null の挙動を意識することが再発防止になる。
+
+### Acceptance criteria verification difficulty
+
+- rubric 条件 2 件 + command 条件 1 件、すべて PASS（CI 参照含む）。検証困難な UNCERTAIN は 0 件。verify command の設計は適切だった。

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -54,11 +54,28 @@ echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
 
 # Detect associated PR for CI wait (patch route has no PR)
-VERIFY_PR_NUMBER=$(gh pr list --search "is:merged linked:issue:$ISSUE_NUMBER" --json number -q '.[0].number' 2>/dev/null || echo "")
+VERIFY_PR_NUMBER=$(gh pr list --head "worktree-code+issue-${ISSUE_NUMBER}" --state merged --json number -q '.[0].number' 2>/dev/null || echo "")
 if [[ -n "$VERIFY_PR_NUMBER" ]]; then
+  # pr route: wait for the associated PR's CI checks
   "$SCRIPT_DIR/wait-ci-checks.sh" "$VERIFY_PR_NUMBER"
 else
-  echo "No PR found for issue #${ISSUE_NUMBER} (patch route), skipping CI wait" >&2
+  # patch route: wait for the latest branch workflow run
+  _WAIT_BRANCH="${BASE_BRANCH:-main}"
+  _RUN_ID=$(gh run list --branch "$_WAIT_BRANCH" --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")
+  if [[ -n "$_RUN_ID" ]]; then
+    TIMEOUT_SEC="${WHOLEWORK_CI_TIMEOUT_SEC:-1200}"
+    echo "Waiting for ${_WAIT_BRANCH} branch CI run #${_RUN_ID} (patch route, timeout: ${TIMEOUT_SEC}s)..." >&2
+    if command -v timeout >/dev/null 2>&1; then
+      timeout "$TIMEOUT_SEC" gh run watch "$_RUN_ID" --interval 60 2>/dev/null || true
+    elif command -v gtimeout >/dev/null 2>&1; then
+      gtimeout "$TIMEOUT_SEC" gh run watch "$_RUN_ID" --interval 60 2>/dev/null || true
+    else
+      gh run watch "$_RUN_ID" --interval 60 2>/dev/null || true
+    fi
+    echo "CI run #${_RUN_ID} complete" >&2
+  else
+    echo "No CI runs found for ${_WAIT_BRANCH} branch (patch route), skipping CI wait" >&2
+  fi
 fi
 
 # Pass SKILL.md body directly as prompt (avoids context: fork issue)

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -61,7 +61,7 @@ if [[ -n "$VERIFY_PR_NUMBER" ]]; then
 else
   # patch route: wait for the latest branch workflow run
   _WAIT_BRANCH="${BASE_BRANCH:-main}"
-  _RUN_ID=$(gh run list --branch "$_WAIT_BRANCH" --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")
+  _RUN_ID=$(gh run list --branch "$_WAIT_BRANCH" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || echo "")
   if [[ -n "$_RUN_ID" ]]; then
     TIMEOUT_SEC="${WHOLEWORK_CI_TIMEOUT_SEC:-1200}"
     echo "Waiting for ${_WAIT_BRANCH} branch CI run #${_RUN_ID} (patch route, timeout: ${TIMEOUT_SEC}s)..." >&2

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -33,12 +33,20 @@ if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
   fi
   exit 0
 fi
-if [[ "$1" == "pr" && "$2" == "list" && "$*" == *"--search"* ]]; then
+if [[ "$1" == "pr" && "$2" == "list" && "$*" == *"--head"* ]]; then
   # Default: no associated PR found (patch route)
   echo ""
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+  exit 0
+fi
+if [[ "$1" == "run" && "$2" == "list" ]]; then
+  # Default: no CI runs found (patch route, skip CI wait)
+  echo ""
+  exit 0
+fi
+if [[ "$1" == "run" && "$2" == "watch" ]]; then
   exit 0
 fi
 echo ""
@@ -126,10 +134,10 @@ MOCK
     [ "$status" -eq 0 ]
 }
 
-@test "success: skips CI wait when no associated PR found (patch route)" {
+@test "success: skips CI wait when no associated PR found and no CI runs (patch route)" {
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
-    [[ "$output" == *"No PR found for issue #123 (patch route), skipping CI wait"* ]]
+    [[ "$output" == *"No CI runs found for main branch (patch route), skipping CI wait"* ]]
 }
 
 @test "success: calls wait-ci-checks.sh when associated PR is found" {
@@ -143,7 +151,7 @@ if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
   fi
   exit 0
 fi
-if [[ "$1" == "pr" && "$2" == "list" && "$*" == *"--search"* ]]; then
+if [[ "$1" == "pr" && "$2" == "list" && "$*" == *"--head"* ]]; then
   echo "99"
   exit 0
 fi
@@ -159,6 +167,46 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" == *"Waiting for CI checks on PR #99"* ]]
     [[ "$output" == *"CI check wait complete for PR #99"* ]]
+}
+
+@test "patch route: does not wait on prior merged PR when no branch PR exists" {
+    # Simulate: --head returns empty (no branch PR), but a run exists on main.
+    # Expected: wait-ci-checks.sh is NOT called; main branch CI wait is attempted.
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test issue title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/issues/123"
+  fi
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" && "$*" == *"--head"* ]]; then
+  # No PR for this branch (patch route)
+  echo ""
+  exit 0
+fi
+if [[ "$1" == "run" && "$2" == "list" ]]; then
+  # Return a run ID for main branch CI wait
+  echo "9999"
+  exit 0
+fi
+if [[ "$1" == "run" && "$2" == "watch" ]]; then
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    # wait-ci-checks.sh must NOT have been called (no "Waiting for CI checks on PR" message)
+    [[ "$output" != *"Waiting for CI checks on PR"* ]]
+    # Main branch CI wait should have been triggered
+    [[ "$output" == *"Waiting for main branch CI run #9999 (patch route"* ]]
+    [[ "$output" == *"CI run #9999 complete"* ]]
 }
 
 @test "error: claude command fails with non-zero exit code" {


### PR DESCRIPTION
## Summary

- `scripts/run-verify.sh` の PR 検索ロジックを `--search "is:merged linked:issue:N"` から `--head "worktree-code+issue-N" --state merged` に変更し、ブランチ名による確定的な PR 特定に修正
- patch route（PR なし）の場合は main branch の最新 workflow run を `gh run list` + `gh run watch` で待機するロジックを追加
- `tests/run-verify.bats` の mock 条件を `--head` マッチに更新し、regression test を追加（13 tests, all pass）

## Verification (pre-merge)

- patch route / pr route で CI wait 対象が明示的に分岐されている（rubric PASS）
- patch route で prior PR への fallback 参照が存在しない（rubric PASS）
- `bats tests/run-verify.bats` — 13/13 PASS

## Verification (post-merge)

- patch route の Issue（XS/S）で `/auto N` を実行し、`/verify` log に `PR #N` 参照が無く、main branch の workflow を wait 対象としていることを手動確認
- pr route の Issue（M/L）で `/auto N` を実行し、従来通り当該 PR の CI wait が正しく動作することを手動確認
- XL 並列（pr route + patch route 混在）で Level 3 patch route sub-issue が先行 PR を参照しないことを手動確認

closes #355