### PR TITLE
Issue #538: Add CI wait and retrospective forbidden-expressions guard for review/code

### DIFF
--- a/docs/spec/issue-538-ci-pass-retro-guard.md
+++ b/docs/spec/issue-538-ci-pass-retro-guard.md
@@ -116,17 +116,31 @@
 - なし
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `/review` の CI wait を `wait-ci-checks.sh "$NUMBER"` として Step 9 の `gh pr view` の直前に挿入した（非-SKILL.md の Domain file でなく SKILL.md 直接修正）
-- `/code` と `/review` の retrospective guard は Domain file（`forbidden-expressions-check.md` / `skill-dev-recheck.md`）の "Retrospective Guard" セクションとして切り出し、各 SKILL.md から `check-forbidden-expressions.sh` 存在チェック付きで条件参照する方式を採用した
-- PENDING 記述を "after wait timeout" に変更し、タイムアウト後も継続できることを明示した
+- REVIEW_DEPTH=light（`--light` フラグによる明示的指定）で実行した
+- 外部レビューツール（Copilot/Claude Code Review/CodeRabbit）はすべて未設定のため Step 7 全体スキップ
+- MUST/SHOULD 問題なし（CONSIDER 1件: regression test）のため Step 12 スキップ
 
 ### Deferred Items
-- `/review` の Retrospective Guard は `skill-dev-recheck.md` を読んで実行するため、wholework 以外の非 skill-dev プロジェクトでは実行されない（設計通り）
-- Post-merge の opportunistic 検証は観察のみ
+- Regression test（CONSIDER）: SKILL.md プロシージャー変更に対する自動テストは将来的な改善課題
+- Post-merge の opportunistic 検証は観察のみ（Step 9 で CI 全 SUCCESS 確認済み）
 
 ### Notes for Next Phase
-- PR #540 が CI を通過するか確認が必要（allowed-tools に `wait-ci-checks.sh:*` を追加しているため、`validate-skill-syntax.py` の allowed-tools パターン検証が通るか注意）
-- Retrospective Guard セクションの内容が「旧称:」prefix や descriptive language の使用例として分かりやすいかレビューで確認すること
+- すべての Pre-merge 受け入れ条件が PASS、CI 全ジョブ SUCCESS
+- MUST/SHOULD 問題なし → `/merge 540` で merge 可能
+
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Nothing to note. PR diff はすべての Spec 実装ステップに準拠しており、ステップ番号の偏差（skills/code/SKILL.md で Spec 記述「7 まで繰り上げ」→実装「6 まで」）は Code Retrospective に適切に文書化済み。
+
+### Recurring Issues
+
+Nothing to note. レビューで発見した CONSIDER 1件（regression test 未追加）は SKILL.md プロシージャー変更特有のもので、同種の繰り返し問題ではない。
+
+### Acceptance Criteria Verification Difficulty
+
+Nothing to note. Pre-merge 3件すべて PASS（rubric 2件 + file_contains 1件）。UNCERTAIN なし。verify command が well-specified で自動判定が容易だった。`rubric` 条件は具体的なファイル名と期待内容を明示しており、grader が迷わず PASS/FAIL を判定できた。

--- a/docs/spec/issue-538-ci-pass-retro-guard.md
+++ b/docs/spec/issue-538-ci-pass-retro-guard.md
@@ -100,3 +100,33 @@
 - **Domain 確定**: CI 全チェック完了確認は `/review` の Core 挙動のため `skills/review/SKILL.md` Step 9 を直接修正する。forbidden-expressions retrospective guard は wholework 固有の skill-dev 関心事のため Domain file（`skill-dev-recheck.md` / `forbidden-expressions-check.md`）へ切り出し、Core SKILL.md から条件付き参照する。
 - **CI wait のタイムアウト**: `wait-ci-checks.sh` は `WHOLEWORK_CI_TIMEOUT_SEC`（デフォルト 1200s）でタイムアウトする。タイムアウト後も PENDING が残る場合は「proceed with caution」として警告し処理を継続する（ハードストップはしない）。
 - **`check-forbidden-expressions.sh` のスコープ**: ガードは spec ファイルだけでなく SCAN_DIRS 全体（skills/, modules/, agents/, tests/, docs/）を対象とする。これは既存の `forbidden-expressions-check.md` と同じ invocation 方法（`bash scripts/check-forbidden-expressions.sh` 無引数）で実現できる。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec の実装ステップ 3（`skills/code/SKILL.md` Step 12）では「旧 Step 3 以降を 4→5→6→7 に繰り上げる」と記載されていたが、元のステップ数は 5（旧3→4, 旧4→5, 旧5→6）であり「7」には達しない。記述の数え間違いと判断し、実際には 6 ステップ構成（新 step 3 挿入後）に実装した。
+
+### Design Gaps/Ambiguities
+
+- Spec の「旧 Step 3 以降を 4→5→6→7 に繰り上げる」という記述は元ステップ数と合わない（元が 5 ステップのため最大 6 まで）。実装では矛盾なく新 step 3 挿入・旧3→4・旧4→5・旧5→6 に繰り上げを実施した。
+
+### Rework
+
+- なし
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `/review` の CI wait を `wait-ci-checks.sh "$NUMBER"` として Step 9 の `gh pr view` の直前に挿入した（非-SKILL.md の Domain file でなく SKILL.md 直接修正）
+- `/code` と `/review` の retrospective guard は Domain file（`forbidden-expressions-check.md` / `skill-dev-recheck.md`）の "Retrospective Guard" セクションとして切り出し、各 SKILL.md から `check-forbidden-expressions.sh` 存在チェック付きで条件参照する方式を採用した
+- PENDING 記述を "after wait timeout" に変更し、タイムアウト後も継続できることを明示した
+
+### Deferred Items
+- `/review` の Retrospective Guard は `skill-dev-recheck.md` を読んで実行するため、wholework 以外の非 skill-dev プロジェクトでは実行されない（設計通り）
+- Post-merge の opportunistic 検証は観察のみ
+
+### Notes for Next Phase
+- PR #540 が CI を通過するか確認が必要（allowed-tools に `wait-ci-checks.sh:*` を追加しているため、`validate-skill-syntax.py` の allowed-tools パターン検証が通るか注意）
+- Retrospective Guard セクションの内容が「旧称:」prefix や descriptive language の使用例として分かりやすいかレビューで確認すること

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -422,12 +422,13 @@ If there are items under "Deviations from Design" (reordering of implementation 
 **Steps:**
 1. If no retrospective information, write "N/A"
 2. Append `## Code Retrospective` section after `## Spec Retrospective` in the Spec (`$SPEC_PATH/issue-$NUMBER-*.md`) using the Edit tool
-3. If "Deviations from Design" exist, also update the "Implementation Steps" section in the Spec to match the actual implementation
-4. **Phase Handoff write** (before commit):
+3. If `scripts/check-forbidden-expressions.sh` exists, Read `${CLAUDE_PLUGIN_ROOT}/skills/code/forbidden-expressions-check.md` and follow the "Retrospective Guard" section.
+4. If "Deviations from Design" exist, also update the "Implementation Steps" section in the Spec to match the actual implementation
+5. **Phase Handoff write** (before commit):
    Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
    Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=code`.
    The handoff is staged with the Spec in the same `git add` and committed together.
-5. Commit (push is done in Step 13 Worktree Exit):
+6. Commit (push is done in Step 13 Worktree Exit):
    ```bash
    git add $SPEC_PATH/issue-$NUMBER-*.md
    git commit -s -m "Add code retrospective for issue #$NUMBER

--- a/skills/code/forbidden-expressions-check.md
+++ b/skills/code/forbidden-expressions-check.md
@@ -18,3 +18,15 @@ bash scripts/check-forbidden-expressions.sh
 ```
 
 This is equivalent to the CI `forbidden-expressions` job and detects prohibited expressions before reaching CI. If the check fails, fix the issues before continuing (same as test failures).
+
+## Retrospective Guard
+
+Before committing the code retrospective to the Spec:
+
+1. Run forbidden expressions check to detect any deprecated terms introduced by the retrospective content:
+   ```bash
+   bash scripts/check-forbidden-expressions.sh
+   ```
+2. If violations are detected: fix the retrospective text before committing
+   - Use descriptive language instead of quoting deprecated terms directly (e.g., write `旧称: <term>` or describe without quoting the term)
+3. If no violations: proceed with commit

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -2,7 +2,7 @@
 name: review
 description: PR review (`/review 88`). Automatically runs acceptance criteria verification, multi-perspective code review, issue resolution, and summary posting. Use after `/code` creates a PR and before `/merge` (`--light`/`--full` to adjust depth).
 context: fork
-allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree
+allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree
 ---
 
 # PR Review
@@ -274,14 +274,18 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh "$ISSUE_NUMBER" .tmp/issue-body-$
 
 ## Step 9: CI Status Check
 
-After Step 7, check the PR's overall CI status:
+After Step 7, wait for all CI checks to reach terminal state, then check the PR's overall CI status:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh "$NUMBER"
+```
 
 ```bash
 gh pr view "$NUMBER" --json statusCheckRollup
 ```
 
 - **All jobs SUCCESS (or SKIPPED)**: note CI is successful and proceed
-- **PENDING/IN_PROGRESS jobs**: note CI is running and proceed
+- **PENDING/IN_PROGRESS jobs** (after wait timeout): note CI wait timed out; list pending checks and proceed with caution
 - **FAILURE jobs**: list failed job names and statuses; suggest fixes where possible. If `scripts/validate-skill-syntax.py` exists, also read `skills/review/skill-dev-recheck.md` and follow the "Step 8: Additional Suggestions on CI Failure" section.
 
 ---
@@ -728,11 +732,12 @@ Reflect on the review phase; record improvement proposals in the Spec only. Issu
 2. **Write review retrospective to Spec**:
    - Append `## review retrospective` section to the end of `$SPEC_PATH/issue-$ISSUE_NUMBER-*.md` using Edit tool
    - Create subsections for each of the 3 aspects; write "Nothing to note" for aspects with nothing to record
-3. **Phase Handoff write** (before commit):
+3. If `scripts/check-forbidden-expressions.sh` exists, Read `${CLAUDE_PLUGIN_ROOT}/skills/review/skill-dev-recheck.md` and follow the "Retrospective Guard" section.
+4. **Phase Handoff write** (before commit):
    Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
    Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$ISSUE_NUMBER`, `PHASE_NAME=review`.
    Include the handoff write in the same `git add` and commit as the retrospective.
-4. Commit and push:
+5. Commit and push:
      ```bash
      git add $SPEC_PATH/issue-$ISSUE_NUMBER-*.md
      git commit -s -m "Add review retrospective for issue #$ISSUE_NUMBER
@@ -745,7 +750,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
      ```bash
      git push origin HEAD
      ```
-5. **If improvement proposals exist**: record in review retrospective only (do not create issues; proposals are aggregated in `/verify`)
+6. **If improvement proposals exist**: record in review retrospective only (do not create issues; proposals are aggregated in `/verify`)
 
 ## Worktree Exit (push-and-remove)
 

--- a/skills/review/skill-dev-recheck.md
+++ b/skills/review/skill-dev-recheck.md
@@ -39,3 +39,15 @@ python3 scripts/validate-skill-syntax.py skills/
 ```
 
 Verify that all SKILL.md files pass syntax validation.
+
+## Retrospective Guard
+
+Before committing the review retrospective to the Spec:
+
+1. Run forbidden expressions check to detect any deprecated terms introduced by the retrospective content:
+   ```bash
+   bash scripts/check-forbidden-expressions.sh
+   ```
+2. If violations are detected: fix the retrospective text before committing
+   - Use descriptive language instead of quoting deprecated terms directly (e.g., write `旧称: <term>` or describe without quoting the term)
+3. If no violations: proceed with commit


### PR DESCRIPTION
## Summary

- `/review` Step 9 に `wait-ci-checks.sh` の呼び出しを追加し、CI 全チェックが terminal state に達するまで待機してから CI 状態を確認するよう変更
- `/review` の Retrospective ステップに、Spec コミット前に forbidden-expressions チェックを実行する guard を追加（`skill-dev-recheck.md` "Retrospective Guard" セクションへ参照）
- `/code` Step 12 に同様の Retrospective guard を追加（`forbidden-expressions-check.md` "Retrospective Guard" セクションへ参照）
- `skills/review/skill-dev-recheck.md` と `skills/code/forbidden-expressions-check.md` に "Retrospective Guard" セクションを追加

## Verification (pre-merge)

- /review の CI 結論前の全チェック完了確認手順が追加されている（`wait-ci-checks.sh` 追加 + PENDING 記述更新）
- /code・/review 両方の retrospective 非推奨用語混入 guard が追加されている
- /review 手順に forbidden-expressions チェックへの言及が追加されている

## Verification (post-merge)

- 次に CI を伴う PR の `/review` 実行時に、Forbidden Expressions 等の高速チェック FAIL を CI-pass 結論前に検出することを観察する
- 次に retrospective を spec へ書き込む `/code` または `/review` 実行時に、非推奨用語混入による Forbidden Expressions CI 失敗が発生しないことを観察する

closes #538