### PR TITLE
Issue #401: Add dirty-working-tree pattern to Tier 2 catalog

### DIFF
--- a/docs/spec/issue-401-detect-dirty-working-tree.md
+++ b/docs/spec/issue-401-detect-dirty-working-tree.md
@@ -46,3 +46,17 @@
 ## Notes
 
 - なし
+
+## Code Retrospective
+
+### Deviations from Design
+
+- なし
+
+### Design Gaps/Ambiguities
+
+- `detect-wrapper-anomaly.sh` のパターンマッチ順序: 新しい `dirty-working-tree` パターンは `watchdog-kill` の後、`EXIT_CODE == 0` チェックの前に配置。Spec の挿入位置指定通りで問題なし。
+
+### Rework
+
+- なし

--- a/docs/spec/issue-401-detect-dirty-working-tree.md
+++ b/docs/spec/issue-401-detect-dirty-working-tree.md
@@ -60,3 +60,18 @@
 ### Rework
 
 - なし
+
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Spec の実装ステップ1で `ANOMALY_DESC` に `#393` 参照を含めることが指定されていたが、テストのアサーションでこの参照が検証されていなかった。Spec とコードは整合しているが、テストが Spec の要求を完全にカバーしていない漏れパターン。
+
+### Recurring Issues
+
+- なし。今回のレビューで発見した指摘は1件のみで、再発パターンとして記録できるほどの頻度ではない。
+
+### Acceptance Criteria Verification Difficulty
+
+- 全 AC が `grep` と `rubric` を組み合わせており、auto-verify は安定して PASS。UNCERTAIN は発生しなかった。
+- CI の `Forbidden Expressions check` が PR とは無関係の既存ファイル（`docs/spec/issue-385-default-permission-mode-auto.md`）で失敗しており、PR 単位のアクセプタンス検証に外部ノイズが混入するパターン。既存ファイルの `verify hint` 表記を修正する別 Issue が必要。

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -200,6 +200,32 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 
 ---
 
+## dirty-working-tree
+
+### Symptom
+- `/verify` outputs `VERIFY_FAILED` and `Cannot run verify because there are uncommitted changes`
+- `scripts/detect-wrapper-anomaly.sh` emits pattern: `dirty-working-tree`
+
+### Applicable Phases
+- verify
+
+### Fallback Steps
+1. Run `git status` to list uncommitted files in the working tree
+2. Determine whether each uncommitted file is related to the current issue:
+   - **Unrelated files** (e.g., editor swap files, incidental modifications to unrelated paths): stage and commit or stash the files, then retry verify via `run-verify.sh <issue-num>`; notify the operator of the stashed/committed files
+   - **Related files** (unexpected edits to issue-specific implementation files): abort the verify run and investigate why uncommitted changes remain before retrying
+3. After cleanup, re-run `run-verify.sh <issue-num>`
+
+### Escalation
+- If the uncommitted changes cannot be safely classified as related or unrelated, escalate to recovery sub-agent (#316) for diagnosis
+- If the dirty working tree recurs after cleanup, inspect whether a prior skill phase left uncommitted edits and report as a new anomaly
+
+### Rationale
+- First observed in Issue #393 retrospective: anomaly detector returned empty output because this pattern was not cataloged, blocking Tier 2 automatic recovery
+- `scripts/detect-wrapper-anomaly.sh` (pattern: `dirty-working-tree`) now detects the `VERIFY_FAILED` + `uncommitted` co-occurrence and emits this catalog anchor for Tier 2 lookup
+
+---
+
 ## Operational Notes
 
 This catalog is consumed by:

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -70,6 +70,10 @@ elif grep -q "watchdog: kill and state not reached" "$LOG_FILE"; then
   PATTERN_NAME="watchdog-kill"
   ANOMALY_DESC="Watchdog killed the process in phase \`$PHASE\` (exit code $EXIT_CODE): \`watchdog: kill and state not reached\` detected. The phase did not complete within the timeout."
   IMPROVEMENT_HINT="Increase \`watchdog-timeout-seconds\` in \`.wholework.yml\` or improve liveness signals (progress output) to prevent false-positive kills. Related: #308."
+elif grep -q "VERIFY_FAILED" "$LOG_FILE" && grep -q "uncommitted" "$LOG_FILE"; then
+  PATTERN_NAME="dirty-working-tree"
+  ANOMALY_DESC="Verify failed due to uncommitted changes in phase \`$PHASE\` (exit code $EXIT_CODE): \`VERIFY_FAILED\` and \`uncommitted\` detected in wrapper output. The verify skill cannot run when uncommitted changes are present in the working tree. Reference: #393."
+  IMPROVEMENT_HINT="Run \`git status\` to identify uncommitted files. If the files are unrelated to issue #$ISSUE_NUMBER, notify and retry via \`run-verify.sh $ISSUE_NUMBER\`. If the files are related to the issue (unexpected edits), abort and investigate before retrying. See \`modules/orchestration-fallbacks.md#dirty-working-tree\` for the full recovery procedure."
 elif [[ "$EXIT_CODE" == "0" ]]; then
   if grep -qiE "完了しました|commit and push|successfully committed|pushed to|changes have been committed" "$LOG_FILE" && \
      ! git log --oneline -5 2>/dev/null | grep -q "#${ISSUE_NUMBER}"; then

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -117,6 +117,7 @@ MOCK
     run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 393 --phase verify
     [ "$status" -eq 0 ]
     [[ "$output" == *"dirty-working-tree"* ]]
+    [[ "$output" == *"#393"* ]]
     [[ "$output" == *"### Orchestration Anomalies"* ]]
     [[ "$output" == *"### Improvement Proposals"* ]]
 }

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -111,3 +111,26 @@ MOCK
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }
+
+@test "dirty working tree: detects VERIFY_FAILED with uncommitted changes" {
+    printf "VERIFY_FAILED\nCannot run verify because there are uncommitted changes in the working tree.\n" > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 393 --phase verify
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dirty-working-tree"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+    [[ "$output" == *"### Improvement Proposals"* ]]
+}
+
+@test "dirty working tree: no detection when only VERIFY_FAILED present" {
+    echo "VERIFY_FAILED" > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 393 --phase verify
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "dirty working tree: no detection when only uncommitted present" {
+    echo "Cannot run verify because there are uncommitted changes." > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 393 --phase verify
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

- `scripts/detect-wrapper-anomaly.sh` に `VERIFY_FAILED` + `uncommitted` を検出する `dirty-working-tree` パターンを追加
- `modules/orchestration-fallbacks.md` に `## dirty-working-tree` カタログ項目を追加（`git status` 確認フロー + 関連ファイル分岐リカバリ手順）
- `tests/detect-wrapper-anomaly.bats` に dirty-working-tree パターン検出のテストを3件追加

## Verification (pre-merge)

- `scripts/detect-wrapper-anomaly.sh` に `VERIFY_FAILED` を検出するルールが追加されている
- `scripts/detect-wrapper-anomaly.sh` に `uncommitted changes` を検出するルールが追加されている
- `modules/orchestration-fallbacks.md` に dirty working tree (verify) のカタログ項目が追加されている
- カタログ項目に git status 確認フローと分岐リカバリ手順が含まれている

## Verification (post-merge)

- Issue #393 と同様の VERIFY_FAILED シナリオで、`detect-wrapper-anomaly.sh` が non-empty 出力を返し、Tier 2 catalog 経路に乗ることを確認

closes #401