### PR TITLE
Issue #548: Add fullPage screenshot and dimension normalization to visual-diff-adapter

### DIFF
--- a/docs/spec/issue-548-visual-diff-fullpage-normalize.md
+++ b/docs/spec/issue-548-visual-diff-fullpage-normalize.md
@@ -49,3 +49,40 @@ Extends `modules/visual-diff-adapter.md` to resolve two structural constraints i
 - `capture_mode` parameter name aligns with existing inputs (`viewports`, `states`); implementation may use a slightly different naming as long as the opt-out mechanism is documented. The AC2 verify pattern `capture_mode\|fullpage` (BRE alternation) tolerates either `capture_mode` as a keyword or `fullpage` as a literal value string.
 - AC3 verify `grep "extend\|pad\|max(width"` will match because: `extend` appears in `sharp.extend` API usage; `pad` in the description; `max(width` as notation for `Math.max(ref.info.width, impl.info.width)` mirroring the Issue body phrasing.
 - The `browser-use` CLI fullPage support may need a note if `--full-page` flag is unavailable; document the equivalent approach or note as unsupported in that case.
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Step 5c canvas width computation: Spec said `width: 3 * W` using the normalized W. Implementation used `W` from re-reading the diff file metadata (`{ width: W, height: H } = await sharp(diff).metadata()`) rather than carrying W from Step 5b. This indirection is functionally identical but avoids passing W as a variable across bash heredoc boundaries.
+- browser-use CLI fullPage note: Added explicit fallback note ("if browser-use version does not support --full-page, fall back to omitting the flag") as the Spec's Notes section anticipated this uncertainty. Aligns with Spec Note about browser-use CLI fullPage support.
+
+### Design Gaps/Ambiguities
+
+- The Spec did not specify whether the `padTo` helper should be defined inline or extracted. Implemented as an inline async arrow function in the Node.js `-e` snippet for simplicity — no external helper file needed for a single-file module change.
+- `browser_take_screenshot` `fullPage` parameter form: The Spec listed `fullPage: true` but did not clarify whether the Playwright MCP tool accepts a named `fullPage` parameter or a positional boolean. Documented as `fullPage: true` (keyword argument form), which is the standard Playwright API shape.
+
+### Rework
+
+- None. Implementation proceeded directly from the Spec without rework.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+
+- `capture_mode` parameter added to Input section with `fullpage` (default) | `viewport` values; viewport opt-out is documented in both browser-use and Playwright MCP steps.
+- Step 5b pad normalization uses `sharp.extend` with right/bottom padding and white background; W and H computed as `Math.max(ref.info.width, impl.info.width)` and `Math.max(ref.info.height, impl.info.height)`.
+- Step 5c re-reads W/H from diff file metadata rather than threading variables through bash heredoc — functionally identical but cleaner for a single-file module.
+- All 5 pre-merge AC verify commands PASS (4 grep + 1 rubric); checkboxes updated on the Issue.
+
+### Deferred Items
+
+- post-merge manual AC: koganezawa-com#58 re-run with fullPage to confirm no dimension throw — caller's responsibility, not covered by adapter unit tests.
+- browser-use `--full-page` flag availability: noted as "fall back to omitting the flag" if unsupported; actual verification requires a live browser-use installation.
+
+### Notes for Next Phase
+
+- PR #607 created; CI should run `.github/workflows/test.yml` (bats + validate-skill-syntax + forbidden-expressions).
+- No doc sync changes needed (only `modules/` and `tests/` modified, not `docs/*.md`).
+- The removed "Follow-on constraint (image height mismatch)" Note was the primary motivation for this Issue — reviewer should confirm it is gone from the module.

--- a/docs/spec/issue-548-visual-diff-fullpage-normalize.md
+++ b/docs/spec/issue-548-visual-diff-fullpage-normalize.md
@@ -66,23 +66,38 @@ Extends `modules/visual-diff-adapter.md` to resolve two structural constraints i
 
 - None. Implementation proceeded directly from the Spec without rework.
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Step 5c composite referenced original unpadded `ref.png`/`impl.png` instead of padded variants. The Spec stated "3-panel composite は正規化後寸法で組む" but only covered the canvas dimensions (W×H); it did not explicitly specify that Before/After panel inputs must also be padded files. The AC4 verify command (`grep "正規化後\|normalized"`) passed on the canvas description alone, masking that panel inputs were unpadded.
+- Root pattern: Spec described the *canvas* normalization correctly but omitted a callout that the *input* images for ref/impl panels must also be the padded variants. Future specs for multi-step normalization pipelines should explicitly state which files are consumed at each downstream step.
+
+### Recurring Issues
+
+- Japanese string literal in test source code (`grep -qE "正規化後|normalized"` in `.bats`). CLAUDE.md specifies "Source code: English" but test strings mirrored the Japanese grep pattern from Issue body AC text. Avoid copying Japanese AC text directly into source-code assertions — translate to English equivalents.
+- No repeated issue patterns across aspects in this PR.
+
+### Acceptance Criteria Verification Difficulty
+
+- All 5 pre-merge ACs were grep/rubric-based and auto-verified cleanly (0 UNCERTAIN, 0 POST-MERGE in pre-merge section).
+- The rubric AC5 ("fullPage default + opt-out + pad normalization") was broad enough to PASS despite the Step 5c unpadded-input gap — the rubric checked policy documentation, not code-path completeness. Future rubric conditions should include "all downstream steps use padded outputs" when a normalization pipeline is introduced.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- `capture_mode` parameter added to Input section with `fullpage` (default) | `viewport` values; viewport opt-out is documented in both browser-use and Playwright MCP steps.
-- Step 5b pad normalization uses `sharp.extend` with right/bottom padding and white background; W and H computed as `Math.max(ref.info.width, impl.info.width)` and `Math.max(ref.info.height, impl.info.height)`.
-- Step 5c re-reads W/H from diff file metadata rather than threading variables through bash heredoc — functionally identical but cleaner for a single-file module.
-- All 5 pre-merge AC verify commands PASS (4 grep + 1 rubric); checkboxes updated on the Issue.
+- Fixed Step 5c composite: refPadded/implPadded now saved as `ref-padded.png`/`impl-padded.png` in Step 5b; Step 5c references these padded files so all three panels share W×H dimensions.
+- SHOULD issue (Step 5c unpadded reference) and CONSIDER issue (Japanese in test) both resolved in a single commit on the PR branch.
+- No policy changes detected; AC text and verify commands remain valid after fixes.
 
 ### Deferred Items
 
 - post-merge manual AC: koganezawa-com#58 re-run with fullPage to confirm no dimension throw — caller's responsibility, not covered by adapter unit tests.
-- browser-use `--full-page` flag availability: noted as "fall back to omitting the flag" if unsupported; actual verification requires a live browser-use installation.
+- browser-use `--full-page` flag availability: actual verification requires a live browser-use installation.
 
 ### Notes for Next Phase
 
-- PR #607 created; CI should run `.github/workflows/test.yml` (bats + validate-skill-syntax + forbidden-expressions).
-- No doc sync changes needed (only `modules/` and `tests/` modified, not `docs/*.md`).
-- The removed "Follow-on constraint (image height mismatch)" Note was the primary motivation for this Issue — reviewer should confirm it is gone from the module.
+- CI re-run expected after review-feedback commit (849ea89) — all jobs should PASS.
+- No MUST issues; PR is ready to merge after CI confirms green.

--- a/modules/visual-diff-adapter.md
+++ b/modules/visual-diff-adapter.md
@@ -97,7 +97,7 @@ For each combination of (viewport, state):
 
 For each (viewport, state) pair, run a Node.js script via Bash to generate the diff highlight image using `pixelmatch`:
 
-Dimension normalization (pad-based) runs before `pixelmatch` to handle ref/impl height differences that arise from fullPage captures. Both images are padded to a common `max(width) × max(height)` using `sharp.extend` (right and bottom padding, white background), so size mismatches no longer cause errors.
+Dimension normalization (pad-based) runs before `pixelmatch` to handle ref/impl height differences that arise from fullPage captures. Both images are padded to a common `max(width) × max(height)` using `sharp.extend` (right and bottom padding, white background), so size mismatches no longer cause errors. The padded ref/impl images are saved to `ref-padded.png` / `impl-padded.png` for use in the Step 5c composite so all three panels share the same dimensions.
 
 ```bash
 node -e "
@@ -115,6 +115,9 @@ node -e "
       .raw().toBuffer();
   const refPadded = await padTo(ref.data, ref.info);
   const implPadded = await padTo(impl.data, impl.info);
+  // Save padded images so Step 5c composite uses normalized dimensions for all three panels
+  await sharp(refPadded, { raw: { width: W, height: H, channels: 4 } }).png().toFile('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-ref-padded.png');
+  await sharp(implPadded, { raw: { width: W, height: H, channels: 4 } }).png().toFile('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-impl-padded.png');
   const diff = Buffer.alloc(W * H * 4);
   pixelmatch(refPadded, implPadded, diff, W, H, { threshold: 0.1, includeAA: false });
   await sharp(diff, { raw: { width: W, height: H, channels: 4 } }).png().toFile('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-diff.png');
@@ -126,7 +129,7 @@ node -e "
 
 Composite the three images (Before / After / Diff highlight) side by side using `sharp`:
 
-The composite canvas uses normalized dimensions (W × H from Step 5b) so all three panels have equal width and height. W is the normalized panel width (max of ref/impl widths) and H is the normalized height (max of ref/impl heights).
+The composite canvas uses normalized dimensions (W × H from Step 5b) so all three panels have equal width and height. W is the normalized panel width (max of ref/impl widths) and H is the normalized height (max of ref/impl heights). The Before/After panels use `ref-padded.png` / `impl-padded.png` (saved in Step 5b) so all three inputs share the same W × H dimensions.
 
 ```bash
 node -e "
@@ -137,8 +140,8 @@ node -e "
   await sharp({
     create: { width: 3 * W, height: H, channels: 4, background: { r: 255, g: 255, b: 255, alpha: 1 } }
   }).composite([
-    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-ref.png', left: 0, top: 0 },
-    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-impl.png', left: W, top: 0 },
+    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-ref-padded.png', left: 0, top: 0 },
+    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-impl-padded.png', left: W, top: 0 },
     { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-diff.png', left: 2 * W, top: 0 }
   ]).toFile('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-3panel.png');
 })();

--- a/modules/visual-diff-adapter.md
+++ b/modules/visual-diff-adapter.md
@@ -17,6 +17,7 @@ The following information is passed from the caller:
 - **impl_url**: Implementation URL (e.g., local dev server or preview)
 - **viewports**: Comma-separated viewport widths in px (e.g., `390,1440`). All values required; no defaults.
 - **states**: Comma-separated interactive state labels (opaque labels; e.g., `default,menu-open`). All values required; no defaults. State label → action sequence mapping is the caller's responsibility.
+- **capture_mode**: (optional) `fullpage` (default) | `viewport`. When `fullpage`, the entire page height is captured by scrolling past the visible viewport. Set `capture_mode=viewport` to capture only the visible viewport (above-the-fold only).
 
 ## Processing Steps
 
@@ -82,19 +83,21 @@ For each combination of (viewport, state):
 
 1. Open page: `browser-use open "<url>"`
 2. Set viewport width (if supported): `browser-use eval "document.documentElement.style.width='${viewport}px'"`
-3. Capture: `browser-use screenshot ".tmp/visual-diff-${run_id}/${viewport}-${state}-ref.png"`
+3. Capture (default `capture_mode=fullpage`): `browser-use screenshot --full-page ".tmp/visual-diff-${run_id}/${viewport}-${state}-ref.png"`. When `capture_mode=viewport`, omit `--full-page` to capture only the visible area. Note: if the `browser-use` version does not support `--full-page`, fall back to omitting the flag and document the limitation in the result.
 4. Close: `browser-use close`
 
 **Playwright MCP screenshot steps:**
 
 1. Resize viewport: use `browser_resize` with `width=${viewport}`
 2. Navigate: `browser_navigate` to the URL
-3. Capture: `browser_take_screenshot` and save to the temp path
+3. Capture: `browser_take_screenshot` with `fullPage: true` (default `capture_mode=fullpage`). When `capture_mode=viewport`, omit `fullPage` (or set `fullPage: false`) to capture only the visible area.
 4. Close: `browser_close`
 
 #### 5b. Diff Highlight Generation
 
 For each (viewport, state) pair, run a Node.js script via Bash to generate the diff highlight image using `pixelmatch`:
+
+Dimension normalization (pad-based) runs before `pixelmatch` to handle ref/impl height differences that arise from fullPage captures. Both images are padded to a common `max(width) × max(height)` using `sharp.extend` (right and bottom padding, white background), so size mismatches no longer cause errors.
 
 ```bash
 node -e "
@@ -103,10 +106,18 @@ node -e "
   const pixelmatch = require('pixelmatch').default ?? require('pixelmatch');
   const ref = await sharp('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-ref.png').ensureAlpha().raw().toBuffer({ resolveWithObject: true });
   const impl = await sharp('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-impl.png').ensureAlpha().raw().toBuffer({ resolveWithObject: true });
-  const { width, height } = ref.info;
-  const diff = Buffer.alloc(width * height * 4);
-  pixelmatch(ref.data, impl.data, diff, width, height, { threshold: 0.1, includeAA: false });
-  await sharp(diff, { raw: { width, height, channels: 4 } }).png().toFile('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-diff.png');
+  // Normalize dimensions: pad each image to max(width) x max(height) using sharp.extend
+  const W = Math.max(ref.info.width, impl.info.width);
+  const H = Math.max(ref.info.height, impl.info.height);
+  const padTo = async (buf, info) =>
+    sharp(buf, { raw: { width: info.width, height: info.height, channels: 4 } })
+      .extend({ top: 0, bottom: H - info.height, left: 0, right: W - info.width, background: { r: 255, g: 255, b: 255, alpha: 1 } })
+      .raw().toBuffer();
+  const refPadded = await padTo(ref.data, ref.info);
+  const implPadded = await padTo(impl.data, impl.info);
+  const diff = Buffer.alloc(W * H * 4);
+  pixelmatch(refPadded, implPadded, diff, W, H, { threshold: 0.1, includeAA: false });
+  await sharp(diff, { raw: { width: W, height: H, channels: 4 } }).png().toFile('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-diff.png');
 })();
 "
 ```
@@ -115,17 +126,20 @@ node -e "
 
 Composite the three images (Before / After / Diff highlight) side by side using `sharp`:
 
+The composite canvas uses normalized dimensions (W × H from Step 5b) so all three panels have equal width and height. W is the normalized panel width (max of ref/impl widths) and H is the normalized height (max of ref/impl heights).
+
 ```bash
 node -e "
 (async () => {
   const sharp = require('sharp');
-  const { height: imgHeight } = await sharp('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-ref.png').metadata();
+  // Use normalized dimensions W x H computed in Step 5b (re-read from padded diff metadata)
+  const { width: W, height: H } = await sharp('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-diff.png').metadata();
   await sharp({
-    create: { width: 3 * \${viewport}, height: imgHeight, channels: 4, background: { r: 255, g: 255, b: 255, alpha: 1 } }
+    create: { width: 3 * W, height: H, channels: 4, background: { r: 255, g: 255, b: 255, alpha: 1 } }
   }).composite([
     { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-ref.png', left: 0, top: 0 },
-    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-impl.png', left: \${viewport}, top: 0 },
-    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-diff.png', left: 2 * \${viewport}, top: 0 }
+    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-impl.png', left: W, top: 0 },
+    { input: '.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-diff.png', left: 2 * W, top: 0 }
   ]).toFile('.tmp/visual-diff-\${run_id}/\${viewport}-\${state}-3panel.png');
 })();
 "
@@ -196,4 +210,3 @@ See `modules/browser-adapter.md` Token budget section for per-image cost estimat
 - State label → action sequence mapping is the **caller's responsibility**. The adapter treats state labels as opaque strings. Callers must describe what navigation/interaction steps to perform to reach each state.
 - 3-panel default is the bundled implementation. Projects needing side-by-side only, odiff-based diff, or ROI cropping can override via `.wholework/adapters/visual-diff-adapter.md` using the existing 3-layer resolution.
 - **Follow-on constraint (worktree node_modules)**: When `/verify` runs in a fresh worktree, `node_modules` is absent and `sharp`/`pixelmatch` resolve as UNCERTAIN in Step 3. This is not `visual_diff`-specific — it affects all node-dependency command verifications and is tracked in wholework#443.
-- **Follow-on constraint (image height mismatch)**: `pixelmatch` requires ref and impl images to have identical dimensions. A height mismatch between Live and Impl screenshots will cause Step 5b to fail. This caveat could not be confirmed during the fix for the ESM/pngjs issues (Steps 5b/5c were not reached) and must be re-verified in a post-merge re-run. If reproduced, file a separate Issue.

--- a/tests/visual-diff-adapter.bats
+++ b/tests/visual-diff-adapter.bats
@@ -60,5 +60,5 @@ ADAPTER_FILE="$PROJECT_ROOT/modules/visual-diff-adapter.md"
 }
 
 @test "visual-diff-adapter: normalized composite documented" {
-    grep -qE "正規化後|normalized" "$ADAPTER_FILE"
+    grep -q "normalized" "$ADAPTER_FILE"
 }

--- a/tests/visual-diff-adapter.bats
+++ b/tests/visual-diff-adapter.bats
@@ -46,3 +46,19 @@ ADAPTER_FILE="$PROJECT_ROOT/modules/visual-diff-adapter.md"
 @test "visual-diff-adapter: Playwright tool detection documented" {
     grep -q "Playwright" "$ADAPTER_FILE"
 }
+
+@test "visual-diff-adapter: fullPage screenshot documented" {
+    grep -q "fullPage" "$ADAPTER_FILE"
+}
+
+@test "visual-diff-adapter: capture_mode opt-out documented" {
+    grep -qE "capture_mode|fullpage" "$ADAPTER_FILE"
+}
+
+@test "visual-diff-adapter: dimension normalization documented" {
+    grep -qE "extend|sharp\.extend" "$ADAPTER_FILE"
+}
+
+@test "visual-diff-adapter: normalized composite documented" {
+    grep -qE "正規化後|normalized" "$ADAPTER_FILE"
+}


### PR DESCRIPTION
## Summary

- `modules/visual-diff-adapter.md` に `capture_mode` パラメーター (fullpage default / viewport opt-out) を追加
- Step 5a: Playwright MCP `browser_take_screenshot` に `fullPage: true` を追加 (default: fullPage)。`capture_mode=viewport` で viewport のみに切り替え可能
- Step 5b: `sharp.extend` を使った `max(W) × max(H)` への pad 正規化を pixelmatch の前に追加。ref/impl 寸法差による "Image sizes do not match" throw を解消
- Step 5c: 3-panel composite のキャンバスを正規化後の寸法 (W × H) で作成するように更新
- 「Follow-on constraint (image height mismatch)」Note を削除 (解消済み)
- `tests/visual-diff-adapter.bats` に 4 つのテストケースを追加 (fullPage, capture_mode, extend 正規化, 正規化後 composite)

## Verification (pre-merge)

- Step 5a で fullPage 撮影に対応している (adapter 文書に `fullPage` の記載がある)
- caller 側で viewport-only に切り替える手段が文書化されている
- Step 5b で寸法不一致を pad 正規化してから pixelmatch を実行することが文書化されている
- Step 5c の 3-panel composite が正規化後寸法で組まれることが文書化されている
- 仕様 (fullPage default + opt-out + pad 正規化) が rubric 基準を満たす

## Verification (post-merge)

- koganezawa-com#58 を fullPage で再走し、ページ全体の 3-panel が寸法 throw なく生成される

closes #548