### PR TITLE
Issue #522: worktree-merge-push に base 前進時の rebase フォールバックを追加

### DIFF
--- a/docs/spec/issue-522-worktree-base-diverge-rebase.md
+++ b/docs/spec/issue-522-worktree-base-diverge-rebase.md
@@ -58,3 +58,35 @@
 - **worktree checked out 中の rebase 問題**: `git rebase $BASE $FROM_BRANCH` は worktree で checkout 中のブランチに対して失敗（"already checked out"）するため、`git -C "$worktree_path" rebase origin/$BASE_BRANCH`（worktree 内での rebase）を優先する。
 - **bash 3.2+ 互換**: `awk -v` は POSIX awk で対応済み、`git -C` は git 1.8.5+ で利用可能。`mapfile` 等の bash 4+ 機能は不使用。
 - **競合時の挙動変更なし**: 既存の競合時 abort（conflict-marker-residual チェック）は維持される。新フォールバックも競合時は rebase --abort して exit 1 し、従来同様にユーザーへ委ねる。
+
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+- 乖離なし。Spec記載の4ファイルがすべて変更されており、Implementation Steps と PR diff が 1:1 で対応している。
+
+### 繰り返しイシュー
+
+- 特になし。CONSIDERイシュー1件（elseブランチのテスト）のみで、同種の繰り返しパターンはなし。
+
+### 受け入れ条件検証の難易度
+
+- verify commandはすべて適切に機能した（rubric×2, grep×1, github_check×1）。
+- `github_check "gh run list ..."` はsafeモードのallowlistに含まれないが、PR statusCheckRollupで代替検証できた。今後、CI green検証には `github_check "gh pr checks $PR_NUMBER" "Run bats tests"` 形式を使うとsafeモードでも直接実行可能になる（改善余地）。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- REVIEW_DEPTH=light（Size=M + --lightフラグ）で4側面統合レビューを実施。MUST/SHOULDイシューなし。
+- `review-light` サブエージェントタイプが環境に存在しないため、インラインで4側面レビューを実施した。
+- CONSIDER 1件（elseブランチテスト未追加）はスキップ — Spec Notesで言及済みの稀ケースでMUSTではない。
+
+### Deferred Items
+- elseブランチ（FROM_BRANCHがworktreeにない場合の`git rebase $BASE $FROM`）のテストカバレッジ追加を将来のフォローアップIssueとして検討可能。
+- Post-merge条件（長時間フェーズ中のbase前進を再現して手動確認）は/verify後に実施。
+
+### Notes for Next Phase
+- MUSTイシューなし → `/merge 532` で直接マージ可能。
+- 受け入れ条件は4/4 PASS（Post-mergeは別途）。全CIジョブSUCCESS。
+- `review-light`エージェントタイプが利用できない場合は4側面をインラインで実施するフォールバックが機能することを確認。

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -46,16 +46,24 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 1. Log the FF failure to stderr: `echo "FF merge failed, attempting git pull --rebase origin <base>..." >&2`
 2. Run `git pull --rebase origin <base-branch>` to bring the local branch up to date with remote
 3. Re-attempt `git merge <worktree-branch> --ff-only`
-4. If the second attempt also fails, propagate the error (do not loop)
+4. If the second attempt also fails (base advanced while worktree was running — local base is already in sync with origin but worktree branch has diverged):
+   a. Log to stderr: `echo "FF merge still failed; base may have diverged. Rebasing ..." >&2`
+   b. Detect the worktree path for FROM_BRANCH via `git worktree list --porcelain | awk -v b="refs/heads/<from>" '/^worktree /{p=$2} $0 == "branch " b {print p; exit}'`
+   c. If a worktree path is found: run `git -C <worktree-path> rebase origin/<base-branch>` (rebase from inside the checked-out worktree, which avoids the "already checked out" error); on conflict, run `git -C <worktree-path> rebase --abort 2>/dev/null || true` and exit 1
+   d. If no worktree path is found (branch not checked out in any worktree): run `git rebase <base-branch> <from-branch>`; on conflict, run `git rebase --abort 2>/dev/null || true` and exit 1
+   e. On successful rebase: re-attempt `git merge <worktree-branch> --ff-only` (third attempt); failure propagates via `set -e`
 
 ### Escalation
 - If `git pull --rebase` itself fails (e.g., rebase conflict), abort with a non-zero exit and output an error message requesting manual conflict resolution
-- If two consecutive FF-merge failures occur, hand off to recovery sub-agent (#316) or request human intervention
+- If the rebase in step 4 encounters conflicts, abort rebase and exit 1 — hand off to recovery sub-agent (#316) or request human intervention
+- Automatic rebase is attempted only once; no further looping after step 4e failure
 
 ### Rationale
-- Inline logic in `scripts/worktree-merge-push.sh` (lines 81–85)
+- Inline logic in `scripts/worktree-merge-push.sh`
 - `git pull --rebase` is preferred over `git merge origin/<base>` to preserve a linear history
-- See also: #314 (phase state reconciler), #308 (orchestration improvement series)
+- Step 4 (base-diverged rebase) added in #522: the existing `git pull --rebase` retry (steps 1–3) only handles the case where local base lags origin; when local base is already in sync with origin but the worktree branch was forked before a concurrent merge advanced base, a second ff-only failure occurs and worktree-branch rebase is required
+- `git -C <worktree-path> rebase` is preferred over `git rebase <base> <branch>` when the branch is checked out in a worktree, because git rejects rebase of a branch that is currently checked out elsewhere ("already checked out")
+- See also: #314 (phase state reconciler), #308 (orchestration improvement series), #517 (incident that triggered #522)
 
 ---
 

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -48,7 +48,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh [--base "$BASE_BRANCH"]
    ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh --from "$WORKTREE_BRANCH" [--base "$BASE_BRANCH"]
    ```
 
-   The script handles: lock acquisition (PID stamping, stale detection, configurable timeout via `patch-lock-timeout` in `.wholework.yml`, default 300s), `git merge --ff-only` (with `git pull --rebase` retry on FF failure, see `modules/orchestration-fallbacks.md#ff-only-merge-fallback`), conflict marker check, `git push origin <base>`, and lock release via EXIT trap. On script failure (non-zero exit), abort and skip cleanup.
+   The script handles: lock acquisition (PID stamping, stale detection, configurable timeout via `patch-lock-timeout` in `.wholework.yml`, default 300s), `git merge --ff-only` (with `git pull --rebase` retry on FF failure, and worktree-branch rebase fallback when base has advanced while the worktree was running — see `modules/orchestration-fallbacks.md#ff-only-merge-fallback`), conflict marker check, `git push origin <base>`, and lock release via EXIT trap. On script failure (non-zero exit), abort and skip cleanup.
 
 4. **Cleanup** (output warning and continue if any command fails):
    ```bash

--- a/scripts/worktree-merge-push.sh
+++ b/scripts/worktree-merge-push.sh
@@ -82,7 +82,24 @@ if [[ -n "$FROM_BRANCH" ]]; then
   if ! git merge "$FROM_BRANCH" --ff-only; then
     echo "FF merge failed, attempting git pull --rebase origin ${BASE_BRANCH}..." >&2
     git pull --rebase origin "$BASE_BRANCH"
-    git merge "$FROM_BRANCH" --ff-only
+    if ! git merge "$FROM_BRANCH" --ff-only; then
+      echo "FF merge still failed; base may have diverged. Rebasing ..." >&2
+      worktree_path=$(git worktree list --porcelain | awk -v b="refs/heads/${FROM_BRANCH}" '/^worktree /{p=$2} $0 == "branch " b {print p; exit}')
+      if [[ -n "$worktree_path" ]]; then
+        if ! git -C "$worktree_path" rebase "origin/${BASE_BRANCH}"; then
+          git -C "$worktree_path" rebase --abort 2>/dev/null || true
+          echo "Error: Rebase of ${FROM_BRANCH} onto origin/${BASE_BRANCH} failed with conflicts. Resolve manually." >&2
+          exit 1
+        fi
+      else
+        if ! git rebase "$BASE_BRANCH" "$FROM_BRANCH"; then
+          git rebase --abort 2>/dev/null || true
+          echo "Error: Rebase of ${FROM_BRANCH} onto ${BASE_BRANCH} failed with conflicts. Resolve manually." >&2
+          exit 1
+        fi
+      fi
+      git merge "$FROM_BRANCH" --ff-only
+    fi
   fi
 
   # See modules/orchestration-fallbacks.md#conflict-marker-residual

--- a/tests/worktree-merge-push.bats
+++ b/tests/worktree-merge-push.bats
@@ -165,6 +165,82 @@ MOCK
     grep -q "push origin release/v1" "$GIT_LOG"
 }
 
+@test "--from with base-diverged triggers worktree rebase fallback" {
+    WORKTREE_PATH="$BATS_TEST_TMPDIR/fake-worktree"
+    mkdir -p "$WORKTREE_PATH"
+
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
+    echo "${BATS_TEST_TMPDIR}/test-repo"
+    exit 0
+fi
+if [[ "\$1" == "merge" ]]; then
+    COUNT_FILE="${BATS_TEST_TMPDIR}/merge_count"
+    count=0
+    [ -f "\$COUNT_FILE" ] && count=\$(cat "\$COUNT_FILE")
+    count=\$((count + 1))
+    echo "\$count" > "\$COUNT_FILE"
+    # First two merge attempts fail; third succeeds
+    [ "\$count" -le 2 ] && exit 1
+    exit 0
+fi
+if [[ "\$1" == "worktree" && "\$2" == "list" ]]; then
+    printf "worktree ${WORKTREE_PATH}\nbranch refs/heads/test-branch\n\n"
+    exit 0
+fi
+# git -C <path> rebase origin/main
+if [[ "\$1" == "-C" && "\$3" == "rebase" ]]; then
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"base may have diverged"* ]]
+    grep -q "worktree list --porcelain" "$GIT_LOG"
+    grep -q "rebase origin/main" "$GIT_LOG"
+    grep -q "push origin main" "$GIT_LOG"
+}
+
+@test "--from with base-diverged and rebase conflict aborts and exits non-zero" {
+    WORKTREE_PATH="$BATS_TEST_TMPDIR/fake-worktree"
+    mkdir -p "$WORKTREE_PATH"
+
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
+    echo "${BATS_TEST_TMPDIR}/test-repo"
+    exit 0
+fi
+if [[ "\$1" == "merge" ]]; then
+    exit 1
+fi
+if [[ "\$1" == "pull" ]]; then
+    exit 0
+fi
+if [[ "\$1" == "worktree" && "\$2" == "list" ]]; then
+    printf "worktree ${WORKTREE_PATH}\nbranch refs/heads/test-branch\n\n"
+    exit 0
+fi
+# git -C <path> rebase origin/main fails (conflict)
+if [[ "\$1" == "-C" && "\$3" == "rebase" && "\$4" != "--abort" ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Rebase"*"failed with conflicts"* ]]
+    ! grep -q "push" "$GIT_LOG"
+}
+
 @test "conflict markers cause abort with non-zero exit and no push" {
     cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash


### PR DESCRIPTION
## 概要

`worktree-merge-push.sh` の ff-only マージ失敗時のフォールバックを、**base 前進（base-diverged）ケース**に対応するよう拡張する（closes #522）。

## 背景

長時間フェーズの実行中に並行マージが base ブランチを前進させると、worktree ブランチは fork 時点の古い base を起点としたまま取り残される。この状態では既存の `git pull --rebase origin <base>`（local base を remote に追従）リトライでは fast-forward を成立させられない（local base は origin と同期済みだが worktree ブランチが分岐しているため）。

実際に #517（および #505 verify retrospective、`docs/reports/orchestration-recoveries.md`）で、verify worktree の exit 時に `fatal: Not possible to fast-forward` が発生する事象として観測された。

## 変更内容

- `scripts/worktree-merge-push.sh`: FF 失敗 → `git pull --rebase` リトライでも FF 不成立の場合、worktree ブランチを `origin/<base>` へ rebase してから ff-only マージを再試行する third-attempt フォールバックを追加。
  - ブランチが worktree で checkout 済みのため `git -C <worktree-path> rebase origin/<base>` を使用し、`git rebase <base> <branch>` の "already checked out" エラーを回避。
  - rebase コンフリクト時は `rebase --abort` して exit 1（手動解決へエスカレーション）。
- `modules/orchestration-fallbacks.md`: `ff-only-merge-fallback` カタログに step 4（base-diverged rebase）を追記。
- `tests/worktree-merge-push.bats`: base-diverged rebase フォールバックの成功・コンフリクト時 abort の 2 テストを追加（全 11 テスト PASS）。

## 検証

- `bash -n scripts/worktree-merge-push.sh` — syntax OK
- `bats tests/worktree-merge-push.bats` — 11/11 PASS（test 9: base-diverged rebase 成功、test 10: rebase conflict abort）

## Notes

本 PR は #522 の code phase が watchdog kill で commit/PR 作成前に中断したため、親セッションが worktree 内の未コミット実装を回収して手動でコミット・push・PR 作成したもの（#385 パターン）。実装内容は kill 前に `/code` が生成したもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
