### PR TITLE
Issue #656: Add observation-trigger.sh and wire into emitters

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（55 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（57 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -35,7 +35,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（74 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（78 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents
@@ -177,6 +177,7 @@ wholework/
 - `scripts/get-verify-iteration.sh` — Issue コメントから `<!-- verify-iteration: N -->` マーカーの最大値を読み取る
 - `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: プロンプトが `/auto` パターンにマッチした場合にセッション名を自動リネーム
 - `scripts/log-permission.sh` — 権限イベントログ（JSON 出力）
+- `scripts/observation-trigger.sh` — イベント発火時に observation AC をディスパッチ: `opportunistic-search.sh --event` を呼び出し、マッチした各 Issue に `/verify` 再実行を促すコメントを投稿
 - `scripts/opportunistic-search.sh` — opportunistic スキル検索と observation イベントスキャン
 - `scripts/post_merge_check.sh` — 複数 Issue の post-merge 手動 AC（verify-type: manual）を 1 セッションでバンドル実行; AC ごとに P/F/S を対話入力; 全 PASS で phase/done 遷移、FAIL で reopen
 - `scripts/triage-backlog-filter.sh` — triage 向けバックログフィルタ

--- a/docs/spec/issue-656-observation-trigger-script.md
+++ b/docs/spec/issue-656-observation-trigger-script.md
@@ -52,3 +52,35 @@
 - bats テストスコープ: `observation-trigger.sh` 単体テストのみ（auto-resolve #3）。emitter 配線は grep verify command による pre-merge 静的検証でカバー
 - `scripts/claude-watchdog.sh` の変数名（`_watchdog_event_results` 等）は削除される; 全体の行数が削減される
 - `docs/structure.md` の件数修正: scripts (55→57: 現在の実数 56 + 新規 1)、tests (74→78: 現在の実数 77 + 新規 1) — 既存ドリフト分も含めて修正
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec では `tests/` 件数を「74→78」と記載していたが、実際のドキュメントには「74 ファイル」と記載されており、実数は77（+1で78）。件数差分は既存ドリフトのため deviation なし — Spec の通り修正した。
+- `verify/SKILL.md` への `observation-trigger.sh --event fix-cycle` の追加場所: `gh issue reopen "$NUMBER"` の直後（Spec 通り）に配置し、`emit verify_reopen_cycle event` ブロックの前に挿入。
+
+### Design Gaps/Ambiguities
+
+- `--dry-run` フラグの動作: Spec には「`opportunistic-search.sh` 引数として渡す」とは記載されていなかったが、`--dry-run` 時は `opportunistic-search.sh` 呼び出し自体をスキップするシンプルな実装を選択。ghost API call を避けるという点で合理的。
+- `gh issue comment` の引数配置: `observation-trigger.sh` では「`/verify ${N}` を再実行してください」ではなく英語メッセージ（Spec の文面に従い "Run `/verify ${N}` to verify the condition and update the checkbox."）を使用。CLAUDE.md で「スクリプトのユーザー向けメッセージは英語」とは定められていないが、スクリプト内のコメント言語が英語という慣習に従った。
+
+### Rework
+
+- N/A（設計通り実装できた。テストは一発 PASS）
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `observation-trigger.sh` は comment-posting dispatch のみ（AI judgment なし）: Spec auto-resolve #1/#2 に従いシンプルな shell-only 実装を採用。`run-verify.sh` が存在しないためシェルからの `/verify` spawn は不可。
+- emitter 統合は one-liner 置き換え: `/review`・`/auto` のインライン処理（AI judgment + checkbox update）は削除し、`observation-trigger.sh` 呼び出し一行に統一。
+- `verify/SKILL.md` への `fix-cycle` 追加: `gh issue reopen` 直後に配線し、CLOSED→OPEN 遷移時のみ発火する形を維持（OPEN 時の reopen スキップ branch にはない）。
+
+### Deferred Items
+- AI judgment による observation AC チェックボックス自動更新は削除された（follow-up 候補）。comment-posting のみでユーザー手動 `/verify` 再実行が必要。
+- `gh issue comment` のメッセージ内容（英語）の最終化は review フェーズで確認。
+
+### Notes for Next Phase
+- bats テスト 8件は全 PASS、SKILL.md syntax validation も OK。CI (bats CI run) は PR #671 で確認。
+- `ISSUE_STATE` が `OPEN` の場合（`gh issue reopen` は実行されない）の `fix-cycle` 発火パスは verify/SKILL.md では配線されていないが、これは Spec の "CLOSED 時のみ reopen" 設計に準拠。必要なら別途検討。

--- a/docs/spec/issue-656-observation-trigger-script.md
+++ b/docs/spec/issue-656-observation-trigger-script.md
@@ -69,18 +69,32 @@
 
 - N/A（設計通り実装できた。テストは一発 PASS）
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+`modules/observation-trigger.md` の Emitter Lookup Table（line 66）が PR によって更新されていなかった。`Future Extension` セクションは「実装済み #656」に更新されていたが、テーブル行だけが「(future)」「not yet implemented」のままで残り、同一ファイル内で矛盾が生じた。Spec には「`modules/observation-trigger.md` の Future Extension 節を更新」と記載されていたが、テーブル行の更新は Spec に明示されていなかったため、実装者が見落としたと考えられる。Spec に変更ファイルの具体的な更新箇所（節名だけでなく行レベルで）を記載することで防げた。
+
+### Recurring Issues
+
+今回の review では SHOULD 1件、CONSIDER 1件のみ。MUST 0件。パターンの繰り返しは見られなかった。Nothing to note.
+
+### Acceptance Criteria Verification Difficulty
+
+全9件の verify command が PASS。`github_check "gh pr checks" "Run bats tests"` は safe mode で CI 結果を参照でき、問題なく PASS を判定できた。`file_exists`・`grep` 系はすべて明確。UNCERTAIN 0件。ファイル内の特定行の更新を検証する verify command（`section_contains` 等）があれば Emitter Lookup Table の stale entry を事前検知できたかもしれない。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `observation-trigger.sh` は comment-posting dispatch のみ（AI judgment なし）: Spec auto-resolve #1/#2 に従いシンプルな shell-only 実装を採用。`run-verify.sh` が存在しないためシェルからの `/verify` spawn は不可。
-- emitter 統合は one-liner 置き換え: `/review`・`/auto` のインライン処理（AI judgment + checkbox update）は削除し、`observation-trigger.sh` 呼び出し一行に統一。
-- `verify/SKILL.md` への `fix-cycle` 追加: `gh issue reopen` 直後に配線し、CLOSED→OPEN 遷移時のみ発火する形を維持（OPEN 時の reopen スキップ branch にはない）。
+- `modules/observation-trigger.md` の Emitter Lookup Table line 66 を修正（SHOULD 対応）: review フェーズで検出した stale entry（"/verify skill (future)"）を "implemented in #656" に更新して push した。
+- `--dry-run` 意味論の曖昧さ（CONSIDER）はスキップ: line 66 の更新で主要な混乱は解消され、追加注記は任意レベルと判断。
+- 受け入れ基準は全9件 PASS、CI も全 SUCCESS。MUST issues なし。
 
 ### Deferred Items
-- AI judgment による observation AC チェックボックス自動更新は削除された（follow-up 候補）。comment-posting のみでユーザー手動 `/verify` 再実行が必要。
-- `gh issue comment` のメッセージ内容（英語）の最終化は review フェーズで確認。
+- AI judgment による observation AC チェックボックス自動更新（comment-posting から upgrade）は引き続き follow-up 候補。
+- `observation-trigger.sh` の `--dry-run` と `opportunistic-search.sh` の `--dry-run` の意味論差の明示的な文書化（CONSIDER）は今後任意で対応。
 
 ### Notes for Next Phase
-- bats テスト 8件は全 PASS、SKILL.md syntax validation も OK。CI (bats CI run) は PR #671 で確認。
-- `ISSUE_STATE` が `OPEN` の場合（`gh issue reopen` は実行されない）の `fix-cycle` 発火パスは verify/SKILL.md では配線されていないが、これは Spec の "CLOSED 時のみ reopen" 設計に準拠。必要なら別途検討。
+- MUST issues なし → `/merge 671` で merge 可能。
+- Emitter Lookup Table の修正コミット（9e178e7）が branch に push 済み。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (55 files)
+├── scripts/             # Utility scripts used by skills and agents (57 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -42,7 +42,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (74 files)
+├── tests/               # Bats test files for scripts (78 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -185,6 +185,7 @@ Key modules:
 - `scripts/get-verify-iteration.sh` — read highest `<!-- verify-iteration: N -->` marker from Issue comments
 - `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: auto-rename session title when prompt matches `/auto` pattern
 - `scripts/log-permission.sh` — log permission events (JSON output)
+- `scripts/observation-trigger.sh` — dispatch observation-type ACs on event: calls `opportunistic-search.sh --event`, posts comment to each matched Issue recommending `/verify` re-run
 - `scripts/opportunistic-search.sh` — opportunistic skill search and observation event scan
 - `scripts/post_merge_check.sh` — bundle and run post-merge manual (verify-type: manual) ACs for multiple Issues in one session; prompts P/F/S per AC; transitions to phase/done on all-PASS or reopens on FAIL
 - `scripts/triage-backlog-filter.sh` — filter backlog for triage

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -63,7 +63,7 @@ Each emitter is responsible for:
 | `/review` skill | Opportunistic Verification step (after Step completion) | `pr-review-full` or `pr-review-light` depending on `REVIEW_DEPTH` |
 | `/auto` skill | Post-completion event scan (after Completion Report) | `auto-run` |
 | `scripts/claude-watchdog.sh` | Watchdog kill handler (`_auto_emit_watchdog_kill`) | `watchdog-kill` |
-| `/verify` skill (future) | FAIL → reopen → fix-cycle detection | `fix-cycle` (not yet implemented — follow-up #650 child Issue) |
+| `/verify` skill | FAIL → reopen → fix-cycle detection | `fix-cycle` (implemented in #656) |
 
 ## Output Processing Contract
 

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -82,17 +82,18 @@ In shell contexts where `/verify` cannot be spawned (e.g., inside `claude-watchd
 - Post a comment to the Issue noting the event was observed
 - Recommend the user re-run `/verify <number>` to update the checkbox
 
-## Future Extension: `scripts/observation-trigger.sh`
+## `scripts/observation-trigger.sh` (実装済み #656)
 
-A dedicated dispatch script (`scripts/observation-trigger.sh`) can encapsulate the
+A dedicated dispatch script (`scripts/observation-trigger.sh`) encapsulates the
 processing contract above, making emitter integration a one-liner:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh" --event <event-name>
 ```
 
-This script would handle JSON parsing, state checks, and `/verify` dispatch.
-Implementation is tracked in the child Issue created under #650.
+The script calls `opportunistic-search.sh --event <name>`, and for each matched Issue
+posts a comment recommending the user re-run `/verify <N>` (comment-posting dispatch;
+no AI judgment in shell context). Implemented in #656.
 
 ## Notes
 

--- a/scripts/claude-watchdog.sh
+++ b/scripts/claude-watchdog.sh
@@ -132,19 +132,8 @@ if [[ "$_watchdog_killed" == "true" ]]; then
   echo "watchdog: retrying disabled; please re-run the skill manually" >&2
 
   # Scan for observation ACs waiting for watchdog-kill event
-  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && [[ -x "${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh" ]]; then
-    _watchdog_event_results=$("${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh" --event watchdog-kill 2>/dev/null || true)
-    if [[ -n "$_watchdog_event_results" ]] && [[ "$_watchdog_event_results" != "[]" ]]; then
-      _matched_count=$(echo "$_watchdog_event_results" | jq 'length' 2>/dev/null || echo 0)
-      if [[ "$_matched_count" -gt 0 ]]; then
-        _issue_numbers=$(echo "$_watchdog_event_results" | jq -r '.[].number' 2>/dev/null || true)
-        if [[ -n "$_issue_numbers" ]]; then
-          for _wk_issue in $_issue_numbers; do
-            gh issue comment "$_wk_issue" --body "watchdog-kill event observed — condition FAIL (AI judgment not available in shell context; re-run \`/verify ${_wk_issue}\` to update checkbox)" 2>/dev/null || true
-          done
-        fi
-      fi
-    fi
+  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]] && [[ -x "${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh" ]]; then
+    "${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh" --event watchdog-kill 2>/dev/null || true
   fi
 fi
 

--- a/scripts/observation-trigger.sh
+++ b/scripts/observation-trigger.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# observation-trigger.sh
+# Dispatch observation-type ACs when a named event fires.
+#
+# Usage:
+#   scripts/observation-trigger.sh --event <event-name> [--dry-run]
+#
+# For each matched Issue, posts a comment recommending the user re-run /verify.
+# Errors are non-fatal (2>/dev/null || true pattern throughout).
+
+set -euo pipefail
+
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+
+EVENT_NAME=""
+DRY_RUN=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --event)
+            if [ $# -lt 2 ]; then
+                echo "Error: --event requires an argument" >&2
+                exit 1
+            fi
+            EVENT_NAME="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            echo "Error: Unknown argument: $1" >&2
+            echo "Usage: $0 --event <event-name> [--dry-run]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$EVENT_NAME" ]; then
+    echo "Error: --event <event-name> is required" >&2
+    echo "Usage: $0 --event <event-name> [--dry-run]" >&2
+    exit 1
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    exit 0
+fi
+
+RESULTS=$("${SCRIPT_DIR}/opportunistic-search.sh" --event "$EVENT_NAME" 2>/dev/null || true)
+
+if [ -z "$RESULTS" ] || [ "$RESULTS" = "[]" ]; then
+    exit 0
+fi
+
+NUMBERS=$(echo "$RESULTS" | jq -r '.[].number' 2>/dev/null || true)
+if [ -z "$NUMBERS" ]; then
+    exit 0
+fi
+
+for N in $NUMBERS; do
+    gh issue comment "$N" --body "observation event \`${EVENT_NAME}\` detected. Run \`/verify ${N}\` to verify the condition and update the checkbox." 2>/dev/null || true
+done

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto
 description: Autonomous execution (`/auto 123`). Runs spec (when needed)→code→review→merge→verify in sequence. XL Issues use sub-issue dependency graph with parallel execution. Size auto-detection with `--patch`/`--pr` and `--review=light`/`--review=full` overrides. Issues without `phase/*` labels start from issue triage. `--batch N` processes N backlog XS/S Issues; `--batch N1 N2 ...` processes the explicitly listed Issues in order (assigns a BATCH_ID for parallel-safe checkpointing). `--resume N` resumes a single Issue (restores verify counter from checkpoint); `--batch --resume` resumes an interrupted batch using `list_active_batches` to identify the target session.
-allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, gh issue view:*, gh issue list:*, gh issue close:*, gh issue comment:*, gh issue create:*, gh pr list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-sub-issue-graph.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-spec.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-issue.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-wrapper-anomaly.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/validate-recovery-plan.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*), Read, Edit, Glob, Grep, Write, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, gh issue view:*, gh issue list:*, gh issue close:*, gh issue comment:*, gh issue create:*, gh pr list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-sub-issue-graph.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-spec.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-issue.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-wrapper-anomaly.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/validate-recovery-plan.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*), Read, Edit, Glob, Grep, Write, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Autonomous Execution
@@ -551,14 +551,7 @@ Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "P
 
 **Event-based observation scan (auto-run event, runs after Completion Report regardless of success/failure):**
 
-Run `${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event auto-run`
-
-If the returned JSON array is non-empty, for each matched Issue:
-1. Re-evaluate the matched observation AC using AI judgment on whether today's `/auto` run satisfies the condition
-2. If PASS: update the AC checkbox in the Issue body via `${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh`
-3. If all ACs for the Issue are now checked: run `${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh <issue_number> done` and close the Issue with `gh issue close <issue_number>`
-
-If the array is empty, skip silently.
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event auto-run`
 
 ### Step 6: On Failure: 3-Tier Recovery
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -2,7 +2,7 @@
 name: review
 description: PR review (`/review 88`). Automatically runs acceptance criteria verification, multi-perspective code review, issue resolution, and summary posting. Use after `/code` creates a PR and before `/merge` (`--light`/`--full` to adjust depth).
 context: fork
-allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, Workflow
+allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, Workflow
 ---
 
 # PR Review
@@ -792,17 +792,10 @@ If `opportunistic-verify: true` is set in `.wholework.yml`, read `${CLAUDE_PLUGI
 
 **Event-based observation scan (runs regardless of `opportunistic-verify` setting):**
 
-After the opportunistic verification above (or in its place if `opportunistic-verify` is not set), scan for observation-type ACs that match this review's event:
+After the opportunistic verification above (or in its place if `opportunistic-verify` is not set), fire the observation trigger:
 
-- If `REVIEW_DEPTH=full`: run `${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event pr-review-full`
-- If `REVIEW_DEPTH=light`: run `${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event pr-review-light`
-
-If the returned JSON array is non-empty, for each matched Issue:
-1. Re-evaluate the matched observation AC using the verify-executor in full mode (AI judgment on whether today's review event satisfies the condition)
-2. If PASS: update the AC checkbox in the Issue body via `${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh`
-3. If all ACs for the Issue are now checked: run `${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh <issue_number> done` and close the Issue with `gh issue close <issue_number>`
-
-If the array is empty, skip silently.
+- If `REVIEW_DEPTH=full`: run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event pr-review-full`
+- If `REVIEW_DEPTH=light`: run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event pr-review-light`
 
 ## Completion Report
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -2,7 +2,7 @@
 name: verify
 description: Acceptance test. Automatically verifies post-merge acceptance conditions and updates Issue checkboxes (`/verify 123`). Use after `/merge`. Reopens Issue on FAIL to return to the fix cycle.
 model: sonnet
-allowed-tools: Bash(git checkout:*, git pull:*, git status:*, git stash:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh issue view:*, gh issue edit:*, gh issue list:*, gh issue close:*, gh issue reopen:*, gh issue create:*, gh pr list:*, gh label list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-verify-iteration.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-verify-dirty.sh:*, wc:*, diff:*, test:*, git log:*, git diff:*, npm:*, node:*, make:*, gh pr view:*, gh api:*, date:*, printf:*), Read, Write, Edit, Glob, Grep, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_close
+allowed-tools: Bash(git checkout:*, git pull:*, git status:*, git stash:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh issue view:*, gh issue edit:*, gh issue list:*, gh issue close:*, gh issue reopen:*, gh issue create:*, gh pr list:*, gh label list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-verify-iteration.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-verify-dirty.sh:*, wc:*, diff:*, test:*, git log:*, git diff:*, npm:*, node:*, make:*, gh pr view:*, gh api:*, date:*, printf:*), Read, Write, Edit, Glob, Grep, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_close
 ---
 
 # Acceptance Test
@@ -439,6 +439,12 @@ NEXT_ITERATION=$((CURRENT_ITERATION + 1))
     - When `ISSUE_STATE` is `CLOSED`: reopen the Issue:
       ```bash
       gh issue reopen "$NUMBER"
+      ```
+    - Fire the fix-cycle observation trigger (non-fatal):
+      ```bash
+      if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
+        "${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh" --event fix-cycle 2>/dev/null || true
+      fi
       ```
     - Emit `verify_reopen_cycle` event (only when running inside `/auto` session — both `AUTO_EVENTS_LOG` and `AUTO_SESSION_ID` must be set):
       ```bash

--- a/tests/observation-trigger.bats
+++ b/tests/observation-trigger.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+# Tests for observation-trigger.sh
+# Mock opportunistic-search.sh via WHOLEWORK_SCRIPT_DIR; mock gh via PATH
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$PROJECT_ROOT/scripts/observation-trigger.sh"
+
+setup() {
+    cd "$PROJECT_ROOT"
+
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "gh called: $*" >> "$BATS_TEST_TMPDIR/gh-calls.log"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/opportunistic-search.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "${MOCK_SEARCH_OUTPUT:-[]}"
+exit "${MOCK_SEARCH_EXIT:-0}"
+MOCK_EOF
+    chmod +x "$MOCK_DIR/opportunistic-search.sh"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "error: missing --event argument" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--event"* ]]
+}
+
+@test "error: --event without value" {
+    run bash "$SCRIPT" --event
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--event requires an argument"* ]]
+}
+
+@test "error: unknown argument" {
+    run bash "$SCRIPT" --unknown
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown argument"* ]]
+}
+
+@test "dry-run: exits 0 without calling opportunistic-search.sh" {
+    run bash "$SCRIPT" --event pr-review-full --dry-run
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -f "$BATS_TEST_TMPDIR/gh-calls.log" ]
+}
+
+@test "success: no matches exits silently without posting comments" {
+    export MOCK_SEARCH_OUTPUT="[]"
+    run bash "$SCRIPT" --event auto-run
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -f "$BATS_TEST_TMPDIR/gh-calls.log" ]
+}
+
+@test "success: single match posts one comment" {
+    export MOCK_SEARCH_OUTPUT='[{"number": 42, "condition": "watchdog-kill event is observed"}]'
+    run bash "$SCRIPT" --event watchdog-kill
+    [ "$status" -eq 0 ]
+    grep -q "issue comment 42" "$BATS_TEST_TMPDIR/gh-calls.log"
+    grep -q "watchdog-kill" "$BATS_TEST_TMPDIR/gh-calls.log"
+}
+
+@test "success: multiple matches post one comment each" {
+    export MOCK_SEARCH_OUTPUT='[{"number": 10, "condition": "first"},{"number": 20, "condition": "second"}]'
+    run bash "$SCRIPT" --event fix-cycle
+    [ "$status" -eq 0 ]
+    grep -q "issue comment 10" "$BATS_TEST_TMPDIR/gh-calls.log"
+    grep -q "issue comment 20" "$BATS_TEST_TMPDIR/gh-calls.log"
+}
+
+@test "resilience: opportunistic-search.sh error does not abort trigger" {
+    export MOCK_SEARCH_EXIT=1
+    export MOCK_SEARCH_OUTPUT=""
+    run bash "$SCRIPT" --event pr-review-light
+    [ "$status" -eq 0 ]
+    [ ! -f "$BATS_TEST_TMPDIR/gh-calls.log" ]
+}


### PR DESCRIPTION
## Summary

- `scripts/observation-trigger.sh` を新規作成: `--event <name>` を受け取り、`opportunistic-search.sh --event` を呼び出し、マッチした各 Issue にコメントを投稿して `/verify` 再実行を促す
- `/review`、`/auto` skill のインライン observation scan ブロック（8〜7行）を `observation-trigger.sh` one-liner に置き換え
- `scripts/claude-watchdog.sh` の watchdog-kill 観察スキャンブロック（15行）を `observation-trigger.sh --event watchdog-kill` one-liner に置き換え
- `skills/verify/SKILL.md` の FAIL → reopen ブロック内に `observation-trigger.sh --event fix-cycle` 呼び出しを追加
- `tests/observation-trigger.bats` 新規作成（8テスト: 引数エラー・dry-run・マッチなし・単一マッチ・複数マッチ・エラー継続）
- `docs/structure.md` および `docs/ja/structure.md` の件数修正と新エントリ追加
- `modules/observation-trigger.md` の Future Extension セクションを「実装済み（#656）」に更新

## Verification (pre-merge)

- `scripts/observation-trigger.sh` が新規作成されている
- `--event <name>` 引数を受け取る処理が実装されている
- `opportunistic-search.sh` を呼び出す処理が実装されている
- `/review` skill に `observation-trigger.sh` 呼び出しが配線されている
- `/auto` skill に `observation-trigger.sh` 呼び出しが配線されている
- `claude-watchdog.sh` に `observation-trigger.sh` 呼び出しが配線されている
- `/verify` skill の FAIL → reopen 箇所に `observation-trigger.sh --event fix-cycle` 呼び出しが追加されている
- `tests/observation-trigger.bats` が新規作成されている
- bats テスト（正常系・異常系）が CI で PASS している

## Verification (post-merge)

なし

closes #656