### PR TITLE
Issue #518: Fix verify-after-write to warn-only for Size field

### DIFF
--- a/docs/spec/issue-518-fix-verify-after-write.md
+++ b/docs/spec/issue-518-fix-verify-after-write.md
@@ -41,6 +41,20 @@ fix #1（本 Issue のスコープ）: mutation の成功（exit 0 かつ `proje
 
 - merge 後に `/triage` または `/issue` で Size を設定し、Projects V2 Size フィールドが正しく設定され、eventual-consistency 遅延時にも `size/*` ラベルへ冗長フォールバックしないことを実運用で確認 <!-- verify-type: opportunistic -->
 
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A（設計通りに実装）
+
+### Design Gaps/Ambiguities
+
+- N/A
+
+### Rework
+
+- N/A
+
 ## Notes
 
 ### Step 4 の変更詳細

--- a/docs/spec/issue-518-fix-verify-after-write.md
+++ b/docs/spec/issue-518-fix-verify-after-write.md
@@ -55,6 +55,20 @@ fix #1（本 Issue のスコープ）: mutation の成功（exit 0 かつ `proje
 
 - N/A
 
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- 実装は Spec 通りで divergence なし。ただしレビューで `MUTATION_EXIT=$?` が jq 代入前に必要という点が発覚 — Spec の実装ステップに「mutation の exit code を `$?` で保持する前に jq を実行しない」旨の明示がなかった。LLM 実行向けの pseudo-bash としては意図が伝わるが、将来 shell script 化した場合に確実なバグになる。Spec の Implementation Steps に exit code 保持順序を明示する習慣が望ましい。
+
+### Recurring Issues
+
+- exit code 保持パターン（`MUTATION_EXIT=$?` を先に保存）は shell script への変換を見据えると共通ベストプラクティス。他のモジュールで同様のパターン（command substitution の直後に別コマンドを実行）がある場合は一括で確認する価値がある。
+
+### Acceptance Criteria Verification Difficulty
+
+- rubric / section_contains の verify command は全て PASS で判定容易だった。github_check も CI GREEN で問題なし。UNCERTAIN なし。verify command の質は良好。
+
 ## Notes
 
 ### Step 4 の変更詳細

--- a/modules/project-field-update.md
+++ b/modules/project-field-update.md
@@ -14,7 +14,7 @@ Information provided by the calling skill:
 
 ### Updating Priority / Size Fields
 
-**Important: Execute steps 1→2→3→4 in order. If the GraphQL mutation in step 4 succeeds, processing is complete. Execute the label fallback in step 5 only if steps 1-4 fail.**
+**Important: Execute steps 1→2→3→4 in order. If the GraphQL mutation in step 4 succeeds (exit 0 and `projectV2Item.id` returned), processing is complete. Execute the label fallback in step 5 only if steps 1–4 fail (i.e., mutation error in step 4).**
 
 1. Dynamically fetch projects linked to the repository:
    ```bash
@@ -36,10 +36,11 @@ Information provided by the calling skill:
 4. Set the field value and capture the mutation result:
    ```bash
    MUTATION_RESULT=$(${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query update-field-value -F projectId="$PROJECT_ID" -F itemId="$ITEM_ID" -F fieldId="$FIELD_ID" -F optionId="$OPTION_ID")
+   MUTATION_EXIT=$?
    RETURNED_ID=$(echo "$MUTATION_RESULT" | jq -r '.data.updateProjectV2ItemFieldValue.projectV2Item.id // empty')
    ```
-   - **If exit code is 0 and `RETURNED_ID` is non-empty → mutation succeeded. Field write confirmed. Proceed to verify-after-write (warn-only) below. Skip step 5.**
-   - **If exit code is non-0 or `RETURNED_ID` is empty → mutation failed. Proceed to step 5 (label fallback).**
+   - **If `MUTATION_EXIT` is 0 and `RETURNED_ID` is non-empty → mutation succeeded. Field write confirmed. Proceed to verify-after-write (warn-only) below. Skip step 5.**
+   - **If `MUTATION_EXIT` is non-0 or `RETURNED_ID` is empty → mutation failed. Proceed to step 5 (label fallback).**
 
 #### Verify-after-write (for Size field; warn-only eventual-consistency monitoring)
 

--- a/modules/project-field-update.md
+++ b/modules/project-field-update.md
@@ -33,23 +33,25 @@ Information provided by the calling skill:
    ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query add-project-item -F projectId="$PROJECT_ID" -F contentId="$ISSUE_ID"
    ```
 
-4. Set the field value:
+4. Set the field value and capture the mutation result:
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query update-field-value -F projectId="$PROJECT_ID" -F itemId="$ITEM_ID" -F fieldId="$FIELD_ID" -F optionId="$OPTION_ID"
+   MUTATION_RESULT=$(${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query update-field-value -F projectId="$PROJECT_ID" -F itemId="$ITEM_ID" -F fieldId="$FIELD_ID" -F optionId="$OPTION_ID")
+   RETURNED_ID=$(echo "$MUTATION_RESULT" | jq -r '.data.updateProjectV2ItemFieldValue.projectV2Item.id // empty')
    ```
-   - **If successful → proceed to verify-after-write below. Skip step 5.**
+   - **If exit code is 0 and `RETURNED_ID` is non-empty → mutation succeeded. Field write confirmed. Proceed to verify-after-write (warn-only) below. Skip step 5.**
+   - **If exit code is non-0 or `RETURNED_ID` is empty → mutation failed. Proceed to step 5 (label fallback).**
 
-#### Verify-after-write (for Size field; run after step 4 succeeds)
+#### Verify-after-write (for Size field; warn-only eventual-consistency monitoring)
 
-After the GraphQL mutation in step 4 completes with exit 0, verify that the Size value was actually persisted by reading it back with cache bypass. This detects GitHub eventual consistency delays.
+After the GraphQL mutation in step 4 confirms success (exit 0 and `projectV2Item.id` returned), read back the Size value to monitor for GitHub Projects V2 eventual-consistency delays. Read-back mismatches do **not** trigger label fallback — they emit a warn and monitoring continues. Label fallback is only executed when the mutation itself fails (step 5).
 
 1. Read back the Size immediately after the mutation:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
    ```
 2. Compare the returned value against the determined Size (e.g., `XS`, `M`):
-   - If they match → verification passed. Processing complete.
-   - If they do not match (or the script returns empty / exit 1) → proceed to retry loop below.
+   - If they match → monitoring complete. Processing complete.
+   - If they do not match (or the script returns empty) → output a warn and proceed to retry loop below.
 3. Retry loop (max 3 attempts, increasing wait):
    - Attempt 1: wait 1 second, then re-read:
      ```bash
@@ -58,7 +60,8 @@ After the GraphQL mutation in step 4 completes with exit 0, verify that the Size
      ```bash
      ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
      ```
-     If the value now matches → verification passed. Processing complete.
+     If the value now matches → monitoring complete. Processing complete.
+     If still mismatched → output a warn and continue.
    - Attempt 2: wait 2 seconds, then re-read:
      ```bash
      sleep 2
@@ -66,7 +69,8 @@ After the GraphQL mutation in step 4 completes with exit 0, verify that the Size
      ```bash
      ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
      ```
-     If the value now matches → verification passed. Processing complete.
+     If the value now matches → monitoring complete. Processing complete.
+     If still mismatched → output a warn and continue.
    - Attempt 3: wait 3 seconds, then re-read:
      ```bash
      sleep 3
@@ -74,15 +78,8 @@ After the GraphQL mutation in step 4 completes with exit 0, verify that the Size
      ```bash
      ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh --no-cache $NUMBER
      ```
-     If the value now matches → verification passed. Processing complete.
-4. If all 3 retries fail (value still does not match or remains empty): fall back to label assignment as per step 5:
-   ```bash
-   gh label create "size/$SIZE" --force
-   ```
-   ```bash
-   gh issue edit $NUMBER --remove-label "size/XS" --remove-label "size/S" --remove-label "size/M" --remove-label "size/L" --remove-label "size/XL" --add-label "size/$SIZE"
-   ```
-   This guarantees that `get-issue-size.sh` can resolve the Size via label fallback even if the Project field did not persist.
+     If the value now matches → monitoring complete. Processing complete.
+4. If all 3 retries fail (value still does not match or remains empty): output a warn — "Size field write confirmed by mutation (projectV2Item.id returned), but read-back mismatch after retries — probable eventual-consistency delay. No label fallback." — and complete processing. **Do not proceed to step 5.**
 
 **For Priority/Value fields:** No read-back helper is currently available. When eventual consistency issues arise for these fields, extend this verify-after-write pattern using an appropriate API query to read back the field value.
 


### PR DESCRIPTION
## Summary

`modules/project-field-update.md` の Size 用 verify-after-write を修正し、Projects V2 の eventual-consistency による誤フォールバックを解消する。

**変更内容:**
- Step 4 の mutation 呼び出しを出力キャプチャ形式に変更し、`projectV2Item.id` の返却を一次の書き込み成功判定とする
- `RETURNED_ID` が non-empty かつ exit 0 → mutation 成功（warn-only monitoring へ）
- exit 非 0 または `RETURNED_ID` が empty → mutation 失敗（step 5 ラベルフォールバックへ）
- Verify-after-write セクションを "warn-only eventual-consistency monitoring" に変更
- 読み戻し不一致は warn のみ出力し、ラベルフォールバックを誘発しない
- 3 回全リトライ失敗時も warn のみ。「No label fallback」を明示。

## Verification (pre-merge)

- mutation 成功（exit 0 + `projectV2Item.id` 返却）を一次判定とする方式に変更済み
- Verify-after-write セクションに "warn" の記述あり（section_contains PASS 確認済み）
- CI bats テスト: green 待ち
- CI skill 構文検証: green 待ち

## Verification (post-merge)

- `/triage` または `/issue` で Size を設定し、eventual-consistency 遅延時にも `size/*` ラベルへ冗長フォールバックしないことを実運用で確認

closes #518