### PR TITLE
Issue #397: Add lazy-catch diagnostics for permission-mode auto failures

### DIFF
--- a/docs/spec/issue-397-permission-auto-lazy-catch.md
+++ b/docs/spec/issue-397-permission-auto-lazy-catch.md
@@ -73,3 +73,17 @@ threshold 30 秒の根拠: claude CLI cold start (3-8s) + auth/plan check + auto
 ### `run-*.sh` 改変の影響範囲
 
 `set +e` 直前の `SECONDS=0` 挿入は副作用なし（`SECONDS` は bash builtin で自動リセット）。`set -e` 直後のヘルパー呼び出しは `set -e` 解除後・143 reconcile 前で、ヘルパーが exit 0 を返す前提なので `set -e` の再有効化を待たずに進む。既存 `EXIT_CODE` 変数は保持される。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A: 実装ステップはすべて Spec 通りに実行した。run-verify.sh のみ `VERIFY_TMPOUT=$(mktemp)` の後に `SECONDS=0` を挿入したが、Spec の「`set +e` 直前」という意図には合致している。
+
+### Design Gaps/Ambiguities
+
+- N/A: Spec は十分に詳細で、実装中に解釈の余地が生じる箇所はなかった。
+
+### Rework
+
+- N/A

--- a/docs/spec/issue-397-permission-auto-lazy-catch.md
+++ b/docs/spec/issue-397-permission-auto-lazy-catch.md
@@ -87,3 +87,17 @@ threshold 30 秒の根拠: claude CLI cold start (3-8s) + auth/plan check + auto
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- N/A: Spec と PR diff の間に構造的な乖離はなかった。ヘルパーのロジック・引数・exit 0 ポリシー・6 ファイルへの挿入位置はすべて Spec 通り。
+
+### Recurring issues
+
+- `run-spec.bats` のみ `WHOLEWORK_SCRIPT_DIR=$MOCK_DIR` を設定するパターンを採用しており、新しいヘルパースクリプトが追加されるたびにモック追加が必要になる。今回はこのモックが漏れ、CI が 10 テスト失敗した。`/code` フェーズで同様のモックパターンを採用する他のテストへの横展開確認が不足していた可能性がある。Spec に「`WHOLEWORK_SCRIPT_DIR` を使うテストファイルにはモックを追加すること」のチェックポイントを設けることで再発防止が期待できる。
+
+### Acceptance criteria verification difficulty
+
+- 承認基準の `rubric` 条件（テストが exit 0 を assert しているか）はファイルの直接確認で PASS 判定できたが、「implicit vs explicit assertion」の解釈次第で UNCERTAIN になりうる。今後 `rubric` 条件に「`run` + `[ "$status" -eq 0 ]` を使用していること」と明記することで曖昧さを減らせる。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -27,7 +27,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (7 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (46 files)
+├── scripts/             # Utility scripts used by skills and agents (47 files)
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
@@ -37,7 +37,7 @@ wholework/
 │   └── workflows/
 │       ├── test.yml             # CI: bats tests, skill syntax validation, forbidden expressions check, and macOS shell compatibility test
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
-├── tests/               # Bats test files for scripts (54 files)
+├── tests/               # Bats test files for scripts (55 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -160,6 +160,7 @@ Key modules:
 **Project utilities:**
 - `scripts/collect-recovery-candidates.sh` — parse `docs/reports/orchestration-recoveries.md`; count symptom-short frequency; exclude filed entries; apply `--threshold K` filter; output `<symptom-short>\t<count>` candidates; accepts `--issues-json PATH` for duplicate detection
 - `scripts/get-config-value.sh` — extract a configuration value from `.wholework.yml`
+- `scripts/handle-permission-mode-failure.sh` — diagnose `permission-mode: auto` failures and print remediation hint to stderr (heuristic: exit!=0 AND elapsed<=30s)
 - `scripts/get-verify-permission.sh` — extract permission value from a verify command handler file
 - `scripts/get-issue-size.sh` — get issue size label
 - `scripts/get-issue-type.sh` — get issue type label

--- a/scripts/handle-permission-mode-failure.sh
+++ b/scripts/handle-permission-mode-failure.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# handle-permission-mode-failure.sh
+# Diagnose permission-mode auto failures and suggest remediation.
+# Args: exit_code elapsed permission_mode
+# Always exits 0; prints diagnostic to stderr on heuristic match only.
+# Heuristic: permission_mode=auto AND exit_code!=0 AND elapsed<=30
+
+exit_code="${1:-0}"
+elapsed="${2:-0}"
+permission_mode="${3:-}"
+
+if [ "$permission_mode" = "auto" ] && [ "$exit_code" != "0" ] && [ "$elapsed" -le 30 ]; then
+  cat >&2 <<'EOF'
+Note: /auto failed with permission-mode: auto.
+This requires Claude Max / Team / Enterprise / API plan (Pro is not supported).
+If your plan does not support auto mode, switch to bypass by adding to .wholework.yml:
+  permission-mode: bypass
+See SECURITY.md for the security tradeoff.
+EOF
+fi
+
+exit 0

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -144,6 +144,7 @@ fi
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR"
 
+SECONDS=0
 set +e
 ANTHROPIC_MODEL=sonnet \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
@@ -153,6 +154,7 @@ ANTHROPIC_MODEL=sonnet \
     $PERMISSION_FLAG
 EXIT_CODE=$?
 set -e
+"$SCRIPT_DIR/handle-permission-mode-failure.sh" "$EXIT_CODE" "$SECONDS" "$PERMISSION_MODE"
 
 if [[ $EXIT_CODE -eq 143 ]]; then
   if [[ "$ROUTE_FLAG" == "--patch" ]]; then

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -68,6 +68,7 @@ ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR"
 
+SECONDS=0
 set +e
 ANTHROPIC_MODEL=sonnet \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
@@ -77,6 +78,7 @@ ANTHROPIC_MODEL=sonnet \
     $PERMISSION_FLAG
 EXIT_CODE=$?
 set -e
+"$SCRIPT_DIR/handle-permission-mode-failure.sh" "$EXIT_CODE" "$SECONDS" "$PERMISSION_MODE"
 
 if [[ $EXIT_CODE -eq 143 ]]; then
   _reconcile_out=$("$SCRIPT_DIR/reconcile-phase-state.sh" issue "$ISSUE_NUMBER" --check-completion 2>/dev/null) || true

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -60,6 +60,7 @@ ARGUMENTS: ${PR_NUMBER} --non-interactive"
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR"
 
+SECONDS=0
 set +e
 ANTHROPIC_MODEL=sonnet \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
@@ -69,6 +70,7 @@ ANTHROPIC_MODEL=sonnet \
     $PERMISSION_FLAG
 EXIT_CODE=$?
 set -e
+"$SCRIPT_DIR/handle-permission-mode-failure.sh" "$EXIT_CODE" "$SECONDS" "$PERMISSION_MODE"
 
 if [[ $EXIT_CODE -eq 143 ]]; then
   _MERGE_ISSUE=$("$SCRIPT_DIR/gh-extract-issue-from-pr.sh" "$PR_NUMBER" 2>/dev/null \

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -69,6 +69,7 @@ ARGUMENTS: ${ARGUMENTS}"
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR"
 
+SECONDS=0
 set +e
 ANTHROPIC_MODEL=sonnet \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
@@ -78,6 +79,7 @@ ANTHROPIC_MODEL=sonnet \
     $PERMISSION_FLAG
 EXIT_CODE=$?
 set -e
+"$SCRIPT_DIR/handle-permission-mode-failure.sh" "$EXIT_CODE" "$SECONDS" "$PERMISSION_MODE"
 
 if [[ $EXIT_CODE -eq 143 ]]; then
   _REVIEW_ISSUE=$("$SCRIPT_DIR/gh-extract-issue-from-pr.sh" "$PR_NUMBER" 2>/dev/null \

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -80,6 +80,7 @@ ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR"
 
+SECONDS=0
 set +e
 ANTHROPIC_MODEL="${MODEL}" \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
@@ -89,6 +90,7 @@ ANTHROPIC_MODEL="${MODEL}" \
     $PERMISSION_FLAG
 EXIT_CODE=$?
 set -e
+"$SCRIPT_DIR/handle-permission-mode-failure.sh" "$EXIT_CODE" "$SECONDS" "$PERMISSION_MODE"
 
 if [[ $EXIT_CODE -eq 143 ]]; then
   _reconcile_out=$("$SCRIPT_DIR/reconcile-phase-state.sh" spec "$ISSUE_NUMBER" --check-completion 2>/dev/null) || true

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -114,6 +114,7 @@ fi
 load_watchdog_timeout "$SCRIPT_DIR"
 
 VERIFY_TMPOUT=$(mktemp)
+SECONDS=0
 set +e
 ANTHROPIC_MODEL=sonnet \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
@@ -123,6 +124,7 @@ ANTHROPIC_MODEL=sonnet \
     $PERMISSION_FLAG 2>&1 | tee "$VERIFY_TMPOUT"
 EXIT_CODE=$?
 set -e
+"$SCRIPT_DIR/handle-permission-mode-failure.sh" "$EXIT_CODE" "$SECONDS" "$PERMISSION_MODE"
 
 # Output marker detection: non-zero exit if VERIFY_FAILED is present
 if grep -q "VERIFY_FAILED" "$VERIFY_TMPOUT"; then

--- a/tests/handle-permission-mode-failure.bats
+++ b/tests/handle-permission-mode-failure.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+# Tests for handle-permission-mode-failure.sh
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$PROJECT_ROOT/scripts/handle-permission-mode-failure.sh"
+
+@test "permission-mode auto: elapsed=5 exit=1 prints diagnostic to stderr" {
+    bash "$SCRIPT" 1 5 auto 2>"$BATS_TEST_TMPDIR/stderr"
+    [ -s "$BATS_TEST_TMPDIR/stderr" ]
+}
+
+@test "permission-mode auto: elapsed=60 exit=1 no diagnostic (long elapsed)" {
+    bash "$SCRIPT" 1 60 auto 2>"$BATS_TEST_TMPDIR/stderr"
+    [ ! -s "$BATS_TEST_TMPDIR/stderr" ]
+}
+
+@test "permission-mode bypass: elapsed=5 exit=1 no diagnostic" {
+    bash "$SCRIPT" 1 5 bypass 2>"$BATS_TEST_TMPDIR/stderr"
+    [ ! -s "$BATS_TEST_TMPDIR/stderr" ]
+}
+
+@test "permission-mode auto: elapsed=5 exit=0 no diagnostic (success case)" {
+    bash "$SCRIPT" 0 5 auto 2>"$BATS_TEST_TMPDIR/stderr"
+    [ ! -s "$BATS_TEST_TMPDIR/stderr" ]
+}

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -69,6 +69,13 @@ exec "$@"
 MOCK
     chmod +x "$MOCK_DIR/claude-watchdog.sh"
 
+    # Mock handle-permission-mode-failure.sh (always silent, exits 0)
+    cat > "$MOCK_DIR/handle-permission-mode-failure.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/handle-permission-mode-failure.sh"
+
     # Mock phase-banner.sh (sourced by run-spec.sh)
     cat > "$MOCK_DIR/phase-banner.sh" <<'MOCK'
 print_start_banner() { echo "Starting /$3 for issue #$2"; }


### PR DESCRIPTION
## Summary

- `scripts/handle-permission-mode-failure.sh` を新規作成: `permission-mode: auto` で `exit_code != 0` かつ `elapsed <= 30s` の heuristic 条件で診断 stderr を出力し、`permission-mode: bypass` への切り替え方法を案内する
- 6 つの `scripts/run-*.sh` に `SECONDS=0` + ヘルパー呼び出しを挿入（既存 reconcile/banner/exit 伝播ロジックは無変更）
- `tests/handle-permission-mode-failure.bats` を新規作成: 4 ケース（auto+短時間, auto+長時間, bypass, exit=0）で動作を単体テスト
- `docs/structure.md` のファイル数カウントを更新（scripts: 46→47, tests: 54→55）

## Verification (pre-merge)

- `scripts/handle-permission-mode-failure.sh` が新規作成されている
- 診断メッセージに "Claude Max" plan 要件の記述が含まれる
- remediation として `permission-mode: bypass` 設定方法が含まれる
- 6 つの `run-*.sh` すべてがヘルパーを呼ぶ
- bats テストが新規作成されている
- heuristic の 3 ケースとヘルパー exit 0 が単体テストでカバーされている
- 全 bats テストが PASS する

## Verification (post-merge)

- Pro プラン環境（または mock）で `permission-mode: auto` のまま `/auto N` を実行し、診断 stderr が表示されること、および `permission-mode: bypass` に切り替えれば動作することを確認する

closes #397