### PR TITLE
Issue #469: retro-proposals upstream routing + sanitization

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -86,6 +86,7 @@ This table is the **single source of truth (SSoT)** for all `.wholework.yml` con
 | `patch-lock-timeout` | integer | `300` | Lock acquisition timeout in seconds for `git merge --ff-only` + `git push origin main` (the only protected critical section). The default is generous since the lock is held only for seconds. Increase only if push consistently fails to acquire. Values ≤0 or non-numeric fall back to `300`. |
 | `permission-mode` | string | `"auto"` | Permission mode for `/auto` subprocess. `auto` enables `--permission-mode auto` with allow rules template (see `docs/guide/auto-mode-template.json`); `bypass` uses `--dangerously-skip-permissions` (legacy / opt-out). |
 | `verify-max-iterations` | integer | `3` | Limit verify-reopen loop iterations; stops at N failures and leaves Issue in `phase/verify` for human judgment. Values ≤0, >20, or non-numeric fall back to `3`. |
+| `retro-proposals-upstream` | string | `""` | Upstream repository (`owner/repo`) for routing Skill infrastructure improvement proposals from `/verify` retrospectives. When set, such proposals are sanitized (regex strips absolute paths and downstream issue numbers; LLM removes business-context terms) and filed to this repository; downstream filing is skipped. Unset means downstream filing as before (backward-compatible). |
 
 For the full reference including implementation details and YAML parsing rules, see [`modules/detect-config-markers.md`](../../modules/detect-config-markers.md).
 

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -80,6 +80,7 @@ capabilities:
 | `patch-lock-timeout` | integer | `300` | `git merge --ff-only` + `git push origin main` の lock 取得タイムアウト秒数。lock 保持は数秒のためデフォルトは余裕値。push 取得が常時失敗する場合のみ増やす。0 以下または非数値の場合は `300` にフォールバック。 |
 | `permission-mode` | string | `"auto"` | `/auto` サブプロセスの permission mode。`auto` は `--permission-mode auto` を allow rules テンプレートと共に有効化（`docs/guide/auto-mode-template.json` 参照）; `bypass` は `--dangerously-skip-permissions` を使用（レガシー / オプトアウト）。 |
 | `verify-max-iterations` | integer | `3` | verify-reopen ループの最大試行回数。N 回 FAIL した時点で停止し、Issue を `phase/verify` に留めて人間の判断を促す。0 以下、20 超、または非数値の場合は `3` にフォールバック。 |
+| `retro-proposals-upstream` | string | `""` | Upstream リポジトリ (`owner/repo`) — `/verify` レトロスペクティブから得られた Skill infrastructure improvement 提案の起票先。設定すると、対象提案はサニタイズ（regex で絶対パスと下流固有 Issue 番号を除去、LLM でビジネス文脈用語を除去）されて upstream リポジトリへ起票される。下流リポジトリへの起票はスキップされる。未設定時は従来どおり下流リポジトリへ起票（後方互換）。 |
 
 実装の詳細や YAML パースルールを含む完全なリファレンスは [`modules/detect-config-markers.md`](../../../modules/detect-config-markers.md) を参照してください。
 

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -30,7 +30,7 @@ wholework/
 │   └── workflows/
 │       ├── test.yml             # CI: bats テスト、スキル構文検証、禁止表現チェック、macOS シェル互換性テスト
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
-├── tests/               # スクリプトの Bats テストファイル（57 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（59 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -37,7 +37,7 @@ wholework/
 │   └── workflows/
 │       ├── test.yml             # CI: bats tests, skill syntax validation, forbidden expressions check, and macOS shell compatibility test
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
-├── tests/               # Bats test files for scripts (57 files)
+├── tests/               # Bats test files for scripts (59 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents

--- a/modules/detect-config-markers.md
+++ b/modules/detect-config-markers.md
@@ -47,6 +47,7 @@ From the loaded content, search for each YAML key in the marker definition table
 | `permission-mode` | `PERMISSION_MODE` | String value (extract value as-is) | `"auto"` |
 | `verify-max-iterations` | `VERIFY_MAX_ITERATIONS` | Integer string (extract as-is; use `3` if ≤0, non-numeric, or >20) | `3` |
 | `patch-lock-timeout` | `PATCH_LOCK_TIMEOUT_SECONDS` | Integer string (extract as-is; use `300` if ≤0 or non-numeric) | `300` (used by `scripts/worktree-merge-push.sh`) |
+| `retro-proposals-upstream` | `RETRO_PROPOSALS_UPSTREAM` | String value (extract value as-is; upstream repository in `owner/repo` format) | `""` |
 
 **Dynamic Capability Mapping:**
 
@@ -64,6 +65,7 @@ Example: `capabilities.invoice-api: true` → `HAS_INVOICE_API_CAPABILITY=true`
 - `watchdog-timeout-seconds` is treated as an integer: extract the numeric string; if the value is ≤0 or non-numeric, fall back to the default `1800` (see `scripts/watchdog-defaults.sh` `WATCHDOG_TIMEOUT_DEFAULT`) and log a warning
 - `verify-max-iterations` is treated as an integer: extract the numeric string; if the value is ≤0, non-numeric, or >20, fall back to the default `3` and log a warning
 - `patch-lock-timeout` is treated as an integer: extract the numeric string; if the value is ≤0 or non-numeric, fall back to the default `300` (used by `scripts/worktree-merge-push.sh`)
+- `retro-proposals-upstream` is treated as a string (`owner/repo` format) with quotes removed (same handling as `production-url`)
 - If key does not exist, use default value
 - Comment lines (lines starting with `#`) are ignored
 - Nested values under `capabilities:` section are interpreted as `capabilities.{key}`. Both inline hash format (`capabilities: { browser: true }`) and block format (`capabilities:\n  browser: true`) are supported. If `capabilities:` section is undefined, all capability variables are `false`
@@ -91,4 +93,5 @@ WATCHDOG_TIMEOUT_SECONDS: integer from watchdog-timeout-seconds (default: "1800"
 PERMISSION_MODE: string extracted from permission-mode (default: "auto")
 VERIFY_MAX_ITERATIONS: integer from verify-max-iterations (default: "3"; falls back to "3" if ≤0, non-numeric, or >20)
 PATCH_LOCK_TIMEOUT_SECONDS: integer from patch-lock-timeout (default: "300"; falls back to "300" if ≤0 or non-numeric)
+RETRO_PROPOSALS_UPSTREAM: upstream repository (owner/repo) from retro-proposals-upstream (default: "")
 ```

--- a/modules/retro-proposals.md
+++ b/modules/retro-proposals.md
@@ -15,6 +15,7 @@ Called by:
 - `SPEC_PATH`: path to spec directory (from `detect-config-markers.md`)
 - `NUMBER`: Issue number
 - `HAS_SKILL_PROPOSALS`: `true` if `skill-proposals: true` in `.wholework.yml` (from `detect-config-markers.md`)
+- `RETRO_PROPOSALS_UPSTREAM`: upstream repository in `owner/repo` format (from `detect-config-markers.md`); `""` if `retro-proposals-upstream` is unset
 
 ## Processing Steps
 
@@ -63,6 +64,30 @@ Called by:
         ```
       - **`domain: none`** or classifier fails: Preserve Core target. Proceed to Issue creation without modification.
 
+   4. **Upstream Routing + Sanitization** (Skill infrastructure improvement only, when `RETRO_PROPOSALS_UPSTREAM` is non-empty):
+
+      Evaluate condition: `RETRO_PROPOSALS_UPSTREAM` is non-empty AND the proposal is classified as Skill infrastructure improvement.
+
+      **If condition is met (upstream routing)**:
+
+      a. Apply hybrid sanitization to the Issue body in two passes:
+         - **Regex pass** (mechanical, deterministic):
+           - Replace absolute paths: `s|/Users/[^[:space:]]*|<absolute-path>|g`
+           - Replace downstream-specific Issue numbers: `s/#[0-9][0-9]*/#<downstream-issue>/g`
+         - **LLM pass** (semantic): submit the regex-sanitized body to the LLM with the following instruction: "Remove business-specific terms (company names, product names, ticker symbols, monetary amounts, and other business-context identifiers) by replacing each occurrence with `[redacted]`. Preserve all technical content (file paths, function names, code snippets, workflow descriptions)."
+
+      b. Create Issue in the upstream repository using the sanitized body:
+         ```bash
+         gh issue create --repo "$RETRO_PROPOSALS_UPSTREAM" --title "{normalized title}" --label "retro/verify" --body "{sanitized body}"
+         ```
+         If creation fails, output error log to stderr, skip, and continue (does not affect exit code).
+
+      c. Skip downstream creation for this proposal — do not proceed to steps 8–10 for this proposal.
+
+      d. Output to terminal: `"Routed to upstream {RETRO_PROPOSALS_UPSTREAM}#{issue_number}; skipping downstream creation"`
+
+      **If condition is not met** (`RETRO_PROPOSALS_UPSTREAM` is empty, or proposal is Code improvement): skip step 7.4 and proceed to step 8 for this proposal (downstream fallback path — backward-compatible behavior).
+
 8. **Duplicate check against existing Issues** (always run before creating Issues):
 
    ```bash
@@ -83,6 +108,7 @@ Called by:
    - **If unresolved or cannot determine**: proceed to Issue creation
 
 10. **Create Issues**: For each non-duplicate, non-resolved proposal:
+    - **Skip downstream creation when upstream routed**: If the proposal was routed to upstream in Step 7.4 (condition was met and upstream Issue creation succeeded), skip `gh issue create` for this proposal and continue to the next proposal.
     - Normalize title following `title-normalizer.md` processing steps, then create Issues in standard format (background, purpose, acceptance conditions) with `gh issue create --label "retro/verify"` for each improvement proposal. Do not add the `triaged` label; the `triaged` label is assigned by the `/triage` skill after triage is actually executed.
     - **Add verify commands to acceptance conditions**: add verify commands like `<!-- verify: grep "{keyword}" "{target file}" -->` to the created Issue's acceptance conditions. Extract keywords from acceptance condition text and infer target files from proposal content (improves automation accuracy for `/auto --batch`). Create Issue without verify commands if they cannot be determined.
     - If Issue creation fails, output error log to stderr, skip, and continue (does not affect exit code).

--- a/modules/retro-proposals.md
+++ b/modules/retro-proposals.md
@@ -80,9 +80,9 @@ Called by:
          ```bash
          gh issue create --repo "$RETRO_PROPOSALS_UPSTREAM" --title "{normalized title}" --label "retro/verify" --body "{sanitized body}"
          ```
-         If creation fails, output error log to stderr, skip, and continue (does not affect exit code).
+         If creation fails, output error log to stderr and proceed to steps 8–10 for this proposal (downstream fallback — do not lose the proposal).
 
-      c. Skip downstream creation for this proposal — do not proceed to steps 8–10 for this proposal.
+      c. Skip downstream creation for this proposal only when upstream Issue creation succeeded — do not proceed to steps 8–10 for this proposal.
 
       d. Output to terminal: `"Routed to upstream {RETRO_PROPOSALS_UPSTREAM}#{issue_number}; skipping downstream creation"`
 

--- a/tests/retro-proposals.bats
+++ b/tests/retro-proposals.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+
+# Tests for retro-proposals upstream routing and sanitization logic.
+# Covers: sanitize regex patterns, upstream routing decision, fallback behavior.
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+
+# --- Sanitize helper functions (mirrors retro-proposals.md regex patterns) ---
+
+sanitize_absolute_paths() {
+    sed 's|/Users/[^[:space:]]*|<absolute-path>|g'
+}
+
+sanitize_issue_numbers() {
+    sed 's/#[0-9][0-9]*/#<downstream-issue>/g'
+}
+
+# Routing decision function: mirrors retro-proposals.md Step 7.4 condition.
+# Args: upstream classification
+# Writes "upstream" or "downstream" to stdout.
+route_proposal() {
+    local upstream="$1"
+    local classification="$2"
+    if [ -n "$upstream" ] && [ "$classification" = "skill-infra" ]; then
+        echo "upstream"
+    else
+        echo "downstream"
+    fi
+}
+
+# Full routing action: calls gh issue create with appropriate flags,
+# outputs routing message for upstream case.
+# Args: upstream classification title body
+perform_routing() {
+    local upstream="$1"
+    local classification="$2"
+    local title="$3"
+    local body="$4"
+
+    if [ -n "$upstream" ] && [ "$classification" = "skill-infra" ]; then
+        local sanitized_body
+        sanitized_body="$(printf '%s' "$body" | sanitize_absolute_paths | sanitize_issue_numbers)"
+        gh issue create --repo "$upstream" --title "$title" --label "retro/verify" --body "$sanitized_body"
+        local issue_url="$?"
+        echo "Routed to upstream $upstream; skipping downstream creation"
+        return 0
+    else
+        gh issue create --title "$title" --label "retro/verify" --body "$body"
+        return 0
+    fi
+}
+
+setup() {
+    WORK_DIR="$BATS_TEST_TMPDIR/work"
+    BIN_DIR="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$WORK_DIR" "$BIN_DIR"
+    cd "$WORK_DIR"
+
+    GH_CALLS_LOG="$BATS_TEST_TMPDIR/gh-calls.log"
+    rm -f "$GH_CALLS_LOG"
+
+    cat > "$BIN_DIR/gh" << STUB
+#!/bin/sh
+echo "gh \$*" >> "$GH_CALLS_LOG"
+echo "https://github.com/owner/repo/issues/99"
+exit 0
+STUB
+    chmod +x "$BIN_DIR/gh"
+    export PATH="$BIN_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$WORK_DIR" "$BIN_DIR" "$BATS_TEST_TMPDIR/gh-calls.log"
+}
+
+# --- Sanitize tests ---
+
+@test "sanitize: absolute paths to placeholder" {
+    input="See the module at /Users/dev/wholework/modules/retro-proposals.md for details"
+    expected="See the module at <absolute-path> for details"
+    result="$(printf '%s' "$input" | sanitize_absolute_paths)"
+    [ "$result" = "$expected" ]
+}
+
+@test "sanitize: downstream issue numbers to placeholder" {
+    input="Related to #123 and see also issue #456 for context"
+    expected="Related to #<downstream-issue> and see also issue #<downstream-issue> for context"
+    result="$(printf '%s' "$input" | sanitize_issue_numbers)"
+    [ "$result" = "$expected" ]
+}
+
+# --- Routing decision tests ---
+
+@test "routing: upstream unset falls back to downstream" {
+    result="$(route_proposal "" "skill-infra")"
+    [ "$result" = "downstream" ]
+}
+
+@test "routing: upstream set + skill-infra classification routes to upstream" {
+    result="$(route_proposal "owner/repo" "skill-infra")"
+    [ "$result" = "upstream" ]
+}
+
+@test "routing: upstream set + code classification falls back to downstream" {
+    result="$(route_proposal "owner/repo" "code")"
+    [ "$result" = "downstream" ]
+}
+
+# --- Integration: verify gh is called with correct flags ---
+
+@test "routing action: upstream set + skill-infra calls gh issue create --repo" {
+    run perform_routing "owner/repo" "skill-infra" "Test proposal" "Some body text"
+    [ "$status" -eq 0 ]
+    grep -q "gh issue create --repo owner/repo" "$GH_CALLS_LOG"
+}
+
+@test "routing action: upstream set + skill-infra outputs routed message" {
+    run perform_routing "owner/repo" "skill-infra" "Test proposal" "Some body text"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Routed to upstream owner/repo"* ]]
+}
+
+@test "routing action: upstream unset calls gh issue create without --repo" {
+    run perform_routing "" "skill-infra" "Test proposal" "Some body text"
+    [ "$status" -eq 0 ]
+    grep -q "gh issue create --title" "$GH_CALLS_LOG"
+    ! grep -q -- "--repo" "$GH_CALLS_LOG"
+}
+
+@test "routing action: upstream set + skill-infra sanitizes absolute paths before upstream filing" {
+    body="Fix /Users/dev/wholework/modules/retro-proposals.md"
+    run perform_routing "owner/repo" "skill-infra" "Fix module" "$body"
+    [ "$status" -eq 0 ]
+    ! grep -q "/Users/" "$GH_CALLS_LOG"
+    grep -q "<absolute-path>" "$GH_CALLS_LOG"
+}


### PR DESCRIPTION
## Summary

`retro-proposals` module を拡張し、Skill infrastructure improvement と分類された提案を `.wholework.yml` 設定の upstream リポジトリへ自動 routing + サニタイズする機能を追加。下流リポジトリ側では起票をスキップ (upstream-only) し、下流ユーザーの手動移管 (サニタイズ → upstream 起票 → 下流 close) の 3 ステップを不要化する。

- 新 marker: `retro-proposals-upstream: owner/repo` (`.wholework.yml`) — 未設定時は現状通り downstream 起票 (後方互換)
- Hybrid サニタイズ: 機械的 regex (絶対パス・下流固有 Issue 番号) + LLM (業務固有名詞・金額等)
- bats テスト追加 (`tests/retro-proposals.bats`) — routing 分岐とサニタイズ regex の単体テスト

## Closes

Closes #469

## Test Plan

- [x] `bats tests/retro-proposals.bats` で全テスト通過
- [x] Issue acceptance criteria の verify command が PASS
- [ ] (post-merge) 下流プロジェクトで `/verify` を実行し、Skill infrastructure 分類提案が upstream へサニタイズ済みで起票されることを実機確認

## Recovery Note

本 PR は code phase の watchdog timeout 後、`code-completed-no-pr` パターンを Tier 2 anomaly detector で検出し fallback 手順 (rebase → push → `gh pr create`) で作成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
