### PR TITLE
Issue #662: Fix token_usage / ci_wait / test_result emission in auto-events-log

### DIFF
--- a/docs/spec/issue-662-auto-events-3-missing-events.md
+++ b/docs/spec/issue-662-auto-events-3-missing-events.md
@@ -112,21 +112,35 @@ review phase の emit を確認済み。本 Issue では merge phase（`run-merg
 
 - None
 
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+- 乖離なし。3 つのバグ修正（`2>&1` 除去、`test_result` 条件拡張、`ci_wait` merge phase テスト追加）はすべて Spec の実装ステップと一致していた。`test_result` テストのモック修正方針（skip を proper assertion に昇格）は Code Retrospective で説明済み。
+
+### 繰り返し指摘パターン
+
+- `test_result` テストで skip を proper assertion に昇格させたが、同ファイルの `token_usage` テストに同じ skip パターンが残っていた。fix-and-forget パターン：同類の skip を同一 PR でまとめて修正する規律が必要。
+
+### 受け入れ基準検証の難易度
+
+- `file_not_contains` と `rubric` および `command` の 5 条件すべて UNCERTAIN なし。`command "bats tests/wait-ci-checks.bats"` は CI 参照フォールバック（`Run bats tests` SUCCESS）で PASS 判定。verify command の設計は適切だった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- `2>&1` 除去のみでの修正（`grep '^{' | tail -1` フィルタ方式は採用しなかった）: TOKEN_USAGE_FILE へのリダイレクト時点で watchdog stderr を混入させないのが根本解であり、シンプルで bash 3.2+ 互換
-- `test_result` 条件は `code*` prefix match を採用（`"code" || "code-patch" || "code-pr"` より簡潔で、将来的なフェーズ名追加にも対応）
-- `ci_wait` は既存の `run-auto-sub.sh` → `run-review.sh` / `run-merge.sh` 経路での `export AUTO_EVENTS_LOG` が正しく動作しており、Issue が観察されたのはテスト実行時にレビュー/マージフェーズなしの XS/S issue だったことが原因と判断。merge phase テストを追加して propagation path を明示化した
+- MUST 指摘なし → マージブロック不要。SHOULD（`token_usage` skip 未修正）と CONSIDER（watchdog stderr リスク）の 2 件を記録してスキップ
+- `token_usage` skip 未修正は SHOULD レベル：次 Issue で対処が望ましいが、`2>&1` 除去後に emission は正常動作するため今 PR でブロックしない判断
 
 ### Deferred Items
 
-- post-merge AC（次回 `/auto` 完走後の `token_usage` / `ci_wait` / `test_result` 3 種観察）は observation event として defer
+- `tests/run-auto-sub.bats` L561-562 の `token_usage` skip を proper assertion に昇格（SHOULD）→ `/merge` 後または別 Issue で対処
+- post-merge AC（`token_usage` / `ci_wait` / `test_result` 3 種の observation）→ 次回 `/auto` 完走後に確認
 
 ### Notes for Next Phase
 
-- `/review` は `bats tests/run-auto-sub.bats` の `test_result` テスト（ok 23）が PASS していることを確認する
-- `file_not_contains` ACs はすべて PASS 済み（Issue チェックボックス更新済み）
-- PR #664 でのマージ後、`.tmp/auto-events.jsonl` に 3 種が記録されることを post-merge 観察で確認する
+- CI 全ジョブ SUCCESS、MUST 指摘なし → `/merge 664` 実行可能
+- `token_usage` テストの skip 残存は SHOULD 指摘済み（PR コメント参照）
+- post-merge AC がまだ未観察のため、次回 `/auto` 完走後に `.tmp/auto-events.jsonl` で 3 種を確認する

--- a/docs/spec/issue-662-auto-events-3-missing-events.md
+++ b/docs/spec/issue-662-auto-events-3-missing-events.md
@@ -97,3 +97,36 @@ review phase の emit を確認済み。本 Issue では merge phase（`run-merg
 - `file_not_contains "scripts/run-code.sh" "2>&1"` 等は各ファイルに `2>&1` が 1 箇所のみ存在することを確認済み（除去後は 0 件）
 - ci_wait の既存テスト（`@test "ci_wait: event emitted to AUTO_EVENTS_LOG when AUTO_EVENTS_LOG is set"`、
   `EMIT_PHASE_NAME="review"` で動作確認済み）は変更不要
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `test_result` テストのモック修正方針として、Spec は「stdout に echo するよう変更」と記載していたが、加えて `skip` による条件付きスキップを proper assertion (`grep -q "test_result" "$BATS_TEST_TMPDIR/emit.log"`) に変更した。修正後は `code*` 条件が正しく機能し、テストが実際に PASS することを確認できたため、skip を外した方が正確な検証になる。
+
+### Design Gaps/Ambiguities
+
+- None
+
+### Rework
+
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+
+- `2>&1` 除去のみでの修正（`grep '^{' | tail -1` フィルタ方式は採用しなかった）: TOKEN_USAGE_FILE へのリダイレクト時点で watchdog stderr を混入させないのが根本解であり、シンプルで bash 3.2+ 互換
+- `test_result` 条件は `code*` prefix match を採用（`"code" || "code-patch" || "code-pr"` より簡潔で、将来的なフェーズ名追加にも対応）
+- `ci_wait` は既存の `run-auto-sub.sh` → `run-review.sh` / `run-merge.sh` 経路での `export AUTO_EVENTS_LOG` が正しく動作しており、Issue が観察されたのはテスト実行時にレビュー/マージフェーズなしの XS/S issue だったことが原因と判断。merge phase テストを追加して propagation path を明示化した
+
+### Deferred Items
+
+- post-merge AC（次回 `/auto` 完走後の `token_usage` / `ci_wait` / `test_result` 3 種観察）は observation event として defer
+
+### Notes for Next Phase
+
+- `/review` は `bats tests/run-auto-sub.bats` の `test_result` テスト（ok 23）が PASS していることを確認する
+- `file_not_contains` ACs はすべて PASS 済み（Issue チェックボックス更新済み）
+- PR #664 でのマージ後、`.tmp/auto-events.jsonl` に 3 種が記録されることを post-merge 観察で確認する

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -101,8 +101,8 @@ run_phase_with_recovery() {
     done <<< "$_commits"
   fi
 
-  # test_result: parse bats output from log_file (code phase only)
-  if [[ "$phase" == "code" ]] && [[ -f "$log_file" ]]; then
+  # test_result: parse bats output from log_file (code-patch / code-pr / code phases)
+  if [[ "$phase" == code* ]] && [[ -f "$log_file" ]]; then
     local _bats_line
     _bats_line=$(grep -E "[0-9]+ tests?, [0-9]+ failures?" "$log_file" 2>/dev/null | tail -1 || true)
     if [[ -n "$_bats_line" ]]; then

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -163,7 +163,7 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
       --effort high \
       --output-format json \
       $PERMISSION_FLAG \
-      > "$TOKEN_USAGE_FILE" 2>&1
+      > "$TOKEN_USAGE_FILE"
   EXIT_CODE=$?
   jq -r '.result // empty' "$TOKEN_USAGE_FILE" 2>/dev/null || true
 else

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -77,7 +77,7 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
       --effort low \
       --output-format json \
       $PERMISSION_FLAG \
-      > "$TOKEN_USAGE_FILE" 2>&1
+      > "$TOKEN_USAGE_FILE"
   EXIT_CODE=$?
   jq -r '.result // empty' "$TOKEN_USAGE_FILE" 2>/dev/null || true
 else

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -86,7 +86,7 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
       --effort high \
       --output-format json \
       $PERMISSION_FLAG \
-      > "$TOKEN_USAGE_FILE" 2>&1
+      > "$TOKEN_USAGE_FILE"
   EXIT_CODE=$?
   jq -r '.result // empty' "$TOKEN_USAGE_FILE" 2>/dev/null || true
 else

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -572,13 +572,11 @@ emit_event() {
 }
 MOCK
 
-    # Make run-code.sh write bats output to its log file
-    cat > "$MOCK_DIR/run-code.sh" <<MOCK
+    # run-code.sh echoes bats output to stdout; run-auto-sub.sh captures it
+    # into .tmp/wrapper-out-42-code-patch.log (XS route -> code-patch phase)
+    cat > "$MOCK_DIR/run-code.sh" <<'MOCK'
 #!/bin/bash
-# The log is captured by run-auto-sub.sh into .tmp/wrapper-out-42-code.log
-# We write directly there for the test
-mkdir -p .tmp
-echo "17 tests, 0 failures" > ".tmp/wrapper-out-42-code.log"
+echo "17 tests, 0 failures"
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/run-code.sh"
@@ -599,8 +597,7 @@ MOCK
 
     run bash "$SCRIPT" 42
     [ "$status" -eq 0 ]
-    grep -q "test_result" "$BATS_TEST_TMPDIR/emit.log" 2>/dev/null || \
-      skip "test_result event not logged (emit mock not capturing)"
+    grep -q "test_result" "$BATS_TEST_TMPDIR/emit.log"
 }
 
 @test "concurrent_commit_detected: emit_event called when git log returns commits" {

--- a/tests/wait-ci-checks.bats
+++ b/tests/wait-ci-checks.bats
@@ -143,6 +143,25 @@ MOCK
     grep -q '"phase":"review"' "$EVENTS_LOG"
 }
 
+@test "ci_wait: event emitted with merge phase when EMIT_PHASE_NAME is merge" {
+    EVENTS_LOG="$BATS_TEST_TMPDIR/auto-events-merge.jsonl"
+    EMIT_DIR="$BATS_TEST_TMPDIR/emit-script-dir-merge"
+    mkdir -p "$EMIT_DIR"
+    emit_event_src="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/emit-event.sh"
+    cp "$emit_event_src" "$EMIT_DIR/emit-event.sh"
+
+    run env AUTO_EVENTS_LOG="$EVENTS_LOG" \
+      EMIT_ISSUE_NUMBER="101" \
+      EMIT_PHASE_NAME="merge" \
+      WHOLEWORK_SCRIPT_DIR="$EMIT_DIR" \
+      PATH="$MOCK_DIR:$PATH" \
+      bash "$SCRIPT" 101
+    [ "$status" -eq 0 ]
+    [ -f "$EVENTS_LOG" ]
+    grep -q '"event":"ci_wait"' "$EVENTS_LOG"
+    grep -q '"phase":"merge"' "$EVENTS_LOG"
+}
+
 @test "ci_wait: no event emitted when AUTO_EVENTS_LOG is not set" {
     EVENTS_LOG="$BATS_TEST_TMPDIR/auto-events.jsonl"
 


### PR DESCRIPTION
## Summary

- `scripts/run-code.sh`, `run-review.sh`, `run-merge.sh` の `--output-format json` 行から `2>&1` を除去し、watchdog stderr が TOKEN_USAGE_FILE に混入して `token_usage` event が emit されない問題を修正
- `scripts/run-auto-sub.sh` の `test_result` emission 条件を `[[ "$phase" == "code" ]]` から `[[ "$phase" == code* ]]` に変更し、`code-patch` / `code-pr` フェーズでも発火するよう修正
- `tests/wait-ci-checks.bats` に merge phase（`EMIT_PHASE_NAME="merge"`）での `ci_wait` emission テストを追加

## Verification (pre-merge)

- `scripts/run-code.sh` / `run-review.sh` / `run-merge.sh` から `2>&1` が除去され、TOKEN_USAGE_FILE に watchdog stderr が混入しないことを確認
- `scripts/run-auto-sub.sh` の `test_result` emission 条件が `code-patch` / `code-pr` フェーズを含む `code*` パターンに変更されたことを確認
- `bats tests/wait-ci-checks.bats` 全 13 テストが PASS（新規追加 merge phase テスト含む）

## Verification (post-merge)

- 次回 `/auto` 完走後に `.tmp/auto-events.jsonl` で `token_usage` / `ci_wait` / `test_result` 3 種が記録されることを観察

closes #662