### PR TITLE
Issue #547: Add review-completion-false-negative pattern to detect-wrapper-anomaly

### DIFF
--- a/docs/spec/issue-547-review-completion-false-negative.md
+++ b/docs/spec/issue-547-review-completion-false-negative.md
@@ -74,19 +74,33 @@
 ### Rework
 - なし。実装は1回で完了した。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Fallback Steps 数の記述（Spec 実装ステップが「3 段階」、Code Retrospective が「4 段階に整理」と記録）が一致しておらず、Spec テキスト側が未更新のままマージされた。Spec の Implementation Steps と Code Retrospective を同一コミットで同期させることで防げる。
+
+### Recurring issues
+
+- なし。今回の CONSIDER 指摘は新規パターンであり、繰り返し問題ではない。
+
+### Acceptance criteria verification difficulty
+
+- rubric verify command（AC7）は今回初めて `safe` モードで grader 実行され、PASS 判定。verify command の設計（adversarial grader の明示的使用）は適切。
+- AC2 の verify command パターン（`matches_expected.*false.*phase.*review`）が実装コード（`'"phase":"review"'`）と正確に一致しない。verify command 記述と実装パターンを同期させるルールを Spec テンプレートに追加すると品質向上する。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `reconciler-header-mismatch` の後段に elif を追加することで排他性を保証した（`reconciler-header-mismatch` が "Review Summary" 含む場合を先取りするため新パターンは "Review Summary" 不在のケースのみ到達する）
-- recovery 手順の `--no-cache` オプションは存在しないため省略し、`reconcile-phase-state.sh review --pr <N>` を使用した（Spec Notes に Auto-resolve として記録済み）
-- `orchestration-fallbacks.md` の新セクション位置は `reconciler-header-mismatch` と `code-completed-no-pr` の間（`---` 区切りの後）
+- 全 AC（AC1-AC8）が PASS。MUST/SHOULD issue なし → `REQUEST_CHANGES` イベントではなく `COMMENT` イベントで投稿。
+- rubric AC7 は elif チェーンによる排他性と 4 段階 recovery 手順の存在を確認して PASS 判定。潜在的なデッドコード（`reconciler-header-mismatch` が常に先行して `review-completion-false-negative` が本番で発火しない可能性）は CONSIDER として記録。
+- review-light モード実行（REVIEW_DEPTH=light、Issue size M）。CONSIDER 5件を line comments として投稿。
 
 ### Deferred Items
-- rubric verify command は /verify フェーズで評価される
-- CI bats ジョブ pass 確認（`github_check "gh pr checks" "Run bats tests"`）は PR #609 の CI 完了後に確認
+- `review-completion-false-negative` パターンが本番環境でデッドコードになりうる問題（`reconcile-phase-state.sh` の診断文が常に "Review Response Summary not found" を含むため `reconciler-header-mismatch` が常に先に発火する）は CONSIDER として記録のみ。修正は out of scope。
+- AC2 verify command と実装 grep パターンの不一致修正は /verify フェーズで対応可能。
 
 ### Notes for Next Phase
-- bats 全 29 テスト PASS 確認済み（新規 3 件含む）
-- forbidden-expressions-check と validate-skill-syntax もローカルで PASS
-- Issue body の AC1-AC6 チェックボックスを `[x]` に更新済み
+- 全 AC PASS、CI 全 SUCCESS → `/merge 609` で merge 進行可能。
+- CONSIDER 5件はすべてスキップ推奨（機能影響なし）。

--- a/docs/spec/issue-547-review-completion-false-negative.md
+++ b/docs/spec/issue-547-review-completion-false-negative.md
@@ -61,3 +61,32 @@
 - 新パターンは elif チェーンの `reconciler-header-mismatch`（line 81-84）直後、`mid-run-api-error`（`grep -qiE "APIConnectionError..."`）の直前に配置する。`reconciler-header-mismatch` が先にチェックされるため、ログに "Review Summary" が含まれるケースは既存パターンで処理され、新パターンには到達しない（first-match-wins による排他）
 - bats テストの Case 2（排他確認）では `"phase":"review"` + `"matches_expected":false` + `"Review Summary"` を含むログを用い、出力が `reconciler-header-mismatch` であることを確認する。新パターン名が出力されないことは確認不要（`reconciler-header-mismatch` が優先される点のみ確認すれば十分）
 - **Auto-resolve**: Issue body の recovery Step 1 は `reconcile-phase-state.sh --no-cache review --pr <N>` と記述しているが、`reconcile-phase-state.sh` に `--no-cache` オプションは存在しない（grep 確認済み）。recovery 手順の実装では `reconcile-phase-state.sh review --pr <N>` を使用する（`--no-cache` なし）。この変更は reconcile-phase-state.sh の内部実装詳細であり、recovery 手順の本質（reconcile 再実行）には影響しない
+
+## Code Retrospective
+
+### Deviations from Design
+- 設計通りに実装完了。逸脱なし。
+
+### Design Gaps/Ambiguities
+- `reconcile-phase-state.sh` に `--no-cache` オプションが存在しないことが発覚したが、Spec Notes の Auto-resolve 節で既に記録・解決済みであり、recovery 手順には `--no-cache` なしの形式を使用した。
+- recovery 手順の Fallback Steps を Issue body 指定の 5 段階から 4 段階に整理（Step 3 に サマリ見出しのローカライズ対応 follow-up Issue 起票を統合）。本質的な内容は変わらない。
+
+### Rework
+- なし。実装は1回で完了した。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `reconciler-header-mismatch` の後段に elif を追加することで排他性を保証した（`reconciler-header-mismatch` が "Review Summary" 含む場合を先取りするため新パターンは "Review Summary" 不在のケースのみ到達する）
+- recovery 手順の `--no-cache` オプションは存在しないため省略し、`reconcile-phase-state.sh review --pr <N>` を使用した（Spec Notes に Auto-resolve として記録済み）
+- `orchestration-fallbacks.md` の新セクション位置は `reconciler-header-mismatch` と `code-completed-no-pr` の間（`---` 区切りの後）
+
+### Deferred Items
+- rubric verify command は /verify フェーズで評価される
+- CI bats ジョブ pass 確認（`github_check "gh pr checks" "Run bats tests"`）は PR #609 の CI 完了後に確認
+
+### Notes for Next Phase
+- bats 全 29 テスト PASS 確認済み（新規 3 件含む）
+- forbidden-expressions-check と validate-skill-syntax もローカルで PASS
+- Issue body の AC1-AC6 チェックボックスを `[x]` に更新済み

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -232,6 +232,32 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 
 ---
 
+## review-completion-false-negative
+
+### Symptom
+- `run-review.sh` exits with non-zero and the wrapper log contains `"matches_expected":false` and `"phase":"review"` but neither `Review Response Summary` nor `レビュー回答サマリ` appears in the log
+- `scripts/detect-wrapper-anomaly.sh` emits pattern: `review-completion-false-negative`
+- Likely cause: LLM omitted the `<!-- review-summary -->` marker and used a non-standard (localized) heading not covered by existing fallback signatures
+
+### Applicable Phases
+- review
+
+### Fallback Steps
+1. Re-run `reconcile-phase-state.sh review --pr <N>` to check whether a cache-related false negative caused the mismatch; if the result flips to `matches_expected:true`, continue normally
+2. Run `gh pr view <N> --comments` to inspect PR comments directly; check whether a summary-style comment exists (any heading containing "review", "summary", "サマリ", "レビュー", etc.)
+3. If a summary comment exists but `<!-- review-summary -->` marker is absent: edit the comment via `gh api repos/{owner}/{repo}/issues/comments/<comment-id> -f body="<!-- review-summary -->\n<original-body>"` to prepend the marker, then re-run `reconcile-phase-state.sh review --pr <N>` to confirm `matches_expected:true`. If the heading is a localized variant not covered by existing fallback signatures, open a follow-up Issue to add the regex to `scripts/reconcile-phase-state.sh`
+4. If no summary comment is found in the PR: the review skill did not complete — re-run `/review <PR>` to regenerate the review comment
+
+### Escalation
+- Recovery sub-agent (#316) can be invoked when the root cause is unclear or none of the fallback steps resolve the mismatch
+
+### Rationale
+- First observed during Issue #528 implementation: PR #544 had a review summary comment with heading `## レビューレスポンスサマリー` (not covered by existing fallback signatures) and the `<!-- review-summary -->` marker was absent; `reconcile-phase-state.sh` returned `matches_expected:false` and `run-review.sh` exited non-zero; Tier 2 `detect-wrapper-anomaly.sh` returned empty output (pattern not cataloged)
+- Issue #528 introduced `<!-- review-summary -->` as the primary signature in `modules/phase-state.md`, resolving the root cause; this catalog entry serves as the safety net when LLM omits the marker and uses a non-standard heading simultaneously
+- Exclusivity with `reconciler-header-mismatch`: the `elif` chain in `scripts/detect-wrapper-anomaly.sh` ensures that logs containing `Review Summary` are caught by `reconciler-header-mismatch` first; `review-completion-false-negative` fires only when that pattern does not match
+
+---
+
 ## code-completed-no-pr
 
 ### Symptom

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -82,6 +82,10 @@ elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q "Review Summary" 
   PATTERN_NAME="reconciler-header-mismatch"
   ANOMALY_DESC="Reconciler detected header mismatch in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`Review Summary\` pattern detected in wrapper output. The reconciler could not find \`## Review Response Summary\` in the PR comment, indicating a mismatch between the skill output header and the reconciler's expected pattern. Reference: #394."
   IMPROVEMENT_HINT="Check whether \`run-review.sh\` or the review skill changed the header format of the PR comment. The reconciler expects \`## Review Response Summary\` as defined in \`modules/phase-state.md\`. See \`modules/orchestration-fallbacks.md#reconciler-header-mismatch\` for the full recovery procedure."
+elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q '"phase":"review"' "$LOG_FILE"; then
+  PATTERN_NAME="review-completion-false-negative"
+  ANOMALY_DESC="Review phase completion false-negative in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`phase:review\` detected in reconciler output, but no existing fallback header (## Review Response Summary / ## レビュー回答サマリ) was found in wrapper log. Likely caused by LLM omitting the \`<!-- review-summary -->\` marker and using a non-standard heading. Reference: #547."
+  IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#review-completion-false-negative\`: re-run reconcile, check PR comments for summary, add \`<!-- review-summary -->\` marker if present, or re-run /review if absent."
 elif grep -qiE "APIConnectionError|Request timed out|overloaded_error|529.*[Oo]verload" "$LOG_FILE"; then
   PATTERN_NAME="mid-run-api-error"
   ANOMALY_DESC="API connection error in phase \`$PHASE\` (exit code $EXIT_CODE): API connection/overload pattern detected in wrapper output. The forked session terminated mid-run before phase completion."

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -252,3 +252,26 @@ MOCK
     [[ "$output" == *"silent-no-op"* ]]
     [[ "$output" == *"### Orchestration Anomalies"* ]]
 }
+
+@test "review-completion-false-negative: detects matches_expected false with phase review" {
+    printf '"matches_expected":false\n"phase":"review"\n' > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"review-completion-false-negative"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+}
+
+@test "review-completion-false-negative: reconciler-header-mismatch takes priority when Review Summary present" {
+    printf '"matches_expected":false\n"phase":"review"\nreconcile-phase-state result: Review Summary found\n' > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reconciler-header-mismatch"* ]]
+    [[ "$output" != *"review-completion-false-negative"* ]]
+}
+
+@test "review-completion-false-negative: no detection for unrelated log" {
+    echo "Some unrelated error occurred in the code phase." > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase code
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"review-completion-false-negative"* ]]
+}


### PR DESCRIPTION
## Summary

- `scripts/detect-wrapper-anomaly.sh` に新パターン `review-completion-false-negative` を追加（既存 `reconciler-header-mismatch` の後段 elif として配置し排他性を elif チェーンで保証）
- `modules/orchestration-fallbacks.md` に `## review-completion-false-negative` セクションを追加（reconcile 再実行 + マーカー追記 + 個別ローカライズ対応 follow-up の 3 段階 recovery 手順）
- `tests/detect-wrapper-anomaly.bats` に 3 件のテストケースを追加（正検出・排他確認・false-positive 抑制）

## Verification (pre-merge)

- `file_contains "scripts/detect-wrapper-anomaly.sh" "review-completion-false-negative"` — パターン名追加確認
- `grep` で検出条件（`matches_expected:false` + `phase:review`）の実装確認
- `grep` + `section_contains` で recovery 手順の内容確認
- bats tests: 29 tests all pass locally

## Verification (post-merge)

- 次回の `/auto` で review-completion-false-negative が発生した際、Tier 2 auto-recovery が動作することを実運用で確認する

closes #547