### PR TITLE
Issue #666: Add phase silent window threshold violation to auto-session report

### DIFF
--- a/docs/spec/issue-666-auto-session-silent-threshold.md
+++ b/docs/spec/issue-666-auto-session-silent-threshold.md
@@ -62,18 +62,34 @@
 - None: 実装は一発で全テスト PASS。修正なし。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `watchdog-defaults.sh` を `get-auto-session-report.sh` の先頭 (emit-event.sh source 直後) で source し、`SILENT_MARGIN=600` と phase 別閾値変数を定義した。merge フェーズは threshold=0 なので除外。
-- `PHASE_SILENT_BREAKDOWN` の jq クエリは `--argjson` で 4 変数 (t_spec/t_code/t_review/t_issue) を渡し、違反 phase をカウントして `<total> (code:<n>, spec:<n>)` 形式で出力する設計にした。
-- per-issue Notes は `_at_risk_silent` が空なら既存の `_max_silent > 600` フォールバックを維持する 2 段階フォールバック構造にした。
+- `--light`モード（REVIEW_DEPTH=light）で実行。SHOULDイシュー（Spec Retrospectiveのドキュメント誤記）を修正、CONSIDERイシュー（テストカバレッジ）はスキップ。
+- AC#3のBRE `\|` ERE混在はSpec品質問題として記録し、verify commandをERE `|`に更新することを推奨（今後のIssueで対応）。
+- 全受け入れ基準PASS（rubric含む）、全CI SUCCESS、MUSTイシューなし。
 
 ### Deferred Items
-- merge フェーズの threshold floor (min 60s など) の設定は Issue body で却下され設計から除外。将来 merge watchdog の引き締めが必要になったら別 Issue で対応。
-- `_at_risk_silent` jq クエリのループ内起動コスト最適化は Issue 数が増えた段階で検討 (Icebox 候補)。
+- tests/audit-auto-session.batsのnegative caseテスト追加（CONSIDER level、今後のIterationで対応可）。
+- AC#3のverify command を ERE形式 (`|`) に更新する作業は別Issueで対応推奨。
 
 ### Notes for Next Phase
-- AC#3 の BRE `\|` パターンは `/verify` で ripgrep ERE として実行される点に注意。`_MARGIN` と `at_risk` は実装に含まれているが、ERE モードでは `\\|` パターンがリテラル `|` として解釈されるためFAILになる（spec quality issue）。verify command を ERE `|` に更新することを推奨。
-- bats テスト #5 (`phase silent window threshold violation appears in Summary and Notes`) がフィクスチャの spec phase (max_sec=1500, threshold=1200) で PASS していることを確認済み。
-- Post-merge AC は `verify-type: observation event=auto-run` — 次回 `/auto` 完走後に `/audit auto-session` で確認。
+- MUSTイシューなし → `/merge 674` で進められる。
+- Spec Retrospectiveの記述修正済み（commit f3d55e7: BRE/ERE記述の正確化）。
+- Post-merge ACは `verify-type: observation event=auto-run` で `/auto` 完走後に `/audit auto-session` で確認。
+
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+- なし: 実装はSpec の5ステップに忠実で乖離なし。
+
+### 繰り返しIssue（ワークフロー改善の余地）
+
+- AC#3のverify commandがBRE `\|` 形式で記述されていたが、verify-executorはripgrep (ERE)を使用するため、`\|`がリテラル`|`として解釈されFAILになる。これはERE/BRE書き分けの注意事項であり、同様のパターンが他のIssueのverify commandにも潜在している可能性がある。Issue作成時にverify commandをERE形式（`|`）で記述するよう周知が必要。
+
+### 受け入れ基準検証難易度
+
+- `rubric` verify commandは意味論的検証として機能しており、Summary表・phase breakdown・Notes アノテーションの3要素を一括確認できた（PASS）。
+- AC#3のverify command（`grep "watchdog.limit\|WATCHDOG_THRESHOLD\|_MARGIN\|at_risk"`）はBRE/EREの混在で検証精度が低い。Spec品質問題として記録済み。今後のIssue作成時は `|`（ERE bare alternation）を使用すること。
+- bats CIがSUCCESSであればAC#4（`command "bats ..."`）は確実にPASSできる。CI参照フォールバックが有効に機能した。

--- a/docs/spec/issue-666-auto-session-silent-threshold.md
+++ b/docs/spec/issue-666-auto-session-silent-threshold.md
@@ -54,7 +54,7 @@
 
 ### Design Gaps/Ambiguities
 
-- AC#3 の `grep "watchdog.limit\|WATCHDOG_THRESHOLD\|_MARGIN\|at_risk"` は BRE 形式 (`\|` を OR として使用) だが、verify-executor は ripgrep (ERE デフォルト) を使用する。実際のコードには `_MARGIN` と `at_risk` の両方が含まれているため verify は PASS するが、正確には ERE OR パターン (`|`) を使うべきだった。Issue の Auto-Resolved Ambiguity Points に記載されている AC 分割で対処済み。
+- AC#3 の `grep "watchdog.limit\|WATCHDOG_THRESHOLD\|_MARGIN\|at_risk"` は BRE 形式 (`\|` を OR として使用) だが、verify-executor は ripgrep (ERE デフォルト) を使用するため ERE モードでは `\\|` はリテラル `|` として解釈されFAILになる（実装は条件を満たすためSpec品質問題として分類）。正確には ERE OR パターン (`|`) を使うべきだった。Issue の Auto-Resolved Ambiguity Points に記載されている AC 分割で対処済み。
 - per-issue の `_at_risk_silent` jq クエリは `--argjson` で 4 つの閾値変数を渡す構造になっており、ループ内で毎回実行される。Issue 数が多い場合は jq 起動コストが累積するが、現状の規模では問題ない。
 
 ### Rework
@@ -74,6 +74,6 @@
 - `_at_risk_silent` jq クエリのループ内起動コスト最適化は Issue 数が増えた段階で検討 (Icebox 候補)。
 
 ### Notes for Next Phase
-- AC#3 の BRE `\|` パターンは `/verify` で ripgrep ERE として実行される点に注意。`_MARGIN` と `at_risk` のどちらかが実装に残っていれば PASS するはず。
+- AC#3 の BRE `\|` パターンは `/verify` で ripgrep ERE として実行される点に注意。`_MARGIN` と `at_risk` は実装に含まれているが、ERE モードでは `\\|` パターンがリテラル `|` として解釈されるためFAILになる（spec quality issue）。verify command を ERE `|` に更新することを推奨。
 - bats テスト #5 (`phase silent window threshold violation appears in Summary and Notes`) がフィクスチャの spec phase (max_sec=1500, threshold=1200) で PASS していることを確認済み。
 - Post-merge AC は `verify-type: observation event=auto-run` — 次回 `/auto` 完走後に `/audit auto-session` で確認。

--- a/docs/spec/issue-666-auto-session-silent-threshold.md
+++ b/docs/spec/issue-666-auto-session-silent-threshold.md
@@ -45,3 +45,35 @@
 - merge フェーズ (WATCHDOG_TIMEOUT_MERGE_DEFAULT=600) の threshold = 600 - 600 = 0 → Summary breakdown から除外
 - Implementation Steps 数は 5 (SPEC_DEPTH=light 上限)、Pre-merge verification 数は 6 (Issue body AC をそのまま全コピー — sync rule 優先)
 - Issue body の Auto-Resolved Ambiguity Points に沿って設計した (merge 除外、watchdog-defaults.sh 参照、AC 分割)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None: 実装は Spec の 5 ステップに沿って忠実に実施した。
+
+### Design Gaps/Ambiguities
+
+- AC#3 の `grep "watchdog.limit\|WATCHDOG_THRESHOLD\|_MARGIN\|at_risk"` は BRE 形式 (`\|` を OR として使用) だが、verify-executor は ripgrep (ERE デフォルト) を使用する。実際のコードには `_MARGIN` と `at_risk` の両方が含まれているため verify は PASS するが、正確には ERE OR パターン (`|`) を使うべきだった。Issue の Auto-Resolved Ambiguity Points に記載されている AC 分割で対処済み。
+- per-issue の `_at_risk_silent` jq クエリは `--argjson` で 4 つの閾値変数を渡す構造になっており、ループ内で毎回実行される。Issue 数が多い場合は jq 起動コストが累積するが、現状の規模では問題ない。
+
+### Rework
+
+- None: 実装は一発で全テスト PASS。修正なし。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `watchdog-defaults.sh` を `get-auto-session-report.sh` の先頭 (emit-event.sh source 直後) で source し、`SILENT_MARGIN=600` と phase 別閾値変数を定義した。merge フェーズは threshold=0 なので除外。
+- `PHASE_SILENT_BREAKDOWN` の jq クエリは `--argjson` で 4 変数 (t_spec/t_code/t_review/t_issue) を渡し、違反 phase をカウントして `<total> (code:<n>, spec:<n>)` 形式で出力する設計にした。
+- per-issue Notes は `_at_risk_silent` が空なら既存の `_max_silent > 600` フォールバックを維持する 2 段階フォールバック構造にした。
+
+### Deferred Items
+- merge フェーズの threshold floor (min 60s など) の設定は Issue body で却下され設計から除外。将来 merge watchdog の引き締めが必要になったら別 Issue で対応。
+- `_at_risk_silent` jq クエリのループ内起動コスト最適化は Issue 数が増えた段階で検討 (Icebox 候補)。
+
+### Notes for Next Phase
+- AC#3 の BRE `\|` パターンは `/verify` で ripgrep ERE として実行される点に注意。`_MARGIN` と `at_risk` のどちらかが実装に残っていれば PASS するはず。
+- bats テスト #5 (`phase silent window threshold violation appears in Summary and Notes`) がフィクスチャの spec phase (max_sec=1500, threshold=1200) で PASS していることを確認済み。
+- Post-merge AC は `verify-type: observation event=auto-run` — 次回 `/auto` 完走後に `/audit auto-session` で確認。

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -23,6 +23,12 @@ set -euo pipefail
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 [[ -f "$SCRIPT_DIR/emit-event.sh" ]] && source "$SCRIPT_DIR/emit-event.sh" || true
+[[ -f "$SCRIPT_DIR/watchdog-defaults.sh" ]] && source "$SCRIPT_DIR/watchdog-defaults.sh" || true
+SILENT_MARGIN=600
+SILENT_THRESHOLD_SPEC=$(( ${WATCHDOG_TIMEOUT_SPEC_DEFAULT:-1800} - SILENT_MARGIN ))
+SILENT_THRESHOLD_CODE=$(( ${WATCHDOG_TIMEOUT_CODE_DEFAULT:-1800} - SILENT_MARGIN ))
+SILENT_THRESHOLD_REVIEW=$(( ${WATCHDOG_TIMEOUT_REVIEW_DEFAULT:-2000} - SILENT_MARGIN ))
+SILENT_THRESHOLD_ISSUE=$(( ${WATCHDOG_TIMEOUT_ISSUE_DEFAULT:-1200} - SILENT_MARGIN ))
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 
 SESSION_ID=""
@@ -189,6 +195,31 @@ MAX_SILENT=$(echo "$EVENTS_JSON" | jq -r '
   if length == 0 then "N/A" else max | tostring + "s" end
 ' 2>/dev/null || echo "N/A")
 
+# Phase silent window breakdown (merge excluded: WATCHDOG_TIMEOUT_MERGE_DEFAULT - SILENT_MARGIN = 0)
+PHASE_SILENT_BREAKDOWN=$(echo "$EVENTS_JSON" | jq -r \
+  --argjson t_spec "$SILENT_THRESHOLD_SPEC" \
+  --argjson t_code "$SILENT_THRESHOLD_CODE" \
+  --argjson t_review "$SILENT_THRESHOLD_REVIEW" \
+  --argjson t_issue "$SILENT_THRESHOLD_ISSUE" \
+  '
+  [.[] |
+    select(.event == "max_silent_window" and .phase != null and .phase != "merge") |
+    (if .phase == "spec" then $t_spec
+     elif .phase == "code" then $t_code
+     elif .phase == "review" then $t_review
+     elif .phase == "issue" then $t_issue
+     else -1 end) as $at_risk_limit |
+    select($at_risk_limit > 0 and ((.max_sec | tonumber) > $at_risk_limit)) |
+    .phase
+  ] |
+  if length == 0 then "0"
+  else
+    (length) as $total |
+    (group_by(.) | map(.[0] + ":" + (length | tostring))) as $parts |
+    "\($total) (" + ($parts | join(", ")) + ")"
+  end
+' 2>/dev/null || echo "0")
+
 # Token usage totals (R1 metric; N/A if not present)
 TOKEN_INPUT=$(echo "$EVENTS_JSON" | jq '
   [.[] | select(.event == "token_usage") | .input_tokens | tonumber] |
@@ -276,7 +307,33 @@ for _num in $ISSUE_NUMS_FOR_TABLE; do
   _size_refresh=$(echo "$_issue_events" | jq -r '[.[] | select(.event == "size_refresh")] | first | if . == null then "" else "Size " + .from + "→" + .to end' 2>/dev/null || true)
   [[ -n "$_size_refresh" ]] && _notes_parts+=("$_size_refresh")
   _max_silent=$(echo "$_issue_events" | jq -r '[.[] | select(.event == "max_silent_window") | .max_sec | tonumber] | if length == 0 then 0 else max end' 2>/dev/null || echo 0)
-  [[ "$_max_silent" -gt 600 ]] && _notes_parts+=("Silent ${_max_silent}s")
+  _at_risk_silent=$(echo "$_issue_events" | jq -r \
+    --argjson t_spec "$SILENT_THRESHOLD_SPEC" \
+    --argjson t_code "$SILENT_THRESHOLD_CODE" \
+    --argjson t_review "$SILENT_THRESHOLD_REVIEW" \
+    --argjson t_issue "$SILENT_THRESHOLD_ISSUE" \
+    '
+    [.[] |
+      select(.event == "max_silent_window" and .phase != null and .phase != "merge") |
+      (if .phase == "spec" then $t_spec
+       elif .phase == "code" then $t_code
+       elif .phase == "review" then $t_review
+       elif .phase == "issue" then $t_issue
+       else -1 end) as $at_risk_limit |
+      select($at_risk_limit > 0 and ((.max_sec | tonumber) > $at_risk_limit)) |
+      {phase: .phase, max_sec: (.max_sec | tonumber)}
+    ] |
+    if length == 0 then ""
+    else
+      (max_by(.max_sec)) as $worst |
+      "Silent \($worst.max_sec)s phase=\($worst.phase) (within 600s of watchdog limit)"
+    end
+  ' 2>/dev/null || echo "")
+  if [[ -n "$_at_risk_silent" ]]; then
+    _notes_parts+=("$_at_risk_silent")
+  elif [[ "$_max_silent" -gt 600 ]]; then
+    _notes_parts+=("Silent ${_max_silent}s")
+  fi
   _tier3=$(echo "$_issue_events" | jq -r '[.[] | select(.event == "recovery" and .tier == "3")] | length' 2>/dev/null || echo 0)
   [[ "$_tier3" -gt 0 ]] && _notes_parts+=("Tier 3 recover")
   _concurrent_for_issue=$(echo "$_issue_events" | jq -r '[.[] | select(.event == "concurrent_commit_detected")] | length' 2>/dev/null || echo 0)
@@ -388,6 +445,7 @@ cat > "$OUTPUT_PATH" << REPORT_EOF
 | Tier 1/2/3 recoveries | ${RECOVERY_COUNTS} |
 | Watchdog kills | ${WATCHDOG_KILLS} |
 | Max silent window (any phase) | ${MAX_SILENT} |
+| Phase silent windows > threshold | ${PHASE_SILENT_BREAKDOWN} |
 | Total token usage | ${TOKEN_USAGE} |
 | Concurrent commits detected | ${CONCURRENT_COMMITS} |
 | Parent session manual interventions | ${MANUAL_INTERVENTIONS} |

--- a/tests/audit-auto-session.bats
+++ b/tests/audit-auto-session.bats
@@ -116,3 +116,26 @@ FIXTURE_EOF
     grep -q "backfilled" "$OUTPUT_PATH"
     grep -q "Backfilled phase_complete events" "$OUTPUT_PATH"
 }
+
+@test "success: phase silent window threshold violation appears in Summary and Notes" {
+    # spec phase: WATCHDOG_TIMEOUT_SPEC_DEFAULT=1800, SILENT_MARGIN=600, threshold=1200
+    # max_sec=1500 > 1200 => violation
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-06-15T10:00:00Z","issue":500,"event":"sub_start","session_id":"abc-666","size":"M"}
+{"ts":"2026-06-15T10:00:01Z","issue":500,"event":"phase_start","session_id":"abc-666","phase":"spec"}
+{"ts":"2026-06-15T10:25:00Z","issue":500,"event":"max_silent_window","session_id":"abc-666","phase":"spec","max_sec":1500}
+{"ts":"2026-06-15T10:25:01Z","issue":500,"event":"phase_complete","session_id":"abc-666","phase":"spec"}
+{"ts":"2026-06-15T10:25:02Z","issue":500,"event":"sub_complete","session_id":"abc-666","exit_code":"0"}
+FIXTURE_EOF
+
+    run bash "$SCRIPT" "abc-666" --output "$OUTPUT_PATH" --no-github
+    [ "$status" -eq 0 ]
+    [ -f "$OUTPUT_PATH" ]
+
+    # Summary row must be present
+    grep -q "Phase silent windows" "$OUTPUT_PATH"
+    # Phase breakdown must show spec:1 (1 violation in spec phase)
+    grep -q "spec:1" "$OUTPUT_PATH"
+    # Per-issue Notes must include at-risk annotation
+    grep -q "within 600s of watchdog limit" "$OUTPUT_PATH"
+}


### PR DESCRIPTION
## Summary

- `scripts/get-auto-session-report.sh` に phase 別 watchdog デフォルト − 600 秒を閾値とした silent window 違反検出を追加
- Summary 表に `| Phase silent windows > threshold |` 行を追加（merge フェーズは threshold=0 のため除外）
- Per-Issue Notes 列に閾値超過した silent window の phase-aware アノテーション（`Silent <N>s phase=<phase> (within 600s of watchdog limit)`）を追加
- `scripts/watchdog-defaults.sh` の `WATCHDOG_TIMEOUT_*_DEFAULT` 定数を参照して閾値を動的計算
- `tests/audit-auto-session.bats` に新テスト（spec phase violation fixture）を追加

## Verification (pre-merge)

- `grep "Phase silent windows" scripts/get-auto-session-report.sh` → PASS
- `grep "within 600s of watchdog limit" scripts/get-auto-session-report.sh` → PASS
- `grep "_MARGIN|at_risk" scripts/get-auto-session-report.sh` → PASS
- `bats tests/audit-auto-session.bats` → 5/5 PASS
- Summary 表に Phase silent windows 行が存在し、Per-Issue Notes に at-risk annotation が実装されている

## Verification (post-merge)

- 次回 `/auto` 完走後の `/audit auto-session` レポートで Phase silent windows メトリックが期待通り集計されることを確認

closes #666