### PR TITLE
Issue #403: Expand silent-no-op success phrases with English patterns

### DIFF
--- a/docs/spec/issue-403-wrapper-success-phrases.md
+++ b/docs/spec/issue-403-wrapper-success-phrases.md
@@ -30,3 +30,14 @@
 
 - `detect-wrapper-anomaly.sh` は `--log <path>` で渡された特定のログファイルのみをスキャンするため、bats テストファイル自体に `successfully committed` が含まれても自己参照誤検知は発生しない
 - 現行パターン `grep -qiE "..."` は `-i` フラグで大文字小文字を区別しないため、`Successfully committed` 等も一致する
+
+## Code Retrospective
+
+### Deviations from Design
+- なし。Spec の実装ステップ通りに実装完了。
+
+### Design Gaps/Ambiguities
+- なし。
+
+### Rework
+- なし。

--- a/docs/spec/issue-403-wrapper-success-phrases.md
+++ b/docs/spec/issue-403-wrapper-success-phrases.md
@@ -41,3 +41,15 @@
 
 ### Rework
 - なし。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- なし。実装は Spec の Implementation Steps に完全に準拠しており、3フレーズの追加とテストケースがすべて期待通り実装されていた。
+
+### Recurring issues
+- verify コマンド構文の問題（ripgrep 非互換の `\|` 表記）が AC2 で検出された。verify-executor は ripgrep を使用するが、AC 作成時に `\|` を alternation として記述したため、実際の検証で FAIL/UNCERTAIN になる可能性がある。verify コマンドを書く際は bare `|` を使うよう、Issue テンプレートまたはドキュメントにガイドラインを追記することで再発防止が期待できる。
+- pre-existing な Forbidden Expressions 違反（main の別 Spec ファイル）が pull_request CI で検出され、ブロッカーとなった。main ブランチの健全性チェックを定期的に行うか、push イベント CI と pull_request イベント CI の結果を明確に区別する仕組みが有効かもしれない。
+
+### Acceptance criteria verification difficulty
+- AC2 の verify コマンド `grep "pushed to\|changes have been committed"` が ripgrep 非互換のため、verify-executor での自動検証が FAIL/UNCERTAIN になる可能性があった。実際には `pushed to` と `changes have been committed` をそれぞれ個別の Grep 呼び出しで確認した。verify コマンドは bare `|` を使用する（例: `grep "pushed to|changes have been committed"`）ことで verify-executor との互換性が保たれる。

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -71,7 +71,7 @@ elif grep -q "watchdog: kill and state not reached" "$LOG_FILE"; then
   ANOMALY_DESC="Watchdog killed the process in phase \`$PHASE\` (exit code $EXIT_CODE): \`watchdog: kill and state not reached\` detected. The phase did not complete within the timeout."
   IMPROVEMENT_HINT="Increase \`watchdog-timeout-seconds\` in \`.wholework.yml\` or improve liveness signals (progress output) to prevent false-positive kills. Related: #308."
 elif [[ "$EXIT_CODE" == "0" ]]; then
-  if grep -qiE "完了しました|commit and push" "$LOG_FILE" && \
+  if grep -qiE "完了しました|commit and push|successfully committed|pushed to|changes have been committed" "$LOG_FILE" && \
      ! git log --oneline -5 2>/dev/null | grep -q "#${ISSUE_NUMBER}"; then
     PATTERN_NAME="silent-no-op"
     ANOMALY_DESC="LLM reported success in phase \`$PHASE\` (exit code 0) but no commit for #$ISSUE_NUMBER found in recent git log. Possible silent no-op: output indicated completion but no code was committed. Reference: #365."

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -90,6 +90,21 @@ MOCK
     [[ "$output" == *"### Orchestration Anomalies"* ]]
 }
 
+@test "silent no-op: detects exit_code=0 with English success phrase 'successfully committed'" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/git" <<'MOCK'
+#!/bin/bash
+# mock git: returns empty output for all subcommands
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/git"
+    echo "Successfully committed all changes." > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 0 --issue 403 --phase code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"silent-no-op"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+}
+
 @test "silent no-op: no detection when exit_code=0 but no success phrase" {
     echo "Execution finished normally." > "$LOG_FILE"
     run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 0 --issue 365 --phase code


### PR DESCRIPTION
## Summary

- `scripts/detect-wrapper-anomaly.sh` の silent-no-op 検出パターンに英語成功フレーズ3種 (`successfully committed`, `pushed to`, `changes have been committed`) を追加
- `-i` フラグによる大文字小文字非区別マッチは維持（`Successfully committed` 等も一致）
- `tests/detect-wrapper-anomaly.bats` に英語フレーズ `successfully committed` を使った silent-no-op 検出テストケースを追加

## Verification (pre-merge)

- `scripts/detect-wrapper-anomaly.sh` に `successfully committed` フレーズが追加されていること
- `scripts/detect-wrapper-anomaly.sh` に `pushed to` および `changes have been committed` フレーズが追加されていること
- `tests/detect-wrapper-anomaly.bats` に `successfully committed` を使った新テストケースが追加されていること

## Verification (post-merge)

- 英語成功フレーズ（例: `"successfully committed"` を含むログ）で silent-no-op が検出されること

closes #403