### PR TITLE
Issue #654: Add auto-session-report-published event emit and schema

### DIFF
--- a/docs/reports/event-log-schema.md
+++ b/docs/reports/event-log-schema.md
@@ -204,3 +204,31 @@ Emitted by `run-auto-sub.sh` during the `code` phase when bats test output is de
 | `pattern` | Yes | Test pattern label (`unit`) |
 
 **Emission point**: `run-auto-sub.sh` `run_phase_with_recovery()`, after `wrapper_exit`, when bats output pattern (`N tests, N failures`) is found in the code phase log file.
+
+## New Events (introduced in #654)
+
+### 7. `auto-session-report-published`
+
+Emitted by `scripts/get-auto-session-report.sh` immediately after the `--narrative-draft` processing completes successfully.
+
+```json
+{
+  "ts": "2026-06-15T12:00:00Z",
+  "issue": 0,
+  "event": "auto-session-report-published",
+  "session_id": "abc-999",
+  "report_path": "docs/reports/auto-session-abc-999-2026-06-15.md"
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `ts` | Yes | ISO 8601 UTC timestamp |
+| `issue` | Yes | Always `0` (session-level event, not tied to a specific issue) |
+| `event` | Yes | `"auto-session-report-published"` |
+| `session_id` | Yes | Session ID the report was generated for |
+| `report_path` | Yes | Path to the generated report file |
+
+**Emission point**: `scripts/get-auto-session-report.sh`, after the Python narrative-draft insertion block completes, when `--narrative-draft` is specified and the draft file exists.
+
+**Scope**: Only emitted when `--narrative-draft` flag is used. Standard report generation (without `--narrative-draft`) does not emit this event.

--- a/docs/spec/issue-654-auto-session-report-published-event.md
+++ b/docs/spec/issue-654-auto-session-report-published-event.md
@@ -78,19 +78,32 @@
 
 - None
 
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+記録なし。Spec と実装は完全一致。`emit-event.sh` の条件付き source、`declare -f emit_event` ガード、emit 呼び出し位置（`PYTHON_EOF` 直後・`fi` 直前）のすべてが Spec 記述通りに実装されていた。
+
+### 繰り返しの問題
+
+記録なし。レビュー全4視点（Spec 乖離・エッジケース・セキュリティ・ドキュメント整合性）で MUST/SHOULD issues は検出されなかった。
+
+### 受け入れ基準検証の難しさ
+
+CONSIDER: `tests/audit-auto-session-full.bats` に正ケース（emit される）のテストは追加されたが、負ケース（`--narrative-draft` なしでは emit されない）のテストが不在。`event-log-schema.md` には "Only emitted when `--narrative-draft` flag is used" と明記されており、このスコープ境界を bats テストで保護するとより確実。AC には含まれないため merge を妨げないが、次 Issue での改善候補として記録する。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- emit 呼び出しは `--narrative-draft` ブロック内の Python heredoc 終端 (`PYTHON_EOF`) 直後・`fi` 直前に配置した。これにより「`--narrative-draft` 完了時のみ emit」という設計を正確に実現。
-- `declare -f emit_event` ガードを採用し、emit-event.sh が見つからなくてもスクリプトが fallback する安全設計にした。
-- bats テストでは既存の `AUTO_EVENTS_LOG` fixture ファイルに append される形で event が書き込まれ、grep で検証した。
+- REVIEW_DEPTH=light（`--light` flag 指定）で実施。全4受け入れ基準が PASS、CI 全ジョブ pass、MUST/SHOULD issues なし。
+- CONSIDER issue (負ケーステスト欠如) は AC 要件を超えるものでありスキップ。PR コメントに記録済み。
 
 ### Deferred Items
-- `AUTO_EVENTS_LOG` への append は fixture events と混在するが、テストロジックとして問題ない（grep は事後追記行を検出可能）。
-- CI (bats 全件) の結果は PR #655 の CI で確認。
+- 負ケーステスト (`auto-session-report-published` が `--narrative-draft` なしで emit されないことの検証) は次 Issue で対応可能。
+- `docs/structure.md` の test ファイル件数乖離 (74 vs 77) は本 Issue スコープ外の pre-existing debt。
 
 ### Notes for Next Phase
-- 3 件の `file_contains` verify commands はすべて PASS 確認済み。PR merge 後は `github_check "gh pr checks"` の CI PASS を `/verify` で確認すること。
-- `docs/reports/event-log-schema.md` は `docs/reports/` 除外対象のため translation sync 不要、doc-checker 対象外。
-- structure.md の test ファイル件数 (74 files) は既存の pre-existing 乖離であり、本 Issue のスコープ外。
+- MUST issues なし。`/merge 655` で直接進められる。
+- merge 後は `verify-type: observation event=auto-session-report-published` を持つ #632 AC が trigger されうる（`opportunistic-search.sh --event auto-session-report-published`）。
+- `docs/reports/event-log-schema.md` は translation sync 不要。

--- a/docs/spec/issue-654-auto-session-report-published-event.md
+++ b/docs/spec/issue-654-auto-session-report-published-event.md
@@ -62,3 +62,35 @@
 - `session_id`: `AUTO_SESSION_ID="$SESSION_ID"` で標準フィールドを通じて渡す（追加 key=value で重複させない）
 - `issue`: 0（session 横断 event）
 - `report_path`: 出力先パスをペイロードに含め、observation trigger 側が参照できるようにする
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None
+
+### Design Gaps/Ambiguities
+
+- emit-event.sh の `session_id` フィールドは `AUTO_SESSION_ID` 環境変数経由で渡すため、`SESSION_ID` を事前にセットして呼び出す。Spec の記述通りで問題なかった。
+- `declare -f emit_event` ガードは、emit-event.sh が見つからない環境でもスクリプトが正常終了するために必須。本番では常に found となるが、テスト環境では `WHOLEWORK_SCRIPT_DIR` が mock dir に向くため source できないケースがある。
+
+### Rework
+
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- emit 呼び出しは `--narrative-draft` ブロック内の Python heredoc 終端 (`PYTHON_EOF`) 直後・`fi` 直前に配置した。これにより「`--narrative-draft` 完了時のみ emit」という設計を正確に実現。
+- `declare -f emit_event` ガードを採用し、emit-event.sh が見つからなくてもスクリプトが fallback する安全設計にした。
+- bats テストでは既存の `AUTO_EVENTS_LOG` fixture ファイルに append される形で event が書き込まれ、grep で検証した。
+
+### Deferred Items
+- `AUTO_EVENTS_LOG` への append は fixture events と混在するが、テストロジックとして問題ない（grep は事後追記行を検出可能）。
+- CI (bats 全件) の結果は PR #655 の CI で確認。
+
+### Notes for Next Phase
+- 3 件の `file_contains` verify commands はすべて PASS 確認済み。PR merge 後は `github_check "gh pr checks"` の CI PASS を `/verify` で確認すること。
+- `docs/reports/event-log-schema.md` は `docs/reports/` 除外対象のため translation sync 不要、doc-checker 対象外。
+- structure.md の test ファイル件数 (74 files) は既存の pre-existing 乖離であり、本 Issue のスコープ外。

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -22,6 +22,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+[[ -f "$SCRIPT_DIR/emit-event.sh" ]] && source "$SCRIPT_DIR/emit-event.sh" || true
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 
 SESSION_ID=""
@@ -414,6 +415,8 @@ with open(report_path, 'w') as f:
 
 print("Narrative draft inserted into report.")
 PYTHON_EOF
+  declare -f emit_event > /dev/null 2>&1 && \
+    AUTO_SESSION_ID="$SESSION_ID" emit_event "auto-session-report-published" "report_path=${OUTPUT_PATH}"
 fi
 
 echo "Report written to: $OUTPUT_PATH"

--- a/tests/audit-auto-session-full.bats
+++ b/tests/audit-auto-session-full.bats
@@ -84,6 +84,29 @@ DRAFT_EOF
     grep -q "\[LLM draft" "$OUTPUT_PATH"
 }
 
+@test "full mode: auto-session-report-published event is emitted after --narrative-draft" {
+    # Create a minimal draft file
+    cat > "$BATS_TEST_TMPDIR/draft-fixture.md" << 'DRAFT_EOF'
+### What worked
+1. Session ran without errors.
+
+### Limits and gaps
+1. No gaps identified.
+
+### Improvement candidates surfaced
+1. None.
+
+### Conclusion
+Clean session.
+DRAFT_EOF
+
+    run bash "$SCRIPT" "abc-999" --output "$OUTPUT_PATH" --narrative-draft "$BATS_TEST_TMPDIR/draft-fixture.md" --no-github
+    [ "$status" -eq 0 ]
+
+    # auto-session-report-published event must be appended to AUTO_EVENTS_LOG
+    grep -q "auto-session-report-published" "$AUTO_EVENTS_LOG"
+}
+
 @test "full mode: classification markers appear in narrative draft" {
     # Generate report then apply a draft containing all 3 classification markers
     run bash "$SCRIPT" "abc-999" --output "$OUTPUT_PATH" --no-github


### PR DESCRIPTION
## Summary

- `scripts/get-auto-session-report.sh` に `emit-event.sh` を source し、`--narrative-draft` 完了直後に `auto-session-report-published` event を `.tmp/auto-events.jsonl` へ emit する呼び出しを追加
- `docs/reports/event-log-schema.md` に新 event 種 `auto-session-report-published` のスキーマ定義を追加（JSON 例、フィールド定義表、emission point）
- `tests/audit-auto-session-full.bats` に event emit 確認テストを追加

## Verification (pre-merge)

- `scripts/get-auto-session-report.sh` に `auto-session-report-published` 文字列を含む（PASS 確認済み）
- `docs/reports/event-log-schema.md` に `auto-session-report-published` を記載（PASS 確認済み）
- `tests/audit-auto-session-full.bats` に event emit 検証テストを追加（PASS 確認済み）
- CI (bats テスト) 全件 PASS — CI で確認予定

## Verification (post-merge)

なし

closes #654