### PR TITLE
Issue #501: Add Phase Handoff cross-phase context carryover

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -16,7 +16,7 @@ wholework/
 │   └── <skill-name>/
 │       ├── SKILL.md     # スキル定義（必須）
 │       └── *.md         # 補助的な phase/ガイドラインファイル（任意）
-├── modules/             # スキルから参照される共有モジュール（34 ファイル）
+├── modules/             # スキルから参照される共有モジュール（35 ファイル）
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
@@ -119,6 +119,7 @@ wholework/
 - `modules/measurement-scope.md` — 計測スコープ定義
 - `modules/next-action-guide.md` — 全スキル共通の次アクション案内
 - `modules/phase-banner.md` — スキル用フェーズ識別バナー表示
+- `modules/phase-handoff.md` — phase 間 Phase Handoff 要約の read/write（cross-phase context carryover）
 - `modules/steering-hint.md` — steering docs が無い場合に `/doc init` を促す動的ヒント
 - `modules/orchestration-fallbacks.md` — orchestration レベルの fallback パターン参照カタログ（#319 tier 2・#316 recovery sub-agent・#318 learning loop から参照）
 - `modules/domain-classifier.md` — 改善提案の Domain 分類（composable、LLM-in-context）

--- a/docs/spec/issue-501-auto-phase-handoff.md
+++ b/docs/spec/issue-501-auto-phase-handoff.md
@@ -83,20 +83,32 @@
 
 - merge SKILL.md: allowed-tools への `Glob` 追加と "Write Procedure" 表記の変更（2 回の Edit）。validate-skill-syntax.py 検証で発覚したため、実装後に修正が必要になった。
 
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+Spec の「Step 5 末尾」指定に対し、review SKILL.md は「Step 7.0 detect-config-markers 後」に Phase Handoff read を配置した。SPEC_PATH が Step 7.0 で確定するため技術的に正当な逸脱であり、Code Retrospective に記録済み。今後同様のパターン（`SPEC_PATH` 参照が前提のステップ）では、Spec 作成時点で解決タイミング依存関係を明示するとよい。
+
+### 繰り返し発生する指摘パターン
+
+Phase Handoff write を追加した際、Commit and push を sub-bullet から top-level ステップ 4 に昇格させたが、後続ステップ（`If improvement proposals exist`）の番号更新を漏らした（`3.` → `5.`）。ステップ番号の変更を伴う SKILL.md 編集では後続全ステップの番号確認が必要。spec/code/merge SKILL.md は正しく更新されており、review のみ発生した。
+
+### 受け入れ条件の自動検証難易度
+
+rubric 型の条件（AC 1–5）は全て diff 参照で PASS 判定可能だった。github_check 型（bats CI）も `gh pr checks` で即時確認可能。verify command の記述品質は高く、UNCERTAIN は 0 件。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- 実装箇所は SKILL.md + 共有モジュール（`modules/phase-handoff.md`）の組み合わせとした。SKILL.md が呼び出し側、modules が手順書として役割分担。
-- review の Phase Handoff read 位置を「Step 7.0 detect-config-markers 後」とした。SPEC_PATH が Step 7.0 で確定するため、正しいパスでの Spec 探索を保証するため。
-- merge の Phase Handoff write で worktree ブランチを origin/main に fast-forward した後 commit/push する手順を採用。gh pr merge 後の状態に確実に追従するため。
+- review SKILL.md Retrospective のステップ番号重複（`3. If improvement proposals exist` が `5.` であるべき）を SHOULD 指摘として検出し修正した。validate-skill-syntax.py は構文エラーを検知するが、ステップ番号の論理的な重複は検知しない。
+- Phase Handoff read の位置を Step 7.0 detect-config-markers 後に採用（Spec は Step 5 末尾を指定していたが、SPEC_PATH 確定のタイミングから逸脱が正当）。この判断を再確認し、merge phase に引き継ぐ。
 
 ### Deferred Items
-- Phase Handoff の実際の動作確認（downstream プロジェクトでの `/auto` 実行）は post-merge 検証として残っている。
-- merge SKILL.md の standalone Phase Handoff commit が main への push 競合を起こさないかの実地確認は未実施。
-- Spec が存在しない XS route での graceful skip 動作は実地確認未実施（設計上は問題ないが）。
+- merge SKILL.md の Phase Handoff write 後の `git push origin HEAD:main` が並行マージ時に失敗する可能性は確認済みだが、graceful fallback（verify が graceful skip）により実害なし。実地確認は post-merge 検証に委ねる。
+- Spec が存在しない XS route での graceful skip 動作の実地確認も引き続き post-merge 対象。
 
 ### Notes for Next Phase
-- validate-skill-syntax.py が SKILL.md 本文の大文字 "Write" を Write ツール参照と検知する。modules/phase-handoff.md の `Write Procedure` セクション名を SKILL.md 内で参照する際は backtick 記法か、allowed-tools に Write を含む SKILL.md 内で参照すること（merge はバッククォートで回避済み）。
-- merge SKILL.md の Step 1 に detect-config-markers.md 読み込みを追加したが、merge は従来この読み込みをしていなかった。パフォーマンス面で懸念があれば SPEC_PATH をデフォルト値で固定する代替案もある。
-- Phase Handoff write の内容（Key Decisions 等）は LLM が実装時の判断に基づき生成する。review phase はこの内容の品質も評価対象に含めるとよい。
+- merge SKILL.md の Phase Handoff write commit は `git push origin HEAD:main` で main へ直接 push する設計。競合時は push が失敗する可能性があるが、verify は graceful skip するため致命的な障害にはならない。
+- merge phase で detect-config-markers.md を読み込むようになったため（SPEC_PATH 取得目的）、`.wholework.yml` の `spec-path` 設定が merge にも反映される。デフォルト値（`docs/spec`）を使う場合は影響なし。
+

--- a/docs/spec/issue-501-auto-phase-handoff.md
+++ b/docs/spec/issue-501-auto-phase-handoff.md
@@ -65,3 +65,38 @@
 - **ローテーション実装の注意点**: Spec 末尾の `## Phase Handoff` セクションを Edit tool で置換する際、セクション境界は「次の `##` ヘッダー or ファイル末尾」を正確に特定する必要がある。`/code` 実装時は既存 retrospective セクションとの境界に注意
 - **Non-interactive mode 対応**: Phase Handoff の read/write は決定論的操作（Spec が存在するかどうかの判断）のみであり、AskUserQuestion を必要としない。non-interactive mode でも問題なく動作する
 - **XS route の graceful skip 確認**: `/auto` SKILL.md Step 4b で XS route 用 Spec が code 完了後に生成される場合、code phase 実行中は Spec が存在しないため Phase Handoff write もスキップされる（Spec 存在確認が先行する）
+
+## Code Retrospective
+
+### Deviations from Design
+
+- review SKILL.md の Phase Handoff read 挿入箇所を Spec の「Step 5 末尾」から「Step 7.0 detect-config-markers 後」に変更した。SPEC_PATH が Step 7.0 で初めて確定するため、正しい Spec パスで read するにはこちらが適切。
+- merge SKILL.md の Phase Handoff write で `git fetch origin && git merge origin/main --ff-only` を先行させる手順を追加した。`gh pr merge` 後に origin/main が進んでいるため、worktree ブランチを追従させてから commit/push する必要があった。
+- merge SKILL.md の allowed-tools に `Glob` を追加した（Spec ファイル探索に必要）。Spec では allowed-tools の変更について言及がなかったが、validate-skill-syntax.py の検証でエラーが発覚し修正。
+
+### Design Gaps/Ambiguities
+
+- phase-handoff.md "Write Procedure" の文字列が merge SKILL.md 本文に現れると validate-skill-syntax.py が `Write` ツール参照と誤検知する。他の SKILL.md（code/review/spec）は `Write` が allowed-tools にあるためパスしていたが、merge は含まれていなかった。バッククォートでの inline code 記法（`Write Procedure`）により回避した。
+- merge SKILL.md は独立した retrospective step を持たないため、Phase Handoff write は Step 4 完了後の standalone sub-step となった（Spec 通り）。
+
+### Rework
+
+- merge SKILL.md: allowed-tools への `Glob` 追加と "Write Procedure" 表記の変更（2 回の Edit）。validate-skill-syntax.py 検証で発覚したため、実装後に修正が必要になった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- 実装箇所は SKILL.md + 共有モジュール（`modules/phase-handoff.md`）の組み合わせとした。SKILL.md が呼び出し側、modules が手順書として役割分担。
+- review の Phase Handoff read 位置を「Step 7.0 detect-config-markers 後」とした。SPEC_PATH が Step 7.0 で確定するため、正しいパスでの Spec 探索を保証するため。
+- merge の Phase Handoff write で worktree ブランチを origin/main に fast-forward した後 commit/push する手順を採用。gh pr merge 後の状態に確実に追従するため。
+
+### Deferred Items
+- Phase Handoff の実際の動作確認（downstream プロジェクトでの `/auto` 実行）は post-merge 検証として残っている。
+- merge SKILL.md の standalone Phase Handoff commit が main への push 競合を起こさないかの実地確認は未実施。
+- Spec が存在しない XS route での graceful skip 動作は実地確認未実施（設計上は問題ないが）。
+
+### Notes for Next Phase
+- validate-skill-syntax.py が SKILL.md 本文の大文字 "Write" を Write ツール参照と検知する。modules/phase-handoff.md の `Write Procedure` セクション名を SKILL.md 内で参照する際は backtick 記法か、allowed-tools に Write を含む SKILL.md 内で参照すること（merge はバッククォートで回避済み）。
+- merge SKILL.md の Step 1 に detect-config-markers.md 読み込みを追加したが、merge は従来この読み込みをしていなかった。パフォーマンス面で懸念があれば SPEC_PATH をデフォルト値で固定する代替案もある。
+- Phase Handoff write の内容（Key Decisions 等）は LLM が実装時の判断に基づき生成する。review phase はこの内容の品質も評価対象に含めるとよい。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -23,7 +23,7 @@ wholework/
 │   └── <skill-name>/
 │       ├── SKILL.md     # Skill definition (required)
 │       └── *.md         # Auxiliary phase/guideline files (optional)
-├── modules/             # Shared modules referenced by skills (34 files)
+├── modules/             # Shared modules referenced by skills (35 files)
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
@@ -126,6 +126,7 @@ Key modules:
 - `modules/measurement-scope.md` — measurement scope definition
 - `modules/next-action-guide.md` — unified next action guidance for all skills
 - `modules/phase-banner.md` — phase identification banner display for skills
+- `modules/phase-handoff.md` — phase-to-phase Phase Handoff summary read/write (cross-phase context carryover)
 - `modules/steering-hint.md` — dynamic hint recommending `/doc init` when steering docs are absent
 - `modules/orchestration-fallbacks.md` — orchestration-level fallback pattern reference catalog (consumed by #319 tier 2, #316 recovery sub-agent, #318 learning loop)
 - `modules/domain-classifier.md` — improvement proposal Domain classification (composable, LLM-in-context)

--- a/modules/phase-handoff.md
+++ b/modules/phase-handoff.md
@@ -1,0 +1,90 @@
+# phase-handoff
+
+Shared module for Phase Handoff read/write between phases of `/auto`.
+
+## Purpose
+
+Each `/auto` phase runs in a forked session with no shared in-context memory. This module provides a lightweight mechanism to carry forward a summary of the current phase's key decisions, deferred items, and notes for the next phase — stored directly in the Spec file (the existing cross-phase memory channel).
+
+The handoff retains only the **latest 1 phase** at a time (rotation): when a new handoff is written, the old one is replaced.
+
+## Phase Handoff Section Format
+
+```markdown
+## Phase Handoff
+<!-- phase: {phase-name} -->
+
+### Key Decisions
+- {decision and rationale}
+
+### Deferred Items
+- {item deferred and why}
+
+### Notes for Next Phase
+- {what the next phase should pay attention to}
+```
+
+- `{phase-name}`: one of `spec`, `code`, `review`, `merge`
+- Each subsection: 3–5 bullets as a guideline; omit if nothing to record (write "- None")
+
+## Input
+
+- `SPEC_PATH`: path to the Spec directory (e.g., `docs/spec`)
+- `ISSUE_NUMBER`: the Issue number (e.g., `501`)
+- `PHASE_NAME`: the current phase name (`spec`, `code`, `review`, `merge`, or `verify`)
+
+## Write Procedure
+
+Calling phases: `spec` (write only), `code` (read then write), `review` (read then write), `merge` (read then write). `verify` does **not** write.
+
+1. **Spec existence check**: Glob `$SPEC_PATH/issue-$ISSUE_NUMBER-*.md`.
+   - If no file found: output `[phase-handoff] No Spec found — skipping handoff write.` and return (graceful skip).
+
+2. **Generate handoff content**: Based on the work done in this phase, write a summary with:
+   - `### Key Decisions`: 3–5 bullets on the most important design or implementation decisions made (why this approach was chosen over alternatives)
+   - `### Deferred Items`: 3–5 bullets on items that were explicitly left for a later phase, follow-up Issue, or post-merge observation
+   - `### Notes for Next Phase`: 3–5 bullets on what the next phase should pay special attention to (known risks, ambiguities resolved, constraints discovered)
+   - Write "- None" if a subsection has nothing to record
+
+3. **Check for existing handoff section**: Search the Spec file for `^## Phase Handoff`.
+   - If found (rotation case): Use the Edit tool to replace the **entire existing `## Phase Handoff` block** (from `## Phase Handoff` through the end of that section — i.e., up to the next `## ` header or end of file) with the new handoff content.
+   - If not found: Use the Edit tool to append the new handoff content after the last line of the file.
+
+4. **Include in the same commit**: The handoff write happens in the same step as the retrospective append — stage the Spec file once and commit together.
+
+### Rotation boundary detection
+
+When replacing an existing `## Phase Handoff` section, the section ends at the line immediately before the next `## ` (level-2) heading, or at end of file if no subsequent heading exists. Replace from `## Phase Handoff` through that boundary (exclusive of the next `## ` heading line).
+
+## Read Procedure
+
+Calling phases: `code` (after Step 5 Spec load), `review` (after Step 5), `merge` (after Step 1 Issue fetch), `verify` (after Step 4 Spec load). `spec` does **not** read.
+
+1. **Spec existence check**: Glob `$SPEC_PATH/issue-$ISSUE_NUMBER-*.md`.
+   - If no file found: output `[phase-handoff] No Spec found — skipping handoff read.` and return (graceful skip).
+
+2. **Handoff section check**: Search the Spec for `^## Phase Handoff`.
+   - If not found: output `[phase-handoff] No handoff from prior phase.` and continue (normal — first run or spec phase with no prior handoff).
+
+3. **Read and apply**: Read the `## Phase Handoff` section content and incorporate it into the current phase's execution context:
+   - Review `### Key Decisions` to understand why the previous phase made the choices it did
+   - Review `### Deferred Items` to be aware of explicitly deferred work that may affect this phase
+   - Review `### Notes for Next Phase` for direct guidance from the prior phase
+
+   Output: `[phase-handoff] Loaded handoff from phase: {phase-name}` (extract `{phase-name}` from the `<!-- phase: {phase-name} -->` marker).
+
+## Phase Position Asymmetry
+
+| Phase | Read | Write | Reason |
+|-------|------|-------|--------|
+| spec | No | Yes | First execution phase — no prior phase handoff exists |
+| code | Yes | Yes | Intermediate phase |
+| review | Yes | Yes | Intermediate phase |
+| merge | Yes | Yes | Intermediate phase |
+| verify | Yes | No | Last execution phase — no subsequent phase to hand off to |
+
+## Notes
+
+- This module's read/write operations are deterministic (Spec file existence check → Edit/Read). No AskUserQuestion required; safe in `--non-interactive` mode.
+- XS route: In `/auto` XS handling, the Spec may not exist at code execution time (it is generated post-code in Step 4b). The Spec existence check (step 1 of both procedures) handles this gracefully — output the skip log and continue without error.
+- The handoff section is part of the Spec file and will be included in the worktree branch, committed with the retrospective.

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -154,6 +154,11 @@ If no Spec exists, read the requirements from the Issue body and implement accor
 
 If the Spec has a "Notes" section, cross-reference each item against the implementation steps and recognize them as constraints/specifications to consider during implementation. Skip this step if there is no "Notes" section.
 
+**Phase Handoff read (after loading Spec):**
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Read Procedure" section.
+Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=code`.
+
 ### Step 6: Verify Uncertainties (only if present in Spec)
 
 If the Spec has an "Uncertainties" section, before implementing:
@@ -418,7 +423,11 @@ If there are items under "Deviations from Design" (reordering of implementation 
 1. If no retrospective information, write "N/A"
 2. Append `## Code Retrospective` section after `## Spec Retrospective` in the Spec (`$SPEC_PATH/issue-$NUMBER-*.md`) using the Edit tool
 3. If "Deviations from Design" exist, also update the "Implementation Steps" section in the Spec to match the actual implementation
-4. Commit (push is done in Step 13 Worktree Exit):
+4. **Phase Handoff write** (before commit):
+   Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
+   Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=code`.
+   The handoff is staged with the Spec in the same `git add` and committed together.
+5. Commit (push is done in Step 13 Worktree Exit):
    ```bash
    git add $SPEC_PATH/issue-$NUMBER-*.md
    git commit -s -m "Add code retrospective for issue #$NUMBER

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -3,7 +3,7 @@ name: merge
 description: Squash-merge a PR and delete the remote branch (`/merge 88`). Use when merging review-approved, CI-passing PRs. Automatically attempts conflict resolution when conflicts occur.
 context: fork
 model: sonnet
-allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*), Read, Edit, Grep, EnterWorktree, ExitWorktree
+allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*), Read, Edit, Grep, Glob, EnterWorktree, ExitWorktree
 ---
 
 # Squash Merge
@@ -45,9 +45,17 @@ Key per-step behavior in non-interactive mode:
 
 1. Fetch PR metadata:
    ```bash
-   gh pr view "$NUMBER" --json headRefName,baseRefName,isDraft
+   gh pr view "$NUMBER" --json headRefName,baseRefName,isDraft,body,title
    ```
    Record `baseRefName` as `BASE_BRANCH`. If `BASE_BRANCH` is not `main` (e.g., `release/v2.0`), the Issue will not be auto-closed on merge — inform the user after Step 3 completes.
+
+   **Early Issue number extraction** (for Phase Handoff): from the PR `body`/`title`, extract the related Issue number (`closes #N`, `Issue #N`, etc.) and record as `ISSUE_NUMBER`.
+
+   **Detect config markers** (for Phase Handoff): Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH` for use in Phase Handoff steps.
+
+   **Phase Handoff read** (merge receives handoff from review phase):
+   Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Read Procedure" section.
+   Parameters: `SPEC_PATH`, `ISSUE_NUMBER`, `PHASE_NAME=merge`. (If ISSUE_NUMBER is not yet determined, skip with log.)
 
 2. Determine mergeability:
    ```bash
@@ -187,6 +195,33 @@ If the PR body contains `closes #N` and `BASE_BRANCH` is `main`, the Issue will 
 
 If `BASE_BRANCH` is not `main`, inform the user after merge:
 "Since the base branch is `{BASE_BRANCH}`, `closes #N` will not auto-close the Issue. The Issue will be closed when `{BASE_BRANCH}` is merged to main. You may manually run `gh issue close {ISSUE_NUMBER}` if needed."
+
+**Phase Handoff write** (after squash merge, before label transition):
+
+merge is an intermediate phase — write the Phase Handoff so verify can read it.
+
+1. Align the worktree branch with origin/main (which now contains the squash commit):
+   ```bash
+   git fetch origin
+   git merge origin/main --ff-only
+   ```
+2. Glob `$SPEC_PATH/issue-$ISSUE_NUMBER-*.md` to locate the Spec (now on main):
+   - If not found: output `[phase-handoff] No Spec found — skipping handoff write.` and continue
+3. If Spec found: Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the `Write Procedure` section.
+   Parameters: `SPEC_PATH`, `ISSUE_NUMBER`, `PHASE_NAME=merge`.
+4. Commit and push to main:
+   ```bash
+   git add $SPEC_PATH/issue-$ISSUE_NUMBER-*.md
+   git commit -s -m "Add merge phase handoff for issue #$ISSUE_NUMBER
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   ```
+   ```bash
+   git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }
+   ```
+   ```bash
+   git push origin HEAD:main
+   ```
 
 ### Step 5: Label Transition (after successful merge)
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -189,6 +189,11 @@ SPEC_PATH: path from spec-path (default: "docs/spec")
 STEERING_DOCS_PATH: path from steering-docs-path (default: "docs")
 ```
 
+**Phase Handoff read** (after SPEC_PATH is determined):
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Read Procedure" section.
+Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$ISSUE_NUMBER`, `PHASE_NAME=review`.
+
 After detection, follow `external-review-phase.md`'s Step 7 procedure for external review waiting/issue resolution. For each enabled reviewer type, execute the "wait → resolve" flow in sequence:
 
 - **Copilot** (`HAS_COPILOT_REVIEW=true`): Steps 7.1–7.2 (`wait-external-review.sh "$NUMBER" copilot`)
@@ -723,7 +728,11 @@ Reflect on the review phase; record improvement proposals in the Spec only. Issu
 2. **Write review retrospective to Spec**:
    - Append `## review retrospective` section to the end of `$SPEC_PATH/issue-$ISSUE_NUMBER-*.md` using Edit tool
    - Create subsections for each of the 3 aspects; write "Nothing to note" for aspects with nothing to record
-   - Commit and push:
+3. **Phase Handoff write** (before commit):
+   Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
+   Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$ISSUE_NUMBER`, `PHASE_NAME=review`.
+   Include the handoff write in the same `git add` and commit as the retrospective.
+4. Commit and push:
      ```bash
      git add $SPEC_PATH/issue-$ISSUE_NUMBER-*.md
      git commit -s -m "Add review retrospective for issue #$ISSUE_NUMBER

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -745,7 +745,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
      ```bash
      git push origin HEAD
      ```
-3. **If improvement proposals exist**: record in review retrospective only (do not create issues; proposals are aggregated in `/verify`)
+5. **If improvement proposals exist**: record in review retrospective only (do not create issues; proposals are aggregated in `/verify`)
 
 ## Worktree Exit (push-and-remove)
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -608,7 +608,11 @@ Reflect on the specification phase and present improvement suggestions to the us
 1. Write "Nothing to note" in each section if nothing to record
 2. If issue retrospective found, transfer it first (Edit tool to prepend to Spec)
 3. Edit tool to append spec retrospective to Spec end
-4. Additional commit (push in Step 14 Worktree Exit):
+4. **Phase Handoff write** (spec is the first execution phase — write only, no read):
+   Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
+   Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=spec`.
+   Include the handoff write in the same commit (next step).
+5. Additional commit (push in Step 14 Worktree Exit):
    ```bash
    git add $SPEC_PATH/issue-$NUMBER-short-title.md
    git commit -s -m "Add retrospective notes for issue #$NUMBER"

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -112,6 +112,12 @@ Parse acceptance condition checkboxes:
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/domain-loader.md` and follow the "Processing Steps" section with `SKILL_NAME=verify`. Domain file content provides Skill infrastructure improvement classification criteria for Step 13.
 
+**Phase Handoff read** (verify is the last execution phase — read only, no write):
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Read Procedure" section.
+Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=verify`.
+This is an early Spec read specifically for Phase Handoff context; SPEC_PATH is now known from detect-config-markers above.
+
 **Resolving `{{base_url}}` to production URL**: If verify commands contain `{{base_url}}`, replace `{{base_url}}` with `PRODUCTION_URL` before passing to verify-executor.
 
 - If `PRODUCTION_URL` is found: run browser verification with the replaced URL


### PR DESCRIPTION
## Summary

- `modules/phase-handoff.md` を新規作成 — Phase Handoff の read/write 共有モジュール（Spec ファイルへの軽量な cross-phase 要約引き継ぎ）
- `spec/code/review/merge/verify` の各 SKILL.md に Phase Handoff read/write 手順を追記
- ローテーション設計（最新 1 phase 分のみ保持）、Spec 非存在時の graceful skip に対応
- `docs/structure.md` / `docs/ja/structure.md` のモジュール数コメント・Key Files 一覧を更新

## Verification (pre-merge)

- spec/code/review/merge/verify の各 SKILL.md に Phase Handoff の読み書き手順が追記されていること
- `modules/phase-handoff.md` に Write Procedure（ローテーション置換）と Read Procedure（graceful skip）が定義されていること
- `docs/structure.md` のモジュール数が `(35 files)` に更新されていること
- bats テスト CI が SUCCESS

## Verification (post-merge)

- downstream プロジェクトで `/auto` 実行時に phase 間の文脈喪失が体感的に減ることを観察する

closes #501