### PR TITLE
Issue #561: Add de-prescription audit report for spec skill reasoning steps

### DIFF
--- a/docs/reports/de-prescription-audit.md
+++ b/docs/reports/de-prescription-audit.md
@@ -1,0 +1,272 @@
+# De-prescription Audit Report — Spec Skill Reasoning Steps
+
+## Background
+
+This report documents the findings of a spike to evaluate whether de-prescribing reasoning steps
+in `skills/spec/SKILL.md` (replacing sub-step enumeration with goal+constraints presentation)
+improves spec quality and token efficiency when executed by Fable 5 (`claude-fable-5`).
+
+Scope: `skills/spec/SKILL.md` reasoning steps only. Mechanical steps (label transitions,
+gh commands, file paths, ordering invariants) are not candidates for de-prescription.
+
+Context: Issue #561. Background in `docs/reports/claude-fable-5-impact-strategy.md` §4.3.
+Prerequisite #559 (`run-spec.sh --fable`) is CLOSED.
+
+---
+
+## Step Classification
+
+### Mechanical Steps (not candidates — preserve as-is)
+
+These steps have deterministic behavior and must remain prescriptive.
+
+| Step | Role |
+|------|------|
+| Step 0 | ARGUMENTS parsing, SPEC_DEPTH auto-detection rule table |
+| Step 1 | `gh issue view`, ISSUE_TYPE store |
+| Step 2 | Worktree Entry (EnterWorktree call, init hook) |
+| Step 3 | `gh-label-transition.sh $NUMBER spec` |
+| Step 4 | `gh-check-blocking.sh --dry-run`, exit code handling |
+| Step 5 | Config marker detection, steering doc reads |
+| Step 10 (sub-checks) | Verify command sync, count alignment check, bats test name pattern check, patch-route verify command check, template reference workflow check, self-review checklist |
+| Step 11 | Title drift check (title-normalizer.md delegation) |
+| Step 12 | `git add`, `git commit -s` |
+| Step 13 (commit) | Issue retro transfer, Phase Handoff write, `git commit -s` |
+| Step 14 | Worktree Exit (ExitWorktree, merge-to-main) |
+| Step 15 | Issue comment (Write + gh-issue-comment.sh) |
+| Step 16 | `gh-label-transition.sh $NUMBER ready` |
+| Step 17 | Opportunistic verification (module delegation) |
+| Step 18 | Size re-evaluation, `get-issue-size.sh`, ProjectV2 update |
+| Step 19 | Completion message, next-action-guide delegation |
+
+### Reasoning Steps (candidates for de-prescription)
+
+These steps involve design judgment, investigation, or analysis where prescriptive scaffolding
+may impose unnecessary cognitive overhead on Fable 5.
+
+| Step | Sub-element | Prescriptive Element |
+|------|-------------|---------------------|
+| Step 6 (light path) | File identification method | "directly identify... Infer... verify existence/content with Glob/Grep" |
+| Step 7 | Pre-investigation table | 3-column Aspect/Content/Source table with sequential investigation order |
+| Step 8 | Detection criteria table | 4-row Pattern/Example/Response table |
+
+---
+
+## Candidate Step Analysis
+
+### Candidate A: Step 6 SPEC_DEPTH=light — File Identification
+
+**Current text:**
+
+```
+- **SPEC_DEPTH=light**: skip reading `codebase-search.md`; directly identify changed files
+  using Grep/Read. Infer required files from the issue body, and verify existence/content
+  with Glob/Grep.
+```
+
+**De-prescription variant:**
+
+```
+- **SPEC_DEPTH=light**: skip reading `codebase-search.md`. Goal: identify all files that
+  will be changed by this issue. Constraint: use file-system tools (Grep/Read/Glob);
+  do not modify files in this step.
+```
+
+**Assessment:**
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Prescriptive degree | LOW | Current text is already brief; tool names are appropriate guidance |
+| De-prescription impact | LOW | Removing tool hints may slightly reduce precision in Sonnet-class models |
+| Fable 5 sensitivity | LOW | Fable 5 would infer correct tool usage regardless of explicit naming |
+| Risk | LOW | Both variants produce the same behavior in practice |
+
+### Candidate B: Step 7 — Pre-investigation Q&A Table
+
+**Current text:**
+
+```markdown
+**Pre-investigation (for each unresolved item):**
+
+Refer to `ambiguity-detector.md`'s "Sources to investigate" column and investigate sequentially:
+
+| Aspect       | Content                                  | Source                                       |
+|-------------|------------------------------------------|----------------------------------------------|
+| Existing patterns | Similar implementations/conventions | Project source code (Grep/Read)           |
+| Past knowledge    | Retrospectives from similar issues/specs | `$SPEC_PATH/*.md`. Skip if absent       |
+| Trade-offs        | Pros and cons of each option         | Codebase + Steering Docs                 |
+
+Format Q&A based on investigation results (with recommendation if found, with "no related
+patterns" note if not found).
+```
+
+**De-prescription variant:**
+
+```markdown
+**Pre-investigation (for each unresolved item):**
+
+Goal: gather sufficient context to make a design recommendation. Constraint: ground
+recommendations in observable codebase patterns, past retrospectives (check `$SPEC_PATH/*.md`
+if available), and documented trade-offs. Format as Q&A with a recommendation when found;
+note absence of patterns when not found.
+```
+
+**Assessment:**
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Prescriptive degree | MEDIUM | Table structure is useful scaffolding for systematic investigation |
+| De-prescription impact | MEDIUM | Removing table may cause models to skip past-retrospective lookup |
+| Fable 5 sensitivity | MEDIUM | Fable 5 handles goal-oriented guidance well; `$SPEC_PATH/*.md` pointer preserved |
+| Risk | MEDIUM | Losing the "Past knowledge" row label may cause under-use of retrospective knowledge |
+
+### Candidate C: Step 8 — Uncertainty Detection Criteria Table
+
+**Current text:**
+
+```markdown
+**Detection criteria (examples):**
+
+| Pattern                             | Example                             | Response                                  |
+|------------------------------------|-------------------------------------|-------------------------------------------|
+| Unverified external API/spec dependency | Claude Code hooks target tool list | Check official docs via WebFetch       |
+| Assumptions about timing/ordering  | stdout destination, hook timing     | Verify with prototype or note as uncertain |
+| Environment-dependent behavior     | OS, shell, version differences      | Note target environment; verify with tests |
+| Implicit assumptions in existing code | Permission pattern matching rules | Check code/docs; note if unclear        |
+```
+
+**De-prescription variant:**
+
+```markdown
+**Detection criteria:**
+
+Goal: identify technical uncertainties that would require verification before safe
+implementation. Constraint: focus on claims that cannot be confirmed from the codebase alone
+(external APIs, environment-specific behavior, timing/ordering, implicit assumptions).
+For each item, document a verification method and the affected implementation steps.
+```
+
+**Assessment:**
+
+| Dimension | Rating | Notes |
+|-----------|--------|-------|
+| Prescriptive degree | MEDIUM | The 4 patterns and examples are genuine recognition aids |
+| De-prescription impact | MEDIUM-HIGH | Removing examples may cause under-detection of uncertainty patterns |
+| Fable 5 sensitivity | HIGH | Fable 5 is most likely to benefit here; less likely to miss uncertainty categories |
+| Risk | MEDIUM | If Fable 5 phases coexist with Sonnet phases, reduction in explicit patterns could degrade quality for non-Fable phases |
+
+---
+
+## A/B Test Methodology (Planned — Not Executed)
+
+**Target issues:** 2 closed Issues of Size M or L with non-trivial spec requirements.
+
+**Execution protocol:**
+1. Select 2 closed Issues; run `bash scripts/run-spec.sh <N> --fable` with current
+   `skills/spec/SKILL.md` (baseline); record spec quality and token usage
+2. Create `.tmp/SKILL-deprescription.md` applying Candidates B and C (higher-impact)
+3. Temporarily swap: `cp .tmp/SKILL-deprescription.md skills/spec/SKILL.md`
+4. Run `bash scripts/run-spec.sh <N> --fable` for the same Issues (de-prescription)
+5. Restore: `git checkout skills/spec/SKILL.md`
+6. Delete `.tmp/SKILL-deprescription.md`
+
+**Quality metrics:**
+
+| Metric | Measurement Method |
+|--------|--------------------|
+| Completeness | All acceptance criteria from Issue body covered in spec? |
+| Accuracy | Implementation steps correct and non-redundant? |
+| Conciseness | Fewer tokens output without information loss? |
+
+**Why not executed in this implementation:**
+
+This audit ran in `--non-interactive` autonomous mode (invoked by `run-code.sh` as a
+`claude -p` subprocess). Two constraints prevented A/B execution:
+
+1. **Cost policy**: Fable 5 (`claude-fable-5`) costs $10/$50 per MTok — approximately
+   2× Opus 4.8 and 3.3× Sonnet 4.6. Initiating high-cost model invocations without
+   explicit user authorization is a high-stakes action that the auto-resolve policy defers
+   rather than auto-executes.
+
+2. **Nested subprocess complexity**: spawning `run-spec.sh --fable` (which itself invokes
+   `claude -p`) inside an already-running `claude -p` invocation produces layered subprocess
+   chains whose context isolation behavior is not fully characterized.
+
+**Recommendation for follow-up:** Run the A/B test interactively per the execution protocol
+above. Priority: Candidates B and C (medium/high Fable 5 sensitivity). Candidate A may be
+skipped given its low impact rating.
+
+---
+
+## Conclusion
+
+**Decision: Not adopted**
+
+`skills/spec/SKILL.md` is **unchanged** in this PR.
+
+### Rationale
+
+1. **No empirical improvement data**: the A/B test was not executed due to constraints
+   documented above. Adopting de-prescription without confirmed improvement data would be
+   premature — the Issue and Spec both require confirmed improvements before updating SKILL.md.
+
+2. **Risk asymmetry**: Candidates B and C carry a real risk of degrading spec quality if
+   the prescriptive examples provide essential recognition scaffolding even for Fable 5.
+   Candidate A's impact is too small to justify a change alone.
+
+3. **Conservative policy**: the distributable-first improvement principle (see `docs/tech.md`)
+   requires that changes to `skills/spec/SKILL.md` benefit all Wholework users. Without A/B
+   evidence, a change that might degrade quality for Sonnet-class users is not justifiable.
+
+### Path to adoption
+
+If future interactive A/B testing confirms quality improvement:
+- Apply Candidate B first (lowest risk among medium-impact candidates)
+- Evaluate Candidate C independently
+- Apply only to the verified subset; do not bundle unverified candidates
+
+---
+
+## Appendix: De-prescription Variant Snippets
+
+These snippets are provided for direct use in future A/B testing without re-derivation.
+
+### Candidate A
+
+Replace in Step 6:
+```
+directly identify changed files using Grep/Read. Infer required files from the issue body,
+and verify existence/content with Glob/Grep.
+```
+With:
+```
+Goal: identify all files that will be changed by this issue. Constraint: use file-system
+tools (Grep/Read/Glob); do not modify files in this step.
+```
+
+### Candidate B
+
+Replace in Step 7 (`**Pre-investigation (for each unresolved item):**` block):
+
+The 3-column investigation table and sequential instruction. Replace with:
+```
+Goal: gather sufficient context to make a design recommendation. Constraint: ground
+recommendations in observable codebase patterns, past retrospectives (check
+`$SPEC_PATH/*.md` if available), and documented trade-offs. Format as Q&A with a
+recommendation when found; note absence of patterns when not found.
+```
+
+### Candidate C
+
+Replace in Step 8 (`**Detection criteria (examples):**` block):
+
+The 4-row Pattern/Example/Response table. Replace with:
+```
+**Detection criteria:**
+
+Goal: identify technical uncertainties that would require verification before safe
+implementation. Constraint: focus on claims that cannot be confirmed from the codebase
+alone (external APIs, environment-specific behavior, timing/ordering, implicit
+assumptions). For each item, document a verification method and the affected
+implementation steps.
+```

--- a/docs/spec/issue-561-prompt-deprescription-audit.md
+++ b/docs/spec/issue-561-prompt-deprescription-audit.md
@@ -66,19 +66,31 @@ Fable 5（`run-spec.sh --fable`）採用フェーズを対象に、`skills/spec/
 - **Step 3 (A/B test) の省略判断**: Fable 5 ($10/$50/MTok) を `--non-interactive` モードで実行することは高コスト行為のため auto-resolve ポリシー（high-stakes financial action = skip）に従い実行しなかった。結論: Not adopted（経験的データなし）として記録し、Issue クローズ可能な状態にした。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Not-adopted パスを採用: A/B テスト（Fable 5）は非対話型自律モードでの高コスト行為のため実行せず、レポートのみを成果物とした
-- `docs/reports/de-prescription-audit.md` に 3 候補（Step 6 light、Step 7 Q&A table、Step 8 detection criteria）の分類・代替テキスト・採用見送り結論を記録
-- `skills/spec/SKILL.md` は完全に変更なし
+- COMMENT event でレビュー投稿（MUST 問題なし → REQUEST_CHANGES 不要）
+- 全受け入れ条件 PASS（AC3 は `[ ]` → CI 確認後 `[x]` に更新）
+- review-light エージェント未登録のため 4 アスペクトをインラインで実行（問題なし）
 
 ### Deferred Items
-- 実際の A/B テスト（Fable 5 モデルを用いた対話型実行）は次回インタラクティブセッションに延期
-- de-prescription バリアントの `.tmp/SKILL-deprescription.md` 作成も同様に延期
+- 実際の A/B テスト（Fable 5）は引き続き次回インタラクティブセッションへ延期（/review では変更なし）
 
 ### Notes for Next Phase
-- PR #571 の CI（bats テスト）が green であることを確認（SKILL.md 変更なしのため問題なし）
-- AC3 `github_check "gh pr checks" "Run bats tests"` は CI 完了後に PASS となる
-- rubric 条件（AC1、AC4）は変更なし（SKILL.md 未変更）で PASS 済み
-- 不採用結論のため `/verify` では `docs/reports/de-prescription-audit.md` の存在と内容を確認するのみ
+- MUST issues なし → `/merge 571` で即座にマージ可能
+- 全 CI ジョブ SUCCESS、全受け入れ条件 PASS
+- `docs/reports/de-prescription-audit.md` の存在と内容の整合性は確認済み
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note. コード実装は Spec の "Not-adopted path" に完全準拠しており、Spec と PR diff の間に構造的乖離はなかった。Code Retrospective も適切に文書化されており、review 側で追加指摘は不要だった。
+
+### Recurring issues
+
+Nothing to note. ドキュメントのみの変更であり、同種問題の繰り返しパターンは検出されなかった。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note. 全4条件（rubric×2、file_exists×1、github_check×1）が問題なく検証できた。UNCERTAIN ゼロ。verify コマンドの構文・対象が適切で、not-adopted パスでも全条件が成立した。AC3 の Issue 本文注記（「変更なしクローズの場合も CI は green のため verify は常に成立する」）の通りの結果となった。

--- a/docs/spec/issue-561-prompt-deprescription-audit.md
+++ b/docs/spec/issue-561-prompt-deprescription-audit.md
@@ -45,3 +45,40 @@ Fable 5（`run-spec.sh --fable`）採用フェーズを対象に、`skills/spec/
 - **A/B test methodology**: ベースラインと de-prescription バリアントで同一 closed Issue を再 spec。一時スワップ後は必ず元の SKILL.md を復元する（`git checkout skills/spec/SKILL.md` で安全に復元可能）
 - **Translation sync**: `docs/reports/` は `docs/translation-workflow.md` の除外対象。日本語ミラー不要
 - **Auto-resolved ambiguity** (issue 本文から移管): (1) レポートファイルパス `docs/reports/de-prescription-audit.md` は既存命名規則（kebab-case + 内容記述）に沿って決定。(2) AC3（`github_check "gh pr checks" "Run bats tests"`）は変更なしクローズ時も CI green のため verify は常に成立する
+
+## Code Retrospective
+
+### Deviations from Design
+
+- **Step 3 (A/B test execution) は省略**: 実装ステップでは `run-spec.sh --fable <N>` を用いた実際の A/B 実験を想定していたが、非対話型自律モード（run-code.sh）での Fable 5 コスト（$10/$50/MTok）を伴う高コスト LLM 呼び出しは auto-resolve ポリシーで延期対象のため実行しなかった。Not-adopted パスで完結（Step 5 の `.tmp/SKILL-deprescription.md` 作成も省略）。
+- **実装ステップ Step 2 も省略**: de-prescription バリアントファイル `.tmp/SKILL-deprescription.md` は A/B テスト用中間成果物であり、A/B を実行しない場合は不要。代わりに審査結果のテキストをレポート Appendix に記載した。
+
+### Design Gaps/Ambiguities
+
+- **Spec は「not-adopted でも完結可能」と記載しているが、その場合に Steps 2-3 を省略してよいかは明記されていなかった**: 実装時に auto-resolve で判断した。Spec Notes の "Not-adopted path" 説明に Steps 2-3 省略可否を追記することで将来のあいまいさを防げる。
+
+### Rework
+
+- なし
+
+## Autonomous Auto-Resolve Log
+
+- **Step 3 (A/B test) の省略判断**: Fable 5 ($10/$50/MTok) を `--non-interactive` モードで実行することは高コスト行為のため auto-resolve ポリシー（high-stakes financial action = skip）に従い実行しなかった。結論: Not adopted（経験的データなし）として記録し、Issue クローズ可能な状態にした。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Not-adopted パスを採用: A/B テスト（Fable 5）は非対話型自律モードでの高コスト行為のため実行せず、レポートのみを成果物とした
+- `docs/reports/de-prescription-audit.md` に 3 候補（Step 6 light、Step 7 Q&A table、Step 8 detection criteria）の分類・代替テキスト・採用見送り結論を記録
+- `skills/spec/SKILL.md` は完全に変更なし
+
+### Deferred Items
+- 実際の A/B テスト（Fable 5 モデルを用いた対話型実行）は次回インタラクティブセッションに延期
+- de-prescription バリアントの `.tmp/SKILL-deprescription.md` 作成も同様に延期
+
+### Notes for Next Phase
+- PR #571 の CI（bats テスト）が green であることを確認（SKILL.md 変更なしのため問題なし）
+- AC3 `github_check "gh pr checks" "Run bats tests"` は CI 完了後に PASS となる
+- rubric 条件（AC1、AC4）は変更なし（SKILL.md 未変更）で PASS 済み
+- 不採用結論のため `/verify` では `docs/reports/de-prescription-audit.md` の存在と内容を確認するのみ


### PR DESCRIPTION
## Summary

- `docs/reports/de-prescription-audit.md` を新規作成: `skills/spec/SKILL.md` の mechanical/reasoning ステップ分類と、de-prescription 候補ステップ（Step 6 light path、Step 7 Q&A table、Step 8 detection criteria table）の現行テキストと代替案を文書化
- A/B 実験（Fable 5）は非対話型自律モード（run-code.sh）での Fable 5 コスト制約（$10/$50/MTok）により延期；レポートに実行プロトコルと結論（not adopted）を記録
- `skills/spec/SKILL.md` は変更なし

## Verification (pre-merge)

- A/B の対象範囲が「reasoning steps のみ」に限定され、mechanical steps が不変（SKILL.md 未変更）
- `docs/reports/de-prescription-audit.md` にステップ分類・候補分析・結論が記録されている
- bats テスト green（SKILL.md 変更なし → 既存テストに影響なし）
- 結論「Not adopted」が明記されており、変更なしでもクローズ可能

## Verification (post-merge)

- Fable 5 採用フェーズの実 `/auto` 実行で品質退行が観測されないこと（opportunistic）

closes #561