### PR TITLE
Issue #458: fix --batch triage-to-run-auto-sub Size race with --no-cache and verify-after-write

### DIFF
--- a/docs/spec/issue-458-triage-verify-after-write.md
+++ b/docs/spec/issue-458-triage-verify-after-write.md
@@ -56,6 +56,20 @@
 
 - triage 未実施の Issue（`phase/*` ラベルなし・Size 未設定）を含む `/auto --batch <Issue 番号>` を実行し、`run-auto-sub.sh` が `Error: Size is not set` で中断せず正常に処理が進むことを実環境で確認する <!-- verify-type: opportunistic -->
 
+## Code Retrospective
+
+### Deviations from Design
+
+- Specの実装ステップ4では「`tests/get-issue-size.bats` に `--no-cache` 動作テスト追加」として mock を変更せずテストを追加することを想定していたが、実際には `--no-cache` 時に `gh-graphql.sh` の non-cache パスが `--jq` を `gh api graphql` に渡す挙動を mock が処理しないため、テスト失敗が発生した。mock の `gh api graphql` ハンドラに `--jq` 処理を追加する修正を行い、これを別コミットとした。
+
+### Design Gaps/Ambiguities
+
+- Spec の Notes §「bats テスト Mock 互換性」に「run-auto-sub.bats の Mock は引数を無視するため `--no-cache` 追加でも既存テストはそのまま通過する」と記載されていたが、`get-issue-size.bats` の mock における `gh api graphql` の `--jq` 引数処理については言及がなかった。`--no-cache` 時は non-cache パスが `--jq` を `gh` コマンドに渡すため、既存 mock が `--jq` を無視して生 JSON を返し、テストが失敗するケースが生じた。
+
+### Rework
+
+- `tests/get-issue-size.bats`: 1回目のコミットでテスト追加後、テスト失敗を確認して mock の `gh api graphql` ハンドラに `--jq` 処理を追加する修正を2回目のコミットとして実施。
+
 ## Notes
 
 ### 実装ファイル選択の確定

--- a/scripts/get-issue-size.sh
+++ b/scripts/get-issue-size.sh
@@ -3,7 +3,10 @@
 # Script to retrieve the Size of a GitHub Issue
 #
 # Usage:
-#   scripts/get-issue-size.sh <issue-number>
+#   scripts/get-issue-size.sh [--no-cache] <issue-number>
+#
+# Options:
+#   --no-cache  Bypass the GraphQL response cache (use immediately after triage for freshness)
 #
 # Priority:
 #   1. Project field (GraphQL)
@@ -15,8 +18,30 @@
 
 set -euo pipefail
 
+# Parse flags
+NO_CACHE=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-cache)
+            NO_CACHE=true
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
 if [ $# -lt 1 ]; then
-    echo "Usage: $0 <issue-number>" >&2
+    echo "Usage: $0 [--no-cache] <issue-number>" >&2
     exit 1
 fi
 
@@ -29,12 +54,18 @@ fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
+# CACHE_FLAG is --cache by default; empty when --no-cache is specified
+CACHE_FLAG="--cache"
+if [ "$NO_CACHE" = true ]; then
+    CACHE_FLAG=""
+fi
+
 # Phase 1: Get from Project field
 GQL_QUERY='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:10){nodes{fieldValues(first:20){nodes{... on ProjectV2ItemFieldSingleSelectValue{field{... on ProjectV2SingleSelectField{name}}value:name}}}}}}}}'
 
 PROJECT_SIZE=""
 PROJECT_SIZE=$(
-    "$SCRIPT_DIR/gh-graphql.sh" --cache "$GQL_QUERY" -F num="$NUMBER" \
+    "$SCRIPT_DIR/gh-graphql.sh" $CACHE_FLAG "$GQL_QUERY" -F num="$NUMBER" \
         --jq '.data.repository.issue.projectItems.nodes[].fieldValues.nodes[] | select(.field.name=="Size") | .value' \
         2>/dev/null | head -1 | tr -d '"' || true
 )

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -115,7 +115,7 @@ fi
 echo "---"
 
 # Determine route by fetching Size (before spec phase)
-SIZE=$("$SCRIPT_DIR/get-issue-size.sh" "$SUB_NUMBER" 2>/dev/null || true)
+SIZE=$("$SCRIPT_DIR/get-issue-size.sh" --no-cache "$SUB_NUMBER" 2>/dev/null || true)
 
 # spec phase: run only if phase/ready label is not present
 LABELS=$(gh issue view "$SUB_NUMBER" --json labels -q '.labels[].name' 2>/dev/null || true)
@@ -130,7 +130,7 @@ fi
 
 # Re-fetch SIZE after spec phase in case spec set the Size label
 if [[ -z "$SIZE" ]]; then
-  SIZE=$("$SCRIPT_DIR/get-issue-size.sh" "$SUB_NUMBER" 2>/dev/null || true)
+  SIZE=$("$SCRIPT_DIR/get-issue-size.sh" --no-cache "$SUB_NUMBER" 2>/dev/null || true)
 fi
 if [[ -z "$SIZE" ]]; then
   echo "Error: Size is not set for issue #${SUB_NUMBER}" >&2

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -2,7 +2,7 @@
 model: sonnet
 name: triage
 description: Issue triage. Automates title normalization, Type/Priority/Size/Value assignment (`/triage 123` for single issue + lightweight analysis, `/triage` for bulk execution, `/triage --backlog` for bulk processing + 4-perspective deep analysis).
-allowed-tools: Bash(gh:*, cat:*, echo:*, grep:*, jq:*, test:*, bash:*, printf:*, wc:*, head:*, tail:*, sed:*, awk:*, mkdir:*, rm:*, ${CLAUDE_PLUGIN_ROOT}/scripts/triage-backlog-filter.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*), Read, Write, Glob, Grep
+allowed-tools: Bash(gh:*, cat:*, echo:*, grep:*, jq:*, test:*, bash:*, printf:*, wc:*, head:*, tail:*, sed:*, awk:*, mkdir:*, rm:*, sleep:*, ${CLAUDE_PLUGIN_ROOT}/scripts/triage-backlog-filter.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*), Read, Write, Glob, Grep
 ---
 
 # Issue Triage
@@ -153,6 +153,51 @@ Named queries to use (`--query <n>` format): `get-projects-with-fields`, `get-is
 **Skip when Projects is not configured**: If the repository has no GitHub Projects, `projectsV2.nodes` returns an empty array in Step 1 of `project-field-update.md`, automatically proceeding to Step 5 (label fallback). No additional branching needed.
 
 Estimate the scope of change from the issue body's acceptance conditions and technical notes, and set the project's Size field. Determine in 5 levels: XS/S/M/L/XL.
+
+**Verify-after-write (run after Steps 1→4 succeed)**:
+
+After the GraphQL mutation in Step 4 completes with exit 0, verify that the Size was actually persisted by reading it back with cache bypass. This detects GitHub eventual consistency delays and cases where the LLM skipped the mutation.
+
+1. Read back the Size immediately after the mutation:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
+   ```
+2. Compare the returned value against the determined Size (e.g., `XS`, `M`):
+   - If they match → verification passed. Step 6 is complete.
+   - If they do not match (or the script returns empty / exit 1) → proceed to retry loop below.
+3. Retry loop (max 3 attempts, increasing wait):
+   - Attempt 1: wait 1 second, then re-read:
+     ```bash
+     sleep 1
+     ```
+     ```bash
+     ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
+     ```
+     If the value now matches → verification passed. Step 6 is complete.
+   - Attempt 2: wait 2 seconds, then re-read:
+     ```bash
+     sleep 2
+     ```
+     ```bash
+     ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
+     ```
+     If the value now matches → verification passed. Step 6 is complete.
+   - Attempt 3: wait 3 seconds, then re-read:
+     ```bash
+     sleep 3
+     ```
+     ```bash
+     ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
+     ```
+     If the value now matches → verification passed. Step 6 is complete.
+4. If all 3 retries fail (value still does not match or remains empty): fall back to label assignment as per Step 5 of `project-field-update.md`:
+   ```bash
+   gh label create "size/$SIZE" --force
+   ```
+   ```bash
+   gh issue edit $NUMBER --remove-label "size/XS" --remove-label "size/S" --remove-label "size/M" --remove-label "size/L" --remove-label "size/XL" --add-label "size/$SIZE"
+   ```
+   This guarantees that `get-issue-size.sh` can resolve the Size via Phase 2 (label fallback) even if the Project field did not persist.
 
 ### Step 7: Value Assignment (Projects field)
 

--- a/tests/get-issue-size.bats
+++ b/tests/get-issue-size.bats
@@ -23,12 +23,25 @@ if [[ "$1" == "repo" && "$2" == "view" ]]; then
     printf "testowner\ttestrepo\n"
     exit 0
 fi
-# Response for: gh api graphql ... (called via --cache without --jq)
+# Response for: gh api graphql ... (handles optional --jq for non-cache path)
 if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+    shift 2
+    JQ_EXPR=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --jq) JQ_EXPR="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
     if [ -n "$MOCK_GRAPHQL_RESPONSE" ]; then
-        echo "$MOCK_GRAPHQL_RESPONSE"
+        RESPONSE="$MOCK_GRAPHQL_RESPONSE"
     else
-        echo '{"data":{"repository":{"issue":{"projectItems":{"nodes":[]}}}}}'
+        RESPONSE='{"data":{"repository":{"issue":{"projectItems":{"nodes":[]}}}}}'
+    fi
+    if [ -n "$JQ_EXPR" ]; then
+        echo "$RESPONSE" | jq "$JQ_EXPR"
+    else
+        echo "$RESPONSE"
     fi
     exit 0
 fi

--- a/tests/get-issue-size.bats
+++ b/tests/get-issue-size.bats
@@ -134,3 +134,49 @@ graphql_without_size() {
     [ "$status" -eq 0 ]
     [ "$output" = "L" ]
 }
+
+@test "--no-cache bypasses GraphQL cache and returns fresh value" {
+    export MOCK_GRAPHQL_RESPONSE
+
+    # First call: populate cache with M
+    MOCK_GRAPHQL_RESPONSE="$(graphql_with_size "M")"
+    run bash "$SCRIPT" 200
+    [ "$status" -eq 0 ]
+    [ "$output" = "M" ]
+
+    # Update mock to return L (new value after triage mutation)
+    MOCK_GRAPHQL_RESPONSE="$(graphql_with_size "L")"
+
+    # Without --no-cache: cache hit returns the old value M
+    run bash "$SCRIPT" 200
+    [ "$status" -eq 0 ]
+    [ "$output" = "M" ]
+
+    # With --no-cache: bypasses cache, returns fresh value L
+    run bash "$SCRIPT" --no-cache 200
+    [ "$status" -eq 0 ]
+    [ "$output" = "L" ]
+}
+
+@test "--no-cache works correctly without prior cache" {
+    export MOCK_GRAPHQL_RESPONSE
+    MOCK_GRAPHQL_RESPONSE="$(graphql_with_size "S")"
+    run bash "$SCRIPT" --no-cache 201
+    [ "$status" -eq 0 ]
+    [ "$output" = "S" ]
+}
+
+@test "--no-cache falls back to label when project field has no size" {
+    export MOCK_GRAPHQL_RESPONSE
+    MOCK_GRAPHQL_RESPONSE="$(graphql_without_size)"
+    export MOCK_LABEL_OUTPUT="size/M"
+    run bash "$SCRIPT" --no-cache 202
+    [ "$status" -eq 0 ]
+    [ "$output" = "M" ]
+}
+
+@test "error: unknown option is rejected" {
+    run bash "$SCRIPT" --unknown 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"* ]]
+}


### PR DESCRIPTION
## Summary

- `scripts/get-issue-size.sh`: Added `--no-cache` flag that bypasses the GraphQL response cache (TTL 300s). When specified, `CACHE_FLAG` is set to empty so `gh-graphql.sh` is called without `--cache`, forcing a fresh API call. Backward compatible — default behavior unchanged.
- `scripts/run-auto-sub.sh`: Updated both `get-issue-size.sh` call sites (lines 118 and 133) to pass `--no-cache`, ensuring fresh Size reads immediately after triage completes.
- `skills/triage/SKILL.md` Step 6: Added verify-after-write procedure after the GraphQL mutation succeeds. Reads Size back with cache bypass, retries up to 3 times (1s/2s/3s backoff), and falls back to label assignment if all retries fail. Also added `sleep:*` and `get-issue-size.sh:*` to `allowed-tools`.
- `tests/get-issue-size.bats`: Added 4 new test cases for `--no-cache` behavior. Updated the mock `gh` to handle `--jq` argument in the non-cache path (cache path applies jq locally; non-cache path passes `--jq` to `gh api graphql`).

## Verification (pre-merge)

- triage に verify-after-write 手順（retry + 失敗時 label fallback）が追加されている
- `get-issue-size.sh` に `--no-cache` オプションが追加されている
- `run-auto-sub.sh` が `get-issue-size.sh` を cache bypass で呼び出す
- 既存の「GraphQL 失敗時のみ label fallback」記述が維持されている

## Verification (post-merge)

- triage 未実施の Issue を含む `/auto --batch <Issue 番号>` を実行し、`run-auto-sub.sh` が `Error: Size is not set` で中断せず正常に処理が進むことを確認する

closes #458