### PR TITLE
Issue #639: Normalize symptom-short trailing context in collect-recovery-candidates.sh

### DIFF
--- a/docs/spec/issue-639-audit-recoveries-normalization.md
+++ b/docs/spec/issue-639-audit-recoveries-normalization.md
@@ -77,18 +77,32 @@ CURRENT_SYMPTOM と sym の両方を正規化することで、EXCLUDED_LIST と
 
 - None。初回実装で全 5 テスト PASS、forbidden expressions チェックも問題なし。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- None. 実装は Spec の Implementation Steps を完全に踏襲。`CURRENT_SYMPTOM` と `sym` への sed 挿入箇所・パターン、fixture 内容（3エントリ）、bats アサーション（line_count=1, カウント=3, trailing context 非存在）すべてが Spec の記述と一致した。Spec 品質が高く、review フェーズで divergence を検出する余地がなかった。
+
+### Recurring Issues
+
+- None. 全4視点（Spec 整合・エッジケース・セキュリティ・ドキュメント整合性）で繰り返しパターンの issue なし。`elif` ブランチ内の `CURRENT_SYMPTOM` リセット（sed 未適用）は pre-existing コードで本 PR スコープ外。
+
+### Acceptance Criteria Verification Difficulty
+
+- None. AC1・AC2 ともに `rubric` + `grep` のデュアル verify command で PASS。UNCERTAINs なし。`rubric` グレーダーが adversarial stance で検証しても問題なし。Post-merge AC は `verify-type: manual` で適切にマーク済みであり、`/verify` 実行時に自動スキップされる。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- sed 末尾 strip を `CURRENT_SYMPTOM` と `sym` の両方に適用した（`EXCLUDED_LIST` と `SYMPTOM_LIST` の `grep -qxF` 一致を保つため）
-- strip 対象は末尾の `(...)` 1 つのみ（`$` アンカーで過剰集約を防止）
-- fixture は Specの設計通り 3 エントリ（bare, `(#576, 2nd in session)`, `(#523, #526)`）で正規化後カウント=3 を確認
+- REVIEW_DEPTH=light (`--light` フラグ と Size M の両方が light に収束)
+- 全 pre-merge AC が PASS、MUST/SHOULD/CONSIDER issues ゼロ
+- sed パターン `s/ ([^)]*) *$//` が文書化されたユースケース（`(#576, 2nd in session)`, `(#523, #526)`）を正しく処理することを rubric グレーダーで確認
 
 ### Deferred Items
-- Post-merge AC: 実際の `docs/reports/orchestration-recoveries.md` で `silent-no-op` 系3件が正しく集約されることを次回 `/audit recoveries` 実行時に手動確認
+- Post-merge AC: 次回 `/audit recoveries` 実行で `silent-no-op` 系3件が閾値を満たすことを手動確認
 
 ### Notes for Next Phase
-- 変更ファイルは `scripts/collect-recovery-candidates.sh`、`tests/audit-recoveries.bats`、`tests/fixtures/orchestration-recoveries-trailing.md` の 3 ファイル
-- 全テストスイート PASS 済み
-- `docs/structure.md` は変更不要（高レベル記述が正規化後も正確）
+- MUST issues なし、merge は直接 `/merge 659` で実行可能
+- 全 CI チェック SUCCESS (DCO, bats×2, validate-skill-syntax×2, forbidden-expressions×2, macOS-compat×2)
+- code phase の Phase Handoff 記録通り、全テストスイート PASS 済み

--- a/docs/spec/issue-639-audit-recoveries-normalization.md
+++ b/docs/spec/issue-639-audit-recoveries-normalization.md
@@ -62,3 +62,33 @@ symptom-short を抽出する際に末尾の `(...)` を sed で strip して正
 ### 変数代入の方向
 
 CURRENT_SYMPTOM と sym の両方を正規化することで、EXCLUDED_LIST と SYMPTOM_LIST の比較が `grep -qxF` の exact match で一致するよう保つ。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None。Spec のImplementation Steps に記載された2箇所の sed 挿入、fixture 作成、bats テスト追加をすべてそのまま実装した。
+
+### Design Gaps/Ambiguities
+
+- None。Spec Notes の sed パターン (`s/ ([^)]*) *$//`) とその動作説明が明確で、実装中に解釈の迷いは生じなかった。
+
+### Rework
+
+- None。初回実装で全 5 テスト PASS、forbidden expressions チェックも問題なし。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- sed 末尾 strip を `CURRENT_SYMPTOM` と `sym` の両方に適用した（`EXCLUDED_LIST` と `SYMPTOM_LIST` の `grep -qxF` 一致を保つため）
+- strip 対象は末尾の `(...)` 1 つのみ（`$` アンカーで過剰集約を防止）
+- fixture は Specの設計通り 3 エントリ（bare, `(#576, 2nd in session)`, `(#523, #526)`）で正規化後カウント=3 を確認
+
+### Deferred Items
+- Post-merge AC: 実際の `docs/reports/orchestration-recoveries.md` で `silent-no-op` 系3件が正しく集約されることを次回 `/audit recoveries` 実行時に手動確認
+
+### Notes for Next Phase
+- 変更ファイルは `scripts/collect-recovery-candidates.sh`、`tests/audit-recoveries.bats`、`tests/fixtures/orchestration-recoveries-trailing.md` の 3 ファイル
+- 全テストスイート PASS 済み
+- `docs/structure.md` は変更不要（高レベル記述が正規化後も正確）

--- a/scripts/collect-recovery-candidates.sh
+++ b/scripts/collect-recovery-candidates.sh
@@ -86,6 +86,7 @@ while IFS= read -r line; do
   if echo "$line" | grep -qE '^## [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} UTC: .+'; then
     # Extract symptom-short (everything after "UTC: ")
     CURRENT_SYMPTOM="${line#*UTC: }"
+    CURRENT_SYMPTOM="$(echo "$CURRENT_SYMPTOM" | sed 's/ ([^)]*) *$//')"
     IN_ENTRY=1
   elif [ $IN_ENTRY -eq 1 ]; then
     # Detect "Improvement Candidate" line with 起票済み
@@ -102,6 +103,7 @@ while IFS= read -r line; do
   # Record all seen symptom-shorts (including excluded ones; we filter later)
   if echo "$line" | grep -qE '^## [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} UTC: .+'; then
     sym="${line#*UTC: }"
+    sym="$(echo "$sym" | sed 's/ ([^)]*) *$//')"
     SYMPTOM_LIST="${SYMPTOM_LIST}${sym}
 "
   fi

--- a/tests/audit-recoveries.bats
+++ b/tests/audit-recoveries.bats
@@ -4,6 +4,7 @@
 
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/collect-recovery-candidates.sh"
 FIXTURE="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/fixtures/orchestration-recoveries-sample.md"
+FIXTURE_TRAILING="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/fixtures/orchestration-recoveries-trailing.md"
 ISSUES_JSON_NO_MATCH="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/fixtures/open-issues-sample.json"
 ISSUES_JSON_WITH_GH_PR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/fixtures/open-issues-with-gh-pr.json"
 
@@ -53,4 +54,16 @@ ISSUES_JSON_WITH_GH_PR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/fixtures
   [ "$status" -eq 0 ]
   ! echo "$output" | grep -qF "gh-pr-list-head-glob"
   echo "$output" | grep -qF "code-pr-extraction-fail"
+}
+
+@test "normalize: trailing context stripped and aggregated to same bucket" {
+  # Fixture has 3 entries differing only in trailing context (none, (#576, 2nd in session), (#523, #526)).
+  # After normalization all 3 should map to the same bucket and count=3 >= threshold=3.
+  run bash "$SCRIPT" "$FIXTURE_TRAILING" --threshold 3
+  [ "$status" -eq 0 ]
+  line_count=$(echo "$output" | grep -c $'.\t[0-9]' || true)
+  [ "$line_count" -eq 1 ]
+  echo "$output" | grep -qF "silent-no-op recovered via wrapper-anomaly Tier 2 retry"$'\t'"3"
+  ! echo "$output" | grep -qF "(#576"
+  ! echo "$output" | grep -qF "(#523"
 }

--- a/tests/fixtures/orchestration-recoveries-trailing.md
+++ b/tests/fixtures/orchestration-recoveries-trailing.md
@@ -1,0 +1,14 @@
+## 2026-06-01 10:00 UTC: silent-no-op recovered via wrapper-anomaly Tier 2 retry
+
+- Recovery: Reran with wrapper bypass
+- Improvement Candidate: 未起票
+
+## 2026-06-02 11:00 UTC: silent-no-op recovered via wrapper-anomaly Tier 2 retry (#576, 2nd in session)
+
+- Recovery: Reran with wrapper bypass
+- Improvement Candidate: 未起票
+
+## 2026-06-03 12:00 UTC: silent-no-op recovered via wrapper-anomaly Tier 2 retry (#523, #526)
+
+- Recovery: Reran with wrapper bypass
+- Improvement Candidate: 未起票


### PR DESCRIPTION
## Summary

- `scripts/collect-recovery-candidates.sh` の symptom-short バケット鍵に末尾の `(...)` を strip する正規化処理を追加
- 末尾文脈（例: `(#576, 2nd in session)`, `(#523, #526)`）のみ異なるエントリが同一バケットに集約され、`/audit recoveries` の候補検出感度が改善される
- 新規 fixture `tests/fixtures/orchestration-recoveries-trailing.md` と回帰テスト `normalize: trailing context stripped and aggregated to same bucket` を追加

## Verification (pre-merge)

- `scripts/collect-recovery-candidates.sh` に `sed 's/ ([^)]*) *$//'` による末尾 strip が2箇所追加されている (`grep "sed"` で確認)
- `tests/audit-recoveries.bats` に `trailing`/`normalize` キーワードを含む回帰テストが追加されている
- 全 bats テスト PASS (5/5 in audit-recoveries.bats; 全テストスイート PASS)

## Verification (post-merge)

- 次回以降の `/audit recoveries` 実行で、`silent-no-op` 系エントリ群が正規化後に同一バケットとして threshold を満たし、候補表示に到達することを確認する

closes #639