### PR TITLE
Issue #400: Require phase/done in completion verify

### DIFF
--- a/docs/spec/issue-400-completion-verify-phase-done-only.md
+++ b/docs/spec/issue-400-completion-verify-phase-done-only.md
@@ -43,7 +43,7 @@
 ### Pre-merge
 
 - <!-- verify: file_not_contains "scripts/reconcile-phase-state.sh" "phase/(verify|done)" --> `scripts/reconcile-phase-state.sh` の `_completion_verify` で `phase/verify` を許容する旧パターン `phase/(verify|done)` が削除されている
-- <!-- verify: file_not_contains "tests/reconcile-phase-state.bats" "phase/verify label -> matches_expected true" --> `tests/reconcile-phase-state.bats` の「`phase/verify` → `matches_expected true`」を主張する旧テストが削除または変更されている
+- <!-- verify: file_not_contains "tests/reconcile-phase-state.bats" "completion: issue OPEN + phase/verify label -> matches_expected true" --> `tests/reconcile-phase-state.bats` の「`phase/verify` → `matches_expected true`」を主張する旧テストが削除または変更されている
 - <!-- verify: grep "phase/verify.*false" "tests/reconcile-phase-state.bats" --> `tests/reconcile-phase-state.bats` に「`phase/verify` 状態では `matches_expected: false` を返す」テストが追加されている
 - <!-- verify: file_not_contains "modules/phase-state.md" "phase/(verify" --> `modules/phase-state.md` の verify 成功署名から `phase/(verify` が削除され SSoT が更新されている
 
@@ -55,3 +55,17 @@
 
 - Step 3 の `modules/phase-state.md` 更新はイシュー本文の受入条件には含まれていないが、同ファイルが `reconcile-phase-state.sh` の成功署名の SSoT であるため、スクリプト側の変更と整合させる必要がある。Spec に追加の verify コマンドを設けた（Issue 本文は 3 件、Spec は 4 件）。
 - `scripts/reconcile-phase-state.sh` line 404-407 の `_precondition_verify` が `phase/verify` を参照しているのは「verify フェーズ開始条件の確認」であり、今回の修正対象（completion check）とは別。変更不要。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A（設計どおりに実装）
+
+### Design Gaps/Ambiguities
+
+- AC2 の verify command `file_not_contains "tests/reconcile-phase-state.bats" "phase/verify label -> matches_expected true"` が miscalibrated であることを実装中に発見。`"phase/verify label -> matches_expected true"` は precondition テスト (line 635: `"verify precondition: issue has phase/verify label -> matches_expected true"`) にもマッチするため FAIL となる。`"completion: issue OPEN + phase/verify label -> matches_expected true"` に修正して Issue body と Spec の両方を更新した。
+
+### Rework
+
+- N/A

--- a/docs/spec/issue-400-completion-verify-phase-done-only.md
+++ b/docs/spec/issue-400-completion-verify-phase-done-only.md
@@ -69,3 +69,17 @@
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Nothing to note. 実装は Spec と完全に一致しており、4ファイルすべての変更が設計書の記述と対応している。
+
+### Recurring Issues
+
+Nothing to note. 本 PR は単一の grep パターン修正とそのテスト・ドキュメント更新のみで、複数の同種 issue は発生していない。
+
+### Acceptance Criteria Verification Difficulty
+
+Nothing to note. 4件の verify command（file_not_contains×3、grep×1）はすべて自動判定可能で UNCERTAIN なし。Forbidden Expressions check CI の FAILURE は PR #413 とは無関係の既存ファイル (`docs/spec/issue-401-detect-dirty-working-tree.md`) 由来であり、本 PR の受入条件検証には影響なし。別 Issue での対応が必要（Issue #401 コンテキストで既にトラッキング済み）。

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -39,7 +39,7 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 | code-pr | `phase/ready` label on issue, Spec exists | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
 | review | PR is OPEN | PR has a comment containing `## Review Response Summary` | Implemented |
 | merge | PR is OPEN and reviewDecision is APPROVED | `gh pr view --json state == MERGED` | Implemented |
-| verify | Issue has `phase/verify` label or is CLOSED | Issue is CLOSED or has `phase/(verify\|done)` label | Implemented |
+| verify | Issue has `phase/verify` label or is CLOSED | Issue is CLOSED or has `phase/done` label | Implemented |
 
 **Note**: Stage 2 recovery (push + PR creation for code-pr after watchdog kill) is delegated to #316 recovery sub-agent. `reconcile-phase-state.sh` performs inspection only — no recovery actions.
 

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -268,10 +268,10 @@ _completion_verify() {
     return
   fi
 
-  if echo "$labels" | grep -qE '^phase/(verify|done)$'; then
-    _emit_result "true" "issue #${ISSUE_NUMBER} has phase/verify or phase/done label" "$actual_json"
+  if echo "$labels" | grep -q '^phase/done$'; then
+    _emit_result "true" "issue #${ISSUE_NUMBER} has phase/done label" "$actual_json"
   else
-    _handle_mismatch "issue #${ISSUE_NUMBER} is OPEN with no phase/verify or phase/done label" "$actual_json"
+    _handle_mismatch "issue #${ISSUE_NUMBER} is OPEN with no phase/done label" "$actual_json"
   fi
 }
 

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -377,7 +377,7 @@ MOCK_EOF
     [[ "$output" == *'"issue_state":"CLOSED"'* ]]
 }
 
-@test "verify completion: issue OPEN + phase/verify label -> matches_expected true" {
+@test "verify completion: issue OPEN + phase/verify label -> matches_expected false" {
     cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
 #!/bin/bash
 if [[ "$*" == *"--json state"* ]]; then
@@ -391,8 +391,8 @@ MOCK_EOF
     export PATH="$MOCK_DIR:$PATH"
 
     run bash "$SCRIPT" verify 42 --check-completion --strict
-    [ "$status" -eq 0 ]
-    [[ "$output" == *'"matches_expected":true'* ]]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"matches_expected":false'* ]]
 }
 
 @test "verify completion: issue OPEN + phase/done label -> matches_expected true" {


### PR DESCRIPTION
## Summary

`scripts/reconcile-phase-state.sh` の `_completion_verify` が `phase/verify` を誤って completion 成功として扱うバグを修正。verify completion 判定を `phase/done` のみに限定し、Tier 1 reconcile での誤判定を防ぐ。

変更内容:
- `scripts/reconcile-phase-state.sh`: `grep -qE '^phase/(verify|done)$'` → `grep -q '^phase/done$'` に変更。メッセージも対応する形に更新
- `tests/reconcile-phase-state.bats`: `phase/verify label -> matches_expected true` テストを `-> matches_expected false` に変更（status/アサーション更新）
- `modules/phase-state.md`: verify フェーズの Success Signature を `phase/(verify\|done)` → `phase/done` のみに更新（SSoT 同期）

## Verification (pre-merge)

- `scripts/reconcile-phase-state.sh` の `_completion_verify` で `phase/(verify|done)` パターンが削除されている
- `tests/reconcile-phase-state.bats` の「`phase/verify` → `matches_expected true`」を主張する旧テストが変更されている
- `tests/reconcile-phase-state.bats` に「`phase/verify` 状態では `matches_expected: false` を返す」テストが追加されている
- `modules/phase-state.md` の verify 成功署名から `phase/(verify` が削除されている

## Verification (post-merge)

- Issue #393 と同様のシナリオで、reconcile が `matches_expected:false` を返すことを確認

closes #400