### PR TITLE
Issue #584: Add AC verify command audit step to triage skill

### DIFF
--- a/docs/spec/issue-584-triage-ac-verify-command-audit.md
+++ b/docs/spec/issue-584-triage-ac-verify-command-audit.md
@@ -128,20 +128,32 @@ Domain file（`skills/triage/skill-dev-verify-audit.md`）は `validate-skill-sy
 
 - N/A（1 回の実装で完了、リワークなし）
 
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Spec と実装は完全一致。Step 7 配置（Size Assignment 直後）、5 パターン構成、非破壊的振る舞い仕様のいずれも Spec の設計通り実装されていた。
+
+### Recurring Issues
+
+- CONSIDER 課題が 2 種（Pattern 4 の Bulk Execution Size 参照先未明示、$NUMBER コンテキスト未明示）は同一のルート原因（Single Issue / Bulk Execution の二コンテキストをまたぐ変数説明）。Domain file 記述ガイドラインとして「Bulk Execution での変数参照元を明示せよ」を今後のパターンとして意識する価値がある。
+
+### Acceptance Criteria Verification Difficulty
+
+- 全 9 AC に明示的 verify command があり、UNCERTAIN なし。rubric verify command（AC 7）は grader 実行なしで PASS/FAIL を判定可能であった（SKILL.md + Domain file が共同で非破壊的監査を仕様化していることが diff から自明）。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Step 7 を「AC Verify Command Integrity Audit」（英語見出し）として配置し、本文テキストに「verify command audit patterns」を含めることで verify command の `grep "verify command audit"` マッチを確保した
-- Domain file は `load_when` なし（無条件ロード）を採用し、全リポジトリで監査を保証する設計とした（Spec Auto-Resolve Log に従う）
-- Step 7 を Step 6（Size Assignment）直後に配置し、旧 Step 7-10 を 8-11 に繰り下げた（Pattern 4 の patch route チェックに Size 情報が必要なため）
-- bats テスト全 706 件 PASS（exit code 0）、validate-skill-syntax.py 全 10 skill PASS
+- 全 AC PASS（9/9）、CI 全 SUCCESS、MUST 課題ゼロ。CONSIDER 課題 3 件を修正済み
+- Pattern 4 の "Detection approach:" ブロック追加と "Posting the Comment" `$NUMBER` 説明追加（追記のみ、既存 verify command との矛盾なし）
 
 ### Deferred Items
-- github_check "gh pr checks" "Run bats tests" の verify は CI で確認（PR #608 作成済み、未チェック）
-- Post-merge 観察（次回 `/triage --backlog` で監査コメント投稿を確認）は opportunistic
+- Post-merge 観察: 次回 `/triage --backlog` で監査コメントが新規 Issue に投稿されることを opportunistic で確認
+- Issue #584 の Post-merge AC は `/merge` 完了後に観察
 
 ### Notes for Next Phase
-- PR #608 をレビュー時、domain file の `## Non-Destructive Audit Behavior` セクションが非破壊的振る舞い（コメント投稿のみ、Issue body 自動書き換えなし）を正しく記述しているか確認する
-- rubric verify command の意味チェック: SKILL.md + skill-dev-verify-audit.md が together して非破壊的監査を仕様化していることを確認する
-- CI bats テストの完了後に Issue #584 の最後のチェックボックス（github_check）が green になることを確認する
+- MUST 課題なし、レビュー対応済み。`/merge 608` でマージ可能
+- AC 9（bats テスト green）は CI で確認済み（PASS）
+- Issue #584 の全 Pre-merge AC は `[x]` 完了

--- a/docs/spec/issue-584-triage-ac-verify-command-audit.md
+++ b/docs/spec/issue-584-triage-ac-verify-command-audit.md
@@ -112,3 +112,36 @@ Domain file（`skills/triage/skill-dev-verify-audit.md`）は `validate-skill-sy
 ### 翻訳同期
 
 変更対象は `skills/triage/` 配下のみ（`docs/*.md` 非対象）のため `docs/ja/` 同期不要。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Step 7 の見出し文字列は「AC Verify Command Integrity Audit」（英語）とし、SKILL.md 本文中の説明テキストに「verify command audit patterns」を含めることで、verify command `grep "verify command audit"` パターンマッチを確保した。Spec の仮見出しに含まれた「AC verify command 整合性監査」（日本語）は本文には含めなかった（英語優先の SKILL.md 規約に従う）。
+
+### Design Gaps/Ambiguities
+
+- Stale test assertion check: SKILL.md から削除されたステップ見出し文字列（`Step 7: Value Assignment` 等）を `tests/` で検索したが、triage SKILL.md の内部ステップ名をテストは直接参照していないため stale assertion なし。
+- `validate-skill-syntax.py` はドメインファイル（`skill-dev-verify-audit.md`）を検証対象外とすることを Spec が明示していたため、domain file の frontmatter バリデーションは手動で確認した（`type: domain`, `skill: triage` の存在確認）。
+
+### Rework
+
+- N/A（1 回の実装で完了、リワークなし）
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Step 7 を「AC Verify Command Integrity Audit」（英語見出し）として配置し、本文テキストに「verify command audit patterns」を含めることで verify command の `grep "verify command audit"` マッチを確保した
+- Domain file は `load_when` なし（無条件ロード）を採用し、全リポジトリで監査を保証する設計とした（Spec Auto-Resolve Log に従う）
+- Step 7 を Step 6（Size Assignment）直後に配置し、旧 Step 7-10 を 8-11 に繰り下げた（Pattern 4 の patch route チェックに Size 情報が必要なため）
+- bats テスト全 706 件 PASS（exit code 0）、validate-skill-syntax.py 全 10 skill PASS
+
+### Deferred Items
+- github_check "gh pr checks" "Run bats tests" の verify は CI で確認（PR #608 作成済み、未チェック）
+- Post-merge 観察（次回 `/triage --backlog` で監査コメント投稿を確認）は opportunistic
+
+### Notes for Next Phase
+- PR #608 をレビュー時、domain file の `## Non-Destructive Audit Behavior` セクションが非破壊的振る舞い（コメント投稿のみ、Issue body 自動書き換えなし）を正しく記述しているか確認する
+- rubric verify command の意味チェック: SKILL.md + skill-dev-verify-audit.md が together して非破壊的監査を仕様化していることを確認する
+- CI bats テストの完了後に Issue #584 の最後のチェックボックス（github_check）が green になることを確認する

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -156,7 +156,13 @@ Estimate the scope of change from the issue body's acceptance conditions and tec
 
 **Verify-after-write**: After Steps 1→4 succeed, read `${CLAUDE_PLUGIN_ROOT}/modules/project-field-update.md` and follow the "Verify-after-write" procedure from the "Updating Priority / Size Fields" section.
 
-### Step 7: Value Assignment (Projects field)
+### Step 7: AC Verify Command Integrity Audit
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/triage/skill-dev-verify-audit.md` for the verify command audit patterns and follow the "Processing Steps" section.
+
+Skip this step if the issue body contains no `<!-- verify: ... -->` patterns.
+
+### Step 8: Value Assignment (Projects field)
 
 Since the Value field is a SingleSelect type, update it using the same Steps 1→2→3→4 from `project-field-update.md`'s "Priority / Size Field Update" section (always calculate and update regardless of existing Value):
 
@@ -201,7 +207,7 @@ Reuse the full open issues data already retrieved in Step 2 to calculate Impact 
 
 **Skip when Projects is not configured**: Same as Step 5/6.
 
-### Step 8: Lightweight Analysis
+### Step 9: Lightweight Analysis
 
 Using the full open issues data already retrieved in Step 2, run the following two lightweight analyses (minimal additional API calls).
 
@@ -225,13 +231,13 @@ Extract `Blocked by #N` patterns from the issue body and check the status of blo
 2. If found, use already-retrieved data from Step 2 if the blocked-by issue is included. Otherwise, check status with `gh issue view N --json state,title`
 3. If the blocked-by issue is CLOSED: report as "resolved dependency (#N is CLOSED)"
 
-### Step 9: Triage Marker
+### Step 10: Triage Marker
 
 ```bash
 gh issue edit $NUMBER --add-label "triaged"
 ```
 
-### Step 10: Completion Report
+### Step 11: Completion Report
 
 Output a summary of the processing results to the user:
 
@@ -380,6 +386,9 @@ for each issue in Step 2 results:
      - Write comment body to `.tmp/triage-duplicate-comment-$NUMBER.md` using the Write tool
      - Post: `${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh $NUMBER .tmp/triage-duplicate-comment-$NUMBER.md`
      - Delete: `rm -f .tmp/triage-duplicate-comment-$NUMBER.md`
+  8. AC verify command audit: if the issue body contains `<!-- verify: ... -->` patterns,
+     read ${CLAUDE_PLUGIN_ROOT}/skills/triage/skill-dev-verify-audit.md and follow the
+     "Processing Steps" section. Post audit comment if issues are found (non-destructive).
 ```
 
 **Error handling:**

--- a/skills/triage/skill-dev-verify-audit.md
+++ b/skills/triage/skill-dev-verify-audit.md
@@ -1,0 +1,146 @@
+---
+type: domain
+skill: triage
+---
+
+# AC Verify Command Integrity Audit
+
+This Domain file defines the verify command audit patterns for the `/triage` skill.
+Used in: Step 7 (Single Issue Execution) and Bulk Execution Step 3 substep 8.
+
+## Purpose
+
+Detect defective `<!-- verify: ... -->` patterns in Issue AC sections before they
+propagate to the `/verify` phase and produce false PASSes or false FAILs.
+
+Proven value: In the 2026-06-13 `/auto` session, triage caught verify command defects
+in 3 of 14 Issues (21%) — preventing downstream quality failures.
+
+## Processing Steps
+
+1. Extract all `<!-- verify: ... -->` comments from the issue body
+2. For each extracted verify command, check against the patterns below
+3. Collect all findings
+4. If any findings exist, post a single audit comment to the Issue (see ## Non-Destructive Audit Behavior)
+5. If no findings, skip silently — do not post an empty comment
+
+## Patterns
+
+### Pattern 1: grep 引数順誤り (Reversed grep Arguments)
+
+Detect: `grep "path/to/file" "pattern"` — a path appears as the first argument
+instead of the search pattern. This is the 引数順（引数の順序）誤り anti-pattern.
+
+Indicators that the first argument is a path (not a pattern):
+- Ends with a recognized file extension: `.md`, `.sh`, `.py`, `.yml`, `.yaml`, `.json`, `.txt`
+- Contains `/` (path separator) — path-like string
+
+Example of incorrect grep 引数順:
+```
+<!-- verify: grep "skills/triage/SKILL.md" "some pattern" -->
+```
+
+Correct form (pattern first, path second):
+```
+<!-- verify: grep "some pattern" "skills/triage/SKILL.md" -->
+```
+
+Fix: swap the two arguments so the search pattern comes first.
+
+### Pattern 2: 常時 PASS な verify command (Always-PASS Command)
+
+Detect: A `file_contains` or `grep` verify command whose search string already
+exists in the target file on the `main` branch — before this PR lands.
+
+If the string is already present, the command always returns PASS regardless of
+whether the PR's change is correct. It provides no verification signal.
+
+Detection approach:
+- Run the grep/file_contains check against the current `main` branch
+- If the result is already PASS, flag as 常時 PASS (always-PASS)
+
+Fix options:
+- Choose a string that will appear only after the change lands
+- Switch to `section_not_contains` or `file_not_contains` to assert removal instead
+
+### Pattern 3: 常時 FAIL な verify command (Always-FAIL Command)
+
+Detect: A `file_contains` or `grep` verify command whose search string has already
+been removed from the target file on `main` — before this PR lands.
+
+If the string is already absent, the command always returns FAIL regardless of
+the PR's content. It will block the PR unnecessarily.
+
+Detection approach:
+- Run the grep/file_contains check against the current `main` branch
+- If the result is already FAIL, flag as 常時 FAIL (always-FAIL)
+
+Fix: Update the expected string to match what the implementation will actually produce.
+
+### Pattern 4: patch route × `gh pr checks` 不整合
+
+Detect: Issues with Size XS or S (patch route) whose AC uses
+`github_check "gh pr checks"`.
+
+The patch route commits directly to `main` without creating a PR. Therefore,
+`gh pr checks` will never find a matching pull request and the check always FAILs.
+
+Size information is available from Step 6 (Size Assignment) when this Step 7 runs.
+
+Fix: Replace `github_check "gh pr checks"` with a `github_check "gh run list"` form,
+for example:
+```
+github_check "gh run list --workflow=test.yml --limit=1 --json conclusion --jq '.[0].conclusion'" "success"
+```
+
+If multiple workflow files exist under `.github/workflows/`, add `--workflow=<filename>`
+to target the specific workflow.
+
+### Pattern 5: Destructive Command Safety Check
+
+Detect: verify commands that contain destructive operations, such as:
+- `rm`, `mv`, `cp` (filesystem mutations)
+- `gh issue close`, `gh issue delete`, `gh issue edit`
+- `gh pr merge`, `gh pr close`
+- Any command that modifies external state as a side effect
+
+Verify commands are executed by the `/verify` skill as acceptance tests. They should
+be read-only. Destructive commands in verify context can cause irreversible side
+effects on Issues, PRs, or the filesystem.
+
+Fix: Remove the destructive command from the verify context and mark the AC line as
+`verify-type: manual` so a human performs the check instead.
+
+## Non-Destructive Audit Behavior
+
+This audit is **non-destructive**: triage does NOT auto-edit the Issue body.
+
+When problems are detected, triage posts a comment to the Issue with the findings and
+suggested fixes. The user then decides whether and how to update the Issue body.
+This avoids destructive behavior in cases where `/issue` may regenerate the AC.
+
+**Post the audit comment** only when at least one pattern match is found.
+If no patterns match, skip without posting.
+
+### Comment Format Template
+
+```
+⚠️ Triage AC audit: verify command に問題があります
+
+- AC: `<!-- verify: grep "skills/triage/SKILL.md" "some pattern" -->`
+  - Pattern: grep の引数順誤り（第 1 引数がパス様文字列）
+  - 修復案: `<!-- verify: grep "some pattern" "skills/triage/SKILL.md" -->`
+
+- AC: `<!-- verify: github_check "gh pr checks" "Run bats tests" -->`
+  - Pattern: patch route（Size S）× `gh pr checks` 不整合
+  - 修復案: `<!-- verify: github_check "gh run list --workflow=test.yml --limit=1 --json conclusion --jq '.[0].conclusion'" "success" -->`
+```
+
+### Posting the Comment
+
+```bash
+mkdir -p .tmp
+# Write comment body to .tmp/triage-audit-comment-$NUMBER.md using the Write tool
+${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh $NUMBER .tmp/triage-audit-comment-$NUMBER.md
+rm -f .tmp/triage-audit-comment-$NUMBER.md
+```

--- a/skills/triage/skill-dev-verify-audit.md
+++ b/skills/triage/skill-dev-verify-audit.md
@@ -85,7 +85,10 @@ Detect: Issues with Size XS or S (patch route) whose AC uses
 The patch route commits directly to `main` without creating a PR. Therefore,
 `gh pr checks` will never find a matching pull request and the check always FAILs.
 
-Size information is available from Step 6 (Size Assignment) when this Step 7 runs.
+Detection approach:
+- In Single Issue Execution: read the Size assigned in Step 6 (Size Assignment)
+- In Bulk Execution (Step 3 substep 8): read the `size` field from the Step 2 classification
+  JSON for the current issue
 
 Fix: Replace `github_check "gh pr checks"` with a `github_check "gh run list"` form,
 for example:
@@ -137,6 +140,8 @@ If no patterns match, skip without posting.
 ```
 
 ### Posting the Comment
+
+`$NUMBER` refers to the current Issue number (in Bulk Execution, the per-loop issue number).
 
 ```bash
 mkdir -p .tmp


### PR DESCRIPTION
## Summary

- `skills/triage/SKILL.md` に Step 7「AC Verify Command Integrity Audit」を追加（Step 6 Size Assignment の直後）
- 旧 Step 7-10 を Step 8-11 に繰り下げ
- Bulk Execution Step 3 ループにサブステップ 8（verify command 監査）を追加
- `skills/triage/skill-dev-verify-audit.md` を新規作成（5 パターン定義 + 非破壊的振る舞い仕様）

2026-06-13 の `/auto` セッションで triage が 3/14 Issue（21%）で verify command 欠陥を発見した実績を「保証された責務」に格上げ。

## Verification (pre-merge)

- `/triage` SKILL.md に新ステップ「AC verify command 整合性監査」が追加されている（`grep "verify command audit"`）
- Domain file `skills/triage/skill-dev-verify-audit.md` が存在する
- Domain file が `type: domain` frontmatter を持つ
- grep 引数順誤りパターンが Domain file に文書化されている
- 常時 PASS / 常時 FAIL パターンが文書化されている
- patch route × gh pr checks 不整合パターンが文書化されている
- 監査は非破壊的（コメント投稿のみ）であることが明記されている（rubric）
- Domain file に `non-destructive` / `post.*comment` キーワードが存在する
- 既存 bats テストが green（CI 確認）

## Verification (post-merge)

- 次回の `/triage --backlog` 実行で verify command 監査コメントが新規 Issue に投稿されることを観察（opportunistic）

closes #584