### PR TITLE
Issue #586: Add Tier 0 structured test-failure recovery to /code skill

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（49 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（50 ファイル）
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
@@ -32,7 +32,7 @@ wholework/
 │   └── workflows/
 │       ├── test.yml             # CI: bats テスト、スキル構文検証、禁止表現チェック、macOS シェル互換性テスト
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
-├── tests/               # スクリプトの Bats テストファイル（59 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（60 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents
@@ -181,6 +181,7 @@ wholework/
 - `scripts/wait-ci-checks.sh` — claude 実行前に PR の全 CI チェック完了を待機
 - `scripts/worktree-merge-push.sh` — 短命な patch lock を取得し、worktree ブランチを merge + push（rebase retry 付き）
 - `scripts/detect-wrapper-anomaly.sh` — shell wrapper 出力の既知失敗パターンを検出し、Auto Retrospective の markdown 断片を生成
+- `scripts/test-failure-classify.sh` — テスト失敗出力を回復カテゴリに分類（snapshot/mock/fixture/logic/infra）。exit 0 = 修復可、exit 1 = 修復不可
 - `scripts/validate-recovery-plan.sh` — orchestration-recovery sub-agent が出力する recovery plan JSON を検証（schema チェック + forbidden ops ガード）
 - `scripts/apply-fallback.sh` — `modules/orchestration-fallbacks.md` の Tier 2 bash projection。wrapper ログから既知の symptom anchor を検出し recovery handler を dispatch する（初期 full-impl: dco-signoff-missing-autofix）
 - `scripts/spawn-recovery-subagent.sh` — `run-auto-sub.sh` が呼び出す Tier 3 recovery オーケストレーター。`claude -p` で `agents/orchestration-recovery` を spawn し、`validate-recovery-plan.sh` で plan を検証し、`WHOLEWORK_MAX_RECOVERY_SUBAGENTS` による mkdir-based スロットロックで並列性を制御する

--- a/docs/spec/issue-586-tier0-test-failure-recovery.md
+++ b/docs/spec/issue-586-tier0-test-failure-recovery.md
@@ -229,20 +229,33 @@ Tier 0 コンテキストでの「escalate to Tier 3」は、既存 Step 9 FAIL 
 
 - None. All verification commands passed on first implementation.
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Nothing to note. Implementation followed the Spec exactly — no structural gaps detected between Spec and PR diff. The Code Retrospective (added in code phase) already documents zero deviations. The one SHOULD-level review finding (`"No such file or directory"` infra over-classification) is acknowledged in the Spec's Uncertainty section as an accepted heuristic trade-off, not a divergence.
+
+### Recurring Issues
+
+- Nothing to note. Only 1 confirmed finding across 2 independent review-bug agents (1 SHOULD, no MUST). No recurring pattern of bugs or design issues. 2 of 3 raw findings were rejected as false positives: one for being acknowledged in the Spec Uncertainty section, one for applying shell-script reasoning to a natural-language SKILL.md instruction.
+
+### Acceptance Criteria Verification Difficulty
+
+- Nothing to note. All 10 pre-merge ACs reached PASS with no UNCERTAINs. The `command "bash -n ..."` AC was resolved cleanly via CI reference fallback (Run bats tests passed). The `rubric` AC ran the grader and confirmed all 5 Tier 0 requirements. The `section_contains "### Step 9"` heading partial-match worked as expected (documented in the Spec verification notes). No verify command updates needed.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の Implementation Step 3 に記載の Tier 0 テンプレートをそのまま SKILL.md Step 9 に挿入した。半角感嘆符なし（Forbidden Expressions 準拠）。
-- `test-failure-classify.sh` は `--log <file>` + stdout カテゴリ + exit 0/1 パターンで実装。`apply-fallback.sh`/`detect-wrapper-anomaly.sh` と同じ I/F。
-- `docs/ja/structure.md` の sync は Spec Changed Files に明示されていなかったが `docs/translation-workflow.md` ルールで必要。同じコミットで更新した。
+- SHOULD finding on `"No such file or directory"` infra over-classification skipped — explicitly acknowledged in Spec Uncertainty section; safety guard bounds impact to missed auto-repair only.
+- All 10 pre-merge ACs: PASS. All CI jobs: SUCCESS. review-spec: no issues. COMMENT event (no MUST → not REQUEST_CHANGES).
+- validate-skill-syntax.py: 0 errors, 0 warnings across all 8 SKILL.md files.
 
 ### Deferred Items
-- AC8 (`github_check "gh pr checks" "Run bats tests"`) は CI 完了後に `/verify` で確認。
-- Post-merge observation（fix-cycle での Tier 0 自動修復観察）は次回 fix-cycle まで未確定。
-- `fixture` 検出パターン（ヒューリスティック）の実フレームワーク出力への精度は bats テストで代表ケースを確認済みだが、網羅的ではない。
+- Post-merge observation (fix-cycle での Tier 0 自動修復観察) は次回 fix-cycle まで未確定。
+- `"No such file or directory"` infra over-classification (SHOULD) — accepted trade-off per Spec Uncertainty; may be refined in a follow-up Issue if real-world false positives emerge.
 
 ### Notes for Next Phase
-- PR #612。CI が通れば `/review` → `/merge` → `/verify` の通常フローへ。
-- 全 729 bats テストが PASS（新規 8 件含む）、`validate-skill-syntax.py` と `check-forbidden-expressions.sh` もクリーン。
-- verify で確認すべき未チェック AC: AC8 (`github_check "gh pr checks" "Run bats tests"`) のみ。他 AC1-7/AC9/AC10 はチェック済み。
+- No MUST issues. Proceed with `/merge 612`.
+- PR is ready to merge: all ACs PASS, all CI PASS, no blocking review findings.
+- Post-merge: run `/verify 586` to confirm AC8 (github_check CI) and observe Post-merge AC (Tier 0 auto-repair observation on next fix-cycle).

--- a/docs/spec/issue-586-tier0-test-failure-recovery.md
+++ b/docs/spec/issue-586-tier0-test-failure-recovery.md
@@ -214,20 +214,35 @@ Tier 0 コンテキストでの「escalate to Tier 3」は、既存 Step 9 FAIL 
 - AC7 `section_contains "### Step 9"` は見出しの部分一致（`Step 9` が `Step 9: Run Tests` に一致）で機能することを verify-executor.md で確認。
 - 新スクリプトの権限は `.claude/settings.json.template` の `scripts/*.sh` ワイルドカードでカバーされ、settings.json 変更不要であることを確認。
 
+## Code Retrospective
+
+### Deviations from Design
+
+- None. Implementation followed the Spec exactly: `test-failure-classify.sh` uses `--log <file>` interface + stdout category + exit 0/1 pattern; Tier 0 block inserted verbatim from Implementation Step 3; allowed-tools updated; structure.md updated with 50/60 file counts and new entry.
+
+### Design Gaps/Ambiguities
+
+- The `fixture` detection pattern (`expected .+, got .+`) is confirmed to be a heuristic with acknowledged false-positive risk (Spec Uncertainty section). The safety guard (tests/ only, max 1 retry, fallthrough on failure) bounds the impact regardless of misclassification.
+- `docs/ja/structure.md` sync was required (not explicitly called out in Spec Changed Files, but covered by the `docs/translation-workflow.md` rule). Updated counts and added Japanese entry for `test-failure-classify.sh` in the same commit as `docs/structure.md`.
+
+### Rework
+
+- None. All verification commands passed on first implementation.
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
-- Tier 0 は `skills/code/SKILL.md` Step 9 内に追加。test FAIL 時の最初のアクションで、修復可（snapshot/mock/fixture）のみ tests/ 限定・最大 1 回の自動修復を試み、修復不可（logic/infra）と失敗時は既存 Step 9 FAIL ハンドリングへフォールスルー。
-- 分類は新スクリプト `scripts/test-failure-classify.sh`（`--log <file>` → stdout カテゴリ → exit 0/1）に委譲。
-- rubric の 5 要件を満たす Tier 0 本文テンプレートを Implementation Step 3 に直接記載済み（実装知識の backfill）。
+- Spec の Implementation Step 3 に記載の Tier 0 テンプレートをそのまま SKILL.md Step 9 に挿入した。半角感嘆符なし（Forbidden Expressions 準拠）。
+- `test-failure-classify.sh` は `--log <file>` + stdout カテゴリ + exit 0/1 パターンで実装。`apply-fallback.sh`/`detect-wrapper-anomaly.sh` と同じ I/F。
+- `docs/ja/structure.md` の sync は Spec Changed Files に明示されていなかったが `docs/translation-workflow.md` ルールで必要。同じコミットで更新した。
 
 ### Deferred Items
-- フレームワーク別の実失敗出力に対する分類精度検証は bats fixture で実施（Uncertainty 参照）。
-- post-merge observation（fix-cycle で Tier 0 自動修復を観察）は次回 fix-cycle まで未確定。
+- AC8 (`github_check "gh pr checks" "Run bats tests"`) は CI 完了後に `/verify` で確認。
+- Post-merge observation（fix-cycle での Tier 0 自動修復観察）は次回 fix-cycle まで未確定。
+- `fixture` 検出パターン（ヒューリスティック）の実フレームワーク出力への精度は bats テストで代表ケースを確認済みだが、網羅的ではない。
 
 ### Notes for Next Phase
-- `skills/code/SKILL.md` allowed-tools への `${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*` 追加（Step 4）を必ず行うこと。漏れると「Validate skill syntax」CI が失敗する。
-- SKILL.md 本文には半角の感嘆符を入れない。Tier 0 ブロックは番号付きリスト（散文）で、トリプルバックティックのリテラル提示は不要。
-- structure.md は scripts `(50 files)` / tests `(60 files)` の両方を更新し、Scripts > Process management に新スクリプト項目を追加すること（AC9/AC10）。
-- bats テストは `test-failure-classify.sh` を直接呼ぶ（WHOLEWORK_SCRIPT_DIR モック不要、自己参照除外も不要）。
+- PR #612。CI が通れば `/review` → `/merge` → `/verify` の通常フローへ。
+- 全 729 bats テストが PASS（新規 8 件含む）、`validate-skill-syntax.py` と `check-forbidden-expressions.sh` もクリーン。
+- verify で確認すべき未チェック AC: AC8 (`github_check "gh pr checks" "Run bats tests"`) のみ。他 AC1-7/AC9/AC10 はチェック済み。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (49 files)
+├── scripts/             # Utility scripts used by skills and agents (50 files)
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
@@ -39,7 +39,7 @@ wholework/
 │   └── workflows/
 │       ├── test.yml             # CI: bats tests, skill syntax validation, forbidden expressions check, and macOS shell compatibility test
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
-├── tests/               # Bats test files for scripts (59 files)
+├── tests/               # Bats test files for scripts (60 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -188,6 +188,7 @@ Key modules:
 - `scripts/wait-ci-checks.sh` — wait for all CI checks to complete on a PR before running claude
 - `scripts/worktree-merge-push.sh` — acquire short-lived patch lock and merge worktree branch + push to main (with rebase retry)
 - `scripts/detect-wrapper-anomaly.sh` — detect known failure patterns in shell wrapper output and generate Auto Retrospective markdown fragments
+- `scripts/test-failure-classify.sh` — classify test failure output into recovery categories (snapshot/mock/fixture/logic/infra); exit 0 = repairable, exit 1 = not repairable
 - `scripts/validate-recovery-plan.sh` — validate recovery plan JSON from orchestration-recovery sub-agent (schema check + forbidden ops guard)
 - `scripts/apply-fallback.sh` — Tier 2 bash projection of `modules/orchestration-fallbacks.md`; detects known symptom anchors from wrapper logs and dispatches recovery handlers (initial full-impl: dco-signoff-missing-autofix)
 - `scripts/spawn-recovery-subagent.sh` — Tier 3 recovery orchestrator invoked by `run-auto-sub.sh`; spawns `agents/orchestration-recovery` via `claude -p`, validates the returned plan with `validate-recovery-plan.sh`, and enforces concurrency via `WHOLEWORK_MAX_RECOVERY_SUBAGENTS` mkdir-based slot locks

--- a/scripts/test-failure-classify.sh
+++ b/scripts/test-failure-classify.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# test-failure-classify.sh - Classify test failure output into recovery categories.
+#
+# Usage: test-failure-classify.sh --log <test-output-file>
+#
+# Outputs a single category to stdout:
+#   snapshot  - snapshot mismatch (repairable, exit 0)
+#   mock      - mock/call expectation mismatch (repairable, exit 0)
+#   fixture   - literal value mismatch in assertion (repairable, exit 0)
+#   logic     - logic error or unrecognized failure (not repairable, exit 1)
+#   infra     - infrastructure/environment failure (not repairable, exit 1)
+#
+# Exit 0: repairable (snapshot/mock/fixture)
+# Exit 1: not repairable (infra/logic)
+# Bash 3.2+ compatible.
+
+set -uo pipefail
+
+LOG_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log)
+      if [[ -z "${2:-}" ]]; then
+        echo "Error: --log requires a file path" >&2
+        exit 1
+      fi
+      LOG_FILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Error: unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$LOG_FILE" ]]; then
+  echo "Error: --log <test-output-file> is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "Error: log file not found: $LOG_FILE" >&2
+  exit 1
+fi
+
+# Detection priority: infra first (may co-occur with other patterns), then
+# snapshot, mock, fixture in order, falling back to logic.
+
+# 1. infra: environment/tooling failures take highest priority
+if grep -qiE "command not found|permission denied|No such file or directory|ModuleNotFoundError" "$LOG_FILE" 2>/dev/null; then
+  echo "infra"
+  exit 1
+fi
+
+# 2. snapshot: snapshot mismatch patterns
+if grep -qiE "snapshot doesn't match|expected snapshot to be|--update-snapshot" "$LOG_FILE" 2>/dev/null; then
+  echo "snapshot"
+  exit 0
+fi
+
+# 3. mock: call/argument expectation patterns
+if grep -qiE "expected calls|not called with expected arguments|mock returned" "$LOG_FILE" 2>/dev/null; then
+  echo "mock"
+  exit 0
+fi
+
+# 4. fixture: literal value comparison mismatch (heuristic: "expected ... got ..." line)
+if grep -qiE "expected .+, got .+" "$LOG_FILE" 2>/dev/null; then
+  echo "fixture"
+  exit 0
+fi
+
+# 5. logic: default for unrecognized failures
+echo "logic"
+exit 1

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -2,7 +2,7 @@
 name: code
 description: Local implementation (`/code 123`). Size auto-detection routes XS/S→patch (direct commit to main), M/L→branch+PR. Override with `--patch`/`--pr`.
 context: fork
-allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
+allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
 # Local Implementation
@@ -221,6 +221,27 @@ Skip this sub-step if no out-of-scope remediations are identified.
 ### Step 9: Run Tests
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/test-runner.md` and follow the "Processing Steps" section to run tests.
+
+#### Tier 0: Structured Test-Failure Recovery
+
+On test FAIL, before the generic 1-repair-attempt flow below, run structured recovery:
+
+1. Write the failing test output to `.tmp/test-failure-recovery-$NUMBER.log`.
+2. Classify the failure before acting: run
+   `${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh --log .tmp/test-failure-recovery-$NUMBER.log`
+   and read the category from stdout.
+3. Route by category:
+   - `snapshot` / `mock` / `fixture` (repairable): perform at most one targeted auto-fix attempt for
+     that class (regenerate snapshot / rebuild mock expectations / update fixture literal). No loop.
+   - `logic` / `infra` (not repairable): skip Tier 0 and escalate immediately to Tier 3 — fall through
+     to the existing Step 9 FAIL handling below (in `/auto` this path reaches orchestration Tier 3 recovery).
+4. Safety guard — limit changes to the `tests/` directory: after the auto-fix, run `git status --porcelain`
+   and confirm only `tests/` paths changed. If any non-`tests/` file changed, revert the Tier 0 changes
+   (`git checkout -- <files>`) and fall through to the existing FAIL handling.
+5. Re-run tests once: PASS → continue to commit; still FAIL → fall through to the existing Step 9 FAIL
+   handling (generic 1-repair-attempt / route-specific abort/continue).
+6. Record the Tier 0 attempt (classification, files changed, outcome) in the Spec Code Retrospective (Step 12),
+   and append attempt details to `.tmp/test-failure-recovery-$NUMBER.log` for Tier 3 sub-agent reference.
 
 **Test FAIL handling (when test-runner.md reports FAIL):**
 

--- a/tests/test-failure-classify.bats
+++ b/tests/test-failure-classify.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+
+# Tests for test-failure-classify.sh
+# No WHOLEWORK_SCRIPT_DIR mock needed (script does not call sibling scripts).
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/test-failure-classify.sh"
+
+@test "classify: snapshot failure pattern outputs 'snapshot' with status 0" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    cat > "$LOG_FILE" <<'EOF'
+FAIL  tests/snapshots.test.js
+  - renders component correctly
+    snapshot doesn't match stored snapshot
+    expected snapshot to be equal to stored value
+    Run with --update-snapshot to update
+EOF
+    run bash "$SCRIPT" --log "$LOG_FILE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "snapshot" ]
+}
+
+@test "classify: mock failure pattern outputs 'mock' with status 0" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    cat > "$LOG_FILE" <<'EOF'
+FAIL  tests/api.test.js
+  - calls fetchData with correct args
+    expected calls: 1
+    actual calls: 0
+    not called with expected arguments
+EOF
+    run bash "$SCRIPT" --log "$LOG_FILE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "mock" ]
+}
+
+@test "classify: fixture failure pattern outputs 'fixture' with status 0" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    cat > "$LOG_FILE" <<'EOF'
+FAIL  tests/parser.test.js
+  - parses status field
+    AssertionError: expected "active", got "inactive"
+EOF
+    run bash "$SCRIPT" --log "$LOG_FILE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "fixture" ]
+}
+
+@test "classify: logic failure outputs 'logic' with status 1" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    cat > "$LOG_FILE" <<'EOF'
+FAIL  tests/calculator.test.js
+  - adds two numbers correctly
+    TypeError: Cannot read properties of null (reading 'value')
+    at Calculator.add (src/calculator.js:12:22)
+EOF
+    run bash "$SCRIPT" --log "$LOG_FILE"
+    [ "$status" -eq 1 ]
+    [ "$output" = "logic" ]
+}
+
+@test "classify: infra failure (command not found) outputs 'infra' with status 1" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    cat > "$LOG_FILE" <<'EOF'
+bats: /usr/local/bin/node: command not found
+Error: Cannot find module 'jest'
+EOF
+    run bash "$SCRIPT" --log "$LOG_FILE"
+    [ "$status" -eq 1 ]
+    [ "$output" = "infra" ]
+}
+
+@test "classify: infra takes priority over other patterns" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    cat > "$LOG_FILE" <<'EOF'
+command not found: bats
+snapshot doesn't match stored snapshot
+EOF
+    run bash "$SCRIPT" --log "$LOG_FILE"
+    [ "$status" -eq 1 ]
+    [ "$output" = "infra" ]
+}
+
+@test "classify: missing --log argument exits non-zero" {
+    run bash "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--log"* ]]
+}
+
+@test "classify: --log with nonexistent file exits non-zero" {
+    run bash "$SCRIPT" --log /nonexistent/path/test.log
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not found"* ]]
+}


### PR DESCRIPTION
## Summary

- Add `scripts/test-failure-classify.sh`: classifies test failure output into 5 categories (snapshot/mock/fixture/logic/infra). Exit 0 = repairable (snapshot/mock/fixture), exit 1 = not repairable (logic/infra). Uses `--log <file>` interface matching existing `apply-fallback.sh` / `detect-wrapper-anomaly.sh` pattern.
- Add `tests/test-failure-classify.bats`: 8 tests covering all 5 classification categories plus argument/file error handling.
- Update `skills/code/SKILL.md` Step 9: insert `#### Tier 0: Structured Test-Failure Recovery` block before the existing generic 1-repair-attempt FAIL handling. Add `test-failure-classify.sh:*` to `allowed-tools`.
- Update `docs/structure.md` and `docs/ja/structure.md`: scripts count 49→50, tests count 59→60, add `test-failure-classify.sh` entry to Scripts > Process management.

## Verification (pre-merge)

- `scripts/test-failure-classify.sh` exists and passes `bash -n` syntax check
- Script contains detection logic for snapshot, mock, and fixture patterns
- `skills/code/SKILL.md` Step 9 contains "Tier 0" and references `test-failure-classify.sh`
- Tier 0 block specifies all 5 required behaviors (classify before acting, tests/-only guard, max 1 retry, Code Retrospective recording, logic-error Tier 3 escalation)
- `docs/structure.md` shows `(50 files)` for scripts and `(60 files)` for tests
- CI: bats test suite passes (729 tests including 8 new classification tests)

## Verification (post-merge)

- Observe Tier 0 auto-repair when a mock/snapshot class test failure occurs in the next fix-cycle

closes #586