### PR TITLE
Issue #549: Add auto-rename of session title on /auto invocation

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/hook-rename-on-auto.sh",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -166,6 +166,7 @@ wholework/
 - `scripts/get-issue-priority.sh` — issue priority フィールド取得
 - `scripts/get-sub-issue-graph.sh` — サブ issue 依存グラフ構築
 - `scripts/get-verify-iteration.sh` — Issue コメントから `<!-- verify-iteration: N -->` マーカーの最大値を読み取る
+- `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: プロンプトが `/auto` パターンにマッチした場合にセッション名を自動リネーム
 - `scripts/log-permission.sh` — 権限イベントログ（JSON 出力）
 - `scripts/opportunistic-search.sh` — opportunistic スキル検索
 - `scripts/triage-backlog-filter.sh` — triage 向けバックログフィルタ

--- a/docs/spec/issue-549-auto-rename-session.md
+++ b/docs/spec/issue-549-auto-rename-session.md
@@ -92,23 +92,21 @@
 - **CI への影響**: 新規 bats ファイルは `.github/workflows/test.yml` の `bats --jobs $(nproc) tests/` に自動で含まれる。CI 設定変更は不要
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `set -eu` を使わない設計を採用：hook 失敗時に空出力で安全に抜けるため（gh/jq 失敗で既存セッション名を破壊しない）
-- `case` 文による分岐（`--batch` → `--resume` → generic N）を選択：bash 3.2 互換を維持しつつ可読性を確保
-- bats テストは mock `gh` を `PATH` に差し込む方式（`apply-fallback.bats` と同パターン）
-- `jq -n --arg title "$TITLE"` でセッション名の JSON エスケープを委譲：手動エスケープのバグリスクを排除
+- REVIEW_DEPTH=light で実施（Size M + --light フラグ）：軽量統合レビュー（4観点）のみ、full-mode 2エージェント並列は不要と判断
+- MUST/SHOULD 問題ゼロのため修正作業なし。CONSIDER 2件はスキップ（うち1件はSpec承認済みの既知妥協点）
+- 全受け入れ条件 PASS・全 CI SUCCESS を確認してレビュー完了
 
 ### Deferred Items
-- truncate の UTF-8 正確性は「概ね 50 文字、稀にバイト境界で切れる」と割り切り（Spec Notes 参照）
-- 既存ユーザへの template 適用は `./install.sh` 手動再実行に委ね、自動化は Non-Goals
-- `github_check "gh pr checks" "bats"` の verify は CI 完走後 `/verify` フェーズで確認
+- `--batch --flag N` のような異常入力テストケースは CONSIDER レベルの欠落。後続 Issue での改善候補
+- truncate の UTF-8 バイト数問題は Spec Notes で承認済み妥協点として継続保留
+- Post-merge 検証（セッション名自動変更の実動作確認）は merge 後に手動実施
 
 ### Notes for Next Phase
-- PR #550 の CI bats テストが pass することを確認（次フェーズの主要チェック）
-- install.sh の再実行案内を PR 本文に記載済み
-- docs/structure.md の scripts カウントは 48 で現在の実装数と一致（main の先行記載が偶然一致）
+- MUST 問題なし → `/merge 550` で即マージ可能
+- Post-merge 受け入れ条件（手動）: `/auto 123` 実行時のセッション名変更、`./install.sh` 再実行で template 変更が既存ユーザに適用される確認
 
 ## Code Retrospective
 
@@ -124,3 +122,17 @@
 ### Rework
 
 - bats テスト test 3（--resume ケース）を、タイトル長によるトランケート問題で 1 回修正（issue 456 の短いタイトルに変更）。
+
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+記録事項なし。PR diff と Spec の受け入れ条件の整合性は良好。実装のすべての分岐（`--batch`/`--resume`/番号付き/非マッチ）が Spec 設計通りに実装されており、乖離は検出されなかった。
+
+### 繰り返し問題
+
+記録事項なし。今回のレビューで同種の問題が複数件検出されることはなかった。
+
+### 受け入れ条件の検証難易度
+
+6件すべて `file_exists` / `file_contains` / `github_check` verify command で静的に検証可能で、UNCERTAIN が発生しなかった。verify command の設計が適切であった。Post-merge 条件（セッション名の実動作確認）は手動検証が必要で、これは `<!-- verify-type: manual -->` で正しく分類されている。

--- a/docs/spec/issue-549-auto-rename-session.md
+++ b/docs/spec/issue-549-auto-rename-session.md
@@ -90,3 +90,37 @@
 - **タイムアウト 5000ms の妥当性**: `gh issue view` がネットワーク遅延込みで 1-3 秒、余裕を見て 5 秒。既存 `PermissionRequest` hook と同値で一貫性を保つ
 - **hook 失敗時の安全性**: hook が空出力で終わると Claude Code 側は既存セッション名を保持する。`set -eu` を使わないのは、jq 失敗・gh 失敗で hook 全体が落ちて意図しない side effect が出るのを避けるため
 - **CI への影響**: 新規 bats ファイルは `.github/workflows/test.yml` の `bats --jobs $(nproc) tests/` に自動で含まれる。CI 設定変更は不要
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `set -eu` を使わない設計を採用：hook 失敗時に空出力で安全に抜けるため（gh/jq 失敗で既存セッション名を破壊しない）
+- `case` 文による分岐（`--batch` → `--resume` → generic N）を選択：bash 3.2 互換を維持しつつ可読性を確保
+- bats テストは mock `gh` を `PATH` に差し込む方式（`apply-fallback.bats` と同パターン）
+- `jq -n --arg title "$TITLE"` でセッション名の JSON エスケープを委譲：手動エスケープのバグリスクを排除
+
+### Deferred Items
+- truncate の UTF-8 正確性は「概ね 50 文字、稀にバイト境界で切れる」と割り切り（Spec Notes 参照）
+- 既存ユーザへの template 適用は `./install.sh` 手動再実行に委ね、自動化は Non-Goals
+- `github_check "gh pr checks" "bats"` の verify は CI 完走後 `/verify` フェーズで確認
+
+### Notes for Next Phase
+- PR #550 の CI bats テストが pass することを確認（次フェーズの主要チェック）
+- install.sh の再実行案内を PR 本文に記載済み
+- docs/structure.md の scripts カウントは 48 で現在の実装数と一致（main の先行記載が偶然一致）
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec の Step 2 で `jq '.hooks.UserPromptSubmit = [...]'` による settings.json.template 編集を想定。実装では `.new` ファイル経由のアトミックな置換パターンで実施（設計と同等）。
+- bats テストの --resume ケースで、デフォルト mock が返すタイトルが「auto: Add auto-rename of session title」であったため、resume 形式 (`auto #123 (resume): ...`) に組み合わせると 52 文字になりトランケートが発生。テストを issue 456 (`"Short title"`) に変更して解決。
+
+### Design Gaps/Ambiguities
+
+- Spec の truncate 実装方針として `awk` による文字数判定が記載されていたが、Notes で「安全策として bash の `${#var}` を使う」と補足されていた。実装では bash `${#var}` + `${TITLE:0:49}` を採用（Spec Notes と一致）。
+
+### Rework
+
+- bats テスト test 3（--resume ケース）を、タイトル長によるトランケート問題で 1 回修正（issue 456 の短いタイトルに変更）。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -173,6 +173,7 @@ Key modules:
 - `scripts/get-issue-priority.sh` — get issue priority field
 - `scripts/get-sub-issue-graph.sh` — build sub-issue dependency graph
 - `scripts/get-verify-iteration.sh` — read highest `<!-- verify-iteration: N -->` marker from Issue comments
+- `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: auto-rename session title when prompt matches `/auto` pattern
 - `scripts/log-permission.sh` — log permission events (JSON output)
 - `scripts/opportunistic-search.sh` — opportunistic skill search
 - `scripts/triage-backlog-filter.sh` — filter backlog for triage

--- a/scripts/hook-rename-on-auto.sh
+++ b/scripts/hook-rename-on-auto.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# UserPromptSubmit hook: auto-rename session title on /auto invocation
+# Outputs {"hookSpecificOutput":{"sessionTitle":"..."}} when prompt matches /auto pattern.
+# Silent exit (empty output) on no match or gh failure to preserve existing session name.
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""')
+
+# Early exit: not starting with /auto
+case "$PROMPT" in
+  /auto*) ;;
+  *) exit 0 ;;
+esac
+
+# Early exit: help mode
+case "$PROMPT" in
+  *--help*) exit 0 ;;
+esac
+
+# Strip leading "/auto" and optional whitespace
+REST=$(echo "$PROMPT" | sed 's|^/auto[[:space:]]*||')
+
+TITLE=""
+
+case "$REST" in
+  *"--batch"*)
+    BATCH_PART=$(echo "$REST" | sed -E 's/.*--batch[[:space:]]*//')
+    NUMS=$(echo "$BATCH_PART" | grep -oE '^([0-9]+[[:space:]]+)*[0-9]+' | xargs)
+    if [ -z "$NUMS" ]; then
+      exit 0
+    fi
+    NUM_COUNT=$(echo "$NUMS" | wc -w | tr -d ' ')
+    if [ "$NUM_COUNT" -eq 1 ]; then
+      TITLE="auto batch ($NUMS issues)"
+    else
+      COMMA_NUMS=$(echo "$NUMS" | tr ' ' ',')
+      TITLE="auto batch #$COMMA_NUMS"
+    fi
+    ;;
+
+  *"--resume"*)
+    N=$(echo "$REST" | sed -E 's/.*--resume[[:space:]]*//' | grep -oE '^[0-9]+')
+    if [ -z "$N" ]; then
+      exit 0
+    fi
+    RAW=$(gh issue view "$N" --json title -q .title 2>/dev/null) || exit 0
+    [ -z "$RAW" ] && exit 0
+    STRIPPED=$(echo "$RAW" | sed -E 's/^[A-Za-z0-9_/-]+:[[:space:]]*//')
+    TITLE="auto #$N (resume): $STRIPPED"
+    ;;
+
+  *)
+    N=$(echo "$REST" | grep -oE '[0-9]+' | head -1)
+    if [ -z "$N" ]; then
+      exit 0
+    fi
+    RAW=$(gh issue view "$N" --json title -q .title 2>/dev/null) || exit 0
+    [ -z "$RAW" ] && exit 0
+    STRIPPED=$(echo "$RAW" | sed -E 's/^[A-Za-z0-9_/-]+:[[:space:]]*//')
+    TITLE="auto #$N: $STRIPPED"
+    ;;
+esac
+
+# Truncate to 50 chars (bash ${#} counts bytes on macOS bash 3.2, accepted as compromise)
+if [ ${#TITLE} -gt 50 ]; then
+  TITLE="${TITLE:0:49}…"
+fi
+
+jq -n --arg title "$TITLE" '{"hookSpecificOutput":{"sessionTitle":$title}}'

--- a/tests/hook-rename-on-auto.bats
+++ b/tests/hook-rename-on-auto.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+
+# Tests for hook-rename-on-auto.sh
+# Validates session title generation for /auto prompt patterns
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/hook-rename-on-auto.sh"
+
+setup() {
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    # Default mock gh: return a fixed title for issue 123
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+case "$*" in
+  "issue view 123 --json title -q .title")
+    echo "auto: Add auto-rename of session title"
+    exit 0
+    ;;
+  "issue view 456 --json title -q .title")
+    echo "Short title"
+    exit 0
+    ;;
+  "issue view 999 --json title -q .title")
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "numbered /auto 123 strips component prefix and sets sessionTitle" {
+    INPUT='{"prompt":"/auto 123"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    [ "$TITLE" = "auto #123: Add auto-rename of session title" ]
+}
+
+@test "numbered /auto 123 --patch (flag after number) sets same sessionTitle" {
+    INPUT='{"prompt":"/auto 123 --patch"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    [ "$TITLE" = "auto #123: Add auto-rename of session title" ]
+}
+
+@test "--resume 456 produces resume format" {
+    INPUT='{"prompt":"/auto --resume 456"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    [ "$TITLE" = "auto #456 (resume): Short title" ]
+}
+
+@test "--batch single number produces batch count format" {
+    INPUT='{"prompt":"/auto --batch 5"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    [ "$TITLE" = "auto batch (5 issues)" ]
+}
+
+@test "--batch multiple numbers produces comma-joined format" {
+    INPUT='{"prompt":"/auto --batch 123 124 125"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    [ "$TITLE" = "auto batch #123,124,125" ]
+}
+
+@test "title without component prefix is preserved as-is" {
+    INPUT='{"prompt":"/auto 456"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    [ "$TITLE" = "auto #456: Short title" ]
+}
+
+@test "title exactly 50 chars is not truncated" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+# Title of 45 chars: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst"
+# With "auto #123: " prefix (11 chars) = 56 chars total -> will be truncated
+# Use 38-char title so "auto #123: " + 38 = 49 chars (no truncation)
+echo "abcdefghijklmnopqrstuvwxyzabcdefghijkl"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+    INPUT='{"prompt":"/auto 123"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    # "auto #123: " (11) + 38 = 49 chars, no truncation
+    [ "$TITLE" = "auto #123: abcdefghijklmnopqrstuvwxyzabcdefghijkl" ]
+}
+
+@test "title resulting in over 50 chars is truncated to 49 chars plus ellipsis" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+echo "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwx"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+    INPUT='{"prompt":"/auto 123"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    # Output must end with ellipsis and be at most 52 bytes (49 ASCII + 3-byte UTF-8 ellipsis)
+    [[ "$TITLE" == *"…" ]]
+    # The non-ellipsis part must be 49 chars
+    WITHOUT_ELLIPSIS="${TITLE%…}"
+    [ ${#WITHOUT_ELLIPSIS} -eq 49 ]
+}
+
+@test "non-/auto prompt produces empty output" {
+    INPUT='{"prompt":"/code 123"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    [ -z "$OUTPUT" ]
+}
+
+@test "--help flag produces empty output" {
+    INPUT='{"prompt":"/auto --help"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    [ -z "$OUTPUT" ]
+}
+
+@test "/auto without number produces empty output" {
+    INPUT='{"prompt":"/auto"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    [ -z "$OUTPUT" ]
+}
+
+@test "gh failure produces empty output (session name preserved)" {
+    INPUT='{"prompt":"/auto 999"}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    [ -z "$OUTPUT" ]
+}
+
+@test "missing prompt field in JSON produces empty output" {
+    INPUT='{}'
+    OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
+    [ -z "$OUTPUT" ]
+}


### PR DESCRIPTION
## Summary

`UserPromptSubmit` hook (`scripts/hook-rename-on-auto.sh`) を新規追加し、ユーザの入力が `/auto` パターンにマッチした場合に Issue title からセッション名を自動生成する機能を実装。

- `/auto 123` → `auto #123: <stripped title>` (component prefix 除去 + 50 char truncate)
- `/auto --resume 123` → `auto #123 (resume): <stripped title>`
- `/auto --batch 5` → `auto batch (5 issues)`
- `/auto --batch 123 124 125` → `auto batch #123,124,125`
- `gh` 失敗・Issue 不在・`--help`・番号なし → 空出力（既存セッション名を保持）

`.claude/settings.json.template` の `hooks` に `UserPromptSubmit` エントリを追加。`./install.sh` 再実行で既存ユーザに適用される。

bats テスト 13 件追加（全パターンをカバー）。

## Verification (pre-merge)

- `scripts/hook-rename-on-auto.sh` が新規作成されている
- hook script が `hookSpecificOutput.sessionTitle` を含む JSON を出力する実装になっている
- `.claude/settings.json.template` に `UserPromptSubmit` hook エントリが追加されている
- `.claude/settings.json.template` の `UserPromptSubmit` hook が `hook-rename-on-auto.sh` を参照している
- bats テストファイル `tests/hook-rename-on-auto.bats` が追加されている
- CI で bats テストが pass している

## Verification (post-merge)

- `/auto 123` 実行時、セッション名が `auto #123: <stripped title>` に自動変更される
- `/auto --batch 5` / `/auto --batch 123 124 125` / `/auto --resume 123` がそれぞれ仕様通りのセッション名になる
- 通常プロンプト入力時、hook が動作しても遅延・余計な出力がない
- `gh` 失敗・Issue 不在時に既存セッション名が破壊されない

**Note**: 既存ユーザは template 変更後に `./install.sh` を手動再実行する必要があります。

closes #549