### PR TITLE
Issue #492: Add verify-ignore-paths exclusion to check-verify-dirty.sh

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -47,6 +47,11 @@ watchdog-timeout-seconds: 3600
 # Patch lock timeout for main-branch push (default: 300 seconds; lock is held only during git merge + push)
 patch-lock-timeout: 300
 
+# Paths excluded from dirty-file detection during /verify (gitignore-style glob list)
+verify-ignore-paths:
+  - vault/**
+  - vault/.obsidian/**
+
 # Permission mode for /auto subprocess (default: auto)
 # "auto" uses --permission-mode auto with allow rules template (see docs/guide/auto-mode-template.json)
 # "bypass" uses --dangerously-skip-permissions (legacy / opt-out)
@@ -87,6 +92,7 @@ This table is the **single source of truth (SSoT)** for all `.wholework.yml` con
 | `permission-mode` | string | `"auto"` | Permission mode for `/auto` subprocess. `auto` enables `--permission-mode auto` with allow rules template (see `docs/guide/auto-mode-template.json`); `bypass` uses `--dangerously-skip-permissions` (legacy / opt-out). |
 | `verify-max-iterations` | integer | `3` | Limit verify-reopen loop iterations; stops at N failures and leaves Issue in `phase/verify` for human judgment. Values ≤0, >20, or non-numeric fall back to `3`. |
 | `retro-proposals-upstream` | string | `""` | Upstream repository (`owner/repo`) for routing Skill infrastructure improvement proposals from `/verify` retrospectives. When set, such proposals are sanitized (regex strips absolute paths and downstream issue numbers; LLM removes business-context terms) and filed to this repository; downstream filing is skipped. Unset means downstream filing as before (backward-compatible). |
+| `verify-ignore-paths` | list | `[]` | Glob patterns (gitignore format, block list) of paths to exclude from dirty-file detection in `/verify`. Files matching any pattern are silently ignored and reported on stderr. Unset means no exclusions. |
 
 For the full reference including implementation details and YAML parsing rules, see [`modules/detect-config-markers.md`](../../modules/detect-config-markers.md).
 

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -41,6 +41,11 @@ watchdog-timeout-seconds: 3600
 # main ブランチへの push 用 lock タイムアウト（デフォルト: 300 秒、lock は git merge + push 中のみ保持）
 patch-lock-timeout: 300
 
+# /verify のダーティファイル検出から除外するパス（gitignore 形式の glob リスト）
+verify-ignore-paths:
+  - vault/**
+  - vault/.obsidian/**
+
 # /auto サブプロセスの permission mode（デフォルト: auto）
 # "auto" は --permission-mode auto を allow rules テンプレートと共に使用（docs/guide/auto-mode-template.json 参照）
 # "bypass" は --dangerously-skip-permissions を使用（レガシー / オプトアウト）
@@ -81,6 +86,7 @@ capabilities:
 | `permission-mode` | string | `"auto"` | `/auto` サブプロセスの permission mode。`auto` は `--permission-mode auto` を allow rules テンプレートと共に有効化（`docs/guide/auto-mode-template.json` 参照）; `bypass` は `--dangerously-skip-permissions` を使用（レガシー / オプトアウト）。 |
 | `verify-max-iterations` | integer | `3` | verify-reopen ループの最大試行回数。N 回 FAIL した時点で停止し、Issue を `phase/verify` に留めて人間の判断を促す。0 以下、20 超、または非数値の場合は `3` にフォールバック。 |
 | `retro-proposals-upstream` | string | `""` | Upstream リポジトリ (`owner/repo`) — `/verify` レトロスペクティブから得られた Skill infrastructure improvement 提案の起票先。設定すると、対象提案はサニタイズ（regex で絶対パスと下流固有 Issue 番号を除去、LLM でビジネス文脈用語を除去）されて upstream リポジトリへ起票される。下流リポジトリへの起票はスキップされる。未設定時は従来どおり下流リポジトリへ起票（後方互換）。 |
+| `verify-ignore-paths` | list | `[]` | `/verify` のダーティファイル検出から除外するパスの glob パターン（gitignore 形式、block list）。いずれかのパターンにマッチするファイルは除外され stderr に警告出力される。未設定時は除外なし。 |
 
 実装の詳細や YAML パースルールを含む完全なリファレンスは [`modules/detect-config-markers.md`](../../../modules/detect-config-markers.md) を参照してください。
 

--- a/docs/spec/issue-492-verify-dirty-ignore-paths.md
+++ b/docs/spec/issue-492-verify-dirty-ignore-paths.md
@@ -139,19 +139,35 @@
 
 - テスト 3 件（7, 9, 10）が初回テスト実行で失敗: `git status` の表示形式の問題（ディレクトリ単位表示）と bats の出力合算の問題が原因。スクリプト修正とテストアサーション修正で対応した
 
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+Spec と PR diff の間に構造的な乖離なし。`--untracked-files=all` への変更・bats テストのアサーション変更は Code Retrospective に記録済みで、review 時点で把握済みの逸脱。
+
+### 繰り返し問題
+
+同種の問題は検出されなかった。
+
+### 受け入れ基準検証の難度
+
+- 4 件の `file_contains` AC はすべて明確で検証容易。
+- `github_check "Run bats tests"` AC は初回実行時未チェックだったが、CI 完了後に PASS を確認してチェックボックスを更新した。
+- `_is_ignored` が "gitignore format" と宣伝しているにもかかわらず bash `case` グロブの制約で中間 `**` がサポートされない点は、将来の verify command 追加時に注意が必要（CONSIDER として inline comment を投稿済み）。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `git status --short --untracked-files=all` を採用: 未追跡ディレクトリが単一エントリで表示される問題を回避し、glob パターンが個別ファイルに正確にマッチするよう変更
-- bats テストで `.wholework.yml` を `git commit` してから dirty ファイルを作成: 設定ファイル自体が dirty 検出対象に入ることを防ぐ実装パターン
-- bats 1.13.0 の combined output に合わせてテストアサーションを `=~ "Warning:"` に変更: 警告が確認できることと exit 0 の両方をアサート
+- REVIEW_DEPTH=light 採用（Issue Size M + `--light` フラグ）: 全5件の pre-merge AC は PASS。CI bats tests も SUCCESS 確認
+- MUST 問題なし → Step 12 の実装修正はスキップ。SHOULD/CONSIDER の inline comment はauthorの裁量に委ねる
+- レビュー結果: SHOULD 1件（YAML末尾空白）+ CONSIDER 3件（detect-config-markers補足・bash glob制約ドキュメント・"silently"表現）
 
 ### Deferred Items
-- `--untracked-files=all` は大規模リポジトリで遅くなる可能性あり（フォローアップ考慮事項だがスコープ外）
-- bats の出力挙動の変化に関するドキュメントはなし（テスト内コメントで十分と判断）
+- SHOULD: `check-verify-dirty.sh` のYAMLパターン末尾空白トリム未対応（通常のYAML編集では発生しにくいためスキップ判断）
+- CONSIDER: detect-config-markers.md への `VERIFY_IGNORE_PATHS` コンシューマ補足の追加
+- CONSIDER: docs/guide/customization.md の "silently" 表現修正（日本語版は正確）
 
 ### Notes for Next Phase
-- PR #531 のスクリプト変更（`--untracked-files=all` 追加）が既存テスト 1-6 の動作に影響しないことを CI で確認すること
-- 4 つの `file_contains` verify command は実装前に PASS が確認されている（Issue チェックボックス更新済み）
-- `github_check "gh pr checks" "Run bats tests"` の AC は CI が通過後に `/verify` で確認
+- 全 pre-merge AC が PASS → `/merge 531` でマージ可能
+- post-merge AC: trading リポジトリの `.wholework.yml` に `verify-ignore-paths: ["vault/**"]` を設定して手動確認が必要

--- a/docs/spec/issue-492-verify-dirty-ignore-paths.md
+++ b/docs/spec/issue-492-verify-dirty-ignore-paths.md
@@ -120,3 +120,38 @@
 - **`verify-ignore-paths` 未設定時**: `ignore_patterns` 配列が空になるため `_is_ignored` は常に return 1。`ignored_files` も空で既存分類に影響なし。
 - **`${ignore_patterns[@]+"${ignore_patterns[@]}"}` パターン**: bash の `set -u` 下での空配列展開エラー回避（bash 3.2 で `"${arr[@]}"` が空配列で unbound variable エラーになる場合の対策）。
 - **文字列マッチ verify command 確認**: 4つの `file_contains` verify command はすべて実装により新たに追加される文字列を対象とする（現時点では存在しない）。実装時に確認が必要。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `git status --short` を `git status --short --untracked-files=all` に変更: Spec の実装例は `git status --short` を使用していたが、未追跡ディレクトリが `vault/` のように単一エントリとして表示されるため、`vault/.obsidian/**` 等のサブパターンがマッチしない問題が発生。`--untracked-files=all` で個別ファイル表示に変更した
+- `_is_ignored` にディレクトリエントリ（トレーリングスラッシュ）のストリップ処理を追加: `--untracked-files=all` 採用後は主にファイル単位で表示されるが、念のため `file_stripped="${file%/}"` でトレーリングスラッシュを除去し、`pfx==file_stripped` の exact match も追加した
+- bats テストの `git commit` 追加: Spec の擬似コードにはなかったが、`.wholework.yml` 自体がテスト内で untracked として dirty 扱いされることを防ぐため `git add && git commit` をテスト内に追加した
+- bats テストのアサーション変更: Spec は `[ "$output" = "" ]`（警告は stderr のため stdout 空）と想定していたが、bats 1.13.0 では `run` が stdout/stderr を `$output` に合算するため、`[[ "$output" =~ "Warning: ignoring dirty file excluded by verify-ignore-paths" ]]` に変更した
+
+### Design Gaps/Ambiguities
+
+- Spec の Note「bats では run コマンドは stdout のみキャプチャする」は bats < 1.7 の挙動。bats 1.7+ (1.13.0 実環境) では stdout/stderr が合算される。Spec の注記が古かった
+- 未追跡ディレクトリのエントリ表示 (`vault/`) の挙動が Spec で考慮されていなかった。`--untracked-files=all` で解決
+
+### Rework
+
+- テスト 3 件（7, 9, 10）が初回テスト実行で失敗: `git status` の表示形式の問題（ディレクトリ単位表示）と bats の出力合算の問題が原因。スクリプト修正とテストアサーション修正で対応した
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `git status --short --untracked-files=all` を採用: 未追跡ディレクトリが単一エントリで表示される問題を回避し、glob パターンが個別ファイルに正確にマッチするよう変更
+- bats テストで `.wholework.yml` を `git commit` してから dirty ファイルを作成: 設定ファイル自体が dirty 検出対象に入ることを防ぐ実装パターン
+- bats 1.13.0 の combined output に合わせてテストアサーションを `=~ "Warning:"` に変更: 警告が確認できることと exit 0 の両方をアサート
+
+### Deferred Items
+- `--untracked-files=all` は大規模リポジトリで遅くなる可能性あり（フォローアップ考慮事項だがスコープ外）
+- bats の出力挙動の変化に関するドキュメントはなし（テスト内コメントで十分と判断）
+
+### Notes for Next Phase
+- PR #531 のスクリプト変更（`--untracked-files=all` 追加）が既存テスト 1-6 の動作に影響しないことを CI で確認すること
+- 4 つの `file_contains` verify command は実装前に PASS が確認されている（Issue チェックボックス更新済み）
+- `github_check "gh pr checks" "Run bats tests"` の AC は CI が通過後に `/verify` で確認

--- a/modules/detect-config-markers.md
+++ b/modules/detect-config-markers.md
@@ -48,6 +48,7 @@ From the loaded content, search for each YAML key in the marker definition table
 | `verify-max-iterations` | `VERIFY_MAX_ITERATIONS` | Integer string (extract as-is; use `3` if ≤0, non-numeric, or >20) | `3` |
 | `patch-lock-timeout` | `PATCH_LOCK_TIMEOUT_SECONDS` | Integer string (extract as-is; use `300` if ≤0 or non-numeric) | `300` (used by `scripts/worktree-merge-push.sh`) |
 | `retro-proposals-upstream` | `RETRO_PROPOSALS_UPSTREAM` | String value (extract value as-is; upstream repository in `owner/repo` format) | `""` |
+| `verify-ignore-paths` | `VERIFY_IGNORE_PATHS` | Newline-separated glob pattern list | `""` |
 
 **Dynamic Capability Mapping:**
 
@@ -66,6 +67,7 @@ Example: `capabilities.invoice-api: true` → `HAS_INVOICE_API_CAPABILITY=true`
 - `verify-max-iterations` is treated as an integer: extract the numeric string; if the value is ≤0, non-numeric, or >20, fall back to the default `3` and log a warning
 - `patch-lock-timeout` is treated as an integer: extract the numeric string; if the value is ≤0 or non-numeric, fall back to the default `300` (used by `scripts/worktree-merge-push.sh`)
 - `retro-proposals-upstream` is treated as a string (`owner/repo` format) with quotes removed (same handling as `production-url`)
+- `verify-ignore-paths` is written in block list format (`- pattern`), parsed the same way as `capabilities.mcp`. Each entry is a glob pattern (gitignore style). If undefined or an empty list, `VERIFY_IGNORE_PATHS=""`
 - If key does not exist, use default value
 - Comment lines (lines starting with `#`) are ignored
 - Nested values under `capabilities:` section are interpreted as `capabilities.{key}`. Both inline hash format (`capabilities: { browser: true }`) and block format (`capabilities:\n  browser: true`) are supported. If `capabilities:` section is undefined, all capability variables are `false`
@@ -94,4 +96,5 @@ PERMISSION_MODE: string extracted from permission-mode (default: "auto")
 VERIFY_MAX_ITERATIONS: integer from verify-max-iterations (default: "3"; falls back to "3" if ≤0, non-numeric, or >20)
 PATCH_LOCK_TIMEOUT_SECONDS: integer from patch-lock-timeout (default: "300"; falls back to "300" if ≤0 or non-numeric)
 RETRO_PROPOSALS_UPSTREAM: upstream repository (owner/repo) from retro-proposals-upstream (default: "")
+VERIFY_IGNORE_PATHS: newline-separated glob pattern list from verify-ignore-paths (default: "")
 ```

--- a/scripts/check-verify-dirty.sh
+++ b/scripts/check-verify-dirty.sh
@@ -37,6 +37,55 @@ if [[ ${#dirty_files[@]} -eq 0 ]]; then
   exit 0
 fi
 
+# Load verify-ignore-paths from .wholework.yml (block list format)
+ignore_patterns=()
+if [[ -f ".wholework.yml" ]]; then
+  in_section=false
+  while IFS= read -r line; do
+    case "$line" in \#*) continue ;; esac
+    if [[ "$line" =~ ^verify-ignore-paths[[:space:]]*: ]]; then
+      in_section=true; continue
+    fi
+    if $in_section; then
+      if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
+        p="${BASH_REMATCH[1]//\'/}"; p="${p//\"/}"
+        ignore_patterns+=("$p")
+      elif [[ "$line" =~ ^[^[:space:]] ]]; then
+        in_section=false
+      fi
+    fi
+  done < ".wholework.yml"
+fi
+
+# Check if a file matches any ignore pattern
+_is_ignored() {
+  local file="$1" pat
+  for pat in "${ignore_patterns[@]+"${ignore_patterns[@]}"}"; do
+    if [[ "$pat" == *"/**" ]]; then
+      local pfx="${pat%/**}"
+      [[ "$file" == "$pfx/"* ]] && return 0
+    else
+      case "$file" in $pat) return 0 ;; esac
+    fi
+  done
+  return 1
+}
+
+# Apply ignore filter before classification
+ignored_files=()
+filtered=()
+for f in "${dirty_files[@]}"; do
+  if _is_ignored "$f"; then ignored_files+=("$f")
+  else filtered+=("$f"); fi
+done
+if [[ ${#ignored_files[@]} -gt 0 ]]; then
+  for f in "${ignored_files[@]}"; do
+    echo "Warning: ignoring dirty file excluded by verify-ignore-paths: $f" >&2
+  done
+  if [[ ${#filtered[@]} -eq 0 ]]; then exit 0; fi
+  dirty_files=("${filtered[@]}")
+fi
+
 # Classify each dirty file
 unrelated_spec_files=()
 has_other=false

--- a/scripts/check-verify-dirty.sh
+++ b/scripts/check-verify-dirty.sh
@@ -30,7 +30,7 @@ while IFS= read -r line; do
     path="${path##* -> }"
   fi
   dirty_files+=("$path")
-done < <(git status --short 2>/dev/null | grep -v '^$' || true)
+done < <(git status --short --untracked-files=all 2>/dev/null | grep -v '^$' || true)
 
 # Clean working directory
 if [[ ${#dirty_files[@]} -eq 0 ]]; then
@@ -58,14 +58,17 @@ if [[ -f ".wholework.yml" ]]; then
 fi
 
 # Check if a file matches any ignore pattern
+# Handles both "file/path" and "dir/" (trailing slash from untracked directory entries)
 _is_ignored() {
   local file="$1" pat
+  local file_stripped="${file%/}"
   for pat in "${ignore_patterns[@]+"${ignore_patterns[@]}"}"; do
     if [[ "$pat" == *"/**" ]]; then
       local pfx="${pat%/**}"
-      [[ "$file" == "$pfx/"* ]] && return 0
+      [[ "$file_stripped" == "$pfx" || "$file_stripped" == "$pfx/"* ]] && return 0
     else
       case "$file" in $pat) return 0 ;; esac
+      case "$file_stripped" in $pat) return 0 ;; esac
     fi
   done
   return 1

--- a/tests/verify-dirty-detection.bats
+++ b/tests/verify-dirty-detection.bats
@@ -81,3 +81,51 @@ make_dirty() {
     run bash "$REAL_SCRIPT" 123
     [ "$status" -eq 1 ]
 }
+
+@test "verify-ignore-paths: vault only dirty -> exit 0 with warning on stderr" {
+    cd "$REPO_DIR"
+    cat > .wholework.yml <<'EOF'
+verify-ignore-paths:
+  - vault/**
+EOF
+    make_dirty "vault/knowledge/note.md"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "verify-ignore-paths: vault and scripts both dirty -> exit 1" {
+    cd "$REPO_DIR"
+    cat > .wholework.yml <<'EOF'
+verify-ignore-paths:
+  - vault/**
+EOF
+    make_dirty "vault/note.md"
+    make_dirty "scripts/foo.sh"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 1 ]
+}
+
+@test "verify-ignore-paths: .obsidian workspace dirty -> exit 0" {
+    cd "$REPO_DIR"
+    cat > .wholework.yml <<'EOF'
+verify-ignore-paths:
+  - vault/.obsidian/**
+EOF
+    make_dirty "vault/.obsidian/workspace.json"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "verify-ignore-paths: unrelated spec dirty -> exit 2 regression check" {
+    cd "$REPO_DIR"
+    cat > .wholework.yml <<'EOF'
+verify-ignore-paths:
+  - vault/**
+EOF
+    make_dirty "docs/spec/issue-999-unrelated.md"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"docs/spec/issue-999-unrelated.md"* ]]
+}

--- a/tests/verify-dirty-detection.bats
+++ b/tests/verify-dirty-detection.bats
@@ -82,16 +82,17 @@ make_dirty() {
     [ "$status" -eq 1 ]
 }
 
-@test "verify-ignore-paths: vault only dirty -> exit 0 with warning on stderr" {
+@test "verify-ignore-paths: vault only dirty -> exit 0 with warning" {
     cd "$REPO_DIR"
     cat > .wholework.yml <<'EOF'
 verify-ignore-paths:
   - vault/**
 EOF
+    git add .wholework.yml && git commit -q -m "add config"
     make_dirty "vault/knowledge/note.md"
     run bash "$REAL_SCRIPT" 123
     [ "$status" -eq 0 ]
-    [ "$output" = "" ]
+    [[ "$output" =~ "Warning: ignoring dirty file excluded by verify-ignore-paths" ]]
 }
 
 @test "verify-ignore-paths: vault and scripts both dirty -> exit 1" {
@@ -100,6 +101,7 @@ EOF
 verify-ignore-paths:
   - vault/**
 EOF
+    git add .wholework.yml && git commit -q -m "add config"
     make_dirty "vault/note.md"
     make_dirty "scripts/foo.sh"
     run bash "$REAL_SCRIPT" 123
@@ -112,10 +114,11 @@ EOF
 verify-ignore-paths:
   - vault/.obsidian/**
 EOF
+    git add .wholework.yml && git commit -q -m "add config"
     make_dirty "vault/.obsidian/workspace.json"
     run bash "$REAL_SCRIPT" 123
     [ "$status" -eq 0 ]
-    [ "$output" = "" ]
+    [[ "$output" =~ "Warning: ignoring dirty file excluded by verify-ignore-paths" ]]
 }
 
 @test "verify-ignore-paths: unrelated spec dirty -> exit 2 regression check" {
@@ -124,6 +127,7 @@ EOF
 verify-ignore-paths:
   - vault/**
 EOF
+    git add .wholework.yml && git commit -q -m "add config"
     make_dirty "docs/spec/issue-999-unrelated.md"
     run bash "$REAL_SCRIPT" 123
     [ "$status" -eq 2 ]


### PR DESCRIPTION
## Summary

- `.wholework.yml` に `verify-ignore-paths` キー（block list 形式の glob パターン）を追加し、`check-verify-dirty.sh` のダーティファイル検出から除外できるようにした
- `check-verify-dirty.sh` に除外フィルタを追加: `.wholework.yml` の `verify-ignore-paths` をインラインパースし、マッチするファイルを分類前に除外。除外後に全 dirty ファイルが消えた場合は警告（stderr）を出力して exit 0 で継続
- `git status --short --untracked-files=all` に変更し、未追跡ディレクトリ内の個別ファイルを正確に検出できるようにした
- `modules/detect-config-markers.md`、`docs/guide/customization.md`、`docs/ja/guide/customization.md` に `verify-ignore-paths` のドキュメントを追加
- `tests/verify-dirty-detection.bats` に新テストケース 4 件を追加

## Verification (pre-merge)

- `detect-config-markers.md` の marker 定義テーブルに `verify-ignore-paths` 行が追加されている
- `docs/guide/customization.md` に `verify-ignore-paths` の説明が追加されている
- `check-verify-dirty.sh` が `verify-ignore-paths` 設定を解決し除外フィルタリングを行う
- `tests/verify-dirty-detection.bats` が拡張され新シナリオを検証する
- CI の bats テストが全て通過する

## Verification (post-merge)

- 実プロジェクト（trading 等）の `.wholework.yml` に `verify-ignore-paths: [vault/**]` を設定し、`vault/` のみが dirty な状態で `/auto N` の verify フェーズが警告のみで継続することを目視確認する

closes #492