### PR TITLE
Issue #555: Separate find/filter in review-bug for coverage-first approach

### DIFF
--- a/agents/review-bug.md
+++ b/agents/review-bug.md
@@ -1,6 +1,6 @@
 ---
 name: review-bug
-description: Review: Bug/Logic Error Detection (HIGH SIGNAL) — flag only confirmed bugs, logic errors, and security issues; eliminate false positives
+description: Review: Bug/Logic Error Detection (coverage-first) — report all findings with confidence and severity tags; downstream verification sub-agents filter false positives
 tools: Read, Glob, Grep, Bash(git log:*, git diff:*, git show:*)
 model: opus
 ---
@@ -9,9 +9,9 @@ model: opus
 
 ## Purpose
 
-Based on the HIGH SIGNAL principle, detect only **confirmed** bugs, logic errors, and security issues from the PR diff. Minimize false positives and report only problems that genuinely require fixes.
+Role here is **coverage, not filtering**. Report all findings — including uncertain or low-severity ones — tagging each with **confidence** (high/medium/low) and **severity** (MUST/SHOULD/CONSIDER). Downstream verification sub-agents handle false-positive filtering; self-filtering at the finder stage reduces recall with literal filter-following models.
 
-### What to Flag (HIGH SIGNAL)
+### What to Report
 
 - **Compile/Parse Errors**: Syntax errors, undefined variable references, type mismatches (in typed languages)
 - **Clear Logic Errors Independent of Input**: Conditions that always evaluate to false, infinite loops, unreachable code, off-by-one errors
@@ -112,6 +112,7 @@ Output findings in the following format:
 **[Bug/Logic Error] filename:line-number vicinity**
 - path: file path (relative to repository root; null if not identifiable)
 - line: line number (corresponding line in diff; null if not identifiable)
+- confidence: high / medium / low
 Issue description (specify the exact problem and reason). Severity: MUST / SHOULD / CONSIDER
 
 Recommended fix:

--- a/agents/review-light.md
+++ b/agents/review-light.md
@@ -78,6 +78,7 @@ Output findings in the following format:
 **[Spec Deviation] filename:line-number vicinity**
 - path: file path (relative to repository root; null if not identifiable)
 - line: line number (corresponding line in diff; null if not identifiable)
+- confidence: high / medium / low
 Issue description. Severity: MUST / SHOULD / CONSIDER
 
 Recommended fix:
@@ -88,6 +89,7 @@ Recommended fix:
 **[Edge Case/Robustness] filename:line-number vicinity**
 - path: file path (relative to repository root; null if not identifiable)
 - line: line number (corresponding line in diff; null if not identifiable)
+- confidence: high / medium / low
 Issue description. Severity: MUST / SHOULD / CONSIDER
 
 Recommended fix:

--- a/agents/review-light.md
+++ b/agents/review-light.md
@@ -11,6 +11,8 @@ model: sonnet
 
 Analyze PR diff and perform lightweight checks across the following 4 perspectives (at a concise confirmation level, not the depth of full-mode 2-agent parallel). Based on the HIGH SIGNAL principle, report only confirmed issues:
 
+Note: Like `review-bug`, avoid excessive self-suppression. Report findings with confidence and severity tags rather than pre-filtering; downstream verification handles false positives.
+
 1. **Spec deviation** — Consistency with Spec and design documents
 2. **Edge cases and robustness** — Boundary values, failure behavior, cleanup omissions
 3. **Security and safety** — Shell injection, hardcoded secrets

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -134,7 +134,7 @@ wholework/
 
 | Agent | パス | 説明 |
 |---|---|---|
-| review-bug | `agents/review-bug.md` | バグ/ロジックエラー検出（HIGH SIGNAL） |
+| review-bug | `agents/review-bug.md` | バグ/ロジックエラー検出（coverage-first、confidence+severity タグ付き） |
 | review-light | `agents/review-light.md` | 軽量統合レビュー（4 観点すべて） |
 | review-spec | `agents/review-spec.md` | Spec/ドキュメントレビュー |
 | issue-scope | `agents/issue-scope.md` | L/XL issue のスコープ調査 |

--- a/docs/spec/issue-555-review-bug-find-filter-separation.md
+++ b/docs/spec/issue-555-review-bug-find-filter-separation.md
@@ -43,6 +43,24 @@
 
 - 実 PR の `/review --full` で、変更前と比べ review-bug の報告所見が抑制されすぎていない（検証段で適切に絞り込まれている）ことを 1 件以上で目視確認 <!-- verify-type: manual -->
 
+## Spec Retrospective
+
+N/A
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None
+
+### Design Gaps/Ambiguities
+
+- None
+
+### Rework
+
+- None
+
 ## Notes
 
 - `/review` Step 10.x の検証段（Step 10.3 の false-positive フィルタ）は現状維持。`skills/review/SKILL.md` の変更は不要
@@ -52,3 +70,20 @@
 - `severity` (小文字) は現在 `agents/review-bug.md` に存在しない（現行は大文字 "Severity"）→ Step 1 で Output Format に `- confidence: high / medium / low` フィールドと、Purpose 本文に小文字 "severity" を追加することで充足
 - `downstream` は現在 `agents/review-bug.md` に存在しない → Step 1 の Purpose 書き換えで追加
 - `file_contains "skills/review/SKILL.md" "Step 10.3"` は現行ファイル line 401 に "Pass integrated results to Step 10.3" として確認済み（変更不要）
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- coverage-first 方針への切り替え: Purpose セクション本文を丸ごと置き換え、downstream 検証段へのフィルタ委譲を明示した
+- `confidence` フィールドを Output Format の `- line:` 直後に追加（Spec 指定通り）
+- `review-light.md` への注記は Purpose 1段落目の直後に挿入（自然な読み順）
+- `docs/structure.md` + `docs/ja/structure.md` の両方を更新（translation-workflow.md に従う）
+
+### Deferred Items
+- post-merge 確認（実 PR で review-bug の所見が抑制されすぎないこと）は `/review` 後の目視確認として残置
+
+### Notes for Next Phase
+- 変更ファイル: `agents/review-bug.md`, `agents/review-light.md`, `docs/structure.md`, `docs/ja/structure.md`
+- 全 6 件の pre-merge verify commands は PASS 済み（Issue チェックボックス更新済み）
+- `skills/review/SKILL.md` は変更なし（Step 10.3 は現状維持）

--- a/docs/spec/issue-555-review-bug-find-filter-separation.md
+++ b/docs/spec/issue-555-review-bug-find-filter-separation.md
@@ -71,19 +71,33 @@ N/A
 - `downstream` は現在 `agents/review-bug.md` に存在しない → Step 1 の Purpose 書き換えで追加
 - `file_contains "skills/review/SKILL.md" "Step 10.3"` は現行ファイル line 401 に "Pass integrated results to Step 10.3" として確認済み（変更不要）
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+`review-light.md` への注記追加で、注記内容とOutput Formatの不整合が発生した。注記が "confidence and severity tags" を指示したが、Output Formatに confidence フィールドの定義がなかった。注記と出力形式を同一コミットで整合させる（または `review-output-format.md` の共通形式を先に更新してから参照させる）ことで防げる。
+
+### Recurring Issues
+
+`review-bug.md` と `review-light.md` は Output Format が類似構造だが独立定義されている。`review-bug.md` の format 変更（confidence 追加）が `review-light.md` に波及しなかった。複数エージェントに共通する format 変更は `review-output-format.md` の共通テンプレートを更新することで一括適用できる。
+
+### Acceptance Criteria Verification Difficulty
+
+全6件とも verify command で即時自動判定可能（UNCERTAIN なし）。verify command の精度は良好。Post-merge 条件（実 PR での review-bug 所見数の目視確認）は手動確認として適切に分類されている。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- coverage-first 方針への切り替え: Purpose セクション本文を丸ごと置き換え、downstream 検証段へのフィルタ委譲を明示した
-- `confidence` フィールドを Output Format の `- line:` 直後に追加（Spec 指定通り）
-- `review-light.md` への注記は Purpose 1段落目の直後に挿入（自然な読み順）
-- `docs/structure.md` + `docs/ja/structure.md` の両方を更新（translation-workflow.md に従う）
+- `review-light.md` Output Format に `- confidence: high / medium / low` フィールドを追加（注記と出力形式を整合）
+- CONSIDER 所見（"downstream verification handles false positives" の不正確な表現）は実害が限定的のためスキップ
+- validate-skill-syntax.py: 全10スキル PASS
 
 ### Deferred Items
-- post-merge 確認（実 PR で review-bug の所見が抑制されすぎないこと）は `/review` 後の目視確認として残置
+- post-merge 確認（実 PR で review-bug の所見が抑制されすぎないこと）は引き続き残置
+- "downstream verification handles false positives" の表現改善は次の機会での対応候補
 
 ### Notes for Next Phase
-- 変更ファイル: `agents/review-bug.md`, `agents/review-light.md`, `docs/structure.md`, `docs/ja/structure.md`
-- 全 6 件の pre-merge verify commands は PASS 済み（Issue チェックボックス更新済み）
-- `skills/review/SKILL.md` は変更なし（Step 10.3 は現状維持）
+- 変更ファイル: `agents/review-bug.md`, `agents/review-light.md`（confidence field 追加）, `docs/structure.md`, `docs/ja/structure.md`
+- 全 6 件の pre-merge verify commands は PASS
+- CI: 全ジョブ SUCCESS（DCO, Run bats tests, Validate skill syntax, Forbidden Expressions check, macOS shell compatibility）

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -141,7 +141,7 @@ Key modules:
 
 | Agent | Path | Description |
 |---|---|---|
-| review-bug | `agents/review-bug.md` | Bug/Logic Error Detection (HIGH SIGNAL) |
+| review-bug | `agents/review-bug.md` | Bug/Logic Error Detection (coverage-first, confidence+severity tagged) |
 | review-light | `agents/review-light.md` | Lightweight Integrated review (all 4 perspectives) |
 | review-spec | `agents/review-spec.md` | Spec/Documentation review |
 | issue-scope | `agents/issue-scope.md` | Scope investigation for L/XL issues |


### PR DESCRIPTION
## Summary

- `agents/review-bug.md` の Purpose セクションを coverage-first 方針に書き換え、自己フィルタ指示（HIGH SIGNAL, Minimize false positives）を削除
- Output Format に `confidence: high / medium / low` フィールドを追加し、各所見にタグ付けを義務化
- `agents/review-light.md` に `review-bug` とのフィルタ温度感整合の注記を追加
- `docs/structure.md` および `docs/ja/structure.md` の review-bug エージェント説明を coverage-first に更新

## Verification (pre-merge)

- `agents/review-bug.md` が各所見に confidence を付して報告するよう指示している
- `agents/review-bug.md` が各所見に severity を付して報告するよう指示している
- finder の役割が「カバレッジ（フィルタは後段）」であることが明記されている
- 自己フィルタ方針（Minimize false positives）が Purpose セクションから削除されている
- `agents/review-light.md` に `review-bug` とのフィルタ温度感整合の注記がある
- 既存の `/review` 検証段（false-positive フィルタ, Step 10.3）が温存されている

## Verification (post-merge)

- 実 PR の `/review --full` で、変更前と比べ review-bug の報告所見が抑制されすぎていないことを 1 件以上で目視確認

closes #555