### PR TITLE
Issue #627: Namespace auto-checkpoint batch state by BATCH_ID

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -34,7 +34,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（70 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（71 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents
@@ -176,7 +176,7 @@ wholework/
 - `scripts/triage-backlog-filter.sh` — triage 向けバックログフィルタ
 
 **プロセス管理:**
-- `scripts/auto-checkpoint.sh` — `/auto --resume` 用チェックポイントヘルパー: 単一 Issue の verify カウンタと batch 残リストの atomic 読み書き削除（サブコマンド: `read_single`、`write_single`、`delete_single`、`read_batch`、`write_batch`、`update_batch`、`delete_batch`）
+- `scripts/auto-checkpoint.sh` — `/auto --resume` 用チェックポイントヘルパー: 単一 Issue の verify カウンタと batch 残リストの atomic 読み書き削除。BATCH_ID 名前空間化により並列 `--batch` セッション間の衝突を防止（サブコマンド: `read_single`、`write_single`、`delete_single`、`read_batch`、`write_batch`、`update_batch`、`delete_batch`、`list_active_batches`）
 - `scripts/watchdog-defaults.sh` — `WATCHDOG_TIMEOUT_DEFAULT` 定数と `load_watchdog_timeout` 関数を提供する run-*.sh 用 source 可能なヘルパー
 - `scripts/claude-watchdog.sh` — `claude -p` 呼び出し用の watchdog ラッパー（hang 検知 + 1 回リトライ）
 - `scripts/reconcile-phase-state.sh` — 全 phase の precondition チェックと completion チェックを行う汎用 state reconciler。`modules/phase-state.md` SSoT に基づく JSON v1 を出力（watchdog-reconcile.sh の後継）

--- a/docs/spec/issue-627-auto-checkpoint-batch-id.md
+++ b/docs/spec/issue-627-auto-checkpoint-batch-id.md
@@ -71,19 +71,34 @@
 
 - N/A
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Spec定義と実装の整合性は良好。`_batch_file_path`、`list_active_batches`、BATCH_ID生成・伝播すべてSpec通りに実装されていた。
+- `_add_to_active_index` の戻り値チェック漏れを発見・修正。Specには記載のないエラー処理の詳細だったが、resume機能の信頼性に影響するSHOULD指摘として適切だった。
+
+### Recurring issues
+
+- なし（同種の問題の繰り返しは見られない）。
+- エラー処理の非対称パターン（既存ファイル更新分岐は`if ! jq ...`でチェックするが、新規作成分岐はチェックしない）が1件見られたが、CONSIDERレベルで留置。今後のshell scriptレビューでは非対称なエラーチェックパターンに注意する。
+
+### Acceptance criteria verification difficulty
+
+- 7件のpre-merge ACすべてがgrep/file_contains/rubric/commandで自動検証可能だった。UNCERTAINなし。
+- `command`型2件（bats/bash -n）はsafe modeでCI参照フォールバックを使用→SUCCESS確認。verify commandの品質は高い。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- BATCH_ID は `${PPID}-$(date +%s)` 形式を採用（bash 3.2+ 互換、実用的な一意性）
-- arg count 検出による旧 API 後方互換（スクリプトレベル）を採用し、既存 bats テスト（`auto-checkpoint.bats`）を無変更で維持
-- `"default"` BATCH_ID は active index に追加しない設計で単独運用ユーザーへの影響ゼロを保証
+- SHOULD指摘（`_add_to_active_index`戻り値チェック）のみ修正。CONSIDERは留置。MUSTイシューなし→COMMENTイベントでPR Review投稿
+- review-lightエージェントが未登録のため、SKILL.mdのreview-light定義に従いインライン実行
 
 ### Deferred Items
-- `--batch-id <id>` フラグによる Resume mode での明示的 BATCH_ID 指定は未実装（Issue 本文の提案だが Spec 範囲外）
-- Post-merge AC (observation) の確認は /verify フェーズで実施
+- Post-merge AC (observation: concurrent-batch, batch-resume) の確認は /verify フェーズで実施
+- `_add_to_active_index` else分岐のエラーチェック非対称（CONSIDER）は留置
 
 ### Notes for Next Phase
-- `tests/auto-checkpoint-batch.bats` 3 件 + 既存 `tests/auto-checkpoint.bats` 6 件 すべて green であることを verify 時に確認すること
-- pre-merge verify 7 件すべて PASS 済み（Issue body のチェックボックス更新済み）
-- `rubric` タイプの AC5（backward compat）は `/verify` 時に再確認が必要
+- MUSTイシューなし、全CIジョブSUCCESSのため `/merge 634` で進めてOK
+- `/verify` 時にPost-merge observation AC 2件（concurrent-batch / batch-resume）が残っていることを確認すること

--- a/docs/spec/issue-627-auto-checkpoint-batch-id.md
+++ b/docs/spec/issue-627-auto-checkpoint-batch-id.md
@@ -56,3 +56,34 @@
 - **Resume mode の non-interactive 選択**: `list_active_batches` の出力が複数行の場合、最後の行 (最新) を BATCH_ID として使用する。
 - **verify-executor ripgrep**: `grep "BATCH_ID|batch_id"` は `|` が alternation として機能するため、実装コードに "BATCH_ID" が含まれれば PASS する。
 - **Pre-merge verify 数**: 7 項目 (light limit=5 を超過)。Issue body が 7 項目定義済みのため verbatim コピーとし、削減しない。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `tests/auto-checkpoint.bats`（既存）の更新は Spec の "Changed Files" に未記載だったが、`write_batch` / `update_batch` の API 変更（引数追加）後も既存テストが通るよう arg count 検出で旧 API を吸収した。既存テストの改変は不要だった。
+
+### Design Gaps/Ambiguities
+
+- 後方互換の実現方法について Spec は「BATCH_ID 未指定時は default」と定義するが、スクリプトレベルで 3-arg `write_batch` と 4-arg `write_batch` をどう区別するかが未定義だった。arg count 検出（`$# == 3` → old API、`$# >= 4` → new API）で解決し、既存テストを無変更で通過させた。
+
+### Rework
+
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- BATCH_ID は `${PPID}-$(date +%s)` 形式を採用（bash 3.2+ 互換、実用的な一意性）
+- arg count 検出による旧 API 後方互換（スクリプトレベル）を採用し、既存 bats テスト（`auto-checkpoint.bats`）を無変更で維持
+- `"default"` BATCH_ID は active index に追加しない設計で単独運用ユーザーへの影響ゼロを保証
+
+### Deferred Items
+- `--batch-id <id>` フラグによる Resume mode での明示的 BATCH_ID 指定は未実装（Issue 本文の提案だが Spec 範囲外）
+- Post-merge AC (observation) の確認は /verify フェーズで実施
+
+### Notes for Next Phase
+- `tests/auto-checkpoint-batch.bats` 3 件 + 既存 `tests/auto-checkpoint.bats` 6 件 すべて green であることを verify 時に確認すること
+- pre-merge verify 7 件すべて PASS 済み（Issue body のチェックボックス更新済み）
+- `rubric` タイプの AC5（backward compat）は `/verify` 時に再確認が必要

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -41,7 +41,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (70 files)
+├── tests/               # Bats test files for scripts (71 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -184,7 +184,7 @@ Key modules:
 - `scripts/triage-backlog-filter.sh` — filter backlog for triage
 
 **Process management:**
-- `scripts/auto-checkpoint.sh` — checkpoint helper for `/auto --resume`: atomic read/write/delete of single-Issue verify counter and batch remaining list (subcommands: `read_single`, `write_single`, `delete_single`, `read_batch`, `write_batch`, `update_batch`, `delete_batch`)
+- `scripts/auto-checkpoint.sh` — checkpoint helper for `/auto --resume`: atomic read/write/delete of single-Issue verify counter and batch remaining list; BATCH_ID-namespaced per-session state files prevent parallel `--batch` collisions (subcommands: `read_single`, `write_single`, `delete_single`, `read_batch`, `write_batch`, `update_batch`, `delete_batch`, `list_active_batches`)
 - `scripts/watchdog-defaults.sh` — sourceable helper providing `WATCHDOG_TIMEOUT_DEFAULT` constant and `load_watchdog_timeout` function for run-*.sh scripts
 - `scripts/claude-watchdog.sh` — watchdog wrapper for `claude -p` invocations (hang detection + 1 retry)
 - `scripts/reconcile-phase-state.sh` — general-purpose state reconciler for precondition and completion checks across all phases; outputs JSON v1 per `modules/phase-state.md` SSoT (supersedes watchdog-reconcile.sh)

--- a/scripts/auto-checkpoint.sh
+++ b/scripts/auto-checkpoint.sh
@@ -5,20 +5,26 @@
 #   auto-checkpoint.sh read_single <NUMBER>
 #   auto-checkpoint.sh write_single <NUMBER> <COUNT>
 #   auto-checkpoint.sh delete_single <NUMBER>
-#   auto-checkpoint.sh read_batch
-#   auto-checkpoint.sh write_batch <REMAINING> <COMPLETED> <FAILED>
-#   auto-checkpoint.sh update_batch <NUMBER> complete|fail
-#   auto-checkpoint.sh delete_batch
+#   auto-checkpoint.sh read_batch [<BATCH_ID>]
+#   auto-checkpoint.sh write_batch [<BATCH_ID>] <REMAINING> <COMPLETED> <FAILED>
+#   auto-checkpoint.sh update_batch [<BATCH_ID>] <NUMBER> complete|fail
+#   auto-checkpoint.sh delete_batch [<BATCH_ID>]
+#   auto-checkpoint.sh list_active_batches
 #
 # Subcommand descriptions:
-#   read_single  NUMBER        Print verify_iteration_count (stale/absent -> 0)
-#   write_single NUMBER COUNT  Write .tmp/auto-state-NUMBER.json atomically
-#   delete_single NUMBER       Delete .tmp/auto-state-NUMBER.json (absent is noop)
-#   read_batch                 Print remaining list (space-separated; absent/empty -> "")
-#   write_batch REM COM FAIL   Write .tmp/auto-batch-state.json atomically
-#                              (each arg is space-separated number list; empty -> "")
-#   update_batch NUMBER state  Move NUMBER from remaining to completed or failed (atomic)
-#   delete_batch               Delete .tmp/auto-batch-state.json (absent is noop)
+#   read_single  NUMBER            Print verify_iteration_count (stale/absent -> 0)
+#   write_single NUMBER COUNT      Write .tmp/auto-state-NUMBER.json atomically
+#   delete_single NUMBER           Delete .tmp/auto-state-NUMBER.json (absent is noop)
+#   read_batch [BATCH_ID]          Print remaining list (space-separated; absent/empty -> "")
+#   write_batch [BATCH_ID] REM COM FAIL  Write per-BATCH_ID state file atomically;
+#                                        adds BATCH_ID to active index (skips "default")
+#   update_batch [BATCH_ID] NUMBER state  Move NUMBER from remaining to completed or failed
+#   delete_batch [BATCH_ID]        Delete batch state file; remove from active index
+#   list_active_batches            Print active BATCH_IDs one per line (absent/empty -> "")
+#
+# Backward compatibility: BATCH_ID omitted or "default" maps to .tmp/auto-batch-state.json
+# (same as the pre-BATCH_ID single-file behavior). "default" is not added to the active index.
+# write_batch and update_batch auto-detect old (3/2-arg) vs. new (4/3-arg) API by arg count.
 #
 # Design: reconciler-first / checkpoint-as-hint
 #   - Phase authority: GitHub labels + reconcile-phase-state.sh
@@ -29,6 +35,7 @@
 set -uo pipefail
 
 TMP_DIR=".tmp"
+ACTIVE_INDEX_PATH="${TMP_DIR}/auto-batch-active.json"
 
 _ensure_tmp() {
   mkdir -p "$TMP_DIR"
@@ -36,6 +43,18 @@ _ensure_tmp() {
 
 _now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# Return the file path for a given BATCH_ID.
+# Empty string or "default" -> .tmp/auto-batch-state.json (backward compat)
+# Any other value -> .tmp/auto-batch-state-${batch_id}.json
+_batch_file_path() {
+  local batch_id="${1:-}"
+  if [[ -z "$batch_id" || "$batch_id" == "default" ]]; then
+    echo "${TMP_DIR}/auto-batch-state.json"
+  else
+    echo "${TMP_DIR}/auto-batch-state-${batch_id}.json"
+  fi
 }
 
 # Emit a JSON array from a space-separated list of numbers.
@@ -58,6 +77,53 @@ _numbers_to_json_array() {
   done
   arr="${arr}]"
   echo "$arr"
+}
+
+# Add BATCH_ID to active index. Skips "default" and empty.
+_add_to_active_index() {
+  local batch_id="$1"
+  [[ -z "$batch_id" || "$batch_id" == "default" ]] && return 0
+  _ensure_tmp
+  local tmp_path="${ACTIVE_INDEX_PATH}.tmp"
+  local ts
+  ts=$(_now)
+
+  if [[ -f "$ACTIVE_INDEX_PATH" ]]; then
+    if ! jq --arg id "$batch_id" --arg ts "$ts" '
+      .active_batch_ids = ((.active_batch_ids // []) | if any(. == $id) then . else . + [$id] end) |
+      .last_update = $ts
+    ' "$ACTIVE_INDEX_PATH" > "$tmp_path"; then
+      rm -f "$tmp_path"
+      return 1
+    fi
+  else
+    jq -n \
+      --arg sv "v1" \
+      --arg id "$batch_id" \
+      --arg ts "$ts" \
+      '{schema_version: $sv, active_batch_ids: [$id], last_update: $ts}' \
+      > "$tmp_path"
+  fi
+  mv "$tmp_path" "$ACTIVE_INDEX_PATH"
+}
+
+# Remove BATCH_ID from active index. Skips "default" and empty.
+_remove_from_active_index() {
+  local batch_id="$1"
+  [[ -z "$batch_id" || "$batch_id" == "default" ]] && return 0
+  [[ ! -f "$ACTIVE_INDEX_PATH" ]] && return 0
+  local tmp_path="${ACTIVE_INDEX_PATH}.tmp"
+  local ts
+  ts=$(_now)
+
+  if ! jq --arg id "$batch_id" --arg ts "$ts" '
+    .active_batch_ids = ([(.active_batch_ids // [])[] | select(. != $id)]) |
+    .last_update = $ts
+  ' "$ACTIVE_INDEX_PATH" > "$tmp_path"; then
+    rm -f "$tmp_path"
+    return 1
+  fi
+  mv "$tmp_path" "$ACTIVE_INDEX_PATH"
 }
 
 # -----------------------------------------------------------------------
@@ -120,11 +186,14 @@ cmd_delete_single() {
 }
 
 # -----------------------------------------------------------------------
-# read_batch
+# read_batch BATCH_ID
 # Prints remaining list as space-separated numbers. "" if absent or empty.
+# BATCH_ID omitted or "default" -> .tmp/auto-batch-state.json (backward compat)
 # -----------------------------------------------------------------------
 cmd_read_batch() {
-  local path="${TMP_DIR}/auto-batch-state.json"
+  local batch_id="${1:-default}"
+  local path
+  path=$(_batch_file_path "$batch_id")
 
   if [[ ! -f "$path" ]]; then
     echo ""
@@ -137,16 +206,19 @@ cmd_read_batch() {
 }
 
 # -----------------------------------------------------------------------
-# write_batch REMAINING COMPLETED FAILED
-# Each argument is a space-separated number list (empty string for empty).
-# Writes .tmp/auto-batch-state.json atomically.
+# write_batch BATCH_ID REMAINING COMPLETED FAILED
+# Each list argument is a space-separated number list (empty string for empty).
+# Writes per-BATCH_ID state file atomically.
+# Adds BATCH_ID to active index (skips "default").
 # -----------------------------------------------------------------------
 cmd_write_batch() {
-  local remaining="$1"
-  local completed="$2"
-  local failed="$3"
+  local batch_id="$1"
+  local remaining="$2"
+  local completed="$3"
+  local failed="$4"
   _ensure_tmp
-  local path="${TMP_DIR}/auto-batch-state.json"
+  local path
+  path=$(_batch_file_path "$batch_id")
   local tmp_path="${path}.tmp"
   local ts
   ts=$(_now)
@@ -165,16 +237,20 @@ cmd_write_batch() {
     '{schema_version: $sv, mode: "list", remaining: $rem, completed: $comp, failed: $fail, last_update: $ts}' \
     > "$tmp_path"
   mv "$tmp_path" "$path"
+
+  _add_to_active_index "$batch_id"
 }
 
 # -----------------------------------------------------------------------
-# update_batch NUMBER complete|fail
+# update_batch BATCH_ID NUMBER complete|fail
 # Moves NUMBER from remaining to completed or failed. Atomic write.
 # -----------------------------------------------------------------------
 cmd_update_batch() {
-  local number="$1"
-  local action="$2"
-  local path="${TMP_DIR}/auto-batch-state.json"
+  local batch_id="$1"
+  local number="$2"
+  local action="$3"
+  local path
+  path=$(_batch_file_path "$batch_id")
   local tmp_path="${path}.tmp"
 
   if [[ ! -f "$path" ]]; then
@@ -207,12 +283,28 @@ cmd_update_batch() {
 }
 
 # -----------------------------------------------------------------------
-# delete_batch
-# Deletes .tmp/auto-batch-state.json. Absent is noop.
+# delete_batch BATCH_ID
+# Deletes batch state file. Removes BATCH_ID from active index.
+# Absent is noop.
 # -----------------------------------------------------------------------
 cmd_delete_batch() {
-  local path="${TMP_DIR}/auto-batch-state.json"
+  local batch_id="${1:-default}"
+  local path
+  path=$(_batch_file_path "$batch_id")
   rm -f "$path"
+  _remove_from_active_index "$batch_id"
+}
+
+# -----------------------------------------------------------------------
+# list_active_batches
+# Prints active BATCH_IDs one per line. Empty output if absent or none active.
+# -----------------------------------------------------------------------
+cmd_list_active_batches() {
+  if [[ ! -f "$ACTIVE_INDEX_PATH" ]]; then
+    return 0
+  fi
+
+  jq -r '(.active_batch_ids // []) | .[]' "$ACTIVE_INDEX_PATH" 2>/dev/null
 }
 
 # -----------------------------------------------------------------------
@@ -240,18 +332,35 @@ case "$SUBCMD" in
     cmd_delete_single "$1"
     ;;
   read_batch)
-    cmd_read_batch
+    cmd_read_batch "${1:-}"
     ;;
   write_batch)
-    [[ $# -lt 3 ]] && { echo "Usage: auto-checkpoint.sh write_batch <REMAINING> <COMPLETED> <FAILED>" >&2; exit 1; }
-    cmd_write_batch "$1" "$2" "$3"
+    # Detect old API (3 args: remaining completed failed) vs new API (4 args: batch_id remaining completed failed)
+    if [[ $# -eq 3 ]]; then
+      cmd_write_batch "default" "$1" "$2" "$3"
+    elif [[ $# -ge 4 ]]; then
+      cmd_write_batch "$1" "$2" "$3" "$4"
+    else
+      echo "Usage: auto-checkpoint.sh write_batch [<BATCH_ID>] <REMAINING> <COMPLETED> <FAILED>" >&2
+      exit 1
+    fi
     ;;
   update_batch)
-    [[ $# -lt 2 ]] && { echo "Usage: auto-checkpoint.sh update_batch <NUMBER> complete|fail" >&2; exit 1; }
-    cmd_update_batch "$1" "$2"
+    # Detect old API (2 args: number action) vs new API (3 args: batch_id number action)
+    if [[ $# -eq 2 ]]; then
+      cmd_update_batch "default" "$1" "$2"
+    elif [[ $# -ge 3 ]]; then
+      cmd_update_batch "$1" "$2" "$3"
+    else
+      echo "Usage: auto-checkpoint.sh update_batch [<BATCH_ID>] <NUMBER> complete|fail" >&2
+      exit 1
+    fi
     ;;
   delete_batch)
-    cmd_delete_batch
+    cmd_delete_batch "${1:-}"
+    ;;
+  list_active_batches)
+    cmd_list_active_batches
     ;;
   *)
     echo "Unknown subcommand: $SUBCMD" >&2

--- a/scripts/auto-checkpoint.sh
+++ b/scripts/auto-checkpoint.sh
@@ -238,7 +238,9 @@ cmd_write_batch() {
     > "$tmp_path"
   mv "$tmp_path" "$path"
 
-  _add_to_active_index "$batch_id"
+  if ! _add_to_active_index "$batch_id"; then
+    echo "Warning: failed to register batch_id '$batch_id' in active index" >&2
+  fi
 }
 
 # -----------------------------------------------------------------------

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auto
-description: Autonomous execution (`/auto 123`). Runs spec (when needed)→code→review→merge→verify in sequence. XL Issues use sub-issue dependency graph with parallel execution. Size auto-detection with `--patch`/`--pr` and `--review=light`/`--review=full` overrides. Issues without `phase/*` labels start from issue triage. `--batch N` processes N backlog XS/S Issues; `--batch N1 N2 ...` processes the explicitly listed Issues in order. `--resume N` resumes a single Issue (restores verify counter from checkpoint); `--batch --resume` resumes an interrupted batch from `.tmp/auto-batch-state.json`.
+description: Autonomous execution (`/auto 123`). Runs spec (when needed)→code→review→merge→verify in sequence. XL Issues use sub-issue dependency graph with parallel execution. Size auto-detection with `--patch`/`--pr` and `--review=light`/`--review=full` overrides. Issues without `phase/*` labels start from issue triage. `--batch N` processes N backlog XS/S Issues; `--batch N1 N2 ...` processes the explicitly listed Issues in order (assigns a BATCH_ID for parallel-safe checkpointing). `--resume N` resumes a single Issue (restores verify counter from checkpoint); `--batch --resume` resumes an interrupted batch using `list_active_batches` to identify the target session.
 allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, gh issue view:*, gh issue list:*, gh issue close:*, gh issue comment:*, gh issue create:*, gh pr list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-sub-issue-graph.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-spec.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-issue.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-wrapper-anomaly.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/validate-recovery-plan.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*), Read, Edit, Glob, Grep, Write, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
@@ -703,44 +703,50 @@ Process the selected N Issues **sequentially** (serially):
 
 **Batch checkpoint initialization (List mode only):**
 
-At the start of List mode, write the full batch state:
+At the start of List mode, generate a BATCH_ID and write the full batch state:
 ```
-${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh write_batch "N1 N2 N3" "" ""
+BATCH_ID="${PPID}-$(date +%s)"
+${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh write_batch "$BATCH_ID" "N1 N2 N3" "" ""
 ```
-(first arg: space-separated full list in double quotes — quoting is required when the list contains spaces; second and third args: empty strings for completed and failed)
+(`BATCH_ID` is used for all subsequent checkpoint calls in this batch session; first list arg: space-separated full list in double quotes — quoting is required when the list contains spaces; remaining args: empty strings for completed and failed)
 
 Process each Issue in `BATCH_LIST` in order:
 
 1. Check Issue labels: `gh issue view $NUMBER --json labels -q '.labels[].name'`
 2. **If no `phase/*` labels**: run `${CLAUDE_PLUGIN_ROOT}/scripts/run-issue.sh $NUMBER` (issue triage → Size setting → `phase/ready` assignment)
-   - On failure: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
-3. Re-check Size: call `${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh $NUMBER`; if Size is XL: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
+   - On failure: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
+3. Re-check Size: call `${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh $NUMBER`; if Size is XL: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
 4. Run `${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh $NUMBER` (all phases spec→code→review→merge→verify, auto-starting from the current `phase/*` state)
    - On success: proceed to step 5
-   - On failure: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
+   - On failure: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
 5. **Verify orchestration** (after run-auto-sub.sh success):
    - Re-fetch current labels: `gh issue view $NUMBER --json labels -q '.labels[].name'`
    - If `phase/verify` is present in labels:
      - If `--non-interactive` is NOT in ARGUMENTS: invoke `Skill(skill="wholework:verify", args="$NUMBER")` in the parent session
-       - On success: call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch $NUMBER complete`
-       - On failure or output contains `MAX_ITERATIONS_REACHED`: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch $NUMBER fail`; skip to the next Issue
-     - If `--non-interactive` IS in ARGUMENTS: output "Skipping verify for #$NUMBER (non-interactive mode); phase/verify remains"; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch $NUMBER complete`
-   - If `phase/verify` is NOT in labels: call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch $NUMBER complete`
+       - On success: call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
+       - On failure or output contains `MAX_ITERATIONS_REACHED`: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER fail`; skip to the next Issue
+     - If `--non-interactive` IS in ARGUMENTS: output "Skipping verify for #$NUMBER (non-interactive mode); phase/verify remains"; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
+   - If `phase/verify` is NOT in labels: call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
 
 After all Issues are processed, delete the batch checkpoint:
 ```
-${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh delete_batch
+${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh delete_batch "$BATCH_ID"
 ```
 
 ### Resume mode (--batch --resume)
 
 Entered from Step 1 when `--batch --resume` is detected with no numeric tokens after `--batch`.
 
-1. Call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh read_batch` and capture the output as `REMAINING`.
-2. If `REMAINING` is empty: output "No resume target found. Run `/auto --batch N1 N2 ...` to start a new batch." and exit.
-3. Output a log line: "Resuming batch: remaining issues = $REMAINING"
-4. Treat `REMAINING` as `BATCH_LIST` and process each Issue following the same steps as `### List mode (--batch N1 N2 ...)`.
-   - Note: do NOT call `write_batch` again at the start (the existing `.tmp/auto-batch-state.json` is the live state); only call `update_batch` and `delete_batch` as per List mode.
+1. Call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh list_active_batches` and capture the output as `ACTIVE_BATCH_IDS` (newline-separated list).
+   - If `ACTIVE_BATCH_IDS` is non-empty:
+     - In interactive mode: present candidates to user via AskUserQuestion to select a BATCH_ID
+     - In non-interactive mode: use the last line (most recent entry) as `BATCH_ID`
+   - If `ACTIVE_BATCH_IDS` is empty: fall back to `BATCH_ID="default"` (handles pre-BATCH_ID migration case where `.tmp/auto-batch-state.json` may exist from an older run)
+2. Call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh read_batch "$BATCH_ID"` and capture the output as `REMAINING`.
+3. If `REMAINING` is empty: output "No resume target found. Run `/auto --batch N1 N2 ...` to start a new batch." and exit.
+4. Output a log line: "Resuming batch: batch_id=$BATCH_ID, remaining issues = $REMAINING"
+5. Treat `REMAINING` as `BATCH_LIST` and process each Issue following the same steps as `### List mode (--batch N1 N2 ...)`.
+   - Note: do NOT call `write_batch` again at the start (the existing batch state file is the live state); only call `update_batch "$BATCH_ID"` and `delete_batch "$BATCH_ID"` as per List mode.
 
 ### Batch Completion Report
 
@@ -787,7 +793,9 @@ When checkpoint and labels conflict, labels win and the checkpoint is discarded 
 ```
 
 ```json
-// .tmp/auto-batch-state.json  (batch)
+// .tmp/auto-batch-state-${BATCH_ID}.json  (batch, per-session)
+// BATCH_ID="default" -> .tmp/auto-batch-state.json (backward compat)
+// BATCH_ID="12345-1718336400" -> .tmp/auto-batch-state-12345-1718336400.json
 {
   "schema_version": "v1",
   "mode": "list",
@@ -797,6 +805,19 @@ When checkpoint and labels conflict, labels win and the checkpoint is discarded 
   "last_update": "2026-04-22T16:10:05Z"
 }
 ```
+
+```json
+// .tmp/auto-batch-active.json  (active batch index)
+{
+  "schema_version": "v1",
+  "active_batch_ids": ["12345-1718336400", "67890-1718336500"],
+  "last_update": "2026-04-22T16:10:05Z"
+}
+```
+
+- `BATCH_ID` format: `${PPID}-$(date +%s)` (parent PID + Unix timestamp; bash 3.2+ compatible)
+- `"default"` BATCH_ID maps to `.tmp/auto-batch-state.json` and is not tracked in the active index
+- Parallel `/auto --batch` sessions each use a distinct BATCH_ID, so their state files do not collide
 
 Writes are **atomic**: write to `*.json.tmp` then `mv` to the target path to prevent corrupt reads on interruption.
 
@@ -816,7 +837,7 @@ In both cases, the label + reconciler state is the authority and the checkpoint 
 | Verify loop succeeds | `delete_single $NUMBER` |
 | `MAX_ITERATIONS_REACHED` | `delete_single $NUMBER` |
 | Issue CLOSED / `phase/done` detected at resume | `delete_single $NUMBER` (stale label conflict path) |
-| Batch fully processed | `delete_batch` |
+| Batch fully processed | `delete_batch "$BATCH_ID"` (also removes from active index) |
 
 `.tmp/` files are gitignored and are not committed.
 

--- a/tests/auto-checkpoint-batch.bats
+++ b/tests/auto-checkpoint-batch.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+# Tests for auto-checkpoint.sh BATCH_ID namespacing (Issue #627)
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/auto-checkpoint.sh"
+
+setup() {
+    export BATS_TMPDIR="${BATS_TEST_TMPDIR}"
+    cd "$BATS_TEST_TMPDIR"
+}
+
+teardown() {
+    cd /
+    rm -rf "$BATS_TEST_TMPDIR/.tmp"
+}
+
+@test "parallel write non-collision: two BATCH_IDs maintain independent state files" {
+    run bash "$SCRIPT" write_batch "batch-a" "101 102" "" ""
+    [ "$status" -eq 0 ]
+
+    run bash "$SCRIPT" write_batch "batch-b" "201 202 203" "" ""
+    [ "$status" -eq 0 ]
+
+    [ -f ".tmp/auto-batch-state-batch-a.json" ]
+    [ -f ".tmp/auto-batch-state-batch-b.json" ]
+
+    remaining_a=$(jq '.remaining | length' .tmp/auto-batch-state-batch-a.json)
+    [ "$remaining_a" = "2" ]
+
+    remaining_b=$(jq '.remaining | length' .tmp/auto-batch-state-batch-b.json)
+    [ "$remaining_b" = "3" ]
+
+    run bash "$SCRIPT" update_batch "batch-a" 101 complete
+    [ "$status" -eq 0 ]
+
+    remaining_a_after=$(jq '.remaining | length' .tmp/auto-batch-state-batch-a.json)
+    [ "$remaining_a_after" = "1" ]
+
+    remaining_b_unchanged=$(jq '.remaining | length' .tmp/auto-batch-state-batch-b.json)
+    [ "$remaining_b_unchanged" = "3" ]
+
+    active_ids=$(bash "$SCRIPT" list_active_batches)
+    [[ "$active_ids" == *"batch-a"* ]]
+    [[ "$active_ids" == *"batch-b"* ]]
+}
+
+@test "resume restoration: read_batch returns correct remaining after updates" {
+    run bash "$SCRIPT" write_batch "resume-test" "301 302 303" "" ""
+    [ "$status" -eq 0 ]
+
+    run bash "$SCRIPT" update_batch "resume-test" 301 complete
+    [ "$status" -eq 0 ]
+
+    run bash "$SCRIPT" update_batch "resume-test" 302 fail
+    [ "$status" -eq 0 ]
+
+    run bash "$SCRIPT" read_batch "resume-test"
+    [ "$status" -eq 0 ]
+    [ "$output" = "303" ]
+
+    completed=$(jq '.completed[0]' .tmp/auto-batch-state-resume-test.json)
+    [ "$completed" = "301" ]
+
+    failed=$(jq '.failed[0]' .tmp/auto-batch-state-resume-test.json)
+    [ "$failed" = "302" ]
+}
+
+@test "backward compat: omitted BATCH_ID uses existing .tmp/auto-batch-state.json path" {
+    run bash "$SCRIPT" write_batch "500 501 502" "" ""
+    [ "$status" -eq 0 ]
+    [ -f ".tmp/auto-batch-state.json" ]
+    [ ! -f ".tmp/auto-batch-state-default.json" ]
+
+    run bash "$SCRIPT" read_batch
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"500"* ]]
+    [[ "$output" == *"501"* ]]
+    [[ "$output" == *"502"* ]]
+
+    run bash "$SCRIPT" update_batch 500 complete
+    [ "$status" -eq 0 ]
+
+    completed=$(jq '.completed[0]' .tmp/auto-batch-state.json)
+    [ "$completed" = "500" ]
+
+    run bash "$SCRIPT" delete_batch
+    [ "$status" -eq 0 ]
+    [ ! -f ".tmp/auto-batch-state.json" ]
+
+    active_ids=$(bash "$SCRIPT" list_active_batches)
+    [[ "$active_ids" != *"default"* ]]
+}


### PR DESCRIPTION
## Summary

- `scripts/auto-checkpoint.sh` の batch state file を BATCH_ID で名前空間化し、並列 `/auto --batch` セッション間の state 衝突（last-writer-wins 問題）を解消
- active batch 一覧を管理する index ファイル (`.tmp/auto-batch-active.json`) と `list_active_batches` サブコマンドを新設
- `skills/auto/SKILL.md` の List mode にBATCH_ID生成を追加し、全 checkpoint 呼び出しに伝播
- Resume mode を `list_active_batches` → BATCH_ID 選択 → `read_batch <BATCH_ID>` の流れに更新
- 後方互換: BATCH_ID 省略時は `default` → 既存 `.tmp/auto-batch-state.json` にマップ（3-arg/2-arg 旧 API は arg count 検出で自動ルーティング）

## Verification (pre-merge)

- `grep "BATCH_ID|batch_id" "scripts/auto-checkpoint.sh"` — BATCH_ID 引数受け付けを確認
- `grep "list_active_batches" "scripts/auto-checkpoint.sh"` — list_active_batches メソッド実装確認
- `file_contains "scripts/auto-checkpoint.sh" "auto-batch-active.json"` — active index 管理確認
- `grep "BATCH_ID" "skills/auto/SKILL.md"` — SKILL.md での BATCH_ID 生成・伝播確認
- rubric: backward compat 確認（BATCH_ID 省略時 → default → 既存パス使用）
- `bats tests/auto-checkpoint-batch.bats` — 新規 3 テスト green（並列 write 非衝突・resume 復元・後方互換）
- `bash -n scripts/auto-checkpoint.sh` — 構文エラーなし

## Verification (post-merge)

- 2 つの並列 `/auto --batch` 実行で互いの state を上書きしないことを観察
- 中断後の `/auto --resume --batch --batch-id <id>` で正しい batch が復元できることを確認

closes #627