### PR TITLE
Issue #569: Fix fix-cycle false positive in code-patch completion check

### DIFF
--- a/docs/spec/issue-569-patch-fix-cycle-freshness.md
+++ b/docs/spec/issue-569-patch-fix-cycle-freshness.md
@@ -81,19 +81,33 @@
 
 - 特になし。Spec の実装ステップに沿って実装でき、手戻りは発生しなかった。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Spec に `gh-graphql.sh --jq` 出力がクォート付き文字列を返すことへの言及がなく、`tr -d '"'` 処理が Code Retrospective で事後追記された。Spec の実装ステップではシェル出力のクォート処理を明示する習慣がない可能性がある。今後の Spec 記述では、外部コマンドの出力形式（特に jq の文字列クォート）を明示することを推奨する。
+
+### Recurring Issues
+
+- 特になし。今回の PR は範囲が小さく、同種の問題は検出されなかった。
+
+### Acceptance Criteria Verification Difficulty
+
+- 既存テスト（pre-PR のもの）が暗黙的に fallback パスをカバーしているが、null 値の明示的テストが欠如していた（SHOULD として検出・修正済み）。verify command は既存のテスト実行コマンド（`bats tests/reconcile-phase-state.bats`）のみで、フォールバックパスの入力境界値を個別に検証するヒントがなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `gh-graphql.sh` に `get-last-reopen` クエリを追加し `_completion_code_patch()` 内で自己完結的に reopen タイムスタンプを取得する方式を採用（呼び出し元の変更不要）
-- jq 出力のクォートを `tr -d '"'` で除去してから `git log --after=` に渡す
-- フォールバック diagnosis に `"fix-cycle false positive possible"` を明記し、デバッグ可視性を維持
+- Size=M Bug fix に対して review-light（light mode）を適用。全 4 観点を 1 エージェントで確認する軽量統合レビューが適切と判断
+- SHOULD issue（null fallback パステスト欠如）は解決済み（テスト追加）。CONSIDER issue（モックコメント不明確）はスタイル上の懸念のみのためスキップ
+- MUST issues なし → COMMENT イベントで投稿、`/merge` 進行可
 
 ### Deferred Items
-- タイムスタンプ取得失敗時のフォールバック動作の observability 向上（診断メッセージ強化）は今後の改善課題
-- `code-pr` completion check も同様の false positive リスクを持つ可能性があるが、今回のスコープ外
+- CONSIDER: fix-cycle テストのモックコメント補足（スタイルのみ、機能影響なし）
+- `code-pr` completion check の false positive リスク（コードフェーズから引き継ぎ、今回スコープ外）
 
 ### Notes for Next Phase
-- `tests/reconcile-phase-state.bats` は 54 テスト全通過（fix-cycle テスト 2 件追加含む）
-- `modules/phase-state.md` の code-patch completion signature 更新済み（`/review` 時に参照する SSoT）
-- PR body の Verification (pre-merge) は Issue のチェックボックス管理と分離しており、PR 上はインフォメーションのみ
+- tests/reconcile-phase-state.bats は 55 テスト（fix-cycle 3 件：false positive・正常完了・null fallback）
+- CI 全ジョブ SUCCESS（DCO・bats・validate-skill-syntax・forbidden-expressions・macOS compat）
+- MUST issues なし。/merge 実行可

--- a/docs/spec/issue-569-patch-fix-cycle-freshness.md
+++ b/docs/spec/issue-569-patch-fix-cycle-freshness.md
@@ -66,3 +66,34 @@
 - `gh-graphql.sh` の `get-issue-timeline` クエリ（既存）は `LABELED_EVENT` も含む `first:100` で取得するため、イベント数が多いと最新 reopen が切れる可能性がある。新たに `get-last-reopen`（`REOPENED_EVENT` のみ、`last:1`）を追加して対処。
 - タイムスタンプ取得失敗時のフォールバックは、初回実行（reopen なし）でも既存ヒューリスティックが正しく動作するため後退しない。
 - `git log --after="<ISO8601>"` はコミット author date を基準とする。reopen 後に作成されたコミットは reopen 以降の日時を持つため、フィルタが正しく機能する。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `gh-graphql.sh` の `--jq` 出力はデフォルトで JSON 文字列クォートを含むため、`| tr -d '"'` でクォート除去を追加した。Spec にはこの処理の明示がなかったが、`git log --after=` に渡す際に必要なため追加。
+
+### Design Gaps/Ambiguities
+
+- Spec は `reopen_ts` の取得結果形式（jq がクォート付き文字列を返すこと）について言及していなかった。実装時に `"2024-01-01T00:00:00Z"` のようなクォート付き値が返ることを確認し、`tr -d '"'` で除去する処理を追加した。
+
+### Rework
+
+- 特になし。Spec の実装ステップに沿って実装でき、手戻りは発生しなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `gh-graphql.sh` に `get-last-reopen` クエリを追加し `_completion_code_patch()` 内で自己完結的に reopen タイムスタンプを取得する方式を採用（呼び出し元の変更不要）
+- jq 出力のクォートを `tr -d '"'` で除去してから `git log --after=` に渡す
+- フォールバック diagnosis に `"fix-cycle false positive possible"` を明記し、デバッグ可視性を維持
+
+### Deferred Items
+- タイムスタンプ取得失敗時のフォールバック動作の observability 向上（診断メッセージ強化）は今後の改善課題
+- `code-pr` completion check も同様の false positive リスクを持つ可能性があるが、今回のスコープ外
+
+### Notes for Next Phase
+- `tests/reconcile-phase-state.bats` は 54 テスト全通過（fix-cycle テスト 2 件追加含む）
+- `modules/phase-state.md` の code-patch completion signature 更新済み（`/review` 時に参照する SSoT）
+- PR body の Verification (pre-merge) は Issue のチェックボックス管理と分離しており、PR 上はインフォメーションのみ

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -35,7 +35,7 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 |-------|-------------|-------------------------------|----------------------|
 | issue | Issue exists and state != CLOSED | `triaged` label on issue | Implemented |
 | spec | `phase/issue` or `phase/spec` label on issue | `$SPEC_PATH/issue-N-*.md` exists AND `phase/(ready\|code\|review\|merge\|verify\|done)` label | Implemented |
-| code-patch | `phase/ready` label on issue, Spec exists | `git log origin/main --grep="closes #N"` returns ≥1 commit | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
+| code-patch | `phase/ready` label on issue, Spec exists | `git log origin/main --after=<reopen_ts> --grep="closes #N"` returns ≥1 fresh commit (reopen timestamp obtained via `get-last-reopen`); falls back to `git log origin/main --grep="closes #N"` when reopen timestamp unavailable | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
 | code-pr | `phase/ready` label on issue, Spec exists | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
 | review | PR is OPEN | PR has a comment containing `<!-- review-summary -->` marker (primary); or `## Review Response Summary` / `## レビュー回答サマリ` (fallback for marker-absent posts) | Implemented |
 | merge | PR is OPEN and reviewDecision is APPROVED | `gh pr view --json state == MERGED` | Implemented |

--- a/scripts/gh-graphql.sh
+++ b/scripts/gh-graphql.sh
@@ -64,6 +64,9 @@ get_named_query() {
         get-issue-timeline)
             printf '%s' 'query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){number timelineItems(itemTypes:[LABELED_EVENT,UNLABELED_EVENT,REOPENED_EVENT],first:100){nodes{__typename ... on LabeledEvent{label{name}createdAt} ... on UnlabeledEvent{label{name}createdAt} ... on ReopenedEvent{createdAt}}}}}}'
             ;;
+        get-last-reopen)
+            printf '%s' 'query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){timelineItems(itemTypes:[REOPENED_EVENT],last:1){nodes{... on ReopenedEvent{createdAt}}}}}}'
+            ;;
         *)
             echo "Error: unknown query name: $name" >&2
             return 1

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -196,17 +196,34 @@ _completion_spec() {
 _completion_code_patch() {
   git fetch origin main --quiet 2>/dev/null || _handle_error "git fetch failed"
 
+  local reopen_ts
+  reopen_ts=$("$SCRIPT_DIR/gh-graphql.sh" --query get-last-reopen \
+    -F "num=${ISSUE_NUMBER}" \
+    --jq '.data.repository.issue.timelineItems.nodes[0].createdAt' 2>/dev/null \
+    | tr -d '"' || true)
+
   local found=false
-  if git log origin/main --oneline --grep="closes #${ISSUE_NUMBER}" 2>/dev/null | grep -q .; then
-    found=true
-  fi
-
-  local actual_json="{\"commits_found\":${found}}"
-
-  if [[ "$found" == "true" ]]; then
-    _emit_result "true" "commit with closes #${ISSUE_NUMBER} found on origin/main" "$actual_json"
+  local actual_json
+  if [[ -n "$reopen_ts" && "$reopen_ts" != "null" ]]; then
+    if git log origin/main --after="$reopen_ts" --oneline --grep="closes #${ISSUE_NUMBER}" 2>/dev/null | grep -q .; then
+      found=true
+    fi
+    actual_json="{\"commits_found\":${found},\"reopen_ts\":\"$(_escape_json "$reopen_ts")\"}"
+    if [[ "$found" == "true" ]]; then
+      _emit_result "true" "fresh commit after reopen (${reopen_ts}) with closes #${ISSUE_NUMBER} found on origin/main" "$actual_json"
+    else
+      _handle_mismatch "no fresh commit after reopen (${reopen_ts}) with closes #${ISSUE_NUMBER} found on origin/main" "$actual_json"
+    fi
   else
-    _handle_mismatch "no commit with closes #${ISSUE_NUMBER} found on origin/main" "$actual_json"
+    if git log origin/main --oneline --grep="closes #${ISSUE_NUMBER}" 2>/dev/null | grep -q .; then
+      found=true
+    fi
+    actual_json="{\"commits_found\":${found}}"
+    if [[ "$found" == "true" ]]; then
+      _emit_result "true" "commit with closes #${ISSUE_NUMBER} found on origin/main (fallback: reopen timestamp unavailable; fix-cycle false positive possible)" "$actual_json"
+    else
+      _handle_mismatch "no commit with closes #${ISSUE_NUMBER} found on origin/main" "$actual_json"
+    fi
   fi
 }
 

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -899,6 +899,30 @@ MOCK_EOF
     [[ "$output" == *'"matches_expected":true'* ]]
 }
 
+@test "code-patch completion: first cycle (no reopen) - null from API -> fallback -> matches_expected true" {
+    cat > "$MOCK_DIR/gh-graphql.sh" << 'MOCK_EOF'
+#!/bin/bash
+# Simulates gh-graphql.sh --jq output when no REOPENED_EVENT exists
+echo "null"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    cat > "$MOCK_DIR/git" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "log" ]]; then echo "abc1234 feat: fix (closes #55)"; fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/git"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" code-patch 55 --check-completion --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+    [[ "$output" == *'fix-cycle false positive possible'* ]]
+}
+
 @test "spec completion: spec exists + no ready label -> mismatch includes hint_recent_commit and hint_pr_state" {
     SPEC_DIR="$BATS_TEST_TMPDIR/docs/spec-hints"
     mkdir -p "$SPEC_DIR"

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -845,6 +845,60 @@ MOCK_EOF
     [ "$completion_status" -eq 0 ]
 }
 
+@test "code-patch completion: fix-cycle false positive - pre-reopen commit only -> matches_expected false" {
+    cat > "$MOCK_DIR/gh-graphql.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "2024-01-01T00:00:00Z"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    cat > "$MOCK_DIR/git" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "log" ]]; then
+    if [[ "$*" == *"--after="* ]]; then
+        echo ""
+    else
+        echo "abc1234 feat: initial fix (closes #55)"
+    fi
+fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/git"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" code-patch 55 --check-completion --strict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"matches_expected":false'* ]]
+}
+
+@test "code-patch completion: fix-cycle - fresh commit after reopen -> matches_expected true" {
+    cat > "$MOCK_DIR/gh-graphql.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "2024-01-01T00:00:00Z"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    cat > "$MOCK_DIR/git" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "log" ]]; then
+    if [[ "$*" == *"--after="* ]]; then
+        echo "def5678 feat: fresh fix (closes #55)"
+    fi
+fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/git"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" code-patch 55 --check-completion --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+}
+
 @test "spec completion: spec exists + no ready label -> mismatch includes hint_recent_commit and hint_pr_state" {
     SPEC_DIR="$BATS_TEST_TMPDIR/docs/spec-hints"
     mkdir -p "$SPEC_DIR"


### PR DESCRIPTION
## Summary

`reconcile-phase-state.sh` の `code-patch` 完了判定が、fix cycle（verify FAIL → reopen → `run-code.sh --patch` 再実行）でも初回実装コミットにマッチして false positive を返すバグを修正。

- `scripts/gh-graphql.sh` に `get-last-reopen` named query を追加（`REOPENED_EVENT` のみ `last:1` で取得）
- `_completion_code_patch()` を修正: reopen タイムスタンプ取得成功時は `--after=<reopen_ts>` でフレッシュなコミットのみを要求。取得失敗時は既存ヒューリスティックへフォールバックし、diagnosis に fix-cycle の可能性を注記
- `modules/phase-state.md` の code-patch Completion 列を freshness 条件反映に更新
- `tests/reconcile-phase-state.bats` に fix-cycle シナリオのテストケース 2 件追加（合計 54 テスト全通過）

## Verification (pre-merge)

- `grep "[Rr]eopen|REOPEN|since" "scripts/reconcile-phase-state.sh"` → PASS
- `grep "[Rr]eopen" "modules/phase-state.md"` → PASS
- `bats tests/reconcile-phase-state.bats` → PASS (54/54)

## Verification (post-merge)

- 次回の verify FAIL → reopen → code 再実行サイクルで、wrapper がコミットなしで終了した場合に completion check が `matches_expected:false` を返すことを観察

closes #569