### PR TITLE
Issue #505: Accept JA/EN review completion signature in phase-state and reconciler

### DIFF
--- a/docs/spec/issue-505-phase-state-ja-en-signature.md
+++ b/docs/spec/issue-505-phase-state-ja-en-signature.md
@@ -43,6 +43,17 @@
 
 - `reconcile-phase-state.sh review <issue> --pr <pr> --check-completion` が `## レビュー回答サマリ` ヘッダーを含む PR で `matches_expected:true` を返すことを手動確認（該当環境がある場合）
 
+## Code Retrospective
+
+### Deviations from Design
+- N/A
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A
+
 ## Notes
 
 - Auto-Resolved Ambiguity Points（Issue body より転記）:

--- a/docs/spec/issue-505-phase-state-ja-en-signature.md
+++ b/docs/spec/issue-505-phase-state-ja-en-signature.md
@@ -62,3 +62,18 @@
   - **github_check の形式**: `gh run list --workflow=test.yml` 形式に統一（PR route/patch route 両方で動作するため）。
 - `grep -qE` は bash 3.2+ 互換（macOS system bash でも動作）。
 - docs/ja/ 同期不要（変更対象は `modules/` と `scripts/` と `tests/`、いずれも `docs/` 以下ではない）。
+
+## review retrospective
+
+### Spec vs. Implementation Divergence
+
+実装ステップ 3 では bats テストを `@test "review completion: no Review Summary comment -> mismatch"` の「直後」に追加と指定していたが、実際は EN pass テストの直後（"no Review Summary" テストの直前）に挿入された。テスト順序は EN pass → JA pass → fail の論理グループになっており機能上の問題はない。次回以降の Spec では挿入位置をテスト名で「直前」/「直後」双方向から明示するか、グループ番号で指定するとよい。
+
+### Recurring Issues
+
+特になし。
+
+### Acceptance Criteria Verification Difficulty
+
+全 6 条件を PASS で判定できた。`github_check` 条件のみ実際の CI 実行結果参照が必要だったが、`gh run list` で確認可能。`section_contains` 条件が 2 件あり verify コマンドの精度を要したが、いずれも明確にマッチした。UNCERTAIN は 0 件。
+

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -37,7 +37,7 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 | spec | `phase/issue` or `phase/spec` label on issue | `$SPEC_PATH/issue-N-*.md` exists AND `phase/(ready\|code\|review\|merge\|verify\|done)` label | Implemented |
 | code-patch | `phase/ready` label on issue, Spec exists | `git log origin/main --grep="closes #N"` returns ≥1 commit | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
 | code-pr | `phase/ready` label on issue, Spec exists | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
-| review | PR is OPEN | PR has a comment containing `## Review Response Summary` | Implemented |
+| review | PR is OPEN | PR has a comment containing `## Review Response Summary` or `## レビュー回答サマリ` | Implemented |
 | merge | PR is OPEN and reviewDecision is APPROVED | `gh pr view --json state == MERGED` | Implemented |
 | verify | Issue has `phase/verify` label or is CLOSED | Issue is CLOSED or has `phase/done` label | Implemented |
 

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -224,7 +224,7 @@ _completion_review() {
 
   local actual_json="{\"pr_number\":${PR_NUMBER}}"
 
-  if echo "$comments" | grep -q "## Review Response Summary"; then
+  if echo "$comments" | grep -qE "## Review Response Summary|## レビュー回答サマリ"; then
     _emit_result "true" "Review Response Summary found in PR #${PR_NUMBER} comments" "$actual_json"
   else
     _handle_mismatch "Review Response Summary not found in PR #${PR_NUMBER} comments" "$actual_json"

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -299,6 +299,21 @@ MOCK_EOF
     [[ "$output" == *'"matches_expected":true'* ]]
 }
 
+@test "review completion: PR comment with Japanese header -> matches_expected true" {
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "## レビュー回答サマリ"
+echo "All good"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" review 42 --pr 10 --check-completion --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+}
+
 @test "review completion: no Review Summary comment -> mismatch (strict exit 1)" {
     cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
 #!/bin/bash


### PR DESCRIPTION
## Summary

- Updated `modules/phase-state.md` Phase Table review row to document both `## Review Response Summary` (EN) and `## レビュー回答サマリ` (JA) as accepted completion signatures
- Changed `scripts/reconcile-phase-state.sh` `_completion_review` from `grep -q "## Review Response Summary"` to `grep -qE "## Review Response Summary|## レビュー回答サマリ"` to accept either header
- Added bats test for Japanese header case: `review completion: PR comment with Japanese header -> matches_expected true`

## Verification (pre-merge)

- `modules/phase-state.md` Phase Table contains English signature `Review Response Summary`
- `modules/phase-state.md` Phase Table contains Japanese signature `レビュー回答サマリ`
- JA/EN dual-language support implemented in `modules/phase-state.md`
- `_completion_review` in `scripts/reconcile-phase-state.sh` matches Japanese signature
- `tests/reconcile-phase-state.bats` has Japanese signature completion test
- bats test CI passes

## Verification (post-merge)

- `reconcile-phase-state.sh review <issue> --pr <pr> --check-completion` returns `matches_expected:true` for PRs with `## レビュー回答サマリ` header (manual confirmation when applicable)

closes #505