### PR TITLE
Issue #678: Fix newline injection in wait-ci-checks.sh and add emit-event.sh value sanitization

### DIFF
--- a/docs/spec/issue-678-wait-ci-checks-newline-fix.md
+++ b/docs/spec/issue-678-wait-ci-checks-newline-fix.md
@@ -74,3 +74,32 @@
 - 暫定対処: Python スクリプトで破損行を修復し再生成成功 (483 → 476 lines)
 - Auto-Resolved: AC2 verify command を `grep "_failed=.*$"` → `grep -E "_failed=.*(\|\| true|awk)"` に強化済み（旧パターンは修正前も `_failed=` が存在し常時 PASS になる false-positive のため）
 - 関連: #662 (ci_wait event 配線), #630 (event log 基盤), #654 (auto-session-report-published event)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None. Spec の案 A (`|| true` + `:-0` fallback) をそのまま採用。案 B (awk) は不採用（Spec の推奨案 A の方がシンプルで bash 3.2+ 互換性も明確）。
+
+### Design Gaps/Ambiguities
+
+- `emit-event.sh` の `local` 変数宣言 (`local v_sanitized`) は bash 関数スコープ内での使用を前提にしており、sourceして使う使い方と整合していることを確認（emit_event() 内部で `local` を使う既存パターンに倣った）。
+
+### Rework
+
+- None. 実装は1パスで完了。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `|| true` + `${var:-0}` パターン採用: `|| echo 0` から置換。`true` は追加出力なし、`:-0` は空文字列 fallback として機能する。awk 案は不採用（Spec 推奨の単純実装を優先）
+- `emit-event.sh` sanitization 順序: backslash escape → double-quote escape の順（逆順にすると backslash を二重 escape する）
+- bats 回帰テストで `TEST_VAL` 環境変数経由で制御文字を注入（bash -c 内での直接埋め込みは引用符問題を引き起こすため）
+
+### Deferred Items
+- 次回 `/auto --batch` 完走後に `.tmp/auto-events.jsonl` を `jq -s . > /dev/null` でパースして error 0 件を確認（post-merge observation AC）
+
+### Notes for Next Phase
+- 修正は内部ロジックのみ（インターフェース変更なし）。`/review` では `scripts/wait-ci-checks.sh` L34-35 の変更前後の挙動差に注目すること
+- 並列実行時に `post_merge_check.bats` テスト 7 が稀に失敗するが、単体実行では PASS する既存の flaky テスト。今回の変更とは無関係

--- a/docs/spec/issue-678-wait-ci-checks-newline-fix.md
+++ b/docs/spec/issue-678-wait-ci-checks-newline-fix.md
@@ -89,17 +89,36 @@
 
 - None. 実装は1パスで完了。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- 構造的な乖離なし。Spec 案 A (`|| true` + `:-0` fallback) がそのまま実装されており、diff と Spec の対応は完全一致。
+- AC1〜4 の verify command は実装と正確に対応しており、FAIL や UNCERTAIN は発生しなかった。
+
+### Recurring Issues
+
+- 同種イシューの繰り返しはなし。CONSIDER 1 件（`\r` 未サニタイズ）は今回修正スコープ外の軽微なギャップ。
+- 今後 `emit-event.sh` に非数値 value を渡す呼び出し元が追加された場合に顕在化しうる。
+
+### Acceptance Criteria Verification Difficulty
+
+- 4 件の pre-merge AC すべてが自動検証成功（`grep` verify × 3 + CI 参照フォールバック × 1）。UNCERTAIN ゼロ。
+- AC2 は code phase で `grep -E "_failed=.*(\|\| true|awk)"` に強化済みで false-positive を回避できていた。verify command の精度は良好。
+- post-merge AC は observation 型（event=auto-run 待ち）で正常動作。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `|| true` + `${var:-0}` パターン採用: `|| echo 0` から置換。`true` は追加出力なし、`:-0` は空文字列 fallback として機能する。awk 案は不採用（Spec 推奨の単純実装を優先）
-- `emit-event.sh` sanitization 順序: backslash escape → double-quote escape の順（逆順にすると backslash を二重 escape する）
-- bats 回帰テストで `TEST_VAL` 環境変数経由で制御文字を注入（bash -c 内での直接埋め込みは引用符問題を引き起こすため）
+- MUST イシューなし。CONSIDER 1 件（`\r` 未サニタイズ）はスコープ外として skip。
+- review-light モード（Size=M Bug）が適切だった。全 CI SUCCESS、全 AC PASS。
+- CI 参照フォールバック（bats verify command → "Run bats tests" SUCCESS）が正常に機能した。
 
 ### Deferred Items
-- 次回 `/auto --batch` 完走後に `.tmp/auto-events.jsonl` を `jq -s . > /dev/null` でパースして error 0 件を確認（post-merge observation AC）
+- `\r` sanitization gap: 将来別呼び出し元が増えた場合の潜在リスク。必要に応じて Issue 起票。
+- post-merge observation AC: 次回 `/auto --batch` 完走後に `.tmp/auto-events.jsonl` を `jq -s . > /dev/null` でパース確認。
 
 ### Notes for Next Phase
-- 修正は内部ロジックのみ（インターフェース変更なし）。`/review` では `scripts/wait-ci-checks.sh` L34-35 の変更前後の挙動差に注目すること
-- 並列実行時に `post_merge_check.bats` テスト 7 が稀に失敗するが、単体実行では PASS する既存の flaky テスト。今回の変更とは無関係
+- ブロッキングイシューなし。`/merge 680` 即時実行可能。
+- flaky テスト（`post_merge_check.bats` テスト 7）は今回の変更と無関係。merge に影響しない。

--- a/scripts/emit-event.sh
+++ b/scripts/emit-event.sh
@@ -31,7 +31,12 @@ emit_event() {
   local json="{\"ts\":\"${ts}\",\"issue\":${_issue},\"event\":\"${event_type}\",\"session_id\":\"${_sid}\""
   while [[ $# -gt 0 ]]; do
     local kv="$1"; local k="${kv%%=*}"; local v="${kv#*=}"
-    json="${json},\"${k}\":\"${v}\""
+    # sanitize value: strip newlines, replace tabs, escape backslash and double-quote
+    local v_sanitized="${v//$'\n'/}"
+    v_sanitized="${v_sanitized//$'\t'/ }"
+    v_sanitized="${v_sanitized//\\/\\\\}"
+    v_sanitized="${v_sanitized//\"/\\\"}"
+    json="${json},\"${k}\":\"${v_sanitized}\""
     shift
   done
   json="${json}}"

--- a/scripts/wait-ci-checks.sh
+++ b/scripts/wait-ci-checks.sh
@@ -31,8 +31,10 @@ if [[ "$_emit_ci_wait" == "true" ]]; then
   fi
   _ci_wait_end=$(date +%s)
   _wait_sec=$(( _ci_wait_end - _ci_wait_start ))
-  _passed=$(echo "${_ci_checks_output:-}" | grep -c -i "pass\|success" 2>/dev/null || echo 0)
-  _failed=$(echo "${_ci_checks_output:-}" | grep -c -i "fail\|error" 2>/dev/null || echo 0)
+  _passed=$(echo "${_ci_checks_output:-}" | grep -c -i "pass\|success" 2>/dev/null || true)
+  _passed=${_passed:-0}
+  _failed=$(echo "${_ci_checks_output:-}" | grep -c -i "fail\|error" 2>/dev/null || true)
+  _failed=${_failed:-0}
   emit_event "ci_wait" \
     "phase=${EMIT_PHASE_NAME:-review}" \
     "wait_sec=${_wait_sec}" \

--- a/tests/emit-event.bats
+++ b/tests/emit-event.bats
@@ -78,3 +78,50 @@ teardown() {
     [[ "$line" == *'"event":"wrapper_exit"'* ]]
     [[ "$line" == *'"exit_code":"0"'* ]]
 }
+
+@test "emit_event sanitizes newline in value to produce parseable JSON (regression #678)" {
+    export TEST_VAL=$'0\n0'
+    bash -c "source \"$SCRIPT\" && emit_event \"ci_wait\" \"checks_failed=\${TEST_VAL}\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    run jq -r '.checks_failed' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "00" ]]
+}
+
+@test "emit_event sanitizes tab in value" {
+    export TEST_VAL=$'value\ttab'
+    bash -c "source \"$SCRIPT\" && emit_event \"test_event\" \"key=\${TEST_VAL}\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    run jq -r '.key' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "value tab" ]]
+}
+
+@test "emit_event sanitizes backslash in value" {
+    export TEST_VAL='value\backslash'
+    bash -c "source \"$SCRIPT\" && emit_event \"test_event\" \"key=\${TEST_VAL}\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    run jq -r '.key' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == 'value\backslash' ]]
+}
+
+@test "emit_event sanitizes double-quote in value" {
+    export TEST_VAL='value"quote'
+    bash -c "source \"$SCRIPT\" && emit_event \"test_event\" \"key=\${TEST_VAL}\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    run jq -r '.key' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == 'value"quote' ]]
+}
+
+@test "emit_event sanitizes combined control characters in value (regression #678)" {
+    export TEST_VAL=$'line1\nline2\ttab\\end"quote'
+    bash -c "source \"$SCRIPT\" && emit_event \"test_event\" \"key=\${TEST_VAL}\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+}

--- a/tests/wait-ci-checks.bats
+++ b/tests/wait-ci-checks.bats
@@ -189,3 +189,38 @@ MOCK
     grep -q "pr checks 88" "$GH_CALL_LOG"
     ! grep -q "\-\-required" "$GH_CALL_LOG"
 }
+
+@test "ci_wait: event JSON is parseable when gh output has no pass/success matches (regression #678)" {
+    EVENTS_LOG="$BATS_TEST_TMPDIR/auto-events-nomatch.jsonl"
+    EMIT_DIR="$BATS_TEST_TMPDIR/emit-nomatch"
+    mkdir -p "$EMIT_DIR"
+    emit_event_src="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/emit-event.sh"
+    cp "$emit_event_src" "$EMIT_DIR/emit-event.sh"
+
+    # gh outputs text with no pass/success matches, causing grep -c to exit 1
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    echo "pending: check1 waiting" >&2
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run env AUTO_EVENTS_LOG="$EVENTS_LOG" \
+      EMIT_ISSUE_NUMBER="88" \
+      EMIT_PHASE_NAME="review" \
+      WHOLEWORK_SCRIPT_DIR="$EMIT_DIR" \
+      PATH="$MOCK_DIR:$PATH" \
+      bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    [ -f "$EVENTS_LOG" ]
+    # Verify the JSONL line is parseable (no literal newlines embedded in values)
+    run jq . "$EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    # checks_passed must be a clean integer string, not "0\n0"
+    run jq -r '.checks_passed' "$EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9]+$ ]]
+}


### PR DESCRIPTION
## Summary

- `scripts/wait-ci-checks.sh`: `grep -c ... || echo 0` パターンを `|| true` + `${var:-0}` に修正。0-match 時に `grep -c` が exit 1 → `|| echo 0` が発火して追加の `0\n` を出力し、変数値に literal newline が混入するバグを解消
- `scripts/emit-event.sh`: `emit_event()` の value 挿入前に newline 除去・tab 置換・backslash/double-quote escape の sanitization を追加（今後の同種バグに対する safety net）
- `tests/wait-ci-checks.bats`: 0-match 時のイベント JSON がパース可能なことを検証する regression test を追加
- `tests/emit-event.bats`: newline / tab / backslash / double-quote を含む value の sanitization regression test を追加

## Verification (pre-merge)

- `grep -E "_passed=.*grep -c.*\|\| true|_passed=.*awk" "scripts/wait-ci-checks.sh"` → PASS
- `grep -E "_failed=.*(\|\| true|awk)" "scripts/wait-ci-checks.sh"` → PASS
- `grep -E "sanitize|strip|escape" "scripts/emit-event.sh"` → PASS
- `bats tests/wait-ci-checks.bats tests/emit-event.bats` (25 tests) → PASS

## Verification (post-merge)

- 次回 `/auto --batch` 完走後に `.tmp/auto-events.jsonl` を `jq -s . > /dev/null` でパースして error 0 件を確認

closes #678