### PR TITLE
Issue #438: Add visual-state-enumeration Domain file for spec skill

### DIFF
--- a/docs/environment-adaptation.md
+++ b/docs/environment-adaptation.md
@@ -148,6 +148,7 @@ When multiple `load_when` keys are specified, all conditions are evaluated with 
 | `skills/issue/spec-test-guidelines.md` | `/issue` | `validate-skill-syntax.py` exists | `file_exists_any: [scripts/validate-skill-syntax.py]` | Skill development test recommendations |
 | `skills/verify/browser-verify-phase.md` | `/verify` | `HAS_BROWSER_CAPABILITY=true` | `capability: browser` | Browser verification |
 | `skills/spec/visual-diff-guidance.md` | `/spec` | `HAS_VISUAL_DIFF_CAPABILITY=true` | `capability: visual-diff` | Visual reproduction verify guidance |
+| `skills/spec/visual-state-enumeration.md` | `/spec` | `HAS_VISUAL_DIFF_CAPABILITY=true` | `capability: visual-diff` | Visual reproduction state enumeration scaffold |
 | `skills/issue/mcp-call-guidelines.md` | `/issue` | `MCP_TOOLS` non-empty | `capability: mcp` | MCP tool detection |
 | `skills/doc/translate-phase.md` | `/doc` | `translate` subcommand | `arg_starts_with: translate` | Translation generation |
 | `skills/doc/skill-dev-sync.md` | `/doc` | `validate-skill-syntax.py` or `skills/` exists | `file_exists_any: [scripts/validate-skill-syntax.py, skills/]` | Skill development sync |

--- a/docs/ja/environment-adaptation.md
+++ b/docs/ja/environment-adaptation.md
@@ -138,6 +138,7 @@ applies_to_proposals:               # 省略可; 改善提案 Issue をこの Do
 | `skills/issue/spec-test-guidelines.md` | `/issue` | `validate-skill-syntax.py` が存在 | `file_exists_any: [scripts/validate-skill-syntax.py]` | スキル開発テスト推奨事項 |
 | `skills/verify/browser-verify-phase.md` | `/verify` | `HAS_BROWSER_CAPABILITY=true` | `capability: browser` | ブラウザ検証 |
 | `skills/spec/visual-diff-guidance.md` | `/spec` | `HAS_VISUAL_DIFF_CAPABILITY=true` | `capability: visual-diff` | 視覚再現 verify ガイダンス |
+| `skills/spec/visual-state-enumeration.md` | `/spec` | `HAS_VISUAL_DIFF_CAPABILITY=true` | `capability: visual-diff` | 視覚再現 state enumeration scaffold |
 | `skills/issue/mcp-call-guidelines.md` | `/issue` | `MCP_TOOLS` が空でない | `capability: mcp` | MCP ツール検出 |
 | `skills/doc/translate-phase.md` | `/doc` | `translate` サブコマンド | `arg_starts_with: translate` | 翻訳生成 |
 | `skills/doc/skill-dev-sync.md` | `/doc` | `validate-skill-syntax.py` または `skills/` が存在 | `file_exists_any: [scripts/validate-skill-syntax.py, skills/]` | スキル開発同期 |

--- a/docs/spec/issue-438-state-enumeration.md
+++ b/docs/spec/issue-438-state-enumeration.md
@@ -50,6 +50,20 @@ Domain 外プロジェクト (`HAS_VISUAL_DIFF_CAPABILITY=false`) では `domain
 
 - N/A
 
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+- `skills/spec/visual-state-enumeration.md` Step 2 の bundled default にインライン条件分岐 (`Add 768 when...`) があり、Priority 1/2 との優先関係が記述されていなかった。3-tier 解決順序の説明に "only applies when Priority 1 and 2 are skipped" の明記を追加して解決。Domain file の step 内インライン条件は tier 間の適用スコープを明示する必要がある。
+
+### 繰り返し Issue
+
+- なし。今回の SHOULD issues はいずれも Domain file 設計の新パターン（navigation_context エンコーディング、viewport 条件付きデフォルト）に起因するもの。繰り返しパターンは見られない。
+
+### 受け入れ条件検証の難易度
+
+- V1〜V4 はすべて file_exists / file_contains / section_contains で自動判定でき、verify command が適切だった。V5 (github_check) も問題なく機能した。UNCERTAIN はゼロ。verify command の品質良好。
+
 ## Notes
 
 - 三位一体: #441 (visual_diff 実装、`skills/spec/visual-diff-guidance.md`) / 本 Issue #438 (state enumeration scaffold) / #439 (methodology guide `docs/visual-reproduction.md`) は同じ `capability: visual-diff` gate で連動し、いずれも domain 外プロジェクトでは lazy load (eager overhead ゼロ)

--- a/docs/spec/issue-438-state-enumeration.md
+++ b/docs/spec/issue-438-state-enumeration.md
@@ -36,6 +36,20 @@ Domain 外プロジェクト (`HAS_VISUAL_DIFF_CAPABILITY=false`) では `domain
 
 - サンプル UI 再現 Issue (`capabilities.visual-diff: true` 宣言済) で `/spec` を実行し、`## State Enumeration` セクションが Spec に含まれ、state 直積から `<!-- verify: visual_diff ... -->` 形式の AC entry が auto-generate されることを実機で確認 <!-- verify-type: opportunistic -->
 
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A
+
+### Design Gaps/Ambiguities
+
+- N/A
+
+### Rework
+
+- N/A
+
 ## Notes
 
 - 三位一体: #441 (visual_diff 実装、`skills/spec/visual-diff-guidance.md`) / 本 Issue #438 (state enumeration scaffold) / #439 (methodology guide `docs/visual-reproduction.md`) は同じ `capability: visual-diff` gate で連動し、いずれも domain 外プロジェクトでは lazy load (eager overhead ゼロ)

--- a/skills/spec/visual-state-enumeration.md
+++ b/skills/spec/visual-state-enumeration.md
@@ -93,7 +93,7 @@ Bundled default:
 1440  (desktop)
 ```
 
-Add `768` (tablet) when the Issue body mentions tablet breakpoints or the design system declares distinct tablet styles.
+Add `768` (tablet) when the Issue body mentions tablet breakpoints or the design system declares distinct tablet styles. This conditional applies only when Priority 1 (project-local override) and Priority 2 (AskUserQuestion) are both skipped; a project-local viewport declaration takes precedence and is used as-is.
 
 ### Step 3: Extract Pages and Navigation Contexts from Issue Body
 
@@ -149,7 +149,7 @@ Apply collapsing conservatively — when in doubt, emit separate entries to pres
 - `{{ref_url}}`: Replaced by the reference URL at verify time (declared in `.wholework.yml` or Issue body)
 - `{{base_url}}`: Replaced by the implementation URL at verify time (resolved via `LOCAL_BASE_URL` or `http://localhost:3000`)
 
-**State label convention**: State labels in `--states=` are opaque identifiers (see `skills/spec/visual-diff-guidance.md` § State Label Convention). Document the action sequence for each label in the `### State Mapping` subsection generated in Step 4.
+**State label convention**: State labels in `--states=` are opaque identifiers (see `skills/spec/visual-diff-guidance.md` § State Label Convention). Navigation context is encoded into the state label where distinct visual behavior is expected (e.g., `menu-open@home-active` represents the `menu-open` state while the home navigation link is active). Document the action sequence for each combined label in the `### State Mapping` subsection generated in Step 4.
 
 ### Step 6: Output
 

--- a/skills/spec/visual-state-enumeration.md
+++ b/skills/spec/visual-state-enumeration.md
@@ -1,0 +1,163 @@
+---
+type: domain
+skill: spec
+domain: visual-reproduction
+load_when:
+  capability: visual-diff
+---
+
+# Visual State Enumeration (Domain File)
+
+Prerequisite: Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` before reading this file and have `HAS_VISUAL_DIFF_CAPABILITY` already fetched.
+
+This file is only loaded when `HAS_VISUAL_DIFF_CAPABILITY=true`. Enabled by declaring `capabilities:\n  visual-diff: true` in `.wholework.yml`.
+
+## Purpose
+
+Scaffold systematic state enumeration for UI reproduction Issues. Generates a `## State Enumeration` section in the Spec covering the full Cartesian product of `(viewport × page × interactive_state × navigation_context)`, then auto-generates `visual_diff` verify command AC entries for each combination.
+
+This eliminates the "state coverage blind spot" failure mode: building a verify plan from only the `default` state (idle / scroll-top) and discovering `menu-open`, `active-link`, or viewport-specific bugs only after PR merge.
+
+## Input
+
+- `HAS_VISUAL_DIFF_CAPABILITY=true` (declared in `.wholework.yml`)
+- Issue body: target pages, interaction flows, and any state hints
+
+## Processing Steps
+
+### Step 1: Resolve State List
+
+Resolve the state list using a 3-tier priority order:
+
+**Priority 1 — Project-local Domain file (highest)**
+
+Glob `.wholework/domains/spec/visual-state-enumeration.md`. If the file exists, extract the state list from its frontmatter or body list. The file may declare states in either format:
+
+```yaml
+# frontmatter format
+states:
+  - default
+  - hover
+  - focus
+  - menu-open
+  - active-link
+```
+
+```markdown
+<!-- body list format -->
+- default
+- hover
+- focus
+- menu-open
+- active-link
+```
+
+Use the extracted list and skip Priority 2 and 3.
+
+**Priority 2 — AskUserQuestion (interactive mode only)**
+
+If no project-local file exists and the skill is running in interactive mode (no `--non-interactive` flag), ask:
+
+> Which interactive states should be covered? (Select all that apply, or enter custom states)
+
+Offer the bundled default list as pre-selected options.
+
+If running in `--non-interactive` mode, skip to Priority 3.
+
+**Priority 3 — Bundled default list**
+
+```
+default    (initial page load, no interaction)
+hover      (pointer over interactive element)
+focus      (keyboard focus on interactive element)
+menu-open  (navigation drawer or dropdown expanded)
+```
+
+### Step 2: Resolve Viewport List
+
+Resolve the viewport list following the same 3-tier order as Step 1.
+
+Project-local override format (`.wholework/domains/spec/visual-state-enumeration.md`):
+
+```yaml
+viewports:
+  - 390
+  - 768
+  - 1440
+```
+
+Bundled default:
+
+```
+390   (mobile — iPhone 14)
+1440  (desktop)
+```
+
+Add `768` (tablet) when the Issue body mentions tablet breakpoints or the design system declares distinct tablet styles.
+
+### Step 3: Extract Pages and Navigation Contexts from Issue Body
+
+Read the Issue body and extract:
+
+- **Pages**: URLs or route paths the reproduction covers (e.g., `/`, `/about`, `/blog`)
+- **Navigation contexts**: Link states relevant to the page (e.g., `none` for pages without nav highlighting, `home-active` when on the home page, `about-active` when on the about page)
+
+When the Issue body does not specify pages, default to the root page `/` with navigation context `none`.
+
+### Step 4: Generate `## State Enumeration` Section
+
+Append the following section to the Spec being built. Use the resolved lists from Steps 1–3.
+
+```markdown
+## State Enumeration
+
+### Viewports
+- {resolved viewport list, one per line as `- {px}`}
+
+### Pages
+- {extracted pages, one per line as `- {route}`}
+
+### Interactive States
+- {resolved state list, one per line as `- {state}: {description}`}
+
+### Navigation Contexts
+- {extracted nav contexts, one per line as `- {context}: {description}`}
+
+### State Mapping
+<!-- Document the action sequence required to reach each interactive state -->
+{state label}: {action sequence description}
+{state label}: {action sequence description}
+```
+
+### Step 5: Auto-generate AC Entries
+
+For each combination in `viewport × page × interactive_state × navigation_context`, emit one AC entry in the Spec's `## Acceptance Criteria > Pre-merge` section:
+
+```html
+<!-- verify: visual_diff "{{ref_url}}{page}" "{{base_url}}{page}" --viewports="{viewport}" --states="{state}" -->
+```
+
+**Collapsing rules** (reduce entry count before emitting):
+
+1. **Viewport collapse**: When multiple viewports share the same state and navigation context for a page, combine into one entry: `--viewports="390,1440"`.
+2. **State collapse**: When all navigation contexts for a page and viewport share the same state behavior, collapse navigation contexts into a single representative entry.
+3. **Page collapse**: When all pages share the same state and viewport combination without page-specific variation, combine into one multi-page entry if `visual_diff` supports it; otherwise emit one entry per page.
+
+Apply collapsing conservatively — when in doubt, emit separate entries to preserve explicit coverage.
+
+**Placeholder convention**:
+- `{{ref_url}}`: Replaced by the reference URL at verify time (declared in `.wholework.yml` or Issue body)
+- `{{base_url}}`: Replaced by the implementation URL at verify time (resolved via `LOCAL_BASE_URL` or `http://localhost:3000`)
+
+**State label convention**: State labels in `--states=` are opaque identifiers (see `skills/spec/visual-diff-guidance.md` § State Label Convention). Document the action sequence for each label in the `### State Mapping` subsection generated in Step 4.
+
+### Step 6: Output
+
+The generated content is incorporated into the Spec at two locations:
+
+1. A new `## State Enumeration` section (from Step 4) — placed after `## Implementation Steps` and before `## Verification`
+2. AC entries (from Step 5) — appended to the `## Acceptance Criteria > Pre-merge` list
+
+After generating, inform the user:
+
+> State Enumeration scaffold generated: {N} viewports × {M} pages × {P} states × {Q} nav contexts = {total} combinations → {emitted} AC entries (after collapsing).


### PR DESCRIPTION
## Summary

`skills/spec/visual-state-enumeration.md` Domain file を新設する。`capabilities.visual-diff: true` 宣言済みプロジェクトで `/spec` 実行時に domain-loader 経由で自動 load され、UI 再現 Issue の Spec 化時に `(viewport × page × interactive_state × navigation_context)` の完全直積 AC エントリを体系的に scaffold する。

変更点:
- `skills/spec/visual-state-enumeration.md`: 新規 Domain file (`type: domain`, `skill: spec`, `load_when: capability: visual-diff`)
- `docs/environment-adaptation.md`: Layer 3 Domain Files テーブルに追加
- `docs/ja/environment-adaptation.md`: 日本語ミラー同期

## Verification (pre-merge)

- V1: `skills/spec/visual-state-enumeration.md` が frontmatter + Processing Steps を含む Domain file として実装されている
- V2: `/spec` SKILL.md 本体に専用分岐なし (domain-loader 経由 lazy load、Core/Domain 分離準拠)
- V3: `docs/environment-adaptation.md` Domain Files テーブルに行追加
- V4: `docs/ja/environment-adaptation.md` ミラー同期
- V5: bats test CI PASS

## Verification (post-merge)

- `capabilities.visual-diff: true` 宣言済みプロジェクトで `/spec` 実行時に State Enumeration scaffold と AC entry auto-generation が機能することを実機確認

closes #438