### PR TITLE
Issue #514: Add post-merge manual implementation guard to code and spec skills

### DIFF
--- a/docs/spec/issue-514-fix-postmerge-manual-skip.md
+++ b/docs/spec/issue-514-fix-postmerge-manual-skip.md
@@ -44,3 +44,31 @@
 - review 側の強化（spec-deviation 検出）は本 Issue のスコープ外
 - ガードテキストは SKILL.md body 内に追加するため、半角 `!` は使用しない（CLAUDE.md の Forbidden Expression）
 - `skills/spec/SKILL.md` の `**Step recording rules:**` ブロックは SPEC_DEPTH=full テンプレート（2 箇所）と SPEC_DEPTH=light テンプレートの計 3 箇所あるが、実際の Spec 生成で使われるのはテンプレートの `## Implementation Steps` 節の直下のブロック（full テンプレートは line 498 付近、light テンプレートは別途）。両テンプレートに共通のルールとして追加する方が漏れがない。調査結果: SKILL.md の `**Step recording rules:**` は full テンプレート本文に 1 箇所（line 498 付近）、light テンプレートには記録ルールの記述がないため、full テンプレートの Step recording rules のみに追加する。
+
+## Code Retrospective
+
+### Deviations from Design
+- None
+
+### Design Gaps/Ambiguities
+- Spec Notes の調査結果（`**Step recording rules:**` が full テンプレートの 1 箇所のみ）が正確であり、light テンプレートには記録ルールがなかったため追加不要と判断できた。追加の調査コストなしに Spec を信頼して実装できた。
+
+### Rework
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `skills/code/SKILL.md` Step 8 の「Implement the code...」の直後に guard paragraph を挿入（`**Implementation scope: all Spec steps are required**`）。箇条書きではなく段落形式を採用し、verify-type と実装要否の独立性を明示した
+- `skills/spec/SKILL.md` の `**Step recording rules:**` 内の `**Acceptance criteria mapping**` 直後に bullet を追加。守備範囲は full テンプレートの 1 箇所のみ（light テンプレートには記録ルールブロックなし）
+- 半角 `!` 禁止制約を遵守し、ダッシュ（`—`）+ "not whether" 形式で否定表現を実現
+
+### Deferred Items
+- Post-merge AC（`observation event=auto-run`）: `/auto` で post-merge manual AC を含む Issue を実行した際の観察による確認。verify phase での対応事項
+- review 側強化（spec-deviation 検出で post-merge manual 項目の実装漏れを MUST 検出）は本 Issue スコープ外。別 Issue 対応
+
+### Notes for Next Phase
+- 変更は 2 ファイルへのテキスト追加のみ。コード変更・ロジック変更・テスト変更はない
+- 両 pre-merge AC（rubric + file_contains）が PASS 確認済み
+- bats テスト 771 件 PASS、forbidden-expressions チェック PASS、validate-skill-syntax PASS

--- a/docs/spec/issue-514-fix-postmerge-manual-skip.md
+++ b/docs/spec/issue-514-fix-postmerge-manual-skip.md
@@ -57,18 +57,32 @@
 - None
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `skills/code/SKILL.md` Step 8 の「Implement the code...」の直後に guard paragraph を挿入（`**Implementation scope: all Spec steps are required**`）。箇条書きではなく段落形式を採用し、verify-type と実装要否の独立性を明示した
-- `skills/spec/SKILL.md` の `**Step recording rules:**` 内の `**Acceptance criteria mapping**` 直後に bullet を追加。守備範囲は full テンプレートの 1 箇所のみ（light テンプレートには記録ルールブロックなし）
-- 半角 `!` 禁止制約を遵守し、ダッシュ（`—`）+ "not whether" 形式で否定表現を実現
+- REVIEW_DEPTH=light（Issue Size=M および --light フラグ）で review-light 軽量統合レビューを実施
+- 外部レビューツール（Copilot/Claude Code Review/CodeRabbit）は無効設定のため全て省略
+- 全4観点（Spec 逸脱・エッジケース・セキュリティ・ドキュメント整合性）で問題なし、MUST 課題ゼロ
 
 ### Deferred Items
 - Post-merge AC（`observation event=auto-run`）: `/auto` で post-merge manual AC を含む Issue を実行した際の観察による確認。verify phase での対応事項
 - review 側強化（spec-deviation 検出で post-merge manual 項目の実装漏れを MUST 検出）は本 Issue スコープ外。別 Issue 対応
 
 ### Notes for Next Phase
-- 変更は 2 ファイルへのテキスト追加のみ。コード変更・ロジック変更・テスト変更はない
-- 両 pre-merge AC（rubric + file_contains）が PASS 確認済み
-- bats テスト 771 件 PASS、forbidden-expressions チェック PASS、validate-skill-syntax PASS
+- 課題なし、CI 全 SUCCESS のため `/merge 633` で即座にマージ可
+- Post-merge AC（observation: event=auto-run）は merge 後の `/auto` 実行で確認
+- 変更はテキスト追加のみであり、マージ後のリグレッションリスクは低い
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+特記なし。Spec の Implementation Steps 2 件と PR diff が 1:1 で対応しており、乖離は検出されなかった。テキスト追加のみの変更であり、乖離が生じにくい性質の PR だった。
+
+### 繰り返し課題
+
+特記なし。Spec のスコープ（2 ファイルへのテキスト追加）に対して PR が過不足なく対応しており、同種の課題は見当たらない。
+
+### 受け入れ条件検証の困難さ
+
+特記なし。全 pre-merge AC が `rubric` + `file_contains` の組み合わせで検証可能であり、UNCERTAIN 件数はゼロだった。Post-merge AC は `observation: event=auto-run` 型であり、verify phase での確認が必要だが、これは設計上の意図である。

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -195,6 +195,10 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/domain-loader.md` and follow the "Processing
 
 Implement the code following the "Implementation Steps" in the Spec.
 
+**Implementation scope: all Spec steps are required**
+
+Implement every step listed in the Spec's "Implementation Steps" regardless of the verify-type of its associated acceptance condition. A step whose AC is marked `<!-- verify-type: post-merge manual -->` must still be implemented in this PR — "post-merge manual" describes *how the AC is verified* (by human observation after merge), not whether the step can be skipped. Omitting a step because its AC is post-merge manual is an implementation error.
+
 - Use TaskCreate/TaskUpdate to manage tasks while working
 - Commit after each step completes
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -499,6 +499,7 @@ When the Issue involves real external or MCP tool calls (examples: verify comman
 - **Step numbers**: integers only (Step 1, 2, 3...). No decimal numbers (Step 1.5, etc.). Renumber subsequent steps when inserting new ones.
 - **Dependencies**: note "(after N)" for sequential deps, "(parallel with N, M)" for parallel-safe steps
 - **Acceptance criteria mapping**: note "(→ acceptance criteria X)" for each step
+- **post-merge manual steps are required**: even when an AC's verify-type is `post-merge manual`, the corresponding implementation step is mandatory in the current PR. "post-merge manual" describes how the AC is verified (human observation after merge), not whether implementation can be deferred. Record the step explicitly so the code phase does not skip it.
 - **Insertion position**: specify by nearby code context (e.g., "immediately before `--dangerously-skip-permissions`") rather than line numbers. Line numbers shift as files change and become unreliable guides for implementation.
 
 1. Step 1 (→ acceptance criteria A)


### PR DESCRIPTION
## Summary

- `skills/code/SKILL.md` Step 8 に、post-merge manual verify-type を持つ AC に対応する Implementation Steps であっても実装が必須であることを明示するガードテキストを追加した
- `skills/spec/SKILL.md` の Step recording rules に、post-merge manual ステップの実装義務を明示するガイダンスを追加した

## Verification (pre-merge)

- `skills/code/SKILL.md` Step 8 に post-merge manual 含む全 Implementation Steps の実装義務を明示するガードテキストが追加される
- `skills/spec/SKILL.md` の Implementation Steps 記録ルールに、post-merge manual ステップの実装義務を示すガイダンスが追加される

## Verification (post-merge)

- `/auto` で post-merge manual AC を含む Issue を実行した際、対応する Implementation Steps がすべて実装されていることが確認できる（observation: event=auto-run）

closes #514