### PR TITLE
Issue #552: Plugin-distribute session auto-rename hook with opt-in via .wholework.yml

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -23,6 +23,9 @@ claude-code-review: true    # Wait for Claude Code Review before merging
 coderabbit-review: true     # Wait for CodeRabbit review before merging
 review-bug: false           # Disable bug-detection agent in /review
 
+# Session title auto-rename when /auto is invoked
+session-auto-rename: true   # Rename session title to issue number and title when /auto N is invoked
+
 # Post-skill verification
 opportunistic-verify: true  # Run quick verify commands at skill completion
 
@@ -82,6 +85,7 @@ This table is the **single source of truth (SSoT)** for all `.wholework.yml` con
 | `review-bug` | boolean | `true` | Run bug-detection agent in `/review` |
 | `opportunistic-verify` | boolean | `false` | Run quick verify commands at skill completion |
 | `skill-proposals` | boolean | `false` | Generate Wholework improvement issues during `/verify` |
+| `session-auto-rename` | boolean | `false` | Rename session title to issue number and title when `/auto N` is invoked |
 | `steering-hint` | boolean | `true` | Show `/doc init` hint when steering docs are missing |
 | `production-url` | string | `""` | Production URL for browser-based verify commands |
 | `spec-path` | string | `docs/spec` | Where specs are stored |

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -17,6 +17,9 @@ claude-code-review: true    # マージ前に Claude Code Review を待つ
 coderabbit-review: true     # マージ前に CodeRabbit review を待つ
 review-bug: false           # /review でバグ検出 agent を無効化
 
+# /auto 実行時のセッションタイトル自動リネーム
+session-auto-rename: true   # /auto N 実行時にセッションタイトルを Issue 番号とタイトルにリネーム
+
 # スキル後検証
 opportunistic-verify: true  # スキル完了時に軽量 verify command を実行
 
@@ -76,6 +79,7 @@ capabilities:
 | `review-bug` | boolean | `true` | `/review` でバグ検出 agent を実行する |
 | `opportunistic-verify` | boolean | `false` | スキル完了時に軽量 verify command を実行する |
 | `skill-proposals` | boolean | `false` | `/verify` 中に Wholework 改善 issue を生成する |
+| `session-auto-rename` | boolean | `false` | `/auto N` 実行時にセッションタイトルを Issue 番号とタイトルにリネームする |
 | `steering-hint` | boolean | `true` | steering docs が欠如している場合に `/doc init` ヒントを表示する |
 | `production-url` | string | `""` | ブラウザベース verify command 用の本番 URL |
 | `spec-path` | string | `docs/spec` | spec の保存先 |

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -12,6 +12,8 @@ wholework/
 ├── .claude-plugin/      # Plugin マニフェストディレクトリ
 │   ├── plugin.json      # Plugin マニフェスト（name: "wholework"）
 │   └── marketplace.json # Marketplace マニフェスト（name: "saitoco-wholework"）
+├── hooks/               # Plugin レベルの hook 定義
+│   └── hooks.json       # UserPromptSubmit hook（session-auto-rename opt-in）
 ├── skills/              # Claude Code スキル（1 スキル 1 サブディレクトリ）
 │   └── <skill-name>/
 │       ├── SKILL.md     # スキル定義（必須）

--- a/docs/spec/issue-552-plugin-session-auto-rename.md
+++ b/docs/spec/issue-552-plugin-session-auto-rename.md
@@ -109,3 +109,33 @@ Issue body の AC4/AC5 は `file_contains ".claude-plugin/plugin.json"` を veri
 ### 既存 `.claude/settings.json.template` エントリの扱い
 
 当面は残す（plugin hook との二重起動になるが、両方が opt-in チェックを通過した場合は同じ JSON を出力するため冪等。先に exit したほうの出力が使われ、後発は無害）。Plugin 経由配布が定着したら別 Issue で削除を検討。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `hooks/hooks.json` を新規作成して plugin-level hook 登録（`plugin.json` への hooks フィールド追加ではない）
+- opt-in チェックは `CLAUDE_PROJECT_DIR/.wholework.yml` を直接 `grep -q` で参照（`get-config-value.sh` 呼び出しではなく bash 3.2 互換の直接 grep を採用）
+- `docs/ja/structure.md` は Spec の Changed Files に含まれていなかったが、`translation-workflow.md` 準拠で追加更新した
+
+### Deferred Items
+- 既存 `.claude/settings.json.template` の `UserPromptSubmit` hook エントリは残存（二重起動だが冪等）。Plugin 配布定着後に削除 Issue を別途起票予定
+- AC7（`github_check "gh pr checks" "bats"`）は PR 作成後 CI で確認
+
+### Notes for Next Phase
+- `hooks/hooks.json` が Claude Code plugin hooks schema として正しいかどうかは CI（bats は PASS、hooks の実動作は手動後確認）
+- PR #553 作成済み。Post-merge 手動確認 2 項目が残っている
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None — 実装ステップはすべて Spec 通りに実行。順番の変更なし。
+
+### Design Gaps/Ambiguities
+
+- `docs/ja/structure.md` の同期が Spec の Changed Files リストに含まれていなかった。`docs/structure.md` を変更したため `docs/translation-workflow.md` の手順に従い `docs/ja/structure.md` も更新した（追加コミットで対応）。
+
+### Rework
+
+- None

--- a/docs/spec/issue-552-plugin-session-auto-rename.md
+++ b/docs/spec/issue-552-plugin-session-auto-rename.md
@@ -110,13 +110,35 @@ Issue body の AC4/AC5 は `file_contains ".claude-plugin/plugin.json"` を veri
 
 当面は残す（plugin hook との二重起動になるが、両方が opt-in チェックを通過した場合は同じ JSON を出力するため冪等。先に exit したほうの出力が使われ、後発は無害）。Plugin 経由配布が定着したら別 Issue で削除を検討。
 
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+Spec と PR diff の間に構造的乖離はなし。全 acceptance criteria が実装済みで、変更スコープも Issue 目的と一致。spec 段階で verify command を `plugin.json` → `hooks/hooks.json` に修正済みのため、review フェーズでの乖離指摘は不要だった（spec の事前整合が review 負荷を下げた）。
+
+### 再発パターン
+
+CONSIDER レベル 2 件（bats テストの冗長な環境変数プレフィックス、`:-` フォールバックの意図曖昧さ）。いずれも動作に影響しないスタイル/明確さの問題。同種の問題はテストコードで再発しやすい（env 変数設定を pipe の前後両方に置くパターン）。次回 bats テスト作成時に `echo "$INPUT" | ENV=VALUE bash "$SCRIPT"` の最小形式を守ることで防止できる。
+
+### 承認条件検証難易度
+
+全 7 件が `file_contains` / `github_check` で自動検証可能だった（UNCERTAIN ゼロ）。verify command が具体的なファイル名と文字列を指定する形式のため、精度が高い。CI bats テストは `github_check "gh pr checks" "bats"` で正確に照合できた。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `hooks/hooks.json` を新規作成して plugin-level hook 登録（`plugin.json` への hooks フィールド追加ではない）
-- opt-in チェックは `CLAUDE_PROJECT_DIR/.wholework.yml` を直接 `grep -q` で参照（`get-config-value.sh` 呼び出しではなく bash 3.2 互換の直接 grep を採用）
-- `docs/ja/structure.md` は Spec の Changed Files に含まれていなかったが、`translation-workflow.md` 準拠で追加更新した
+- MUST/SHOULD 指摘なし → fix work スキップ、COMMENT イベントで review 投稿
+- CONSIDER 2 件（bats テスト冗長プレフィックス、`:-` フォールバック意図曖昧さ）は動作に影響しないためスキップ
+- 承認条件 7/7 PASS（CI bats テスト含む）を確認済み
+
+### Deferred Items
+- CONSIDER 指摘 2 件を fix しなかった（merge ブロッカーではないため）
+- post-merge 手動確認 2 件は merge 後のオペレーター確認に委ねる
+
+### Notes for Next Phase
+- merge は `/merge 553` で直接実行可能（MUST/SHOULD なし、CI 全 SUCCESS）
+- post-merge 手動確認（別リポジトリでの opt-in/opt-out 動作検証）が残っている
 
 ### Deferred Items
 - 既存 `.claude/settings.json.template` の `UserPromptSubmit` hook エントリは残存（二重起動だが冪等）。Plugin 配布定着後に削除 Issue を別途起票予定

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -19,6 +19,8 @@ wholework/
 ├── .claude-plugin/      # Plugin manifest directory
 │   ├── plugin.json      # Plugin manifest (name: "wholework")
 │   └── marketplace.json # Marketplace manifest (name: "saitoco-wholework")
+├── hooks/               # Plugin-level hook definitions
+│   └── hooks.json       # UserPromptSubmit hook (session-auto-rename opt-in)
 ├── skills/              # Claude Code skills (one subdirectory per skill)
 │   └── <skill-name>/
 │       ├── SKILL.md     # Skill definition (required)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-rename-on-auto.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/modules/detect-config-markers.md
+++ b/modules/detect-config-markers.md
@@ -36,6 +36,7 @@ From the loaded content, search for each YAML key in the marker definition table
 | `review-bug` | `SKIP_REVIEW_BUG` | `false` (enabled) | `false`-treated as true. If `review-bug: false` then `SKIP_REVIEW_BUG=true` |
 | `opportunistic-verify` | `HAS_OPPORTUNISTIC_VERIFY` | `true` | `false` |
 | `skill-proposals` | `HAS_SKILL_PROPOSALS` | `true` | `false` |
+| `session-auto-rename` | `HAS_SESSION_AUTO_RENAME` | `true` | `false` |
 | `steering-hint` | `HAS_STEERING_HINT` | `true` | `true` (default true; `false` when `steering-hint: false`) |
 | `production-url` | `PRODUCTION_URL` | URL string (extract value as-is) | `""` |
 | `spec-path` | `SPEC_PATH` | Path string (extract value as-is) | `docs/spec` |
@@ -84,6 +85,7 @@ HAS_CODERABBIT_REVIEW: true if coderabbit-review: true is set (default: false)
 SKIP_REVIEW_BUG: true if review-bug: false is set (default: false)
 HAS_OPPORTUNISTIC_VERIFY: true if opportunistic-verify: true is set (default: false)
 HAS_SKILL_PROPOSALS: true if skill-proposals: true is set (default: false)
+HAS_SESSION_AUTO_RENAME: true if session-auto-rename: true is set (default: false)
 HAS_STEERING_HINT: false if steering-hint: false is set (default: true)
 PRODUCTION_URL: URL string extracted from production-url (default: "")
 SPEC_PATH: path string extracted from spec-path (default: "docs/spec")

--- a/scripts/hook-rename-on-auto.sh
+++ b/scripts/hook-rename-on-auto.sh
@@ -4,6 +4,13 @@
 # Silent exit (empty output) on no match or gh failure to preserve existing session name.
 
 INPUT=$(cat)
+
+# Opt-in check: session-auto-rename must be true in .wholework.yml
+WHOLEWORK_YML="${CLAUDE_PROJECT_DIR:-}/.wholework.yml"
+if [ ! -f "$WHOLEWORK_YML" ] || ! grep -q "^session-auto-rename:[[:space:]]*true" "$WHOLEWORK_YML"; then
+  exit 0
+fi
+
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""')
 
 # Early exit: not starting with /auto

--- a/tests/hook-rename-on-auto.bats
+++ b/tests/hook-rename-on-auto.bats
@@ -10,6 +10,12 @@ setup() {
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"
 
+    # Set CLAUDE_PROJECT_DIR with session-auto-rename: true so existing tests pass opt-in check
+    PROJ_DIR="$BATS_TEST_TMPDIR/wholework-proj"
+    mkdir -p "$PROJ_DIR"
+    echo "session-auto-rename: true" > "$PROJ_DIR/.wholework.yml"
+    export CLAUDE_PROJECT_DIR="$PROJ_DIR"
+
     # Default mock gh: return a fixed title for issue 123
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
@@ -143,4 +149,31 @@ MOCK
     INPUT='{}'
     OUTPUT=$(echo "$INPUT" | bash "$SCRIPT")
     [ -z "$OUTPUT" ]
+}
+
+@test "no .wholework.yml produces empty output" {
+    EMPTY_DIR="$BATS_TEST_TMPDIR/empty-proj"
+    mkdir -p "$EMPTY_DIR"
+    INPUT='{"prompt":"/auto 123"}'
+    OUTPUT=$(CLAUDE_PROJECT_DIR="$EMPTY_DIR" echo "$INPUT" | CLAUDE_PROJECT_DIR="$EMPTY_DIR" bash "$SCRIPT")
+    [ -z "$OUTPUT" ]
+}
+
+@test "session-auto-rename: false produces empty output" {
+    OPT_OUT_DIR="$BATS_TEST_TMPDIR/optout-proj"
+    mkdir -p "$OPT_OUT_DIR"
+    echo "session-auto-rename: false" > "$OPT_OUT_DIR/.wholework.yml"
+    INPUT='{"prompt":"/auto 123"}'
+    OUTPUT=$(echo "$INPUT" | CLAUDE_PROJECT_DIR="$OPT_OUT_DIR" bash "$SCRIPT")
+    [ -z "$OUTPUT" ]
+}
+
+@test "session-auto-rename: true fires hook and returns sessionTitle" {
+    OPT_IN_DIR="$BATS_TEST_TMPDIR/optin-proj"
+    mkdir -p "$OPT_IN_DIR"
+    echo "session-auto-rename: true" > "$OPT_IN_DIR/.wholework.yml"
+    INPUT='{"prompt":"/auto 123"}'
+    OUTPUT=$(echo "$INPUT" | CLAUDE_PROJECT_DIR="$OPT_IN_DIR" bash "$SCRIPT")
+    TITLE=$(echo "$OUTPUT" | jq -r '.hookSpecificOutput.sessionTitle')
+    [ "$TITLE" = "auto #123: Add auto-rename of session title" ]
 }


### PR DESCRIPTION
## Summary

- `hooks/hooks.json` を新規作成し、plugin レベルの `UserPromptSubmit` hook として `hook-rename-on-auto.sh` を登録
- `scripts/hook-rename-on-auto.sh` の冒頭に opt-in チェックを追加（`CLAUDE_PROJECT_DIR/.wholework.yml` に `session-auto-rename: true` が設定されている場合のみ動作）
- `modules/detect-config-markers.md` に `session-auto-rename` / `HAS_SESSION_AUTO_RENAME` マーカーを追加
- `docs/guide/customization.md` と `docs/ja/guide/customization.md` に新マーカーの説明を追記
- `docs/structure.md` と `docs/ja/structure.md` に `hooks/` ディレクトリエントリを追加
- `tests/hook-rename-on-auto.bats` に opt-in 3 パターン（yml 不在、false、true）のテストを追加

## Verification (pre-merge)

- `modules/detect-config-markers.md` に `session-auto-rename` 行と `HAS_SESSION_AUTO_RENAME` 変数が追加されている ✅
- `scripts/hook-rename-on-auto.sh` の冒頭に opt-in チェックが実装されている ✅
- `hooks/hooks.json` に `UserPromptSubmit` hook エントリと `hook-rename-on-auto.sh` 参照が追加されている ✅
- `docs/guide/customization.md` に新マーカーの説明が追加されている ✅
- CI で bats テストが pass（opt-in チェックの 3 パターンを含む）

## Verification (post-merge)

- 別の git リポジトリ（wholework plugin を enable 済み）で `.wholework.yml` に `session-auto-rename: true` を追加して新セッション起動、`/auto N` でセッション名が変わることを確認
- `.wholework.yml` に `session-auto-rename` を書かない（または `false`）リポジトリで `/auto N` を打ち、セッション名が変わらないことを確認

closes #552