### PR TITLE
Issue #675: Add BRE metacharacter detection to issue/spec skills

### DIFF
--- a/docs/spec/issue-675-bre-metacharacter-validation.md
+++ b/docs/spec/issue-675-bre-metacharacter-validation.md
@@ -37,3 +37,34 @@
 - `skills/issue/SKILL.md` には現状 "ERE" という文字列が存在しない（grep 0 件）。実装で追加することで AC #2 を満たす。
 - `skills/spec/SKILL.md` の "ERE" 4件はすべて `ENTERED_WORKTREE` の部分文字列であり、ERE (Extended Regular Expressions) の略語としては存在しない。実装で追加することで AC #3 の rubric 要件を補完する。
 - 挿入テキストは「BRE metacharacter」「ERE」両方を含む必要がある（AC #1〜#3 の verify patterns を満たすため）
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None: Spec の実装ステップ通りに実装完了。挿入箇所・検出対象 metacharacter 5種・出力フォーマットすべて設計通り。
+
+### Design Gaps/Ambiguities
+
+- `skills/spec/SKILL.md` Notes に「"ERE" 4件はすべて ENTERED_WORKTREE の部分文字列」と記載されていたが、確認するとその通りであり、実装で追加した ERE 記述が AC #2 相当の要件を補完する形になった。Notes の予測が正確で、実装時に改めて確認の手間なく進められた。
+
+### Rework
+
+- None: 一発実装で bats 853 件全 PASS。skill syntax validation・forbidden expressions check も PASS。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `skills/issue/SKILL.md` Step 4 末尾（verify-type タグ割り当ての直後）に BRE 検出サブステップを追加した。Existing Issue フロー（Step 6）は "Follow Step 4" 参照なので Step 4 への追加で自動適用される。
+- `skills/spec/SKILL.md` は Step 10 の「Verification conditions consistency check」直後、「Patch route verify command check」直前に追加した。Spec 生成フローの verify command 確定後に検出する配置が最適。
+- 検出対象は5種類の BRE metacharacter (`\|`, `\(`, `\)`, `\+`, `\?`) に限定した（Spec 指示通り）。
+
+### Deferred Items
+- post-merge の実際の挙動確認（`/issue` または `/spec` 実行で警告が出るか）は `verify-type: opportunistic` で次回実行時に観測。
+- `/review` 時に rubric AC #4 の詳細判定が行われる。rubric grader には worktree 上の最新コンテンツを参照させること。
+
+### Notes for Next Phase
+- AC #1〜#3 は grep/file_contains で自動 PASS 確認済み（pre-merge チェックボックスも更新済み）。
+- PR #682 でブランチは `worktree-code+issue-675` → base `main`。
+- rubric AC #4 は `/review` の safe mode rubric grader が評価する。grader に `skills/issue/SKILL.md` と `skills/spec/SKILL.md` の内容を PR ブランチから読み込ませること（main branch との混同に注意）。

--- a/docs/spec/issue-675-bre-metacharacter-validation.md
+++ b/docs/spec/issue-675-bre-metacharacter-validation.md
@@ -53,18 +53,32 @@
 - None: 一発実装で bats 853 件全 PASS。skill syntax validation・forbidden expressions check も PASS。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `skills/issue/SKILL.md` Step 4 末尾（verify-type タグ割り当ての直後）に BRE 検出サブステップを追加した。Existing Issue フロー（Step 6）は "Follow Step 4" 参照なので Step 4 への追加で自動適用される。
-- `skills/spec/SKILL.md` は Step 10 の「Verification conditions consistency check」直後、「Patch route verify command check」直前に追加した。Spec 生成フローの verify command 確定後に検出する配置が最適。
-- 検出対象は5種類の BRE metacharacter (`\|`, `\(`, `\)`, `\+`, `\?`) に限定した（Spec 指示通り）。
+- AC #1〜#3 は grep/file_contains で PASS。rubric AC #4 は `/review` 内の AI 判定で PASS（PR ブランチからファイル内容を読み込んで評価）。
+- 外部レビューツール（Copilot/Claude Code Review/CodeRabbit）は未設定のため Step 7 をスキップした。
+- REVIEW_DEPTH=light（`--light` フラグ指定）で review-light 相当の全4アスペクトを実行。MUST/SHOULD 指摘なし。
 
 ### Deferred Items
-- post-merge の実際の挙動確認（`/issue` または `/spec` 実行で警告が出るか）は `verify-type: opportunistic` で次回実行時に観測。
-- `/review` 時に rubric AC #4 の詳細判定が行われる。rubric grader には worktree 上の最新コンテンツを参照させること。
+- post-merge の実際の挙動確認（`/issue` または `/spec` 実行で BRE 警告が出るか）は `verify-type: opportunistic` で次回実行時に観測。
+- CONSIDER: ERE リテラル `|` マッチ目的の verify command に対して誤検出警告が発生しうる（極めて稀）。
 
 ### Notes for Next Phase
-- AC #1〜#3 は grep/file_contains で自動 PASS 確認済み（pre-merge チェックボックスも更新済み）。
-- PR #682 でブランチは `worktree-code+issue-675` → base `main`。
-- rubric AC #4 は `/review` の safe mode rubric grader が評価する。grader に `skills/issue/SKILL.md` と `skills/spec/SKILL.md` の内容を PR ブランチから読み込ませること（main branch との混同に注意）。
+- MUST 指摘なし。全 CI 成功。`/merge 682` で main にマージ可能。
+- PR ブランチ: `worktree-code+issue-675` → base `main`。
+- post-merge verify: opportunistic（次回 `/issue` または `/spec` 実行時に観測）。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note. 実装は Spec の挿入箇所・内容・フォーマットを厳密に踏襲しており、逸脱なし。
+
+### Recurring issues
+
+Nothing to note. MUST/SHOULD 指摘なし。全4アスペクトでクリーンな実装。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note. 4条件すべて auto-verified（PASS 3件、rubric PASS 1件）。UNCERTAIN なし。AC の verify command は適切に設計されており、`grep "BRE metacharacter"` が具体的で誤検出リスクが低い点も良好。

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -173,6 +173,24 @@ Reuse `MCP_TOOLS` already fetched via `detect-config-markers.md` in Step 2. If n
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/verify-classifier.md` and assign `<!-- verify-type: auto|opportunistic|manual -->` tags to each post-merge condition.
 
+**BRE metacharacter detection in verify commands:**
+
+After assigning verify-type tags, scan all `<!-- verify: grep "PATTERN" ... -->` commands in the Issue body. For each `grep` verify command, extract the PATTERN string (the first quoted argument after `grep`) and check whether it contains BRE metacharacters: `\|`, `\(`, `\)`, `\+`, `\?`.
+
+If any BRE metacharacter is detected:
+- Output a warning to terminal listing the affected verify command
+- Present the ERE rewrite candidate: replace `\|` → `|`, `\(` → `(`, `\)` → `)`, `\+` → `+`, `\?` → `?`
+- Note that `grep` verify commands in Wholework use ripgrep (ERE by default); BRE metacharacters like `\|` are interpreted as literal `|` in ERE and do not function as OR alternation
+- If the intended behavior is BRE alternation, suggest switching to ERE form or using `command "grep -G ..."` to force BRE mode
+
+Example warning format:
+```
+Warning: BRE metacharacter detected in verify command:
+  grep "PATTERN_WITH_\|" "path/to/file"
+Suggested ERE rewrite: grep "PATTERN_WITH_|" "path/to/file"
+Note: verify-executor uses ripgrep (ERE); \| in BRE means OR but is a literal | in ERE.
+```
+
 ### Step 5: Clarification Questions
 
 If ambiguity points were found, process them as follows.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -458,6 +458,24 @@ After creating `## Verification > Pre-merge`, compare Spec items against Issue b
 - Detect: Spec items not in Issue body (omission), or mismatched `<!-- verify: ... -->` hints
 - If mismatched, auto-update Issue body (use Spec's `## Verification > Pre-merge` as source of truth): `mkdir -p .tmp`, write to `.tmp/issue-body-$NUMBER.md`, update with `gh-issue-edit.sh`, delete temp file
 
+**BRE metacharacter detection in verify commands:**
+
+After the consistency check, scan all `<!-- verify: grep "PATTERN" ... -->` commands in the Spec's `## Verification > Pre-merge` section. For each `grep` verify command, extract the PATTERN string (the first quoted argument after `grep`) and check whether it contains BRE metacharacters: `\|`, `\(`, `\)`, `\+`, `\?`.
+
+If any BRE metacharacter is detected:
+- Output a warning to terminal listing the affected verify command
+- Present the ERE rewrite candidate: replace `\|` → `|`, `\(` → `(`, `\)` → `)`, `\+` → `+`, `\?` → `?`
+- Note that `grep` verify commands in Wholework use ripgrep (ERE by default); BRE metacharacters like `\|` are interpreted as literal `|` in ERE and do not function as OR alternation
+- If the intended behavior is BRE alternation, suggest switching to ERE form or using `command "grep -G ..."` to force BRE mode
+
+Example warning format:
+```
+Warning: BRE metacharacter detected in verify command:
+  grep "PATTERN_WITH_\|" "path/to/file"
+Suggested ERE rewrite: grep "PATTERN_WITH_|" "path/to/file"
+Note: verify-executor uses ripgrep (ERE); \| in BRE means OR but is a literal | in ERE.
+```
+
 **Patch route verify command check:**
 
 After `## Verification > Pre-merge` is finalized and the Issue body is updated, if Size is `XS` or `S` (patch route — no PR exists), scan `## Verification > Pre-merge` in the Spec for `github_check "gh pr checks"` entries.


### PR DESCRIPTION
## Summary

- `skills/issue/SKILL.md` Step 4 末尾（「Assign verify-type tags to post-merge conditions」の後）に BRE metacharacter 検出サブステップを追加
- `skills/spec/SKILL.md` Step 10 の「Verification conditions vs. Issue body acceptance criteria consistency check」の後に同様の BRE metacharacter 検出サブステップを追加
- 検出ロジック: `<!-- verify: grep "PATTERN" ... -->` コマンドを抽出し、PATTERN に `\|`, `\(`, `\)`, `\+`, `\?` が含まれる場合に terminal へ警告と ERE 書き換え候補を出力

## Verification (pre-merge)

- `skills/issue/SKILL.md` に BRE metacharacter 検出ロジックの記述が追加されている（grep "BRE metacharacter" PASS）
- `skills/issue/SKILL.md` に ERE への書き換え推奨ガイダンスが含まれる（file_contains "ERE" PASS）
- `skills/spec/SKILL.md` に BRE metacharacter 検出ロジックの記述が追加されている（grep "BRE metacharacter" PASS）
- 両 skill に BRE 検出・警告ロジックが定義されている（rubric PASS）

## Verification (post-merge)

- 次回 `/issue` または `/spec` 実行で BRE pattern を含む verify command が AC に紛れた際、警告が表示されることを確認

closes #675