### PR TITLE
Issue #585: Add phase-specific watchdog timeout defaults

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -47,6 +47,13 @@ production-url: https://yourapp.example.com
 # can produce silent periods exceeding 2700 seconds. Set to 3600 for meta-development.
 watchdog-timeout-seconds: 3600
 
+# Per-phase overrides (optional; take precedence over watchdog-timeout-seconds)
+# watchdog-timeout-spec-seconds: 1800
+# watchdog-timeout-code-seconds: 1800
+# watchdog-timeout-review-seconds: 2000
+# watchdog-timeout-merge-seconds: 600
+# watchdog-timeout-issue-seconds: 600
+
 # Patch lock timeout for main-branch push (default: 300 seconds; lock is held only during git merge + push)
 patch-lock-timeout: 300
 
@@ -96,6 +103,11 @@ This table is the **single source of truth (SSoT)** for all `.wholework.yml` con
 | `capabilities.mcp` | list | `[]` | MCP tool names available to skills |
 | `capabilities.{name}` | boolean | `false` | Dynamic capability mapping (e.g., `capabilities.invoice-api: true`) |
 | `watchdog-timeout-seconds` | integer | `2700` | Watchdog timeout in seconds before killing a silent `claude -p` process. Claude's extended thinking time on Size L+ tasks (especially Opus with high effort) can produce silent periods exceeding 2700 seconds; set to `3600` for meta-development or Size L+ work. Values ≤0 fall back to the default. |
+| `watchdog-timeout-spec-seconds` | integer | `""` (falls back to `1800`) | Per-phase watchdog timeout override for `/spec`. Priority: this key > `watchdog-timeout-seconds` > `1800`. |
+| `watchdog-timeout-code-seconds` | integer | `""` (falls back to `1800`) | Per-phase watchdog timeout override for `/code`. Priority: this key > `watchdog-timeout-seconds` > `1800`. |
+| `watchdog-timeout-review-seconds` | integer | `""` (falls back to `2000`) | Per-phase watchdog timeout override for `/review`. Priority: this key > `watchdog-timeout-seconds` > `2000`. |
+| `watchdog-timeout-merge-seconds` | integer | `""` (falls back to `600`) | Per-phase watchdog timeout override for `/merge`. Priority: this key > `watchdog-timeout-seconds` > `600`. |
+| `watchdog-timeout-issue-seconds` | integer | `""` (falls back to `600`) | Per-phase watchdog timeout override for `/issue`. Priority: this key > `watchdog-timeout-seconds` > `600`. |
 | `patch-lock-timeout` | integer | `300` | Lock acquisition timeout in seconds for `git merge --ff-only` + `git push origin main` (the only protected critical section). The default is generous since the lock is held only for seconds. Increase only if push consistently fails to acquire. Values ≤0 or non-numeric fall back to `300`. |
 | `permission-mode` | string | `"auto"` | Permission mode for `/auto` subprocess. `auto` enables `--permission-mode auto` with allow rules template (see `docs/guide/auto-mode-template.json`); `bypass` uses `--dangerously-skip-permissions` (legacy / opt-out). |
 | `verify-max-iterations` | integer | `3` | Limit verify-reopen loop iterations; stops at N failures and leaves Issue in `phase/verify` for human judgment. Values ≤0, >20, or non-numeric fall back to `3`. |

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -41,6 +41,13 @@ production-url: https://yourapp.example.com
 # 2700 秒を超える silent 期間が発生しうる。メタ開発用途では 3600 を推奨。
 watchdog-timeout-seconds: 3600
 
+# フェーズ別上書き（オプション; watchdog-timeout-seconds より優先）
+# watchdog-timeout-spec-seconds: 1800
+# watchdog-timeout-code-seconds: 1800
+# watchdog-timeout-review-seconds: 2000
+# watchdog-timeout-merge-seconds: 600
+# watchdog-timeout-issue-seconds: 600
+
 # main ブランチへの push 用 lock タイムアウト（デフォルト: 300 秒、lock は git merge + push 中のみ保持）
 patch-lock-timeout: 300
 
@@ -90,6 +97,11 @@ capabilities:
 | `capabilities.mcp` | list | `[]` | スキルから利用できる MCP ツール名 |
 | `capabilities.{name}` | boolean | `false` | 動的 capability マッピング（例: `capabilities.invoice-api: true`） |
 | `watchdog-timeout-seconds` | integer | `2700` | watchdog が silent な `claude -p` プロセスを kill するまでのタイムアウト秒数。Size L+ タスク（特に Opus / xhigh effort）では claude の長い思考時間により 2700 秒を超える silent 期間が発生しうる。メタ開発や Size L+ 作業では `3600` を推奨。0 以下の値はデフォルトにフォールバック。 |
+| `watchdog-timeout-spec-seconds` | integer | `""` (フォールバック: `1800`) | `/spec` フェーズ用 watchdog タイムアウト上書き。優先順位: このキー > `watchdog-timeout-seconds` > `1800`。 |
+| `watchdog-timeout-code-seconds` | integer | `""` (フォールバック: `1800`) | `/code` フェーズ用 watchdog タイムアウト上書き。優先順位: このキー > `watchdog-timeout-seconds` > `1800`。 |
+| `watchdog-timeout-review-seconds` | integer | `""` (フォールバック: `2000`) | `/review` フェーズ用 watchdog タイムアウト上書き。優先順位: このキー > `watchdog-timeout-seconds` > `2000`。 |
+| `watchdog-timeout-merge-seconds` | integer | `""` (フォールバック: `600`) | `/merge` フェーズ用 watchdog タイムアウト上書き。優先順位: このキー > `watchdog-timeout-seconds` > `600`。 |
+| `watchdog-timeout-issue-seconds` | integer | `""` (フォールバック: `600`) | `/issue` フェーズ用 watchdog タイムアウト上書き。優先順位: このキー > `watchdog-timeout-seconds` > `600`。 |
 | `patch-lock-timeout` | integer | `300` | `git merge --ff-only` + `git push origin main` の lock 取得タイムアウト秒数。lock 保持は数秒のためデフォルトは余裕値。push 取得が常時失敗する場合のみ増やす。0 以下または非数値の場合は `300` にフォールバック。 |
 | `permission-mode` | string | `"auto"` | `/auto` サブプロセスの permission mode。`auto` は `--permission-mode auto` を allow rules テンプレートと共に有効化（`docs/guide/auto-mode-template.json` 参照）; `bypass` は `--dangerously-skip-permissions` を使用（レガシー / オプトアウト）。 |
 | `verify-max-iterations` | integer | `3` | verify-reopen ループの最大試行回数。N 回 FAIL した時点で停止し、Issue を `phase/verify` に留めて人間の判断を促す。0 以下、20 超、または非数値の場合は `3` にフォールバック。 |

--- a/docs/spec/issue-585-watchdog-phase-specific-timeout.md
+++ b/docs/spec/issue-585-watchdog-phase-specific-timeout.md
@@ -142,7 +142,7 @@ Priority order (highest to lowest):
 - <!-- verify: grep "watchdog-timeout-spec-seconds" "docs/ja/guide/customization.md" --> `docs/ja/guide/customization.md` の翻訳が同期されている
 - <!-- verify: command "bash -n scripts/run-spec.sh && bash -n scripts/run-code.sh && bash -n scripts/run-review.sh && bash -n scripts/run-merge.sh && bash -n scripts/run-issue.sh" --> 5 本の run-*.sh が構文エラーなし
 - <!-- verify: command "bats tests/watchdog-defaults.bats" --> bats テストが green（フェーズ別 timeout 解決テストの新規追加含む）
-- <!-- verify: command "scripts/check-translation-sync.sh --fail-if-outdated" --> docs/guide/customization.md と docs/ja/guide/customization.md の翻訳同期が保たれている
+- <!-- verify: command "scripts/check-translation-sync.sh | grep 'customization.md' | grep -q IN_SYNC" --> docs/guide/customization.md と docs/ja/guide/customization.md の翻訳同期が保たれている
 
 ### Post-merge
 

--- a/docs/spec/issue-585-watchdog-phase-specific-timeout.md
+++ b/docs/spec/issue-585-watchdog-phase-specific-timeout.md
@@ -155,3 +155,34 @@ Priority order (highest to lowest):
 - `eval` による間接変数参照は `${!var_name}` に代替可能（どちらも bash 3.2+ 対応）。どちらも許容。
 - `get-config-value.sh` は空文字列 default (`""`) をサポート。phase 別キー不在時の空文字判定に利用。
 - Issue body の Auto-Resolved Ambiguity Points で `docs/guide/customization.md` 更新と `--fail-if-outdated` の追加は既に自動解決済み。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `check-translation-sync.sh --fail-if-outdated` の verify command を `check-translation-sync.sh | grep 'customization.md' | grep -q IN_SYNC` に変更した。理由: `--fail-if-outdated` は全ファイルをチェックするため、本 Issue スコープ外の既存翻訳 lag（`docs/environment-adaptation.md`, `docs/product.md`, `docs/tech.md`）で常時 FAIL となる miscalibrated hint だったため。
+
+### Design Gaps/Ambiguities
+
+- `check-translation-sync.sh` が特定ファイルのフィルタリングをサポートしていないため、Issue 作成時の Auto-Resolved ambiguity「`--fail-if-outdated` を追加」では不十分だった。新キーが `customization.md` に IN_SYNC であることを確認するには grep ベースの命令に変更が必要だった。
+
+### Rework
+
+- なし。実装はSpec の手順通りに進行し、rework は発生しなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `check-translation-sync.sh --fail-if-outdated` を使った AC の代わりに customization.md 専用の grep コマンドに変更した（全ファイルチェックで既存 lag により false FAIL するため）
+- `eval` による間接変数参照を採用（bash 3.2+ 互換; `${!var}` も同等）
+- 既存テスト（WATCHDOG_TIMEOUT_DEFAULT fallback 等）は後方互換パスで引き続き通過することを確認済み
+
+### Deferred Items
+- `docs/environment-adaptation.md`, `docs/product.md`, `docs/tech.md` の翻訳 lag は本 Issue スコープ外（既存の lag で本変更起因ではない）
+- post-merge 観察条件（merge フェーズ 60s〜10分完走、真のストール kill）は実際の `/auto` 実行後に確認
+
+### Notes for Next Phase
+- PR #610 は全 16 pre-merge AC チェック済み（Issue body の checkbox 完了）
+- 全 715 bats テスト PASS（新規 5 テスト含む）
+- 翻訳同期チェックは `check-translation-sync.sh | grep 'customization.md' | grep -q IN_SYNC` の形式に修正済み（Spec および Issue body 両方）

--- a/docs/spec/issue-585-watchdog-phase-specific-timeout.md
+++ b/docs/spec/issue-585-watchdog-phase-specific-timeout.md
@@ -171,18 +171,34 @@ Priority order (highest to lowest):
 - なし。実装はSpec の手順通りに進行し、rework は発生しなかった。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `check-translation-sync.sh --fail-if-outdated` を使った AC の代わりに customization.md 専用の grep コマンドに変更した（全ファイルチェックで既存 lag により false FAIL するため）
-- `eval` による間接変数参照を採用（bash 3.2+ 互換; `${!var}` も同等）
-- 既存テスト（WATCHDOG_TIMEOUT_DEFAULT fallback 等）は後方互換パスで引き続き通過することを確認済み
+- MUST 課題ゼロのため Step 12 の実装変更なし。全 AC を safe モードで検証し、14 件 PASS / 2 件 UNCERTAIN（CI fallback 不可）/ 2 件 POST-MERGE
+- `command` 型 AC（bash -n / 翻訳同期 grep）は対応 CI ジョブがなく UNCERTAIN となったが、実装品質には問題なし
+- Step 13 のポリシー変更なし（review phase で実装変更がなかったため）
 
 ### Deferred Items
-- `docs/environment-adaptation.md`, `docs/product.md`, `docs/tech.md` の翻訳 lag は本 Issue スコープ外（既存の lag で本変更起因ではない）
-- post-merge 観察条件（merge フェーズ 60s〜10分完走、真のストール kill）は実際の `/auto` 実行後に確認
+- post-merge 観察条件（merge フェーズ 60s〜10 分完走、真のストール kill）は `/auto` 実行後に確認
+- AC14/AC16 の UNCERTAIN 解消（CI ジョブ追加または verify command 変更）は将来の改善 Issue で対処
 
 ### Notes for Next Phase
-- PR #610 は全 16 pre-merge AC チェック済み（Issue body の checkbox 完了）
-- 全 715 bats テスト PASS（新規 5 テスト含む）
-- 翻訳同期チェックは `check-translation-sync.sh | grep 'customization.md' | grep -q IN_SYNC` の形式に修正済み（Spec および Issue body 両方）
+- 全 CI ジョブ（DCO/bats/validate-syntax/forbidden-expressions/macos-shell）が SUCCESS
+- MUST 課題なし。`/merge 610` で merge 可能
+- merge 後、post-merge AC（観察型 2 件）を `/auto` 実行時に観察する
+
+## review retrospective
+<!-- phase: review -->
+
+### Spec vs. Implementation Divergence Patterns
+
+- なし。実装は Spec 設計（4 段階優先解決、5 フェーズ別デフォルト、detect-config-markers 追加）に完全一致。code phase の Spec 乖離（verify command 変更）はすでに Code Retrospective で記録・正当化済みであり、review phase での新規乖離はない。
+
+### Recurring Issues
+
+- `command` 型 AC（AC14: bash -n 構文チェック、AC16: 翻訳同期 grep）が /review safe モードで UNCERTAIN になった。対応する CI ジョブが存在しないため CI reference fallback が機能しなかった。今後 `command` 型 AC を追加する際は対応する CI ジョブを同時に追加するか、`github_check` 型で代替を検討する。
+
+### Acceptance Criteria Verification Difficulty
+
+- AC14（`bash -n run-*.sh`）: CI に bash -n 専用ジョブが存在せず UNCERTAIN。改善案: `.github/workflows/test.yml` に `bash -n scripts/run-*.sh` を実行するジョブを追加する、または AC を `file_exists` + AI judgment に切り替える。
+- AC16（翻訳同期 grep）: macOS shell compatibility ジョブは `check-translation-sync.sh` を実行するが grep フィルタなし。`github_check` 型に変更して CI ジョブ成功を検証する形式も有効。

--- a/modules/detect-config-markers.md
+++ b/modules/detect-config-markers.md
@@ -46,6 +46,11 @@ From the loaded content, search for each YAML key in the marker definition table
 | `capabilities.workflow` | `HAS_WORKFLOW_CAPABILITY` | `true` | `false` |
 | `capabilities.mcp` | `MCP_TOOLS` | Comma-separated tool name list | `""` |
 | `watchdog-timeout-seconds` | `WATCHDOG_TIMEOUT_SECONDS` | Integer string (extract as-is; use `1800` if ≤0 or non-numeric) | `1800` (see `scripts/watchdog-defaults.sh` `WATCHDOG_TIMEOUT_DEFAULT`) |
+| `watchdog-timeout-spec-seconds` | `WATCHDOG_TIMEOUT_SPEC_SECONDS` | Integer string (extract as-is; use phase-specific default if ≤0 or non-numeric) | `""` (unset; falls through to global key or phase default `1800`) |
+| `watchdog-timeout-code-seconds` | `WATCHDOG_TIMEOUT_CODE_SECONDS` | Integer string (extract as-is; use phase-specific default if ≤0 or non-numeric) | `""` (unset; falls through to global key or phase default `1800`) |
+| `watchdog-timeout-review-seconds` | `WATCHDOG_TIMEOUT_REVIEW_SECONDS` | Integer string (extract as-is; use phase-specific default if ≤0 or non-numeric) | `""` (unset; falls through to global key or phase default `2000`) |
+| `watchdog-timeout-merge-seconds` | `WATCHDOG_TIMEOUT_MERGE_SECONDS` | Integer string (extract as-is; use phase-specific default if ≤0 or non-numeric) | `""` (unset; falls through to global key or phase default `600`) |
+| `watchdog-timeout-issue-seconds` | `WATCHDOG_TIMEOUT_ISSUE_SECONDS` | Integer string (extract as-is; use phase-specific default if ≤0 or non-numeric) | `""` (unset; falls through to global key or phase default `600`) |
 | `permission-mode` | `PERMISSION_MODE` | String value (extract value as-is) | `"auto"` |
 | `verify-max-iterations` | `VERIFY_MAX_ITERATIONS` | Integer string (extract as-is; use `3` if ≤0, non-numeric, or >20) | `3` |
 | `patch-lock-timeout` | `PATCH_LOCK_TIMEOUT_SECONDS` | Integer string (extract as-is; use `300` if ≤0 or non-numeric) | `300` (used by `scripts/worktree-merge-push.sh`) |
@@ -96,6 +101,11 @@ HAS_VISUAL_DIFF_CAPABILITY: true if capabilities.visual-diff: true is set (defau
 HAS_WORKFLOW_CAPABILITY: true if capabilities.workflow: true is set (default: false)
 MCP_TOOLS: tool name list from capabilities.mcp (comma-separated, default: "")
 WATCHDOG_TIMEOUT_SECONDS: integer from watchdog-timeout-seconds (default: "1800" (see `scripts/watchdog-defaults.sh` `WATCHDOG_TIMEOUT_DEFAULT`); falls back to "1800" if ≤0 or non-numeric)
+WATCHDOG_TIMEOUT_SPEC_SECONDS: integer from watchdog-timeout-spec-seconds (default: "" — unset; resolution handled by load_watchdog_timeout())
+WATCHDOG_TIMEOUT_CODE_SECONDS: integer from watchdog-timeout-code-seconds (default: "" — unset; resolution handled by load_watchdog_timeout())
+WATCHDOG_TIMEOUT_REVIEW_SECONDS: integer from watchdog-timeout-review-seconds (default: "" — unset; resolution handled by load_watchdog_timeout())
+WATCHDOG_TIMEOUT_MERGE_SECONDS: integer from watchdog-timeout-merge-seconds (default: "" — unset; resolution handled by load_watchdog_timeout())
+WATCHDOG_TIMEOUT_ISSUE_SECONDS: integer from watchdog-timeout-issue-seconds (default: "" — unset; resolution handled by load_watchdog_timeout())
 PERMISSION_MODE: string extracted from permission-mode (default: "auto")
 VERIFY_MAX_ITERATIONS: integer from verify-max-iterations (default: "3"; falls back to "3" if ≤0, non-numeric, or >20)
 PATCH_LOCK_TIMEOUT_SECONDS: integer from patch-lock-timeout (default: "300"; falls back to "300" if ≤0 or non-numeric)

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -148,7 +148,7 @@ fi
 
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
-load_watchdog_timeout "$SCRIPT_DIR"
+load_watchdog_timeout "$SCRIPT_DIR" "code"
 
 SECONDS=0
 set +e

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -70,7 +70,7 @@ ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
-load_watchdog_timeout "$SCRIPT_DIR"
+load_watchdog_timeout "$SCRIPT_DIR" "issue"
 
 SECONDS=0
 set +e

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -62,7 +62,7 @@ ARGUMENTS: ${PR_NUMBER} --non-interactive"
 
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
-load_watchdog_timeout "$SCRIPT_DIR"
+load_watchdog_timeout "$SCRIPT_DIR" "merge"
 
 SECONDS=0
 set +e

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -71,7 +71,7 @@ ARGUMENTS: ${ARGUMENTS}"
 
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
-load_watchdog_timeout "$SCRIPT_DIR"
+load_watchdog_timeout "$SCRIPT_DIR" "review"
 
 SECONDS=0
 set +e

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -93,7 +93,7 @@ ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
-load_watchdog_timeout "$SCRIPT_DIR"
+load_watchdog_timeout "$SCRIPT_DIR" "spec"
 
 SECONDS=0
 set +e

--- a/scripts/watchdog-defaults.sh
+++ b/scripts/watchdog-defaults.sh
@@ -3,13 +3,32 @@
 
 WATCHDOG_TIMEOUT_DEFAULT=2700
 
+WATCHDOG_TIMEOUT_SPEC_DEFAULT=1800
+WATCHDOG_TIMEOUT_CODE_DEFAULT=1800
+WATCHDOG_TIMEOUT_REVIEW_DEFAULT=2000
+WATCHDOG_TIMEOUT_MERGE_DEFAULT=600
+WATCHDOG_TIMEOUT_ISSUE_DEFAULT=600
+
 load_watchdog_timeout() {
   local script_dir="$1"
-  local val
-  val=$("$script_dir/get-config-value.sh" watchdog-timeout-seconds "$WATCHDOG_TIMEOUT_DEFAULT" 2>/dev/null || echo "$WATCHDOG_TIMEOUT_DEFAULT")
-  if ! echo "$val" | grep -qE '^[0-9]+$' || [[ "$val" -le 0 ]]; then
-    echo "Warning: invalid watchdog-timeout-seconds '${val}', using default ${WATCHDOG_TIMEOUT_DEFAULT}" >&2
-    val="$WATCHDOG_TIMEOUT_DEFAULT"
+  local phase="${2:-}"
+  local val phase_default
+  phase_default="$WATCHDOG_TIMEOUT_DEFAULT"
+  if [ -n "$phase" ]; then
+    local phase_upper
+    phase_upper=$(echo "$phase" | tr '[:lower:]' '[:upper:]')
+    local var_name="WATCHDOG_TIMEOUT_${phase_upper}_DEFAULT"
+    eval "phase_default=\"\${${var_name}:-$WATCHDOG_TIMEOUT_DEFAULT}\""
+    val=$("$script_dir/get-config-value.sh" "watchdog-timeout-${phase}-seconds" "" 2>/dev/null || echo "")
+    if [ -z "$val" ]; then
+      val=$("$script_dir/get-config-value.sh" watchdog-timeout-seconds "$phase_default" 2>/dev/null || echo "$phase_default")
+    fi
+  else
+    val=$("$script_dir/get-config-value.sh" watchdog-timeout-seconds "$WATCHDOG_TIMEOUT_DEFAULT" 2>/dev/null || echo "$WATCHDOG_TIMEOUT_DEFAULT")
+  fi
+  if ! echo "$val" | grep -qE '^[0-9]+$' || [ "$val" -le 0 ]; then
+    echo "Warning: invalid watchdog timeout '${val}', using default ${phase_default}" >&2
+    val="$phase_default"
   fi
   WATCHDOG_TIMEOUT="$val"
 }

--- a/tests/watchdog-defaults.bats
+++ b/tests/watchdog-defaults.bats
@@ -62,3 +62,62 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"* ]]
 }
+
+@test "load_watchdog_timeout uses phase-specific default when phase is spec" {
+    cat > "$MOCK_DIR/get-config-value.sh" <<'MOCK'
+#!/bin/bash
+echo ""
+MOCK
+    chmod +x "$MOCK_DIR/get-config-value.sh"
+    run bash -c "source '$SCRIPT_DIR/watchdog-defaults.sh'; load_watchdog_timeout '$MOCK_DIR' 'spec' 2>/dev/null; echo \$WATCHDOG_TIMEOUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "1800" ]
+}
+
+@test "load_watchdog_timeout uses WATCHDOG_TIMEOUT_MERGE_DEFAULT when phase is merge" {
+    cat > "$MOCK_DIR/get-config-value.sh" <<'MOCK'
+#!/bin/bash
+echo ""
+MOCK
+    chmod +x "$MOCK_DIR/get-config-value.sh"
+    run bash -c "source '$SCRIPT_DIR/watchdog-defaults.sh'; load_watchdog_timeout '$MOCK_DIR' 'merge' 2>/dev/null; echo \$WATCHDOG_TIMEOUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "600" ]
+}
+
+@test "load_watchdog_timeout uses phase yml key when set" {
+    cat > "$MOCK_DIR/get-config-value.sh" <<'MOCK'
+#!/bin/bash
+echo "900"
+MOCK
+    chmod +x "$MOCK_DIR/get-config-value.sh"
+    run bash -c "source '$SCRIPT_DIR/watchdog-defaults.sh'; load_watchdog_timeout '$MOCK_DIR' 'spec'; echo \$WATCHDOG_TIMEOUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "900" ]
+}
+
+@test "load_watchdog_timeout falls back to global yml key when phase key is unset" {
+    cat > "$MOCK_DIR/get-config-value.sh" <<'MOCK'
+#!/bin/bash
+if [ "$1" = "watchdog-timeout-spec-seconds" ]; then
+  echo ""
+else
+  echo "3600"
+fi
+MOCK
+    chmod +x "$MOCK_DIR/get-config-value.sh"
+    run bash -c "source '$SCRIPT_DIR/watchdog-defaults.sh'; load_watchdog_timeout '$MOCK_DIR' 'spec'; echo \$WATCHDOG_TIMEOUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "3600" ]
+}
+
+@test "load_watchdog_timeout without phase argument uses WATCHDOG_TIMEOUT_DEFAULT" {
+    cat > "$MOCK_DIR/get-config-value.sh" <<'MOCK'
+#!/bin/bash
+echo ""
+MOCK
+    chmod +x "$MOCK_DIR/get-config-value.sh"
+    run bash -c "source '$SCRIPT_DIR/watchdog-defaults.sh'; load_watchdog_timeout '$MOCK_DIR' 2>/dev/null; echo \$WATCHDOG_TIMEOUT"
+    [ "$status" -eq 0 ]
+    [ "$output" = "2700" ]
+}


### PR DESCRIPTION
## Summary

- `scripts/watchdog-defaults.sh` に 5 つのフェーズ別デフォルト定数（`WATCHDOG_TIMEOUT_{SPEC,CODE,REVIEW,MERGE,ISSUE}_DEFAULT`）を追加
- `load_watchdog_timeout()` に optional な `phase` 引数を追加（後方互換）: フェーズ別 yml キー → 全体 yml キー → フェーズ別デフォルト → `WATCHDOG_TIMEOUT_DEFAULT` の 4 段階優先解決
- 5 本の `run-*.sh` にフェーズ引数を追加（`run-spec.sh "spec"`, `run-code.sh "code"` など）
- `tests/watchdog-defaults.bats` にフェーズ別 timeout 解決テスト 5 件を追加（計 10 テスト）
- `modules/detect-config-markers.md` に 5 件の新キー行を追加
- `docs/guide/customization.md` および `docs/ja/guide/customization.md` に Available Keys テーブルと YAML コメント例を追加

## Verification (pre-merge)

- `watchdog-defaults.sh` に spec/code/review/merge/issue フェーズ別デフォルトが定義されている
- `load_watchdog_timeout` が phase 引数を受け付ける（`local phase` 追加）
- 5 本の `run-*.sh` がフェーズ引数付きで `load_watchdog_timeout` を呼び出す
- フェーズ別キーが `modules/detect-config-markers.md` の Marker Definition Table に追加されている
- `docs/guide/customization.md` および `docs/ja/guide/customization.md` の Available Keys テーブルに新キーが追記されている
- 5 本の `run-*.sh` が構文エラーなし（`bash -n`）
- `bats tests/watchdog-defaults.bats` — 10 テスト全 PASS（フェーズ別 timeout 解決テスト新規追加含む）
- `docs/guide/customization.md` 翻訳同期確認（IN_SYNC）

## Verification (post-merge)

- 次回 `/auto` 実行で `merge` フェーズが 60s 〜 10 分以内に完走し、誤 kill が発生しないことを観察
- 真のストール（commit ゼロ）が発生した場合、該当フェーズの timeout で kill されることを観察

closes #585