### PR TITLE
Issue #386: Isolate run-*.bats from repo .wholework.yml

### DIFF
--- a/docs/spec/issue-386-isolate-bats-from-repo-config.md
+++ b/docs/spec/issue-386-isolate-bats-from-repo-config.md
@@ -85,3 +85,17 @@ bats tests/run-code.bats
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Nothing to note. All 7 files match the design exactly; isolation block position (before `MOCK_DIR=`) and content are consistent across all files.
+
+### Recurring Issues
+
+Nothing to note. No review issues found across any perspective.
+
+### Acceptance Criteria Verification Difficulty
+
+Nothing to note. All 8 verify commands resolved cleanly (7 `grep` commands + 1 `rubric`). The unique marker comment string `# Isolate test from repo .wholework.yml` served as an effective verify target with no false-positive risk.

--- a/docs/spec/issue-386-isolate-bats-from-repo-config.md
+++ b/docs/spec/issue-386-isolate-bats-from-repo-config.md
@@ -71,3 +71,17 @@ bats tests/run-code.bats
 - **検出マーカー**: `# Isolate test from repo .wholework.yml` コメントを設置。`permission-mode: bypass` 単独 grep は run-code.bats:319-329 の既存テスト本文で既に true となるため、setup() への新規追加を区別できない。コメント文字列はリポジトリ全体で他箇所に存在しない一意な検出マーカーとして機能する。
 - **`scripts/get-config-value.sh` 構造変更は対象外**: Issue Purpose で確認済み。本 Issue ではテスト隔離のみに集中し、`WHOLEWORK_CONFIG_PATH` 等の env 経路導入は別 Issue で扱う。
 - **#385 との整合**: `permission-mode: bypass` を明示書き込みするため、#385（permission-mode デフォルト反転）マージ後も bats テストの挙動は変わらない。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A
+
+### Design Gaps/Ambiguities
+
+- N/A
+
+### Rework
+
+- N/A

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -6,6 +6,9 @@
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-auto-sub.sh"
 
 setup() {
+    # Isolate test from repo .wholework.yml
+    echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"
+    cd "$BATS_TEST_TMPDIR"
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -7,6 +7,9 @@ SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-code.sh"
 SKILLS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/skills/code"
 
 setup() {
+    # Isolate test from repo .wholework.yml
+    echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"
+    cd "$BATS_TEST_TMPDIR"
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"

--- a/tests/run-issue.bats
+++ b/tests/run-issue.bats
@@ -7,6 +7,9 @@ SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-issue.sh"
 SKILLS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/skills/issue"
 
 setup() {
+    # Isolate test from repo .wholework.yml
+    echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"
+    cd "$BATS_TEST_TMPDIR"
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -6,6 +6,9 @@
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-merge.sh"
 
 setup() {
+    # Isolate test from repo .wholework.yml
+    echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"
+    cd "$BATS_TEST_TMPDIR"
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -6,6 +6,9 @@
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-review.sh"
 
 setup() {
+    # Isolate test from repo .wholework.yml
+    echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"
+    cd "$BATS_TEST_TMPDIR"
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -6,6 +6,9 @@
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-spec.sh"
 
 setup() {
+    # Isolate test from repo .wholework.yml
+    echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"
+    cd "$BATS_TEST_TMPDIR"
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -6,6 +6,9 @@
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/run-verify.sh"
 
 setup() {
+    # Isolate test from repo .wholework.yml
+    echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"
+    cd "$BATS_TEST_TMPDIR"
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"


### PR DESCRIPTION
## Summary

`tests/run-*.bats` 全 7 ファイルの `setup()` 冒頭に CWD 隔離ブロックを追加し、repo root の `.wholework.yml` がテスト挙動に影響しない構造にする。

- `BATS_TEST_TMPDIR/.wholework.yml` に `permission-mode: bypass` を書き込み
- `cd "$BATS_TEST_TMPDIR"` で CWD を一時ディレクトリへ切り替え
- 隔離マーカーコメント `# Isolate test from repo .wholework.yml` を各 `setup()` 直前に追加

根本原因: `scripts/get-config-value.sh` が CWD 相対で `.wholework.yml` を読む構造のため、`permission-mode: auto` が repo root に設定されるとテストが一斉 FAIL する。

## Verification (pre-merge)

- 全 7 ファイル (`run-code.bats`, `run-spec.bats`, `run-review.bats`, `run-verify.bats`, `run-merge.bats`, `run-issue.bats`, `run-auto-sub.bats`) の `setup()` に隔離ブロックが追加される
- `bats tests/` 603 件全 PASS

## Verification (post-merge)

- main で `Test / Run bats tests` workflow が success する

closes #386