### PR TITLE
Issue #649: Add DCO commit-msg hook via core.hooksPath

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,16 @@ git config --global format.signoff true
 
 Adding `Signed-off-by: Your Name <you@example.com>` to a commit certifies (under the DCO) that you have the right to submit this work under the Apache 2.0 license. It is **not** a copyright assignment — you retain ownership of your contribution.
 
+### Automatic hook enforcement
+
+Running `./install.sh` configures `core.hooksPath = scripts/git-hooks` for this repository. This setting is stored in `.git/config` and automatically inherited by all git worktrees, so the `commit-msg` hook runs on every commit and rejects any commit missing `Signed-off-by:`.
+
+To apply the hook manually (without re-running `./install.sh`):
+
+```sh
+git config core.hooksPath scripts/git-hooks
+```
+
 ### CI enforcement
 
 The `DCO` check in CI will fail if any commit in a pull request is missing the `Signed-off-by:` trailer. Fix missing sign-offs by amending commits (see above) before pushing again.

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -23,6 +23,7 @@ wholework/
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
 ├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（55 ファイル）
+│   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   ├── ISSUE_TEMPLATE/

--- a/docs/spec/issue-649-git-hooks-dco-commit-msg.md
+++ b/docs/spec/issue-649-git-hooks-dco-commit-msg.md
@@ -41,3 +41,33 @@
 - Auto-resolved: ドキュメント記載先 → `CONTRIBUTING.md`（既存 DCO セクションが存在し自然な格納場所; `docs/setup.md` は不在で新規作成が必要）
 - Auto-resolved: AC2 verify command → `file_contains "CONTRIBUTING.md" "core.hooksPath"`（wholework 仕様準拠、単一ファイル・単一パターン）
 - Auto-resolved: AC4 bats テスト実行検証 → `github_check "gh pr checks" "Run bats tests"`（Size M PR route; `.github/workflows/test.yml` の CI ジョブ名 "Run bats tests" を確認済み）
+
+## Code Retrospective
+
+### Deviations from Design
+- `install.sh` の追記箇所を Spec では `echo "Done..."` の直後と記載していたが、実際には既存の plugin update ブロックの後（最終行 `echo "Done. Restart Claude Code..."` の直後）に追記した。意味的に同一だが、install.sh の末尾構造を確認した上で適切な位置に配置した
+- `docs/structure.md` の file count (55 files) は既に実態 (56) と乖離していたため、カウント修正は今回のスコープ外として据え置き、`git-hooks/` サブディレクトリエントリの追加のみを行った
+
+### Design Gaps/Ambiguities
+- `scripts/git-hooks/commit-msg` の `set -e` と `grep -q` の組み合わせ: `grep -q` が見つからない場合（exit 1）に `set -e` が先に反応するため、明示的な `if ! grep -q ... then exit 1; fi` パターンで実装した。Spec の記述よりも堅牢な実装
+- `install.sh` は `git config` を `git -C "$SCRIPT_DIR"` 形式で呼び出す必要があった（`install.sh` 実行ディレクトリが repo root でない場合の安全策）
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `core.hooksPath` を `install.sh` に組み込む方針を採用（EnterWorktree hook ではなく）。理由: `.git/config` に記録されるため worktree 作成時に自動継承、clone 後 1 回の `./install.sh` で完結
+- `commit-msg` フックは bash 3.2+ 互換で `set -e` + `if ! grep -q` パターンを使用
+- `CONTRIBUTING.md` の "### Automatic hook enforcement" は既存 "### CI enforcement" の前に配置（フック設定の説明が先、CI 説明が後の流れが自然）
+
+### Deferred Items
+- `docs/structure.md` の file count (55 files vs 実態 56) の乖離修正は今回のスコープ外
+- `install.sh` の `git config core.hooksPath` は既存ユーザー向けのマイグレーション手順（既 clone ユーザーは `git pull && ./install.sh` を実行する必要がある）の追記は今回スコープ外
+
+### Notes for Next Phase
+- AC1/AC2/AC3 はローカルで PASS 確認済み。AC4 (`github_check "gh pr checks" "Run bats tests"`) は PR #657 の CI 完了後に verify フェーズで確認
+- bats 3 ケース全て PASS（signed PASS / unsigned FAIL / error output チェック）
+- Post-merge AC: `git config --get core.hooksPath` が新 worktree でも有効かを手動確認が必要

--- a/docs/spec/issue-649-git-hooks-dco-commit-msg.md
+++ b/docs/spec/issue-649-git-hooks-dco-commit-msg.md
@@ -55,19 +55,30 @@
 ### Rework
 - N/A
 
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+- Spec で指定した `install.sh` への追記位置（"Done..." の直後）は実装上も同位置だったが、`git config` ブロックを "Done" メッセージの後に置くと UX 上の問題（"Done" 表示後に設定が完了する）が生じることを review で発見。Spec 段階でスクリプト末尾の出力順序を明示しておくと code フェーズで順序ミスを防げた。
+
+### 繰り返し指摘パターン
+- 新規スクリプト追加時のテストケース完全性: bats 第3テストが exit code と output を両方アサートすべきところ output のみだった。テストケースを追加する際には「正常系: exit 0」「異常系: exit 1」「エラーメッセージ: output 内容」の3軸を全て assert するチェックリストを Spec に含めると改善できる。
+
+### AC 検証難易度（UNCERTAIN 件数）
+- 今回は全 Pre-merge AC が `file_exists` / `file_contains` / `github_check` で自動判定可能で UNCERTAIN なし。`github_check` の CI ジョブ名 "Run bats tests" が事前確定済みだったことが効いた。ジョブ名を Spec 段階で明記する方針は今後も継続すること。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `core.hooksPath` を `install.sh` に組み込む方針を採用（EnterWorktree hook ではなく）。理由: `.git/config` に記録されるため worktree 作成時に自動継承、clone 後 1 回の `./install.sh` で完結
-- `commit-msg` フックは bash 3.2+ 互換で `set -e` + `if ! grep -q` パターンを使用
-- `CONTRIBUTING.md` の "### Automatic hook enforcement" は既存 "### CI enforcement" の前に配置（フック設定の説明が先、CI 説明が後の流れが自然）
+- MUST 指摘なし。SHOULD（install.sh メッセージ順序）と CONSIDER（bats exit code アサーション）の 2 件を review フェーズ内で修正・コミット済み
+- `git config core.hooksPath` ブロックを "Done. Restart Claude Code..." より前に移動（UX 改善）
+- bats 第3テストに `[ "$status" -eq 1 ]` を追加してリグレッション耐性を強化
 
 ### Deferred Items
-- `docs/structure.md` の file count (55 files vs 実態 56) の乖離修正は今回のスコープ外
-- `install.sh` の `git config core.hooksPath` は既存ユーザー向けのマイグレーション手順（既 clone ユーザーは `git pull && ./install.sh` を実行する必要がある）の追記は今回スコープ外
+- `docs/structure.md` の file count (55 files vs 実態 56) の乖離修正は引き続きスコープ外
+- Post-merge AC（`git config --get core.hooksPath` が新 worktree でも有効か）は merge 後の手動確認が必要
 
 ### Notes for Next Phase
-- AC1/AC2/AC3 はローカルで PASS 確認済み。AC4 (`github_check "gh pr checks" "Run bats tests"`) は PR #657 の CI 完了後に verify フェーズで確認
-- bats 3 ケース全て PASS（signed PASS / unsigned FAIL / error output チェック）
-- Post-merge AC: `git config --get core.hooksPath` が新 worktree でも有効かを手動確認が必要
+- 全 Pre-merge AC PASS 確認済み（file_exists × 2、file_contains × 1、github_check × 1）
+- CI 全ジョブ SUCCESS（DCO、Run bats tests、Validate skill syntax、Forbidden Expressions check、macOS shell compatibility）
+- MUST 指摘なし → `/merge 657` で merge 可能

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -30,6 +30,7 @@ wholework/
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
 ├── scripts/             # Utility scripts used by skills and agents (55 files)
+│   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
 │   ├── ISSUE_TEMPLATE/

--- a/install.sh
+++ b/install.sh
@@ -89,3 +89,7 @@ fi
 
 echo ""
 echo "Done. Restart Claude Code to apply the updated plugin."
+
+# Configure core.hooksPath so the DCO commit-msg hook applies to all worktrees.
+git -C "$SCRIPT_DIR" config core.hooksPath scripts/git-hooks
+echo "Configured core.hooksPath = scripts/git-hooks"

--- a/install.sh
+++ b/install.sh
@@ -87,9 +87,9 @@ if [ "$NO_PLUGIN" = false ]; then
   fi
 fi
 
-echo ""
-echo "Done. Restart Claude Code to apply the updated plugin."
-
 # Configure core.hooksPath so the DCO commit-msg hook applies to all worktrees.
 git -C "$SCRIPT_DIR" config core.hooksPath scripts/git-hooks
 echo "Configured core.hooksPath = scripts/git-hooks"
+
+echo ""
+echo "Done. Restart Claude Code to apply the updated plugin."

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,12 @@
+#!/bin/bash
+# DCO enforcement: require Signed-off-by in every commit message.
+set -e
+
+COMMIT_MSG_FILE="$1"
+
+if ! grep -q "^Signed-off-by:" "$COMMIT_MSG_FILE"; then
+  echo "Error: Commit is missing Signed-off-by. Use: git commit -s" >&2
+  exit 1
+fi
+
+exit 0

--- a/tests/git-hooks-commit-msg.bats
+++ b/tests/git-hooks-commit-msg.bats
@@ -23,5 +23,6 @@ setup() {
 @test "commit-msg: error output mentions Signed-off-by" {
     printf "feat: add feature\n" > "$COMMIT_MSG_FILE"
     run bash "$HOOK" "$COMMIT_MSG_FILE"
+    [ "$status" -eq 1 ]
     [[ "$output" == *"Signed-off-by"* ]]
 }

--- a/tests/git-hooks-commit-msg.bats
+++ b/tests/git-hooks-commit-msg.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/git-hooks/commit-msg
+
+HOOK="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/git-hooks/commit-msg"
+
+setup() {
+    COMMIT_MSG_FILE="$BATS_TEST_TMPDIR/COMMIT_EDITMSG"
+}
+
+@test "commit-msg: signed commit passes" {
+    printf "feat: add feature\n\nSigned-off-by: Alice <alice@example.com>\n" > "$COMMIT_MSG_FILE"
+    run bash "$HOOK" "$COMMIT_MSG_FILE"
+    [ "$status" -eq 0 ]
+}
+
+@test "commit-msg: unsigned commit fails" {
+    printf "feat: add feature\n" > "$COMMIT_MSG_FILE"
+    run bash "$HOOK" "$COMMIT_MSG_FILE"
+    [ "$status" -eq 1 ]
+}
+
+@test "commit-msg: error output mentions Signed-off-by" {
+    printf "feat: add feature\n" > "$COMMIT_MSG_FILE"
+    run bash "$HOOK" "$COMMIT_MSG_FILE"
+    [[ "$output" == *"Signed-off-by"* ]]
+}


### PR DESCRIPTION
## Summary

- `scripts/git-hooks/commit-msg` を新規作成し、コミットメッセージに `Signed-off-by:` がなければ exit 1 で拒否する DCO 強制フックを実装
- `install.sh` に `git config core.hooksPath scripts/git-hooks` を追加。`.git/config` に記録されるため全 worktree に自動継承
- `CONTRIBUTING.md` に「### Automatic hook enforcement」セクションを追加し、`core.hooksPath` のセットアップ手順を記載
- `tests/git-hooks-commit-msg.bats` で 3 ケース（signed PASS / unsigned FAIL / error output）をテスト
- `docs/structure.md` および `docs/ja/structure.md` に `scripts/git-hooks/` サブディレクトリを追記

## Verification (pre-merge)

- `scripts/git-hooks/commit-msg` が存在し、Signed-off-by チェックを実装している
- `CONTRIBUTING.md` に `core.hooksPath` の設定手順が記載されている
- `tests/git-hooks-commit-msg.bats` が作成されている
- CI bats テストが全て PASS

## Verification (post-merge)

- 既存 EnterWorktree フローで `git config --get core.hooksPath` が新 worktree でも有効であることを確認

closes #649