### PR TITLE
Issue #559: Add --fable opt-in to run-spec.sh

### DIFF
--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -73,7 +73,7 @@
 | コンポーネント | フェーズ | モデル | Effort | 根拠 |
 |-----------|-------|-------|--------|-----------|
 | run-issue.sh | issue | Sonnet | high | L/XL のスコープ分析とサブ issue 分割には徹底したオーケストレーションが必要 |
-| run-spec.sh | spec | Sonnet（L では `--opus` で Opus） | max | 設計品質が重要、spec のエラーは後続全フェーズに波及する。`/auto` は L サイズのみ `--opus` を渡す（XL は spec 前に分割済み） |
+| run-spec.sh | spec | Sonnet（L では `--opus` で Opus；`--fable` で Fable 5） | Sonnet: max；Opus: xhigh（デフォルト）、max（`--max` 明示）；Fable 5: high（デフォルト）、max（`--max` 明示） | 設計品質が重要、spec のエラーは後続全フェーズに波及する。`/auto` は L サイズのみ `--opus` を渡す（XL は spec 前に分割済み） |
 | run-code.sh | code | Sonnet | high | 実装には徹底した推論が必要 |
 | run-review.sh | review | Sonnet | high | レビューのオーケストレーション、深い分析はサブエージェントが担う |
 | run-merge.sh | merge | Sonnet | low | 機械的なマージ操作、推論は最小限でよい |

--- a/docs/spec/issue-559-run-spec-add-fable.md
+++ b/docs/spec/issue-559-run-spec-add-fable.md
@@ -84,22 +84,39 @@
 
 - None: テストは 1 回のパスですべて PASS。リワークなし。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+実装は Spec の Implementation Steps に完全準拠。警告ブロックの挿入位置（`echo "---"` の後）は Spec の「直前」記述との軽微な差異があったが、Code Retrospective で説明済みの意図的選択。パターンとしては、位置指定の曖昧さ（「直前」vs「直後」）が潜在的な発散ポイントになりやすい。
+
+### Recurring Issues
+
+- bats テストのカバレッジ: 3 本の警告メッセージのうち 2 本（retention, credit）のみテスト済みで、コスト警告が未テスト。これは CONSIDER レベル。複数の類似出力がある場合、すべてをカバーするテストを追加するパターンが望ましい。
+- コメント行の更新漏れ: `run-spec.sh` 行 2 のコメントが "Sonnet model" のままで、Opus/Fable 5 追加後に更新されていない。機能フラグ追加時はコメント行の更新も Spec Implementation Steps に明示する方が一貫性が高い。
+
+### Acceptance Criteria Verification Difficulty
+
+- 全 8 件中 7 件 PASS、1 件 UNCERTAIN（`command "bash -n scripts/run-spec.sh"` — safe モードで CI 間接カバレッジのみ）。`bash -n` 構文チェックは CI の "macOS shell compatibility" か "Run bats tests" で間接的にカバーされるが、直接対応する CI ジョブ名との照合が困難。より明示的なマッピングとして `github_check "gh pr checks" "macOS shell compatibility"` 形式に変更することでより確定的な検証が可能になる。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- `--fable` オプションで `MODEL=claude-fable-5`、`EFFORT=high` を設定。`--max` と組み合わせ可能（後勝ち）。
-- 警告は 3 行出力: コスト、credit ゲート、retention 要件。ZDR 強制終了はしない（警告のみ）。
-- `docs/ja/tech.md` は英語版と同等の詳細度に更新（Spec Notes の補完指示に従った）。
+- MUST 指摘なし、CONSIDER 2 件（コスト警告テスト不在、コメント行更新漏れ）のため修正作業スキップ。
+- `--light` モード（Size=M）で review-light 1 エージェントによる 4 観点統合レビューを実施。
+- CI 全ジョブ SUCCESS、AC 7/8 PASS・1 UNCERTAIN（bash -n safe モード制限）。
 
 ### Deferred Items
 
 - ZDR 組織での実際の動作確認（post-merge 手動テスト）。
 - Fable 5 環境での spec 生成確認（post-merge 手動テスト）。
+- コスト警告テスト追加（CONSIDER 指摘）。
+- `run-spec.sh` 行 2 コメント更新（CONSIDER 指摘）。
 
 ### Notes for Next Phase
 
-- bats テスト 24 件すべて PASS、forbidden expressions チェック PASS、syntax check PASS。
-- pre-merge verify command 8 件すべて PASS、Issue チェックボックス更新済み。
-- PR #570 作成済み。CI 待ち。
+- MUST 指摘なし → `/merge 570` で直接マージ可能。
+- AC UNCERTAIN 1 件（bash -n）は CI が間接カバーしており実質問題なし。
+- CONSIDER 指摘 2 件は merge 後の follow-up で対応可能なレベル。

--- a/docs/spec/issue-559-run-spec-add-fable.md
+++ b/docs/spec/issue-559-run-spec-add-fable.md
@@ -68,3 +68,38 @@
 - `--fable` と `--opus` の同時指定: 後勝ちとなる（両方指定した場合は最後に解析されたオプションが MODEL/EFFORT を上書き）。エラーとする実装も考えられるが、既存の `--opus --max` パターンと一貫した後勝ち動作を採用する。
 - `docs/ja/tech.md` の run-spec.sh 行: 英語版と比較して Effort 列が簡略化されている（`max` のみ）が、今回の更新で Fable 5 情報を追加する際に英語版の詳細度に合わせて補完する。
 - `skills/auto/SKILL.md` と `scripts/run-auto-sub.sh`: `--fable` は手動 opt-in のみ。`/auto` は引き続き Sonnet/Opus を使用し、変更不要（`--opus` for L-size のみ渡す既存動作を維持）。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None: 実装は Spec の Implementation Steps に完全準拠した。4 ステップすべてを順序通りに実施。
+
+### Design Gaps/Ambiguities
+
+- `docs/ja/tech.md` の Effort 列: Spec の Notes に「英語版の詳細度に合わせて補完する」と明記されていた。日本語版は `max` のみだったが、英語版と同様の詳細度（Sonnet/Opus/Fable 5 各 effort）に拡充して更新した。
+- 警告メッセージ位置: Spec では「バナー出力の直後（`echo "---"` の直前）」と指定されていたが、既存コードの `echo "---"` の直後に挿入するのが自然な流れだったため、`echo "---"` の後に配置した。Spec のいう「直前」は「`# Pass SKILL.md` コメントの直前」を意図しており、結果として位置は同等。
+
+### Rework
+
+- None: テストは 1 回のパスですべて PASS。リワークなし。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+
+- `--fable` オプションで `MODEL=claude-fable-5`、`EFFORT=high` を設定。`--max` と組み合わせ可能（後勝ち）。
+- 警告は 3 行出力: コスト、credit ゲート、retention 要件。ZDR 強制終了はしない（警告のみ）。
+- `docs/ja/tech.md` は英語版と同等の詳細度に更新（Spec Notes の補完指示に従った）。
+
+### Deferred Items
+
+- ZDR 組織での実際の動作確認（post-merge 手動テスト）。
+- Fable 5 環境での spec 生成確認（post-merge 手動テスト）。
+
+### Notes for Next Phase
+
+- bats テスト 24 件すべて PASS、forbidden expressions チェック PASS、syntax check PASS。
+- pre-merge verify command 8 件すべて PASS、Issue チェックボックス更新済み。
+- PR #570 作成済み。CI 待ち。

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -73,7 +73,7 @@ Entries are grouped by workflow order (triage → issue → spec → code → re
 | Component | Phase | Model | Effort | Rationale |
 |-----------|-------|-------|--------|-----------|
 | run-issue.sh | issue | Sonnet | high | L/XL scope analysis and sub-issue splitting require thorough orchestration |
-| run-spec.sh | spec | Sonnet (Opus via `--opus` for L) | Sonnet: max; Opus: xhigh (default), max (explicit `--max`) | Design quality is critical; spec errors propagate to all subsequent phases. `/auto` passes `--opus` for L-size only (XL is split before spec) |
+| run-spec.sh | spec | Sonnet (Opus via `--opus` for L; Fable 5 via `--fable`) | Sonnet: max; Opus: xhigh (default), max (explicit `--max`); Fable 5: high (default), max (explicit `--max`) | Design quality is critical; spec errors propagate to all subsequent phases. `/auto` passes `--opus` for L-size only (XL is split before spec) |
 | run-code.sh | code | Sonnet | high | Implementation requires thorough reasoning |
 | run-review.sh | review | Sonnet | high | Review orchestration; sub-agents handle deep analysis |
 | run-merge.sh | merge | Sonnet | low | Mechanical merge operation; minimal reasoning needed |

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # run-spec.sh - Autonomous /spec execution with Sonnet model
-# Usage: run-spec.sh <issue-number> [--opus] [--max]
+# Usage: run-spec.sh <issue-number> [--opus] [--fable] [--max]
 
 set -euo pipefail
-ISSUE_NUMBER="${1:?Usage: run-spec.sh <issue-number> [--opus] [--max]}"
+ISSUE_NUMBER="${1:?Usage: run-spec.sh <issue-number> [--opus] [--fable] [--max]}"
 shift
 
 # Parse options
@@ -17,13 +17,18 @@ while [[ $# -gt 0 ]]; do
       EFFORT="xhigh"
       shift
       ;;
+    --fable)
+      MODEL="claude-fable-5"
+      EFFORT="high"
+      shift
+      ;;
     --max)
       EFFORT="max"
       shift
       ;;
     *)
       echo "Error: Invalid option: $1" >&2
-      echo "Usage: run-spec.sh <issue-number> [--opus] [--max]" >&2
+      echo "Usage: run-spec.sh <issue-number> [--opus] [--fable] [--max]" >&2
       exit 1
       ;;
   esac
@@ -55,6 +60,11 @@ echo "Effort: ${EFFORT}"
 echo "Permissions: ${_PERM_LABEL}"
 echo "Started at: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "---"
+if [[ "$MODEL" == "claude-fable-5" ]]; then
+  echo "WARNING: Fable 5 opt-in — cost \$10/\$50 per MTok (2x Opus 4.8, ~3.3x Sonnet)"
+  echo "WARNING: Usage credits required after 2026-06-22 (subscription plans)"
+  echo "WARNING: 30-day retention required — ZDR organizations not supported"
+fi
 
 # Pass SKILL.md body directly as prompt (avoids context: fork issue)
 SKILL_FILE="${SCRIPT_DIR}/../skills/spec/SKILL.md"

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -318,3 +318,34 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" != *"Warning:"* ]]
 }
+
+@test "success: --fable switches model to claude-fable-5" {
+    run bash "$SCRIPT" 123 --fable
+    [ "$status" -eq 0 ]
+    grep -q "MODEL_VALUE=claude-fable-5" "$CLAUDE_CALL_LOG"
+    grep -q "ANTHROPIC_MODEL=claude-fable-5" "$CLAUDE_CALL_LOG"
+}
+
+@test "success: --fable default effort is high" {
+    run bash "$SCRIPT" 123 --fable
+    [ "$status" -eq 0 ]
+    grep -q "EFFORT_VALUE=high" "$CLAUDE_CALL_LOG"
+}
+
+@test "success: --fable --max explicit effort is max" {
+    run bash "$SCRIPT" 123 --fable --max
+    [ "$status" -eq 0 ]
+    grep -q "EFFORT_VALUE=max" "$CLAUDE_CALL_LOG"
+}
+
+@test "success: --fable outputs retention warning" {
+    run bash "$SCRIPT" 123 --fable
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"retention"* ]]
+}
+
+@test "success: --fable outputs credit warning" {
+    run bash "$SCRIPT" 123 --fable
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"credit"* ]]
+}


### PR DESCRIPTION
## Summary

- `scripts/run-spec.sh` に `--fable` オプションを追加（`MODEL=claude-fable-5`、`EFFORT=high` デフォルト、`--max` で `max`）
- `--fable` 使用時にコスト・サブスク credit ゲート・30日 retention 要件の警告を出力
- `tests/run-spec.bats` に `--fable` 動作の bats テスト 5 件追加
- `docs/tech.md` および `docs/ja/tech.md` の model-effort-matrix に Fable 5 情報を追記

## Verification (pre-merge)

- `run-spec.sh` が Fable 5 の正式モデル文字列 `claude-fable-5` を使用している
- `run-spec.sh` が `--fable` オプションを解釈する
- `--fable` 使用時に retention 警告が出力される
- `--fable` 使用時に credit 警告が出力される
- `run-spec.sh` が構文エラーなし
- Usage 文字列に `--fable` が追記されている
- 既存の `--opus` / `--max` / デフォルト経路が回帰していないこと（bats テスト green）
- `docs/tech.md` model-effort-matrix §C4 に `--fable` opt-in の行が追記されている

## Verification (post-merge)

- `--fable` 指定の `run-spec.sh` が Fable 5 で spec を生成できること（手動 1 回）
- ZDR / 不可環境で graceful degrade（フォールバックまたは警告継続）すること（手動または擬似環境）

closes #559