### PR TITLE
Issue #679: Add CI test_result emit from merge phase

### DIFF
--- a/docs/spec/issue-679-ci-test-result-from-merge.md
+++ b/docs/spec/issue-679-ci-test-result-from-merge.md
@@ -61,3 +61,35 @@
 - `gh run view --log` は大量出力になる可能性があるが、`grep -E "[0-9]+ tests?, [0-9]+ failures?" | tail -1` でフィルタするため実害なし。
 - bats test でのセルフ参照除外は不要（grep パターンが tests/run-merge.bats 内のコメント/文字列と干渉しない）。
 - `grep -oE` は bash 3.2+ / macOS GNU grep 互換。`||echo 0` で値が取れない場合に 0 を代入するパターンは既存コード (run-auto-sub.sh L130-131) と一致。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- `_passed` の parse パターンを Spec の `grep -oE "^[0-9]+"` から `grep -oE "[0-9]+ tests?" | grep -oE "^[0-9]+"` に変更。理由: `gh run view --log` のログ行にはタイムスタンプ prefix (例: `2026-01-01T12:00:00.000Z`) が付くため、`^[0-9]+` では年 (`2026`) を誤マッチする。`_failed` と同様の2ステップ pattern に統一した。
+
+### Design Gaps/Ambiguities
+
+- None
+
+### Rework
+
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `_passed` parse に2ステップ grep を採用（CI log タイムスタンプ対策）
+- emit block は reconcile ブロック直後、`echo "---"` の前に配置（EXIT_CODE が確定した後）
+- bats mock で emit-event.sh を overwrite してファイル書き込み副作用を再現（no-op ではなく emit.log への追記）
+
+### Deferred Items
+- `source=local` を run-auto-sub.sh の既存 emit に付与（本 Issue AC 範囲外）
+- CI workflow 名 `test.yml` のハードコード解消（設定化は別 Issue）
+- patch route での test_result CI 取得（scope 外）
+
+### Notes for Next Phase
+- verify phase では rubric AC3 が重要な確認ポイント（semantic check）
+- bats テストは全 18 件 PASS 確認済み（既存回帰なし）
+- post-merge AC は `verify-type: observation event=auto-run` のため次回 `/auto` 完走後に自動評価

--- a/docs/spec/issue-679-ci-test-result-from-merge.md
+++ b/docs/spec/issue-679-ci-test-result-from-merge.md
@@ -76,20 +76,35 @@
 
 - None
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- `_passed` の2ステップ grep 変更はCode Retrospectiveに記録済みで、構造的なSpec-PR乖離なし。全5 AC verify commandが正常動作し、PRレビューの整合性確認は高精度だった。
+
+### Recurring Issues
+
+- null `_run_id` による偽陽性 warning（CONSIDER）: `gh run list` が run 不在で `"null"` を返すケースへの非対応。稀なエッジケースで実害なし。
+- warning path の regression test 未追加（CONSIDER）: success path のみテストされており、warning path（`_bats_summary` 空）のテストが不足。Type=Feature 案件ではエラーパステスト補完を推奨。
+
+### Acceptance Criteria Verification Difficulty
+
+- 全AC にvalidな verify command が設定されており、UNCERTAIN ゼロ。rubric AC3 は merge完了後の CI log fetch という外部依存ロジックの意味的検証として特に有効だった。`command "bats tests/run-merge.bats"` は safe mode のため CI fallback 経由でPASS（"Run bats tests" SUCCESS）。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `_passed` parse に2ステップ grep を採用（CI log タイムスタンプ対策）
-- emit block は reconcile ブロック直後、`echo "---"` の前に配置（EXIT_CODE が確定した後）
-- bats mock で emit-event.sh を overwrite してファイル書き込み副作用を再現（no-op ではなく emit.log への追記）
+- MUST/SHOULDイシューなし → `COMMENT` event で PR Review投稿（`REQUEST_CHANGES` ではない）
+- CONSIDER 2件: null run_id guard、warning path テスト。いずれも skip 判断（稀なケース、実害なし）
+- Acceptance Criteria 全 5/5 PASS、CI 全 SUCCESS
 
 ### Deferred Items
-- `source=local` を run-auto-sub.sh の既存 emit に付与（本 Issue AC 範囲外）
-- CI workflow 名 `test.yml` のハードコード解消（設定化は別 Issue）
-- patch route での test_result CI 取得（scope 外）
+- null run_id guard 追加（CONSIDER level、本Issue scope外）
+- warning path regression test 追加（CONSIDER level、後続Issueで検討可）
+- post-merge AC (`verify-type: observation event=auto-run`) は次回 `/auto` 完走後に自動評価
 
 ### Notes for Next Phase
-- verify phase では rubric AC3 が重要な確認ポイント（semantic check）
-- bats テストは全 18 件 PASS 確認済み（既存回帰なし）
-- post-merge AC は `verify-type: observation event=auto-run` のため次回 `/auto` 完走後に自動評価
+- MUST イシューなし → merge をブロックする理由なし。`/merge 681` を直接実行可
+- Spec の verify command 品質は高く、verify phase での再実行もスムーズなはず
+- post-merge AC のみ未評価（observation待ち）のため verify 完了後に observation log 確認を推奨

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -149,6 +149,21 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
   fi
 fi
 
+# CI test_result emit (pr route, EXIT_CODE=0 + AUTO_EVENTS_LOG set)
+if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
+  _run_id=$(gh run list --workflow=test.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+  if [[ -n "$_run_id" ]]; then
+    _bats_summary=$(gh run view "$_run_id" --log 2>/dev/null | grep -E "[0-9]+ tests?, [0-9]+ failures?" | tail -1 || true)
+    if [[ -n "$_bats_summary" ]]; then
+      _passed=$(echo "$_bats_summary" | grep -oE "[0-9]+ tests?" | grep -oE "^[0-9]+" || echo 0)
+      _failed=$(echo "$_bats_summary" | grep -oE "[0-9]+ failures?" | grep -oE "^[0-9]+" || echo 0)
+      emit_event "test_result" "phase=merge" "framework=bats" "source=ci" "passed=${_passed}" "failed=${_failed}" "run_id=${_run_id}"
+    else
+      echo "Warning: run-merge.sh: gh run view ${_run_id} --log: no bats summary found" >&2
+    fi
+  fi
+fi
+
 echo "---"
 echo "=== run-merge.sh: Finished /merge for PR #${PR_NUMBER} ==="
 print_end_banner "pr" "$PR_NUMBER" "merge"

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -373,3 +373,41 @@ MOCK
     [[ "$output" == *"Warning:"*"phase/review"*"Auto-transitioning"* ]]
     grep -q "CALLED: 99 verify" "$LABEL_TRANSITION_LOG"
 }
+
+@test "test_result: emit_event called with source=ci after merge" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    # Override emit-event.sh mock to capture emit_event calls
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+
+    # Override gh mock to handle run list and run view --log
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "run" && "$2" == "list" && "$*" == *"--workflow=test.yml"* ]]; then
+  echo "12345"
+  exit 0
+fi
+if [[ "$1" == "run" && "$2" == "view" && "$*" == *"--log"* ]]; then
+  echo "5 tests, 0 failures"
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  elif [[ "$*" == *"-q"* && "$*" == *".state"* ]]; then
+    echo "MERGED"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "source=ci" "$EMIT_LOG"
+}


### PR DESCRIPTION
## Summary

`scripts/run-merge.sh` の merge 完了後（EXIT_CODE=0）に CI run から test_result を fetch して emit する機能を追加。

- `gh run list --workflow=test.yml --branch=main --limit=1` で最新 CI run を取得
- `gh run view <run_id> --log` で bats summary 行を grep/parse
- `emit_event "test_result" ... "source=ci"` で emit（失敗時は no-op + warning 出力）
- `tests/run-merge.bats` に regression test を追加（18テスト全 PASS）

## Verification (pre-merge)

- `scripts/run-merge.sh` に `source=ci` 付き test_result emit ロジックが追加されている
- `gh run list --workflow=test.yml` および `gh run view --log` の呼び出しが追加されている
- rubric: pr route の merge 完了時に CI log から bats summary を parse して test_result を emit、失敗時は no-op で warning 出力
- `bats tests/run-merge.bats` が全 18 件 PASS（新規テスト含む）
- `tests/run-merge.bats` に `source=ci` パターンの regression test が追加されている

## Verification (post-merge)

- 次回 `/auto` pr route 完走後の `.tmp/auto-events.jsonl` で `source=ci` 付き `test_result` event が emit されることを確認

closes #679