### PR TITLE
Issue #667: Add verify-type breakdown to Verify Phase Residuals section

### DIFF
--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -188,6 +188,7 @@ Issue 本文の "Scope" または "Acceptance Criteria" セクションに以下
 |----------|---------|-------------|
 | `WHOLEWORK_CI_TIMEOUT_SEC` | `1200` | `wait-ci-checks.sh` の最大待機時間（秒）。タイムアウト挙動をテストするときは低い値（例: `60`）に設定する |
 | `WHOLEWORK_CONFIG_PATH` | *(未設定)* | `scripts/get-config-value.sh` が参照する設定ファイルパスを上書きする。設定されている場合、CWD 相対 `.wholework.yml` の代わりに指定したパスを読む。BATS テストでは `/dev/null` を設定してデフォルト値を強制できる。未設定または空の場合は `.wholework.yml`（CWD 相対）にフォールバックする |
+| `WHOLEWORK_ISSUE_BODY_DIR` | *(未設定)* | `scripts/get-auto-session-report.sh` が verify-type 内訳を取得する際の Issue body ソースを上書きする。設定されている場合は `gh issue view` を呼び出す代わりに `${WHOLEWORK_ISSUE_BODY_DIR}/<issue_number>.md` を読む。BATS テストのハーメティック実行用。未設定または空の場合は `gh issue view` にフォールバックする（`--no-github` 時はスキップ）。 |
 
 ## Gotchas
 

--- a/docs/spec/issue-667-verify-type-breakdown.md
+++ b/docs/spec/issue-667-verify-type-breakdown.md
@@ -108,3 +108,33 @@
 - `--no-github` かつ `WHOLEWORK_ISSUE_BODY_DIR` 未設定の場合: body 空文字扱い → per-type カウントはすべて 0 (`—` ではなく 0 を表示。テーブル構造を維持する)
 - observation の event 別内訳は文字列連結で構築 (bash 3.2+ で associative array 不使用)
 - 既存の `VERIFY_REMAINING` (GitHub labels から算出) とは別のカウント。`VERIFY_RESIDUALS` はイベントログから算出
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec の heredoc 出力で `printf '%s\n'` を使用。`printf '%s'` では末尾改行が欠けてテーブル行が次の行と結合するため改行付きに変更した。
+
+### Design Gaps/Ambiguities
+
+- Spec AC #1 の `grep "observation\|opportunistic\|manual"` は BRE 記法 (`\|`) を使用しており、ERE (ripgrep) では literal `|` として扱われ false FAIL になる。実装後に miscalibrated と判定し `observation|opportunistic|manual`（bare pipe）に修正した。
+
+### Rework
+
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `WHOLEWORK_ISSUE_BODY_DIR` を hermetic test 用の body source override として実装。`WHOLEWORK_SCRIPT_DIR` / `WHOLEWORK_CONFIG_PATH` と同パターンを採用した
+- `printf '%s\n'` を使ってテーブル行を heredoc 内で出力（`echo` 代わり）することで末尾改行を保証
+- bash 3.2+ 互換のため associative array を使わず文字列連結でイベント名を蓄積した
+
+### Deferred Items
+- runtime での full ドライランテスト（実際の phase/verify 残 Issue を含む auto-events.jsonl が必要なため post-merge observation AC とした）
+- 複数 event が同一 Issue に存在する場合の重複除去は現時点で未対応（`event=auto-run,auto-run` となる可能性あり）
+
+### Notes for Next Phase
+- AC #1 verify command は `observation|opportunistic|manual`（bare pipe ERE）に修正済み。Spec と Issue body 両方に反映済み
+- `section_contains "scripts/get-auto-session-report.sh" "## Verify Phase Residuals" "observation"` は shell file を対象にしているため、heading 検出が意図通り動作するか /verify 時に注意

--- a/docs/spec/issue-667-verify-type-breakdown.md
+++ b/docs/spec/issue-667-verify-type-breakdown.md
@@ -123,18 +123,31 @@
 
 - None
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Spec の heredoc 内で `printf '%s'` と記述したが実装は `printf '%s\n'` を採用。Code Retrospective に記録済み。今後 Spec 記述時は `printf` の末尾改行有無を明示すると divergence が防げる。
+
+### Recurring issues
+
+- Nothing to note. AC の verify command ERE/BRE 誤記 (BRE `\|` を ERE 文脈で使用) は Code Retrospective に記録済み。発生源は Spec 記述時のレギュラー表現フレーバー未確認。grep verify command は常に ERE として記述する慣習の徹底で再発防止可能。
+
+### Acceptance criteria verification difficulty
+
+- すべての AC が PASS または POST-MERGE で、UNCERTAIN なし。`command "bats ..."` は safe モードで CI 代替検証が成立 (CI ジョブ "Run bats tests" SUCCESS)。verify command の品質は良好。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `WHOLEWORK_ISSUE_BODY_DIR` を hermetic test 用の body source override として実装。`WHOLEWORK_SCRIPT_DIR` / `WHOLEWORK_CONFIG_PATH` と同パターンを採用した
-- `printf '%s\n'` を使ってテーブル行を heredoc 内で出力（`echo` 代わり）することで末尾改行を保証
-- bash 3.2+ 互換のため associative array を使わず文字列連結でイベント名を蓄積した
+- MUST issues なし。Step 12 スキップ。Step 13 スキップ (ポリシー変更なし)。
+- 全 pre-merge AC PASS、全 CI ジョブ SUCCESS で merge 可能と判定。
 
 ### Deferred Items
-- runtime での full ドライランテスト（実際の phase/verify 残 Issue を含む auto-events.jsonl が必要なため post-merge observation AC とした）
-- 複数 event が同一 Issue に存在する場合の重複除去は現時点で未対応（`event=auto-run,auto-run` となる可能性あり）
+- Post-merge observation AC: 次回 `/auto` 完走後に `## Verify Phase Residuals` セクションが期待通り集計されることを確認 (event=auto-run)
+- 複数 event 重複除去 (event=auto-run,auto-run 問題) は引き続き未解決 — Phase Handoff code から引継ぎ
 
 ### Notes for Next Phase
-- AC #1 verify command は `observation|opportunistic|manual`（bare pipe ERE）に修正済み。Spec と Issue body 両方に反映済み
-- `section_contains "scripts/get-auto-session-report.sh" "## Verify Phase Residuals" "observation"` は shell file を対象にしているため、heading 検出が意図通り動作するか /verify 時に注意
+- No MUST/SHOULD/CONSIDER issues found — merge は `/merge 676` で即時実行可能
+- Post-merge observation AC が残っているため `/verify 667` で最終確認が必要

--- a/docs/spec/issue-667-verify-type-breakdown.md
+++ b/docs/spec/issue-667-verify-type-breakdown.md
@@ -92,7 +92,7 @@
 
 ### Pre-merge
 
-- <!-- verify: grep "observation\|opportunistic\|manual" "scripts/get-auto-session-report.sh" --> verify-type 分類ロジックが実装されている
+- <!-- verify: grep "observation|opportunistic|manual" "scripts/get-auto-session-report.sh" --> verify-type 分類ロジックが実装されている
 - <!-- verify: grep "Verify Phase Residuals" "scripts/get-auto-session-report.sh" --> セクション heading が維持されている
 - <!-- verify: command "bats tests/audit-auto-session.bats" --> bats テストが green (verify-type fixture を追加)
 - <!-- verify: rubric "Verify Phase Residuals section shows per-issue verify-type breakdown table (observation event=*, opportunistic, manual columns) and aggregate counts matching /audit stats Section 7 conventions" --> rubric 基準を満たす

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -201,6 +201,7 @@ In gradual migration, there is a period where deprecated terms remain in the sam
 | `WHOLEWORK_CI_TIMEOUT_SEC` | `1200` | Maximum wait time in seconds for `wait-ci-checks.sh`. Set to a lower value (e.g., `60`) to test timeout behavior. |
 | `WHOLEWORK_SCRIPT_DIR` | *(auto-resolved)* | Override the `SCRIPT_DIR` used by `scripts/*.sh` when resolving sibling helpers. Used in BATS tests to redirect calls to a mock directory. In production, leave unset (auto-resolves to the script's own directory). |
 | `WHOLEWORK_CONFIG_PATH` | *(unset)* | Override the config file path used by `scripts/get-config-value.sh`. When set, the script reads the specified path instead of CWD-relative `.wholework.yml`. Set to `/dev/null` in BATS tests to force default values. When unset or empty, falls back to `.wholework.yml` (CWD-relative). |
+| `WHOLEWORK_ISSUE_BODY_DIR` | *(unset)* | Override the issue body source used by `scripts/get-auto-session-report.sh` when fetching verify-type breakdown. When set, reads `${WHOLEWORK_ISSUE_BODY_DIR}/<issue_number>.md` instead of calling `gh issue view`. Used in BATS tests for hermetic execution. When unset or empty, falls back to `gh issue view` (or skips when `--no-github`). |
 
 ## Gotchas
 

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -34,6 +34,7 @@ AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 SESSION_ID=""
 OUTPUT_PATH=""
 NO_GITHUB=false
+ISSUE_BODY_DIR="${WHOLEWORK_ISSUE_BODY_DIR:-}"
 LIST_MODE=false
 SINCE_SPEC="24h"
 NARRATIVE_DRAFT_PATH=""
@@ -425,6 +426,93 @@ if [[ "$WALL_CLOCK" != "N/A" && "$ISSUES_PROCESSED" -gt 0 ]]; then
   fi
 fi
 
+# Verify-type breakdown for phase/verify residuals
+VERIFY_RESIDUALS_TABLE=""
+VERIFY_RESIDUALS_AGGREGATE=""
+VERIFY_RESIDUALS_TOTAL=0
+_total_obs=0
+_total_opp=0
+_total_manual=0
+_all_obs_events=""
+if [[ -n "$VERIFY_RESIDUALS" ]]; then
+  for _r in $VERIFY_RESIDUALS; do
+    VERIFY_RESIDUALS_TOTAL=$(( VERIFY_RESIDUALS_TOTAL + 1 ))
+    _body=""
+    _title=""
+    if [[ -n "$ISSUE_BODY_DIR" && -f "${ISSUE_BODY_DIR}/${_r}.md" ]]; then
+      _body=$(cat "${ISSUE_BODY_DIR}/${_r}.md")
+      _title="#${_r}"
+    elif [[ "$NO_GITHUB" == "false" ]]; then
+      _gh_json=$(gh issue view "$_r" --json body,title 2>/dev/null || echo '{}')
+      _body=$(echo "$_gh_json" | jq -r '.body // ""')
+      _title=$(echo "$_gh_json" | jq -r '.title // ""')
+    fi
+    _obs_count=0
+    _opp_count=0
+    _manual_count=0
+    _obs_events=""
+    _in_post_merge=false
+    while IFS= read -r _line; do
+      if echo "$_line" | grep -q "^### Post-merge"; then
+        _in_post_merge=true
+        continue
+      fi
+      if [[ "$_in_post_merge" == "true" ]] && echo "$_line" | grep -q "^### "; then
+        _in_post_merge=false
+        continue
+      fi
+      if [[ "$_in_post_merge" == "true" ]] && echo "$_line" | grep -qE "^- \[ \]"; then
+        if echo "$_line" | grep -qE "verify-type: observation event="; then
+          _evt=$(echo "$_line" | grep -oE "verify-type: observation event=[^ >]+" | sed 's/verify-type: observation event=//')
+          _obs_count=$(( _obs_count + 1 ))
+          if [[ -z "$_obs_events" ]]; then
+            _obs_events="$_evt"
+          else
+            _obs_events="${_obs_events},${_evt}"
+          fi
+        elif echo "$_line" | grep -qE "verify-type: opportunistic"; then
+          _opp_count=$(( _opp_count + 1 ))
+        else
+          _manual_count=$(( _manual_count + 1 ))
+        fi
+      fi
+    done <<< "$_body"
+    if [[ $_obs_count -eq 0 ]]; then
+      _obs_str="0"
+    else
+      _obs_str="${_obs_count} (event=${_obs_events})"
+    fi
+    _row="| #${_r} | ${_title:-#${_r}} | ${_obs_str} | ${_opp_count} | ${_manual_count} |"
+    if [[ -z "$VERIFY_RESIDUALS_TABLE" ]]; then
+      VERIFY_RESIDUALS_TABLE="$_row"
+    else
+      VERIFY_RESIDUALS_TABLE="${VERIFY_RESIDUALS_TABLE}
+${_row}"
+    fi
+    _total_obs=$(( _total_obs + _obs_count ))
+    _total_opp=$(( _total_opp + _opp_count ))
+    _total_manual=$(( _total_manual + _manual_count ))
+    if [[ -n "$_obs_events" ]]; then
+      if [[ -z "$_all_obs_events" ]]; then
+        _all_obs_events="$_obs_events"
+      else
+        _all_obs_events="${_all_obs_events},${_obs_events}"
+      fi
+    fi
+  done
+  if [[ -z "$VERIFY_RESIDUALS_TABLE" ]]; then
+    VERIFY_RESIDUALS_TABLE="| (none) | — | — | — | — |"
+  fi
+  if [[ $_total_obs -gt 0 && -n "$_all_obs_events" ]]; then
+    _obs_detail=" (event breakdown: ${_all_obs_events})"
+  else
+    _obs_detail=""
+  fi
+  VERIFY_RESIDUALS_AGGREGATE="- observation waiting: ${_total_obs}${_obs_detail}
+- opportunistic remaining: ${_total_opp}
+- manual waiting: ${_total_manual}"
+fi
+
 # Render the markdown report
 cat > "$OUTPUT_PATH" << REPORT_EOF
 # /auto Session Report — ${SESSION_ID}
@@ -465,13 +553,20 @@ ${RECOVERY_EVENTS}
 
 ## Verify Phase Residuals
 
-$(if [[ -z "$VERIFY_RESIDUALS" ]]; then
-  echo "(none)"
-else
-  for _r in $VERIFY_RESIDUALS; do
-    echo "- Issue #${_r}: phase/verify not completed"
-  done
-fi)
+$(
+  if [[ -z "$VERIFY_RESIDUALS" ]]; then
+    echo "(none)"
+  else
+    # verify-type breakdown: observation / opportunistic / manual
+    echo "Total: ${VERIFY_RESIDUALS_TOTAL} phase/verify remaining"
+    echo ""
+    echo "| Issue | Title | observation event=* | opportunistic | manual |"
+    echo "|---|---|---|---|---|"
+    printf '%s\n' "${VERIFY_RESIDUALS_TABLE}"
+    echo ""
+    printf '%s\n' "${VERIFY_RESIDUALS_AGGREGATE}"
+  fi
+)
 
 ## Concurrent Sessions Detected
 

--- a/tests/audit-auto-session.bats
+++ b/tests/audit-auto-session.bats
@@ -139,3 +139,44 @@ FIXTURE_EOF
     # Per-issue Notes must include at-risk annotation
     grep -q "within 600s of watchdog limit" "$OUTPUT_PATH"
 }
+
+@test "success: verify-type breakdown appears in Verify Phase Residuals section" {
+    # Issue 471: has verify phase_start but no phase_complete (residual)
+    # Issue 645: same
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-06-15T10:00:00Z","issue":471,"event":"sub_start","session_id":"abc-vtype","size":"M"}
+{"ts":"2026-06-15T10:01:00Z","issue":471,"event":"phase_start","session_id":"abc-vtype","phase":"verify"}
+{"ts":"2026-06-15T10:02:00Z","issue":645,"event":"sub_start","session_id":"abc-vtype","size":"M"}
+{"ts":"2026-06-15T10:03:00Z","issue":645,"event":"phase_start","session_id":"abc-vtype","phase":"verify"}
+FIXTURE_EOF
+
+    # Create issue body fixtures with verify-type markers in Post-merge section
+    mkdir -p "$BATS_TEST_TMPDIR/issue-bodies"
+    cat > "$BATS_TEST_TMPDIR/issue-bodies/471.md" << 'BODY_EOF'
+## Acceptance Criteria
+
+### Post-merge
+
+- [ ] Confirm next /auto run aggregates correctly <!-- verify-type: observation event=auto-run -->
+BODY_EOF
+
+    cat > "$BATS_TEST_TMPDIR/issue-bodies/645.md" << 'BODY_EOF'
+## Acceptance Criteria
+
+### Post-merge
+
+- [ ] Check opportunistic trigger fires <!-- verify-type: opportunistic -->
+- [ ] Manual review of output format <!-- verify-type: manual -->
+BODY_EOF
+
+    export WHOLEWORK_ISSUE_BODY_DIR="$BATS_TEST_TMPDIR/issue-bodies"
+    run bash "$SCRIPT" "abc-vtype" --output "$OUTPUT_PATH" --no-github
+    [ "$status" -eq 0 ]
+    [ -f "$OUTPUT_PATH" ]
+
+    grep -q "Verify Phase Residuals" "$OUTPUT_PATH"
+    grep -q "observation" "$OUTPUT_PATH"
+    grep -q "opportunistic" "$OUTPUT_PATH"
+    grep -q "#471" "$OUTPUT_PATH"
+    grep -q "auto-run" "$OUTPUT_PATH"
+}


### PR DESCRIPTION
## Summary

`/audit auto-session` レポートの `## Verify Phase Residuals` セクションを拡張し、phase/verify 残 Issue ごとに未チェック AC の verify-type (observation/opportunistic/manual) 内訳テーブルを追加した。

変更点：
- `scripts/get-auto-session-report.sh`: `WHOLEWORK_ISSUE_BODY_DIR` 変数追加、verify-type breakdown 計算ブロック追加、`## Verify Phase Residuals` セクションをテーブル形式に置換
- `tests/audit-auto-session.bats`: verify-type fixture を使った新規テスト追加
- `docs/tech.md` / `docs/ja/tech.md`: `WHOLEWORK_ISSUE_BODY_DIR` 環境変数を Environment Variables テーブルに追加

## Verification (pre-merge)

- `grep "observation|opportunistic|manual"` が `scripts/get-auto-session-report.sh` にマッチ (PASS)
- `grep "Verify Phase Residuals"` が `scripts/get-auto-session-report.sh` にマッチ (PASS)
- `bats tests/audit-auto-session.bats` — 6/6 テスト green (PASS)
- rubric 基準を満たす: per-issue breakdown テーブル、aggregate counts 実装済み (PASS)
- `section_contains "scripts/get-auto-session-report.sh" "## Verify Phase Residuals" "observation"` (PASS)

## Verification (post-merge)

- 次回 `/auto` 完走後の `/audit auto-session` レポートで Verify Phase Residuals セクションが verify-type 内訳テーブル形式で出力されることを確認

closes #667