### PR TITLE
Issue #415: Add code-completed-no-pr pattern to Tier 2 catalog

### DIFF
--- a/docs/spec/issue-415-code-completed-no-pr-pattern.md
+++ b/docs/spec/issue-415-code-completed-no-pr-pattern.md
@@ -83,3 +83,19 @@ Pre-merge verification 6 件は light の 5 件制限を超えるが、`/issue` 
 ### Rework
 
 - なし。
+
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- なし。Spec の実装ステップ 1〜4 はすべて diff と完全に整合していた。Code Retrospective でも「Deviations from Design: なし」が記録されており、Spec 品質は高い。
+
+### Recurring Issues
+
+- なし。review-light 全4観点で確認済みの問題はゼロ件。パターン重複も見られない。
+
+### Acceptance Criteria Verification Difficulty
+
+- `rubric` 条件（AC3）はルーブリック判定を要するが、Fallback Steps の記述が明確であり AI 判定で PASS を確定できた。UNCERTAIN は発生しなかった。
+- `section_contains` （AC4、AC5）は diff から直接確認可能で、verify command の品質は高い。
+- 全 6 件の pre-merge 条件がすべて PASS。verify command の精度に問題なし。

--- a/docs/spec/issue-415-code-completed-no-pr-pattern.md
+++ b/docs/spec/issue-415-code-completed-no-pr-pattern.md
@@ -69,3 +69,17 @@ Pre-merge verification 6 件は light の 5 件制限を超えるが、`/issue` 
 ### `--phase` 制約なし（Issue body Auto-Resolved 3）
 
 新パターンの実装で `--phase` を制約条件に含めない。呼び出し側（`run-auto-sub.sh`）が phase=code 時にのみ呼ぶ前提。これは `dirty-working-tree`（verify phase 専用シグネチャだが phase 制約なし）の前例に揃える。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- なし。実装ステップ 1〜4 をすべて Spec どおりに実行した。
+
+### Design Gaps/Ambiguities
+
+- `scripts/run-code.sh` の `_reconcile_out` echo は `exit 143` 判定ブロック内にのみ存在するため、正常終了・他エラー終了では log に出力されない。これは Spec の意図通り（Tier 2 は EXIT_CODE=143 のみを対象とする前提）であり、設計ギャップではない。
+
+### Rework
+
+- なし。

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -252,6 +252,37 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 
 ---
 
+## code-completed-no-pr
+
+### Symptom
+- `run-code.sh` exits with code 143 (watchdog kill) and the wrapper log contains a line matching `reconcile-phase-state result:` with `"matches_expected":false` and `"phase":"code-pr"`
+- `scripts/detect-wrapper-anomaly.sh` emits pattern: `code-completed-no-pr`
+- The worktree branch contains commits (implementation was completed) but no open PR exists for that branch
+
+### Applicable Phases
+- code (PR route)
+
+### Fallback Steps
+1. Identify the worktree branch: `git branch | grep "worktree-code+issue-N"` (where N is the issue number)
+2. Check out the worktree branch: `git checkout worktree-code+issue-N`
+3. Rebase onto the latest main to incorporate any concurrent patches: `git rebase origin/main`
+4. Push the branch to the remote: `git push origin worktree-code+issue-N`
+5. Create the PR: `gh pr create --title "Issue #N: <summary>" --base main --body "..."`
+6. Continue with `/review <PR-number>` to proceed to the review phase
+
+### Escalation
+- If `git rebase` encounters conflicts, resolve each conflict manually, then `git rebase --continue`; if conflicts cannot be resolved safely, abort with `git rebase --abort` and request human intervention
+- If the worktree directory has already been cleaned up (`.claude/worktrees/` entry is absent), recover commits from `git reflog` or the orphaned worktree branch
+- Recovery sub-agent (#316) can be invoked when the root cause of the anomaly is unclear or the rebase conflicts are complex
+
+### Rationale
+- First observed in Issue #385: watchdog kill after all commits were complete but before `gh pr create` was executed; the parent session manually ran rebase + push + PR creation
+- `reconcile-phase-state.sh` `_completion_code_pr()` returns `matches_expected:false` only when the expected PR is absent (the sole mismatch case); combined with `"phase":"code-pr"` in the JSON output, this uniquely identifies the code-completed-no-pr scenario
+- `run-code.sh` now logs `reconcile-phase-state result:` (added in #415) so Tier 2 can detect this pattern from the wrapper log; prior to this change, `_reconcile_out` was silently discarded and Tier 2 would return empty output (unknown pattern)
+- The `code-completed-no-pr` check precedes `watchdog-kill` in the detector to win the first-match-wins priority, since both signatures can co-occur in the same log
+
+---
+
 ## Operational Notes
 
 This catalog is consumed by:

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -66,6 +66,10 @@ elif grep -q "ERROR: missing sign-off" "$LOG_FILE"; then
   PATTERN_NAME="dco-missing"
   ANOMALY_DESC="DCO sign-off missing in phase \`$PHASE\` (exit code $EXIT_CODE): \`ERROR: missing sign-off\` detected. Commit was created without \`git commit -s\`."
   IMPROVEMENT_HINT="Ensure \`git commit -s\` is used in all SKILL.md commit steps. Check the corresponding skill's commit instructions for missing \`-s\` flag."
+elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q '"phase":"code-pr"' "$LOG_FILE"; then
+  PATTERN_NAME="code-completed-no-pr"
+  ANOMALY_DESC="Watchdog killed the process in phase \`$PHASE\` (exit code $EXIT_CODE) after code-pr completed its commits but before PR creation: \`matches_expected:false\` and \`phase:code-pr\` detected in reconcile-phase-state output. The run-code.sh phase exited without creating a PR. Reference: #415."
+  IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#code-completed-no-pr\`: checkout the worktree branch, rebase onto latest main, push the branch, and create the PR with \`gh pr create\`, then continue with \`/review\`."
 elif grep -q "watchdog: kill and state not reached" "$LOG_FILE"; then
   PATTERN_NAME="watchdog-kill"
   ANOMALY_DESC="Watchdog killed the process in phase \`$PHASE\` (exit code $EXIT_CODE): \`watchdog: kill and state not reached\` detected. The phase did not complete within the timeout."

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -163,6 +163,7 @@ if [[ $EXIT_CODE -eq 143 ]]; then
     _RECONCILE_PHASE="code-pr"
   fi
   _reconcile_out=$("$SCRIPT_DIR/reconcile-phase-state.sh" "$_RECONCILE_PHASE" "$ISSUE_NUMBER" --check-completion 2>/dev/null) || true
+  echo "reconcile-phase-state result: $_reconcile_out"
   if echo "$_reconcile_out" | grep -q '"matches_expected":true'; then
     EXIT_CODE=0
   fi

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -159,3 +159,27 @@ MOCK
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }
+
+@test "code completed no PR: detects matches_expected false with phase code-pr" {
+    printf '"matches_expected":false\n"phase":"code-pr"\n' > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 143 --issue 385 --phase code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"code-completed-no-pr"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+    [[ "$output" == *"### Improvement Proposals"* ]]
+    [[ "$output" == *"#415"* ]]
+}
+
+@test "code completed no PR: no detection when only matches_expected false present" {
+    printf '"matches_expected":false\nno relevant context here\n' > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 143 --issue 385 --phase code
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "code completed no PR: no detection when only phase code-pr present" {
+    printf '"phase":"code-pr"\nsome other content\n' > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 143 --issue 385 --phase code
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary

- `scripts/detect-wrapper-anomaly.sh` に `code-completed-no-pr` パターンを追加（`dco-missing` の直後・`watchdog-kill` の直前に挿入、first-match-wins 優先）
- `scripts/run-code.sh` に `echo "reconcile-phase-state result: $_reconcile_out"` を追加（Tier 2 検出が成立するための前提条件）
- `modules/orchestration-fallbacks.md` に `## code-completed-no-pr` カタログエントリを追加（Symptom / Applicable Phases / Fallback Steps / Escalation / Rationale）
- `tests/detect-wrapper-anomaly.bats` に正例 1 件・負例 2 件のテストを追加

## Verification (pre-merge)

- `scripts/detect-wrapper-anomaly.sh` に `code-completed-no-pr` パターンが追加されている
- `modules/orchestration-fallbacks.md` に `code-completed-no-pr` カタログ項目が追加されている
- カタログ項目に rebase → push → PR 作成 → review 継続の recovery 手順が含まれている
- `## code-completed-no-pr` セクションに `rebase` 手順が含まれている
- `## code-completed-no-pr` セクションに `push` 手順が含まれている
- `tests/detect-wrapper-anomaly.bats` に `code-completed-no-pr` パターン検出テストが追加されている

## Verification (post-merge)

- Issue #385 と同様の watchdog 1800s timeout + 実装完了 + PR 未作成シナリオで `detect-wrapper-anomaly.sh` が non-empty 出力（`code-completed-no-pr`）を返すことを手動確認する

closes #415