### PR TITLE
Issue #528: Add language-independent review-summary marker for reconcile completion detection

### DIFF
--- a/docs/spec/issue-528-review-completion-marker.md
+++ b/docs/spec/issue-528-review-completion-marker.md
@@ -73,19 +73,32 @@
 ### Rework
 - None（1回の実装で全52テストPASSを確認）
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Nothing to note. PR diff は Spec の実装手順（SKILL.md マーカー追加、reconcile grep 更新、phase-state.md SSoT 更新、bats テスト追加）に完全準拠しており、逸脱は検出されなかった。
+
+### Recurring Issues
+
+Nothing to note. 問題は一切検出されなかった（MUST: 0、SHOULD: 0、CONSIDER: 0）。
+
+### Acceptance Criteria Verification Difficulty
+
+Nothing to note. 全8条件を機械検証可能な形で設計されており、UNCERTAIN は発生しなかった。file_contains×5 と rubric×2 の組み合わせ（機械検証 + セマンティック検証）のパターンは有効に機能した。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- マーカー検出を grep OR の先頭に置き、既存テキスト署名を fallback として保持（defense-in-depth）
-- POSIX `[[:space:]]` を使用してマーカー内部の空白揺れを許容（bash 3.2+ 互換）
-- bats テストを2件追加：「localized heading + marker」と「marker only」で両パターンを網羅
+- 全8受け入れ条件 PASS（file_contains×5、rubric×2、github_check×1）
+- MUST 問題なし、COMMENT イベントでレビュー投稿
+- Type=Bug の重点観点（Perspective 2 edge cases + 回帰テスト）も問題なし
 
 ### Deferred Items
-- review LLM がマーカーを出力しないケースの実運用検証（Post-merge AC）
-- Push タイミング（Worktree内での最初のpushが必要）は動作確認済み
+- Post-merge AC: 次回 `/auto` review phase でのローカライズ見出し + reconcile `matches_expected:true` の実運用確認
 
 ### Notes for Next Phase
-- 全52 bats テストPASS、CI push 済み（PR #544）
-- verify コマンドは `github_check` のみPENDING（CI完了待ち）、その他7件はPASS確認済み
-- forbidden expressions チェック PASS、skill syntax validation PASS
+- 全 CI ジョブ SUCCESS（DCO、Run bats tests ×2、Validate skill syntax ×2、Forbidden Expressions ×2、macOS shell compatibility ×2）
+- PR #544 マージ準備完了
+- MUST 問題なし、`/merge 544` で進める

--- a/docs/spec/issue-528-review-completion-marker.md
+++ b/docs/spec/issue-528-review-completion-marker.md
@@ -61,3 +61,31 @@
 - **Forbidden Expressions 回避**: `skills/review/SKILL.md` のマーカー（`<!--` に半角 `!` を含む）は、テンプレートの ` ```markdown ` コードフェンス内、および注記プロースでは inline code バッククォートで囲んで記述する（半角 `!` の禁止はコードフェンス・inline code 外のみ対象）。
 - **スコープ = review phase のみ**（Issue 自動解決済み）: reconcile-phase-state.sh の他フェーズ（issue/spec/code-patch/code-pr/merge/verify）の成功署名はラベル・git state・PR state・英語 gh キーワードで検出しており、ローカライズ脆弱なのは review の見出しのみ。汎用化は対象外。
 - **マーカー欠落リスク**: review LLM がマーカーを出力しないケースは、保持した既存テキスト署名 fallback が受ける（defense-in-depth）。
+
+## Code Retrospective
+
+### Deviations from Design
+- None（Spec の実装手順どおりに実装完了）
+
+### Design Gaps/Ambiguities
+- push タイミング: Worktreeエントリー後の最初の push は Step 11 のPR作成時にエラーになった（`aborted: you must first push the current branch to a remote`）。Step 12 で push してから PR を作成する流れへ修正した。Spec ではこのタイミングについて言及なし。
+
+### Rework
+- None（1回の実装で全52テストPASSを確認）
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- マーカー検出を grep OR の先頭に置き、既存テキスト署名を fallback として保持（defense-in-depth）
+- POSIX `[[:space:]]` を使用してマーカー内部の空白揺れを許容（bash 3.2+ 互換）
+- bats テストを2件追加：「localized heading + marker」と「marker only」で両パターンを網羅
+
+### Deferred Items
+- review LLM がマーカーを出力しないケースの実運用検証（Post-merge AC）
+- Push タイミング（Worktree内での最初のpushが必要）は動作確認済み
+
+### Notes for Next Phase
+- 全52 bats テストPASS、CI push 済み（PR #544）
+- verify コマンドは `github_check` のみPENDING（CI完了待ち）、その他7件はPASS確認済み
+- forbidden expressions チェック PASS、skill syntax validation PASS

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -37,7 +37,7 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 | spec | `phase/issue` or `phase/spec` label on issue | `$SPEC_PATH/issue-N-*.md` exists AND `phase/(ready\|code\|review\|merge\|verify\|done)` label | Implemented |
 | code-patch | `phase/ready` label on issue, Spec exists | `git log origin/main --grep="closes #N"` returns ≥1 commit | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
 | code-pr | `phase/ready` label on issue, Spec exists | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
-| review | PR is OPEN | PR has a comment containing `## Review Response Summary` or `## レビュー回答サマリ` | Implemented |
+| review | PR is OPEN | PR has a comment containing `<!-- review-summary -->` marker (primary); or `## Review Response Summary` / `## レビュー回答サマリ` (fallback for marker-absent posts) | Implemented |
 | merge | PR is OPEN and reviewDecision is APPROVED | `gh pr view --json state == MERGED` | Implemented |
 | verify | Issue has `phase/verify` label or is CLOSED | Issue is CLOSED or has `phase/done` label | Implemented |
 

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -247,7 +247,7 @@ _completion_review() {
 
   local actual_json="{\"pr_number\":${PR_NUMBER}}"
 
-  if echo "$comments" | grep -qE "## Review Response Summary|## レビュー回答サマリ"; then
+  if echo "$comments" | grep -qE "<!--[[:space:]]*review-summary[[:space:]]*-->|## Review Response Summary|## レビュー回答サマリ"; then
     _emit_result "true" "Review Response Summary found in PR #${PR_NUMBER} comments" "$actual_json"
   else
     _handle_mismatch "Review Response Summary not found in PR #${PR_NUMBER} comments" "$actual_json"

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -669,6 +669,7 @@ Refer to `skills/review/external-review-phase.md`'s "Step 14: External Review Re
 Template:
 ```markdown
 ## Review Response Summary
+<!-- review-summary -->
 
 ### Claude Review Response
 
@@ -690,6 +691,8 @@ Template:
 - Updated condition: {before} → {after}
 - Issue comment: posted
 ```
+
+The `<!-- review-summary -->` marker line must be included verbatim even when the heading is localized. `reconcile-phase-state.sh` detects review completion via this language-independent marker.
 
 **If no Claude response (Step 11 skipped)**: omit Claude section.
 

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -328,6 +328,37 @@ MOCK_EOF
     [[ "$output" == *'"matches_expected":false'* ]]
 }
 
+@test "review completion: localized heading with review-summary marker -> matches_expected true" {
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "## レビューレスポンスサマリー"
+echo "<!-- review-summary -->"
+echo "All good"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" review 42 --pr 10 --check-completion --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+}
+
+@test "review completion: marker only (no heading) -> matches_expected true" {
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "<!-- review-summary -->"
+echo "Some content"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" review 42 --pr 10 --check-completion --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+}
+
 @test "review completion: missing --pr flag -> exit 2" {
     run bash "$SCRIPT" review 42 --check-completion
     [ "$status" -eq 2 ]


### PR DESCRIPTION
## Summary

reconcile-phase-state.sh の review completion 検出が `## Review Response Summary` 等の見出しテキストに依存しており、review LLM が日本語慣習で見出しをローカライズした際に false-negative が発生していた問題を解消する。

言語非依存の機械可読マーカー `<!-- review-summary -->` を導入し、既存テキスト署名は後方互換 fallback として保持した。

変更ファイル:
- `skills/review/SKILL.md`: Step 14.1 サマリテンプレートにマーカー行追加 + 注記追記
- `scripts/reconcile-phase-state.sh`: `_completion_review()` のgrep パターンにマーカー検出を追加（POSIX `[[:space:]]` で空白揺れ許容、bash 3.2+ 互換）
- `modules/phase-state.md`: review Success Signature をマーカー方式（primary）＋既存テキスト（fallback）に更新
- `tests/reconcile-phase-state.bats`: ローカライズ見出し＋マーカー検出テスト2件追加（52テスト全PASS）

## Verification (pre-merge)

- review SKILL.md のサマリテンプレートにマーカー `review-summary` が埋め込まれている
- reconcile-phase-state.sh の review completion 検出がマーカー `review-summary` を参照している
- modules/phase-state.md の review success signature 定義がマーカー方式を記述している
- 既存テキスト署名（`## Review Response Summary`）が後方互換 fallback として保持されている
- bats テスト CI が SUCCESS（52テスト、新規2テスト含む）

## Verification (post-merge)

- 次回以降の `/auto` の review phase で、日本語ローカライズされたサマリ見出しが投稿されても reconcile が `matches_expected:true` を返し、false-negative recovery が発生しないことを実運用で確認する

closes #528