### PR TITLE
Issue #444: Add get-issue-timeline named query to gh-graphql.sh

### DIFF
--- a/docs/spec/issue-444-audit-stats-timeline-fix.md
+++ b/docs/spec/issue-444-audit-stats-timeline-fix.md
@@ -90,3 +90,17 @@
 - `--jq '.data.repository.issue'` で `number` + `timelineItems` を含む Issue オブジェクト全体を返す。呼び出し側で `.timelineItems.nodes` を参照する
 - `timelineItems` の `first: 100` 上限は Issue 本文に Out of Scope として明記済み（pagination 対応は別 Issue）
 - bats テストは `gh api graphql` を mock しているので実際のクエリ内容（`timelineItems` キーワード）は `api_call` ログ文字列から確認する
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A
+
+### Design Gaps/Ambiguities
+
+- `section_contains` ヒントの verify executor 実装（awk ベース）が Section 境界を正確に特定できているか、初回確認時にコマンドが誤っていた（awk の終了条件が `^### ` で同一見出し行を除外できていなかった）。verify-executor 実装上は問題ないが、ローカル確認スクリプトの書き方に注意が必要
+
+### Rework
+
+- N/A

--- a/docs/spec/issue-444-audit-stats-timeline-fix.md
+++ b/docs/spec/issue-444-audit-stats-timeline-fix.md
@@ -104,3 +104,17 @@
 ### Rework
 
 - N/A
+
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Nothing to note. 実装は Spec と完全一致。クエリの変数名（`$owner/$repo/$num`）、返却フィールド（`number + timelineItems`）、イベント種別（`LABELED_EVENT/UNLABELED_EVENT/REOPENED_EVENT`）すべて仕様通り。
+
+### Recurring Issues
+
+Nothing to note. レビュー観点（Spec 整合・エッジケース・セキュリティ・ドキュメント）で問題は検出されなかった。
+
+### Acceptance Criteria Verification Difficulty
+
+Nothing to note. 7 条件すべて PASS。`command` 型ヒント（bats テスト・bash 構文チェック）は safe モードで CI 参照フォールバックにより解決。verify command の品質は良好。

--- a/scripts/gh-graphql.sh
+++ b/scripts/gh-graphql.sh
@@ -61,6 +61,9 @@ get_named_query() {
         get-blocked-by)
             printf '%s' 'query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){blockedBy(first:100){nodes{number title state}}}}}'
             ;;
+        get-issue-timeline)
+            printf '%s' 'query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){number timelineItems(itemTypes:[LABELED_EVENT,UNLABELED_EVENT,REOPENED_EVENT],first:100){nodes{__typename ... on LabeledEvent{label{name}createdAt} ... on UnlabeledEvent{label{name}createdAt} ... on ReopenedEvent{createdAt}}}}}}'
+            ;;
         *)
             echo "Error: unknown query name: $name" >&2
             return 1

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -224,7 +224,8 @@ Filter to Issues created on or after `--since DATE`. If `--since` is not specifi
 For each Issue in the filtered list:
 
 ```bash
-gh issue view {number} --json timelineItems
+${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query get-issue-timeline -F num={number} \
+    --jq '.data.repository.issue'
 ```
 
 Extract the following from `timelineItems`:

--- a/tests/gh-graphql.bats
+++ b/tests/gh-graphql.bats
@@ -107,6 +107,15 @@ teardown() {
     [[ "$api_call" == *"blockedBy"* ]]
 }
 
+@test "success: --query get-issue-timeline resolves named query" {
+    run bash "$SCRIPT" --query get-issue-timeline -F num=444
+    [ "$status" -eq 0 ]
+    grep -q "api graphql" "$GH_CALL_LOG"
+    local api_call
+    api_call=$(grep "api graphql" "$GH_CALL_LOG")
+    [[ "$api_call" == *"timelineItems"* ]]
+}
+
 @test "error: --query with unknown name" {
     run bash "$SCRIPT" --query unknown-query-name
     [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary

- `scripts/gh-graphql.sh` の `get_named_query()` に `get-issue-timeline` named query を追加（`timelineItems` を GraphQL 経由で取得）
- `skills/audit/SKILL.md` Step 1 の壊れた `gh issue view --json timelineItems` 呼び出しを `gh-graphql.sh --query get-issue-timeline` に書き換え
- `tests/gh-graphql.bats` に `get-issue-timeline` の正常系テストケースを追加

## Verification (pre-merge)

- `scripts/gh-graphql.sh` に `get-issue-timeline` が追加される
- クエリ本体に `timelineItems` フィールドが含まれる
- `skills/audit/SKILL.md` から壊れた `gh issue view --json timelineItems` 記述が削除される
- `skills/audit/SKILL.md` Step 1 が `get-issue-timeline` を使う形に書き換えられる
- `bats tests/gh-graphql.bats` が PASS する（22/22）
- `bash -n scripts/gh-graphql.sh` の構文チェックが通る

## Verification (post-merge)

- `/audit stats` を再実行し、SKILL.md の手順だけで全工程が完走することを確認する

closes #444