### PR TITLE
Issue #419: Fix VERIFY_FAILED false-positive via line-anchored detection

### DIFF
--- a/docs/spec/issue-419-run-verify-false-positive-fix.md
+++ b/docs/spec/issue-419-run-verify-false-positive-fix.md
@@ -46,3 +46,17 @@
 - New test name recommendation: `@test "false-positive: VERIFY_FAILED in body text does not cause non-zero exit"` — mock claude outputs `"This AC mentions the VERIFY_FAILED scenario from issue #393"` (not at line start), asserts `[ "$status" -eq 0 ]`
 - `tests/run-verify.bats` will contain "VERIFY_FAILED" as a test fixture string, but the pattern `^VERIFY_FAILED` checks only verify output temp files, not source files — no self-reference exclusion needed
 - Verify commands copied verbatim from Issue body `## Acceptance Criteria > Pre-merge`
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A
+
+### Design Gaps/Ambiguities
+
+- Spec Step 2 noted updating "near line 77" and "also apply consistent phrasing near line 123 (open PR case)". The line 123 context was a description line (`If \`OPEN_PR\` is not empty, output \`VERIFY_FAILED\` and abort:`) that did not itself say "standalone line" or "line-anchored" — updated it to match the same wording for consistency.
+
+### Rework
+
+- N/A

--- a/docs/spec/issue-419-run-verify-false-positive-fix.md
+++ b/docs/spec/issue-419-run-verify-false-positive-fix.md
@@ -60,3 +60,18 @@
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+特筆事項なし。Spec 記載のステップ 1–3 がすべて diff と 1:1 対応しており、乖離なし。
+
+### 繰り返し課題
+
+特筆事項なし。レビュー指摘事項 0 件。
+
+### 受け入れ条件検証難易度
+
+- AC1 (`grep "\"\\^VERIFY_FAILED\""`): verify コマンドの `\\^` エスケープ解釈が若干複雑 — 実際には `grep -q "^VERIFY_FAILED"` という文字列が存在するかの確認であり、直接 Grep で `\^VERIFY_FAILED` を検索することで判断可能だった。
+- AC4 (`command "bats tests/run-verify.bats"`): safe モードのため CI 参照フォールバックを使用 (PASS 確定)。verify コマンドとして `command` を使用した場合、`/review` フェーズでは常に CI 依存になる — CI が未完了の場合は UNCERTAIN になる点に留意が必要だが、今回は問題なし。

--- a/scripts/run-verify.sh
+++ b/scripts/run-verify.sh
@@ -126,8 +126,8 @@ EXIT_CODE=$?
 set -e
 "$SCRIPT_DIR/handle-permission-mode-failure.sh" "$EXIT_CODE" "$SECONDS" "$PERMISSION_MODE"
 
-# Output marker detection: non-zero exit if VERIFY_FAILED is present
-if grep -q "VERIFY_FAILED" "$VERIFY_TMPOUT"; then
+# Output marker detection: non-zero exit if VERIFY_FAILED is present at line start
+if grep -q "^VERIFY_FAILED" "$VERIFY_TMPOUT"; then
   echo "Error: verify output contained VERIFY_FAILED marker" >&2
   EXIT_CODE=1
 fi

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -73,7 +73,7 @@ Handle by exit code:
     - "Abort": stop and guide user to run `git stash` or `git commit`, then re-run `/verify $NUMBER`
   - **Non-interactive mode**: Auto-stash — run `git stash`, then continue
 - **Exit 1 (related or non-spec dirty files present)**: output error message and abort.
-  Output the `VERIFY_FAILED` marker at the start of the error message (`run-verify.sh` detects this marker to propagate the error):
+  Output the `VERIFY_FAILED` marker as a standalone line (line-anchored: `run-verify.sh` detects it with `^VERIFY_FAILED` pattern):
   "VERIFY_FAILED"
   Then output the error message:
   "Error: Cannot run verify because there are uncommitted changes. Run `git stash` or `git commit`, then re-run `/verify $NUMBER`."
@@ -119,7 +119,7 @@ If `--base` is not specified and `PR_NUMBER` is empty, search for an OPEN PR bef
 OPEN_PR=$(gh pr list --search "closes #$ISSUE_NUMBER" --state open --json number,title --jq ".[0].number")
 ```
 
-If `OPEN_PR` is not empty, output `VERIFY_FAILED` and abort:
+If `OPEN_PR` is not empty, output `VERIFY_FAILED` as a standalone line (line-anchored: `run-verify.sh` detects it with `^VERIFY_FAILED` pattern) and abort:
 
 ```
 VERIFY_FAILED

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -137,6 +137,21 @@ MOCK
     [ "$status" -eq 0 ]
 }
 
+@test "false-positive: VERIFY_FAILED in body text does not cause non-zero exit" {
+    # Claude outputs VERIFY_FAILED embedded mid-line in body text (not at line start)
+    cat > "$MOCK_DIR/claude" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$CLAUDE_CALL_LOG"
+echo "ANTHROPIC_MODEL=$ANTHROPIC_MODEL" >> "$CLAUDE_CALL_LOG"
+echo "This AC mentions the VERIFY_FAILED scenario from issue #393"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+}
+
 @test "success: skips CI wait when no associated PR found and no CI runs (patch route)" {
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- `scripts/run-verify.sh` の VERIFY_FAILED マーカー検出を `grep -q "VERIFY_FAILED"` から `grep -q "^VERIFY_FAILED"` (行頭錨点) に変更
- `skills/verify/SKILL.md` のマーカー出力仕様に "line-anchored" の整合性を明記
- `tests/run-verify.bats` に false-positive 回帰検出テストを追加 (本文中の "VERIFY_FAILED" キーワードが exit 0 となること)

## Verification (pre-merge)

- `scripts/run-verify.sh` の VERIFY_FAILED 検出が行頭錨点 (`^VERIFY_FAILED`) パターンに変更されている
- `skills/verify/SKILL.md` のマーカー出力仕様が wrapper 側の行頭錨点 (line-anchored) 検出と整合していると明記されている
- `tests/run-verify.bats` に false-positive 回帰検出テストケースが追加されている
- `bats tests/run-verify.bats` が全件 PASS する

## Verification (post-merge)

- Acceptance Criteria 本文に "VERIFY_FAILED" 文字列を含む verify を `/verify 401` 等で再実行した際に wrapper exit 0 で完了することを確認

closes #419