### PR TITLE
Issue #638: Add auto-events-rollup.sh script for daily JSONL rollup

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（54 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（55 ファイル）
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
@@ -34,7 +34,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（71 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（74 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents
@@ -162,6 +162,7 @@ wholework/
 - `scripts/gh-pr-review.sh` — PR レビュー投稿
 
 **プロジェクトユーティリティ:**
+- `scripts/auto-events-rollup.sh` — `.tmp/auto-events.jsonl` を日付単位で集約し `docs/reports/auto-events-rollup-YYYY-MM-DD.md` として出力。`--date`、`--input`、`--output-dir`、`--cleanup` に対応
 - `scripts/collect-recovery-candidates.sh` — `docs/reports/orchestration-recoveries.md` を parse し symptom-short の頻度を集計。起票済みエントリを除外し `--threshold K` フィルタを適用。`<symptom-short>\t<count>` 形式で候補を出力。`--issues-json PATH` で重複チェック用 open issues JSON を受け取り
 - `scripts/get-config-value.sh` — `.wholework.yml` から設定値を抽出
 - `scripts/handle-permission-mode-failure.sh` — `permission-mode: auto` 失敗を診断し remediation hint を stderr に出力（heuristic: exit!=0 かつ elapsed<=30s）

--- a/docs/spec/issue-638-auto-events-rollup.md
+++ b/docs/spec/issue-638-auto-events-rollup.md
@@ -29,7 +29,7 @@
 
 - <!-- verify: file_exists "scripts/auto-events-rollup.sh" --> `scripts/auto-events-rollup.sh` が新規作成されている
 - <!-- verify: command "bash -n scripts/auto-events-rollup.sh" --> 構文エラーなし
-- <!-- verify: grep -- "--date\|--input\|--output-dir\|--cleanup" "scripts/auto-events-rollup.sh" --> 4 オプション (`--date` / `--input` / `--output-dir` / `--cleanup`) すべて実装されている
+- <!-- verify: grep -- "--date|--input|--output-dir|--cleanup" "scripts/auto-events-rollup.sh" --> 4 オプション (`--date` / `--input` / `--output-dir` / `--cleanup`) すべて実装されている
 - <!-- verify: grep "auto-events-rollup" "tests/auto-events-rollup.bats" --> bats テストファイル `tests/auto-events-rollup.bats` が新規作成されている
 - <!-- verify: command "bats tests/auto-events-rollup.bats" --> bats テストが green（最小 4 ケース: empty input / single session rollup / multi-session aggregation / cleanup rotation）
 - <!-- verify: rubric "scripts/auto-events-rollup.sh produces a markdown report under docs/reports/auto-events-rollup-YYYY-MM-DD.md with frontmatter (type/description/generated_by/generated_at), Sessions table, Phase Distribution table, Recovery Tier Invocations table, and Anomalies section, parsing the JSONL input with jq" --> 出力フォーマット 4 セクション（Sessions / Phase Distribution / Recovery Tier / Anomalies）と frontmatter 4 フィールドが仕様通り
@@ -48,3 +48,37 @@
 - `date -u +%Y-%m-%d` は macOS (BSD date) / Linux 共通で動作する
 - Size 計算のためのフィールド (`size`) は現在の event schema に存在しない。Sessions 表の Size 列はイベントに含まれる場合のみ表示し、ない場合は `-` とする
 - `phase_complete` event が存在しない phase の Duration は `-` とする (watchdog kill 等の異常終了)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- bats テスト数が 4 ではなく 5 ケース: empty input の frontmatter テストを独立させた（AC5 の「最小 4 ケース」は満たしつつ frontmatter 検証を独立させる方が可読性が高い）
+- `write_sessions_section` / `write_phase_dist_section` などのヘルパー関数で section データと header を一緒に出力するパターンを採用。Spec は「sections separate write」を明示していなかったが実装上まとめる方が DRY
+
+### Design Gaps/Ambiguities
+
+- verify command #3 の `\|` は ripgrep 文脈では literal backslash-pipe であり alternation ではない（GNU grep BRE の `\|` 挙動と混同されていた）。実装前に検証し `|`（bare pipe）に修正してから進めた
+- `anomaly` event は現在 `run-auto-sub.sh` に emit_event 呼び出しがなく（出力のみ）、Anomalies セクションは常に `- (none)` になる。将来 emit_event("anomaly", ...) が追加されれば自動的に機能する設計で対応済み
+
+### Rework
+
+- N/A（設計通り初回で完成）
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `\|` → `|` への verify command 修正を apply: Issue body と Spec の両方に反映し、齟齬なし
+- bash 3.2+ 互換を jq 一本で実現: `declare -A` や `mapfile` を一切使わず、jq の `group_by` / `map` / `sort_by` で集計ロジックをすべて処理
+- ヘルパー関数（`write_header`, `write_sessions_section` 等）を `{ ... } > FILE` ブロック内で呼ぶパターンを採用: 可読性と DRY を確保
+
+### Deferred Items
+- `anomaly` event emit は本 Issue スコープ外。`run-auto-sub.sh` への emit_event 追加は #630 関連で別途検討
+- 自動実行（cron / hook）は Issue body で明示的に別 Issue 扱いとなっている
+- Duration が midnight をまたぐ場合の `+86400` 補正を実装したが、実際のテストケースは未作成（エッジケース）
+
+### Notes for Next Phase
+- verify command #3 を `\|` → `|` に修正済み（Issue body と Spec 両方）: /review 時に元の形と比較しないよう注意
+- bats テストは 5 ケース（frontmatter テストを独立させたため）。AC の「最小 4 ケース」を超過しているが設計意図通り
+- `anomaly` セクションは現実装では常に `- (none)` となる（emit_event 未実装のため）: /review で設計上の制限として認識すること

--- a/docs/spec/issue-638-auto-events-rollup.md
+++ b/docs/spec/issue-638-auto-events-rollup.md
@@ -66,19 +66,32 @@
 - N/A（設計通り初回で完成）
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `\|` → `|` への verify command 修正を apply: Issue body と Spec の両方に反映し、齟齬なし
-- bash 3.2+ 互換を jq 一本で実現: `declare -A` や `mapfile` を一切使わず、jq の `group_by` / `map` / `sort_by` で集計ロジックをすべて処理
-- ヘルパー関数（`write_header`, `write_sessions_section` 等）を `{ ... } > FILE` ブロック内で呼ぶパターンを採用: 可読性と DRY を確保
+- REVIEW_DEPTH=light（Size=M + --light フラグ）: 1エージェント統合レビューを適用
+- SHOULD issue（cleanup `|| true` の exit code 区別）を修正: exit code 1（no-match）と 2（error）を明示的に区別、エラー時は元ファイルを保護
+- CONSIDER issue（`--date` フォーマット検証なし）はスキップ: ローカルCLIのため現実的リスク低
 
 ### Deferred Items
-- `anomaly` event emit は本 Issue スコープ外。`run-auto-sub.sh` への emit_event 追加は #630 関連で別途検討
-- 自動実行（cron / hook）は Issue body で明示的に別 Issue 扱いとなっている
-- Duration が midnight をまたぐ場合の `+86400` 補正を実装したが、実際のテストケースは未作成（エッジケース）
+- `anomaly` event emit は依然として `run-auto-sub.sh` 未実装のまま。Anomalies セクションは常に `- (none)` だが設計上許容
+- `--date` フォーマット検証なし: CONSIDER でスキップ、必要に応じて後続改善可
 
 ### Notes for Next Phase
-- verify command #3 を `\|` → `|` に修正済み（Issue body と Spec 両方）: /review 時に元の形と比較しないよう注意
-- bats テストは 5 ケース（frontmatter テストを独立させたため）。AC の「最小 4 ケース」を超過しているが設計意図通り
-- `anomaly` セクションは現実装では常に `- (none)` となる（emit_event 未実装のため）: /review で設計上の制限として認識すること
+- cleanup fix のコミット (`37c90ae`) が push 済み: /merge 時は最新 HEAD を対象にすること
+- 全 AC が PASS、全 CI が SUCCESS: マージ前提条件クリア
+- `anomaly` セクション常時 `- (none)` は設計上の制限（emit_event 未実装）: /merge では考慮不要
+
+## review retrospective
+
+### Spec vs. implementation 乖離パターン
+
+特になし。Spec との整合性は高く、codeフェーズで `\|`→`|` 修正も含めて予期された変更が正確に実装されていた。
+
+### 繰り返し Issue
+
+特になし。SHOULD 1件（cleanup の `|| true` によるエラー飲み込み）は grep の exit code 区別という一般的パターンの見落とし。bash スクリプトで `|| true` を使う際は exit code の意味（1=no-match vs 2=error）を明示的に区別する習慣が有用。
+
+### 受け入れ条件検証の困難さ
+
+全条件 PASS。verify command は適切で UNCERTAIN はなし。rubric 条件は diff から直接判断可能で品質良好。`command` 系 verify は CI 参照フォールバックが機能し、safe mode での検証が円滑だった。bats テスト件数（AC では「最小4ケース」、実装は5ケース）の乖離は code retrospective で説明済み。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (54 files)
+├── scripts/             # Utility scripts used by skills and agents (55 files)
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
@@ -41,7 +41,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (71 files)
+├── tests/               # Bats test files for scripts (74 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -169,6 +169,7 @@ Key modules:
 - `scripts/gh-pr-review.sh` — post PR reviews
 
 **Project utilities:**
+- `scripts/auto-events-rollup.sh` — roll up `.tmp/auto-events.jsonl` into a curated daily report under `docs/reports/auto-events-rollup-YYYY-MM-DD.md`; accepts `--date`, `--input`, `--output-dir`, `--cleanup`
 - `scripts/collect-recovery-candidates.sh` — parse `docs/reports/orchestration-recoveries.md`; count symptom-short frequency; exclude filed entries; apply `--threshold K` filter; output `<symptom-short>\t<count>` candidates; accepts `--issues-json PATH` for duplicate detection
 - `scripts/get-config-value.sh` — extract a configuration value from `.wholework.yml`
 - `scripts/handle-permission-mode-failure.sh` — diagnose `permission-mode: auto` failures and print remediation hint to stderr (heuristic: exit!=0 AND elapsed<=30s)

--- a/scripts/auto-events-rollup.sh
+++ b/scripts/auto-events-rollup.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+# auto-events-rollup.sh - Daily rollup of .tmp/auto-events.jsonl into a curated report.
+# Usage: auto-events-rollup.sh [--date YYYY-MM-DD] [--input <file>] [--output-dir <dir>] [--cleanup]
+
+set -euo pipefail
+
+# Defaults
+TARGET_DATE=$(date -u +%Y-%m-%d)
+INPUT_FILE=".tmp/auto-events.jsonl"
+OUTPUT_DIR="docs/reports"
+CLEANUP=false
+
+# Option parsing
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --date)
+      [[ -z "${2:-}" ]] && { echo "Error: --date requires YYYY-MM-DD" >&2; exit 1; }
+      TARGET_DATE="$2"; shift 2;;
+    --input)
+      [[ -z "${2:-}" ]] && { echo "Error: --input requires a file path" >&2; exit 1; }
+      INPUT_FILE="$2"; shift 2;;
+    --output-dir)
+      [[ -z "${2:-}" ]] && { echo "Error: --output-dir requires a directory path" >&2; exit 1; }
+      OUTPUT_DIR="$2"; shift 2;;
+    --cleanup)
+      CLEANUP=true; shift;;
+    *)
+      echo "Error: Unknown option: $1" >&2
+      echo "Usage: $0 [--date YYYY-MM-DD] [--input <file>] [--output-dir <dir>] [--cleanup]" >&2
+      exit 1;;
+  esac
+done
+
+GENERATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+OUTPUT_FILE="${OUTPUT_DIR}/auto-events-rollup-${TARGET_DATE}.md"
+
+mkdir -p "$OUTPUT_DIR"
+
+write_header() {
+  printf '%s\n' \
+    "---" \
+    "type: report" \
+    "description: Daily rollup of /auto session events from .tmp/auto-events.jsonl" \
+    "generated_by: scripts/auto-events-rollup.sh" \
+    "generated_at: ${GENERATED_AT}" \
+    "---" \
+    "" \
+    "# /auto Event Rollup — ${TARGET_DATE}"
+}
+
+write_sessions_section() {
+  local rows="$1"
+  printf '%s\n' \
+    "" \
+    "## Sessions" \
+    "" \
+    "| Issue | Size | Start (UTC) | End (UTC) | Duration | Phases | Recoveries | Outcome |" \
+    "|-------|------|-------------|-----------|----------|--------|------------|---------|"
+  if [[ -n "$rows" ]]; then
+    printf '%s\n' "$rows"
+  fi
+}
+
+write_phase_dist_section() {
+  local rows="$1"
+  printf '%s\n' \
+    "" \
+    "## Phase Distribution" \
+    "" \
+    "| Phase | Count | Median Duration | p95 |" \
+    "|-------|-------|-----------------|-----|"
+  if [[ -n "$rows" ]]; then
+    printf '%s\n' "$rows"
+  fi
+}
+
+write_recovery_section() {
+  local rows="$1"
+  printf '%s\n' \
+    "" \
+    "## Recovery Tier Invocations" \
+    "" \
+    "| Tier | Count | Issues |" \
+    "|------|-------|--------|"
+  if [[ -n "$rows" ]]; then
+    printf '%s\n' "$rows"
+  fi
+}
+
+write_anomalies_section() {
+  local items="$1"
+  printf '%s\n' "" "## Anomalies" "" "$items"
+}
+
+write_empty_report() {
+  write_header
+  write_sessions_section ""
+  write_phase_dist_section ""
+  write_recovery_section ""
+  write_anomalies_section "- (none)"
+}
+
+# Handle missing or empty input
+if [[ ! -f "$INPUT_FILE" ]] || [[ ! -s "$INPUT_FILE" ]]; then
+  write_empty_report > "$OUTPUT_FILE"
+  echo "Rollup complete: ${OUTPUT_FILE} (no input data)"
+  exit 0
+fi
+
+# Filter lines matching target date
+FILTERED=$(grep "\"ts\":\"${TARGET_DATE}" "$INPUT_FILE" 2>/dev/null || true)
+
+if [[ -z "$FILTERED" ]]; then
+  write_empty_report > "$OUTPUT_FILE"
+  echo "Rollup complete: ${OUTPUT_FILE} (no events for ${TARGET_DATE})"
+  exit 0
+fi
+
+# Build Sessions table rows
+SESSIONS_ROWS=$(printf '%s\n' "$FILTERED" | jq -rs '
+  . as $ev |
+  [$ev[] | select(.event == "sub_start")] | sort_by(.ts) |
+  map(
+    .issue as $iss |
+    (.size // "-") as $sz |
+    .ts as $start_ts |
+    ($start_ts | split("T")[1] | rtrimstr("Z")) as $start_time |
+    ($ev | map(select(.event == "sub_complete" and .issue == $iss)) | last) as $comp |
+    (if $comp then $comp.ts | split("T")[1] | rtrimstr("Z") else "-" end) as $end_time |
+    (if $comp then
+      (($comp.ts | split("T")[1] | rtrimstr("Z") | split(":") |
+          (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber)) -
+       ($start_ts | split("T")[1] | rtrimstr("Z") | split(":") |
+          (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber))) as $sec |
+      if $sec < 0 then "\(($sec + 86400) / 60 | floor)m"
+      else if $sec >= 60 then "\($sec / 60 | floor)m"
+      else "\($sec)s"
+      end end
+    else "-" end) as $dur |
+    ([$ev[] | select(.event == "phase_complete" and .issue == $iss) | .phase] | join("→")) as $phases |
+    ([$ev[] | select(.event == "recovery" and .issue == $iss)] | length) as $rec_count |
+    (if $rec_count == 0 then "—" else ($rec_count | tostring) end) as $recs |
+    (if $comp then
+      if (($comp.exit_code // "0") == "0") then "success" else "failure" end
+    else "incomplete" end) as $outcome |
+    "| #\($iss) | \($sz) | \($start_time) | \($end_time) | \($dur) | \($phases) | \($recs) | \($outcome) |"
+  ) | join("\n")
+' 2>/dev/null || true)
+
+# Build Phase Distribution table rows
+PHASE_DIST_ROWS=$(printf '%s\n' "$FILTERED" | jq -rs '
+  . as $ev |
+  [$ev[] | select(.event == "phase_complete")] |
+  map(
+    .issue as $iss |
+    .phase as $ph |
+    .ts as $end_ts |
+    ($ev | map(select(.event == "phase_start" and .issue == $iss and .phase == $ph and .ts <= $end_ts)) | last) as $start |
+    if $start != null then
+      (($end_ts | split("T")[1] | rtrimstr("Z") | split(":") |
+          (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber)) -
+       ($start.ts | split("T")[1] | rtrimstr("Z") | split(":") |
+          (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber))) as $sec |
+      {phase: $ph, sec: (if $sec < 0 then $sec + 86400 else $sec end)}
+    else empty end
+  ) as $durs |
+  if ($durs | length) == 0 then ""
+  else
+    ($durs | map(.phase) | unique | sort) as $phases |
+    ($phases | map(. as $p |
+      ($durs | map(select(.phase == $p) | .sec) | sort) as $secs |
+      ($secs | length) as $n |
+      if $n == 0 then "| \($p) | 0 | - | - |"
+      else
+        ($secs[$n / 2 | floor]) as $med_sec |
+        ($secs[$n * 95 / 100 | floor]) as $p95_sec |
+        (if $med_sec >= 60 then "\($med_sec / 60 | floor)m" else "\($med_sec)s" end) as $med |
+        (if $p95_sec >= 60 then "\($p95_sec / 60 | floor)m" else "\($p95_sec)s" end) as $p95 |
+        "| \($p) | \($n) | \($med) | \($p95) |"
+      end
+    )) | join("\n")
+  end
+' 2>/dev/null || true)
+
+# Build Recovery Tier table rows
+RECOVERY_ROWS=$(printf '%s\n' "$FILTERED" | jq -rs '
+  [.[] | select(.event == "recovery")] |
+  if length == 0 then ""
+  else
+    group_by(.tier) |
+    map(
+      .[0].tier as $t |
+      (length | tostring) as $cnt |
+      (map("#\(.issue)") | unique | join(", ")) as $issues |
+      "| \($t) | \($cnt) | \($issues) |"
+    ) | join("\n")
+  end
+' 2>/dev/null || true)
+
+# Build Anomalies list
+ANOMALIES=$(printf '%s\n' "$FILTERED" | jq -rs '
+  [.[] | select(.event == "anomaly")] |
+  if length == 0 then "- (none)"
+  else
+    map("- `[#\(.issue)]` \(.description // .detail // "anomaly detected") in phase \(.phase // "unknown")") |
+    join("\n")
+  end
+' 2>/dev/null || echo "- (none)")
+
+# Write the report
+{
+  write_header
+  write_sessions_section "$SESSIONS_ROWS"
+  write_phase_dist_section "$PHASE_DIST_ROWS"
+  write_recovery_section "$RECOVERY_ROWS"
+  write_anomalies_section "$ANOMALIES"
+} > "$OUTPUT_FILE"
+
+# Cleanup: remove target date entries from input
+if [[ "$CLEANUP" == "true" ]]; then
+  TEMP_FILE="${INPUT_FILE}.tmp.$$"
+  grep -v "\"ts\":\"${TARGET_DATE}" "$INPUT_FILE" > "$TEMP_FILE" 2>/dev/null || true
+  mv "$TEMP_FILE" "$INPUT_FILE"
+fi
+
+echo "Rollup complete: ${OUTPUT_FILE}"

--- a/scripts/auto-events-rollup.sh
+++ b/scripts/auto-events-rollup.sh
@@ -219,8 +219,14 @@ ANOMALIES=$(printf '%s\n' "$FILTERED" | jq -rs '
 # Cleanup: remove target date entries from input
 if [[ "$CLEANUP" == "true" ]]; then
   TEMP_FILE="${INPUT_FILE}.tmp.$$"
-  grep -v "\"ts\":\"${TARGET_DATE}" "$INPUT_FILE" > "$TEMP_FILE" 2>/dev/null || true
-  mv "$TEMP_FILE" "$INPUT_FILE"
+  grep -v "\"ts\":\"${TARGET_DATE}" "$INPUT_FILE" > "$TEMP_FILE" 2>/dev/null
+  cleanup_exit=$?
+  if [[ $cleanup_exit -gt 1 ]]; then
+    rm -f "$TEMP_FILE"
+    echo "Warning: cleanup grep failed (exit ${cleanup_exit}), original file preserved" >&2
+  else
+    mv "$TEMP_FILE" "$INPUT_FILE"
+  fi
 fi
 
 echo "Rollup complete: ${OUTPUT_FILE}"

--- a/tests/auto-events-rollup.bats
+++ b/tests/auto-events-rollup.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/auto-events-rollup.sh
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/auto-events-rollup.sh"
+
+setup() {
+    cd "$BATS_TEST_TMPDIR"
+    mkdir -p .tmp docs/reports
+}
+
+teardown() {
+    cd /
+}
+
+# (a) Empty input: output file generated with 4 required sections
+@test "auto-events-rollup: empty input produces report with all 4 sections" {
+    run bash "$SCRIPT" --date 2026-06-14 --input .tmp/missing.jsonl --output-dir docs/reports
+    [ "$status" -eq 0 ]
+    [ -f "docs/reports/auto-events-rollup-2026-06-14.md" ]
+
+    grep -q "## Sessions" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "## Phase Distribution" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "## Recovery Tier Invocations" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "## Anomalies" "docs/reports/auto-events-rollup-2026-06-14.md"
+}
+
+# (a) Empty input: frontmatter fields present
+@test "auto-events-rollup: empty input has required frontmatter fields" {
+    run bash "$SCRIPT" --date 2026-06-14 --input .tmp/missing.jsonl --output-dir docs/reports
+    [ "$status" -eq 0 ]
+
+    grep -q "^type: report" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "^description:" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "^generated_by: scripts/auto-events-rollup.sh" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "^generated_at:" "docs/reports/auto-events-rollup-2026-06-14.md"
+}
+
+# (b) Single session rollup: Sessions table has exactly one data row
+@test "auto-events-rollup: single session produces one Sessions row" {
+    cat > .tmp/events.jsonl << 'EOF'
+{"ts":"2026-06-14T07:01:38Z","issue":626,"event":"sub_start","size":"S"}
+{"ts":"2026-06-14T07:02:00Z","issue":626,"event":"phase_start","phase":"spec"}
+{"ts":"2026-06-14T07:20:00Z","issue":626,"event":"phase_complete","phase":"spec"}
+{"ts":"2026-06-14T07:20:05Z","issue":626,"event":"phase_start","phase":"code"}
+{"ts":"2026-06-14T07:35:00Z","issue":626,"event":"phase_complete","phase":"code"}
+{"ts":"2026-06-14T07:36:09Z","issue":626,"event":"sub_complete","exit_code":"0"}
+EOF
+
+    run bash "$SCRIPT" --date 2026-06-14 --input .tmp/events.jsonl --output-dir docs/reports
+    [ "$status" -eq 0 ]
+    [ -f "docs/reports/auto-events-rollup-2026-06-14.md" ]
+
+    # The Sessions table should have exactly one data row (containing #626)
+    session_rows=$(grep "^| #626" "docs/reports/auto-events-rollup-2026-06-14.md" | wc -l | tr -d ' ')
+    [ "$session_rows" -eq 1 ]
+
+    # Outcome should be success
+    grep -q "success" "docs/reports/auto-events-rollup-2026-06-14.md"
+
+    # Phases should show spec->code
+    grep -q "spec.*code" "docs/reports/auto-events-rollup-2026-06-14.md"
+}
+
+# (c) Multi-session aggregation: multiple issues appear in Sessions table
+@test "auto-events-rollup: multi-session aggregation includes all issues" {
+    cat > .tmp/events.jsonl << 'EOF'
+{"ts":"2026-06-14T07:01:38Z","issue":626,"event":"sub_start","size":"S"}
+{"ts":"2026-06-14T07:01:45Z","issue":626,"event":"phase_start","phase":"spec"}
+{"ts":"2026-06-14T07:15:00Z","issue":626,"event":"phase_complete","phase":"spec"}
+{"ts":"2026-06-14T07:36:09Z","issue":626,"event":"sub_complete","exit_code":"0"}
+{"ts":"2026-06-14T08:00:00Z","issue":627,"event":"sub_start","size":"M"}
+{"ts":"2026-06-14T08:00:10Z","issue":627,"event":"phase_start","phase":"spec"}
+{"ts":"2026-06-14T08:20:00Z","issue":627,"event":"phase_complete","phase":"spec"}
+{"ts":"2026-06-14T08:20:05Z","issue":627,"event":"phase_start","phase":"code"}
+{"ts":"2026-06-14T09:10:00Z","issue":627,"event":"phase_complete","phase":"code"}
+{"ts":"2026-06-14T09:15:00Z","issue":627,"event":"recovery","phase":"code","tier":"1","result":"recovered"}
+{"ts":"2026-06-14T09:20:00Z","issue":627,"event":"sub_complete","exit_code":"0"}
+EOF
+
+    run bash "$SCRIPT" --date 2026-06-14 --input .tmp/events.jsonl --output-dir docs/reports
+    [ "$status" -eq 0 ]
+
+    grep -q "^| #626" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "^| #627" "docs/reports/auto-events-rollup-2026-06-14.md"
+
+    # Issue 627 had 1 recovery, issue 626 had none (shown as em-dash)
+    grep "^| #627" "docs/reports/auto-events-rollup-2026-06-14.md" | grep -q "| 1 |"
+    grep "^| #626" "docs/reports/auto-events-rollup-2026-06-14.md" | grep -q "^| #626"
+
+    # Phase Distribution should have spec and code entries
+    grep -q "| spec |" "docs/reports/auto-events-rollup-2026-06-14.md"
+    grep -q "| code |" "docs/reports/auto-events-rollup-2026-06-14.md"
+
+    # Recovery tier 1 should appear
+    grep -q "| 1 |" "docs/reports/auto-events-rollup-2026-06-14.md"
+}
+
+# (d) Cleanup rotation: target date entries removed, other dates preserved
+@test "auto-events-rollup: cleanup removes target date entries and preserves others" {
+    cat > .tmp/events.jsonl << 'EOF'
+{"ts":"2026-06-13T10:00:00Z","issue":600,"event":"sub_start","size":"S"}
+{"ts":"2026-06-13T10:30:00Z","issue":600,"event":"sub_complete","exit_code":"0"}
+{"ts":"2026-06-14T07:01:38Z","issue":626,"event":"sub_start","size":"S"}
+{"ts":"2026-06-14T07:36:09Z","issue":626,"event":"sub_complete","exit_code":"0"}
+{"ts":"2026-06-15T09:00:00Z","issue":640,"event":"sub_start","size":"M"}
+EOF
+
+    run bash "$SCRIPT" --date 2026-06-14 --input .tmp/events.jsonl --output-dir docs/reports --cleanup
+    [ "$status" -eq 0 ]
+    [ -f "docs/reports/auto-events-rollup-2026-06-14.md" ]
+
+    # Target date entries should be removed
+    run grep "\"ts\":\"2026-06-14" .tmp/events.jsonl
+    [ "$status" -ne 0 ]
+
+    # Other dates should be preserved
+    grep -q "\"ts\":\"2026-06-13" .tmp/events.jsonl
+    grep -q "\"ts\":\"2026-06-15" .tmp/events.jsonl
+}


### PR DESCRIPTION
## Summary

- `scripts/auto-events-rollup.sh` を新規作成: `.tmp/auto-events.jsonl` を日付単位で集約し `docs/reports/auto-events-rollup-YYYY-MM-DD.md` として出力。`--date` / `--input` / `--output-dir` / `--cleanup` の 4 オプションを実装（bash 3.2+ 互換・jq ベース）
- `tests/auto-events-rollup.bats` を新規作成: 4 ケース（empty input / single session rollup / multi-session aggregation / cleanup rotation）すべて green
- `docs/structure.md` および `docs/ja/structure.md` を更新: scripts 数 54→55、tests 数 71→74、新スクリプト説明行を追記
- verify command #3 を修正: ripgrep では `\|` が alternation でなく literal なので `|` に書き換え（miscalibrated hint 修正）

## Verification (pre-merge)

- `scripts/auto-events-rollup.sh` が存在する
- `bash -n scripts/auto-events-rollup.sh` が構文エラーなし
- 4 オプション (`--date` / `--input` / `--output-dir` / `--cleanup`) すべて実装されている
- `tests/auto-events-rollup.bats` が存在する
- bats テスト 5 ケース green（4 ケース要件 + frontmatter テスト）
- 出力フォーマット 4 セクション（Sessions / Phase Distribution / Recovery Tier / Anomalies）と frontmatter 4 フィールドが仕様通り
- `docs/structure.md` に新スクリプトが追記されている

## Verification (post-merge)

- 次回の本格 `/auto --batch` 実行後に `scripts/auto-events-rollup.sh --date $(date -u +%Y-%m-%d)` を手動実行し、当日 session が curated に再構成されることを確認
- 自動実行（cron / git hook / `/auto` 終了時 hook 等）の議論 follow-up Issue が起票されている

closes #638