### PR TITLE
Issue #685: Fix wait-ci-checks.sh --watch hang with polling loop

### DIFF
--- a/docs/spec/issue-685-fix-wait-ci-checks-hang.md
+++ b/docs/spec/issue-685-fix-wait-ci-checks-hang.md
@@ -123,19 +123,35 @@ Candidate C（polling ループ + `--kill-after` の両方）を採用し、`--w
 
 - なし。初回実装でテスト 14/14 PASS。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Spec と PR diff の間に構造的な乖離なし。Issue body の verify command（`grep "gh pr checks.*--json|--kill-after"`）が実装と正確に対応しており、false positive/negative なく PASS と判定できた。
+- AC3 の Issue body チェックボックスが未チェックだったが、CI job "Run bats tests" が SUCCESS であることを `github_check` で確認し PASS と判定。
+
+### Recurring Issues
+
+- なし。review-light チェック（4 アスペクト）では CONSIDER 1件のみ（`--watch` 不在 assert の追加提案）。MUST/SHOULD なし。
+
+### Acceptance Criteria Verification Difficulty
+
+- UNCERTAIN: 0件。全 verify command が解決可能だった。
+- `rubric` コマンドの評価は実装内容から明確に PASS と判定できた（polling ループ + elapsed チェック + per-poll kill-after の三重保証が明示的）。
+- `github_check` の CI 状態取得は `gh pr checks --json name,state` で直接確認可能で問題なし。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `--watch` を完全廃止し、polling ループ（`--json name,state` + per-poll `--kill-after=10`）に統一。防御多重化（候補 C）を採用した。
-- `gtimeout` パスには `--kill-after` を付けない（バージョン依存リスクを避けるため）。
-- polling ループ終了条件: `IN_PROGRESS` チェック数が 0 になったら break（SUCCESS/SKIPPED/FAILURE は全て "完了" 扱い）。
+- AC 全件 PASS（grep + rubric + github_check）。MUST/SHOULD 問題なし → `/merge` 推奨。
+- CONSIDER 1件（`--watch` 不在 assert）はスキップ。既存テストで regression リスクは十分低い。
 
 ### Deferred Items
-- gtimeout パスの `--kill-after` 対応は将来的な改善候補として残る（現実装では 30s per-poll タイムアウトのみ）。
-- `event=auto-run` post-merge observation 検証は次回 `/auto` 実行時まで保留。
+- `event=auto-run` post-merge observation 検証は次回 `/auto` 実行時まで保留（Issue AC Post-merge に記載済み）。
+- `--watch` 不在 assert の追加は将来の改善提案として issues 集約予定（/verify レトロスペクティブ）。
 
 ### Notes for Next Phase
-- CI (`test.yml`) の bats テストが 14 テスト全て PASS することを確認済み。
-- `--watch` の削除を `grep -n "\-\-watch" scripts/wait-ci-checks.sh` で確認済み（0件）。
-- rubric AC（polling ループ + TIMEOUT_SEC 内終了ロジック）は実装内容から判断して PASS。
+- 全 CI ジョブ SUCCESS 確認済み。
+- レビューコメント投稿済み（COMMENT イベント）。MUST issue なし。
+- `/merge 686` 実行可能な状態。

--- a/docs/spec/issue-685-fix-wait-ci-checks-hang.md
+++ b/docs/spec/issue-685-fix-wait-ci-checks-hang.md
@@ -106,3 +106,36 @@ Candidate C（polling ループ + `--kill-after` の両方）を採用し、`--w
 - **`gtimeout` の `--kill-after`**: GNU coreutils `timeout` を macOS 向けにリネームした `gtimeout` も `--kill-after` をサポートするが、バージョンに依存する可能性がある。リスクを最小化するため、`gtimeout` パスでは `--kill-after` なしの 30s タイムアウトを使用し、`timeout` パスのみ `--kill-after=10` を付与する。
 - **polling ループの最小間隔**: 各 poll は `gh pr checks --json` の単発実行（非 `--watch`）なので、通常は数秒で返る。per-poll タイムアウトは 30s（`--kill-after=10` で最大 40s）。
 - **Issue body の `--watch` 旧コードの削除確認**: `grep -n "\-\-watch" scripts/wait-ci-checks.sh` で 0 件であることを実装後に確認する。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec の polling ループ設計はほぼそのまま実装できた。`_emit_ci_wait` による if/else 分岐を廃止し、polling ループを共通パスとした後、イベント emission のみ条件分岐するシンプルな構造になった。
+
+### Design Gaps/Ambiguities
+
+- bats テストで `env PATH="$MOCK_DIR" /bin/bash "$SCRIPT"` を使う strict PATH テストが、新実装で `date +%s` を polling ループ外（共通パス）で使用するようになったため `date` を MOCK_DIR に追加する必要が生じた。Spec の setup() モック追加の記述には含まれていなかった（jq/sleep のみ言及）。
+- "continues even when timeout exits non-zero" テストは TIMEOUT_SEC=2 を使用。Spec では TIMEOUT_SEC=1 を示唆していたが、タイミング依存のフラキネスを避けるため 2 秒に設定した。実際には instant sleep モックにより ~1-2 秒で完了する。
+- "continues even when gh pr checks fails" テストは Spec の候補案「gh が `[]` を返す形に変更」を採用。`exit 1` しながら stdout に `[]` を出力する形で `_in_progress=0` → 即 break を実現した。
+
+### Rework
+
+- なし。初回実装でテスト 14/14 PASS。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `--watch` を完全廃止し、polling ループ（`--json name,state` + per-poll `--kill-after=10`）に統一。防御多重化（候補 C）を採用した。
+- `gtimeout` パスには `--kill-after` を付けない（バージョン依存リスクを避けるため）。
+- polling ループ終了条件: `IN_PROGRESS` チェック数が 0 になったら break（SUCCESS/SKIPPED/FAILURE は全て "完了" 扱い）。
+
+### Deferred Items
+- gtimeout パスの `--kill-after` 対応は将来的な改善候補として残る（現実装では 30s per-poll タイムアウトのみ）。
+- `event=auto-run` post-merge observation 検証は次回 `/auto` 実行時まで保留。
+
+### Notes for Next Phase
+- CI (`test.yml`) の bats テストが 14 テスト全て PASS することを確認済み。
+- `--watch` の削除を `grep -n "\-\-watch" scripts/wait-ci-checks.sh` で確認済み（0件）。
+- rubric AC（polling ループ + TIMEOUT_SEC 内終了ロジック）は実装内容から判断して PASS。

--- a/scripts/wait-ci-checks.sh
+++ b/scripts/wait-ci-checks.sh
@@ -20,34 +20,46 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]] && [[ -f "$SCRIPT_DIR/emit-event.sh" ]]; then
 fi
 
 echo "Waiting for CI checks on PR #${PR_NUMBER} (timeout: ${TIMEOUT_SEC}s)..." >&2
-if [[ "$_emit_ci_wait" == "true" ]]; then
-  _ci_checks_output=""
-  if command -v timeout >/dev/null 2>&1; then
-      _ci_checks_output=$(timeout "$TIMEOUT_SEC" gh pr checks "$PR_NUMBER" --watch --interval 60 2>&1 || true)
-  elif command -v gtimeout >/dev/null 2>&1; then
-      _ci_checks_output=$(gtimeout "$TIMEOUT_SEC" gh pr checks "$PR_NUMBER" --watch --interval 60 2>&1 || true)
-  else
-      _ci_checks_output=$(gh pr checks "$PR_NUMBER" --watch --interval 60 2>&1 || true)
+
+_ci_checks_output=""
+_poll_start=$(date +%s)
+while true; do
+  _elapsed=$(( $(date +%s) - _poll_start ))
+  if [[ "$_elapsed" -ge "$TIMEOUT_SEC" ]]; then
+    echo "CI check wait timed out after ${TIMEOUT_SEC}s for PR #${PR_NUMBER}" >&2
+    break
   fi
+  _poll_result=""
+  if command -v timeout >/dev/null 2>&1; then
+    _poll_result=$(timeout --kill-after=10 30 gh pr checks "$PR_NUMBER" --json name,state 2>/dev/null) || true
+  elif command -v gtimeout >/dev/null 2>&1; then
+    _poll_result=$(gtimeout 30 gh pr checks "$PR_NUMBER" --json name,state 2>/dev/null) || true
+  else
+    _poll_result=$(gh pr checks "$PR_NUMBER" --json name,state 2>/dev/null) || true
+  fi
+  if [[ -n "$_poll_result" ]]; then
+    _ci_checks_output="$_poll_result"
+    _in_progress=$(echo "$_poll_result" | jq '[.[] | select(.state == "IN_PROGRESS")] | length' 2>/dev/null || echo "1")
+    if [[ "$_in_progress" -eq 0 ]]; then
+      break
+    fi
+    echo "CI checks in progress: ${_in_progress} check(s) still running..." >&2
+  fi
+  sleep 60
+done
+
+if [[ "$_emit_ci_wait" == "true" ]]; then
   _ci_wait_end=$(date +%s)
   _wait_sec=$(( _ci_wait_end - _ci_wait_start ))
-  _passed=$(echo "${_ci_checks_output:-}" | grep -c -i "pass\|success" 2>/dev/null || true)
+  _passed=$(echo "${_ci_checks_output:-}" | jq '[.[] | select(.state == "SUCCESS")] | length' 2>/dev/null || echo "0")
   _passed=${_passed:-0}
-  _failed=$(echo "${_ci_checks_output:-}" | grep -c -i "fail\|error" 2>/dev/null || true)
+  _failed=$(echo "${_ci_checks_output:-}" | jq '[.[] | select(.state == "FAILURE")] | length' 2>/dev/null || echo "0")
   _failed=${_failed:-0}
   emit_event "ci_wait" \
     "phase=${EMIT_PHASE_NAME:-review}" \
     "wait_sec=${_wait_sec}" \
     "checks_passed=${_passed}" \
     "checks_failed=${_failed}"
-else
-  if command -v timeout >/dev/null 2>&1; then
-      timeout "$TIMEOUT_SEC" gh pr checks "$PR_NUMBER" --watch --interval 60 || true
-  elif command -v gtimeout >/dev/null 2>&1; then
-      gtimeout "$TIMEOUT_SEC" gh pr checks "$PR_NUMBER" --watch --interval 60 || true
-  else
-      gh pr checks "$PR_NUMBER" --watch --interval 60 || true
-  fi
 fi
 
 echo "CI check wait complete for PR #${PR_NUMBER}" >&2

--- a/tests/wait-ci-checks.bats
+++ b/tests/wait-ci-checks.bats
@@ -13,26 +13,54 @@ setup() {
     TIMEOUT_CALL_LOG="$BATS_TEST_TMPDIR/timeout_calls.log"
     export TIMEOUT_CALL_LOG
 
-    # Default: timeout passes through to gh (skip duration arg, exec the rest)
+    # Default: timeout handles --kill-after=N prefix, passes through to gh
     cat > "$MOCK_DIR/timeout" <<'MOCK'
 #!/bin/bash
+if [[ "$1" == --kill-after* ]]; then shift; fi
 shift  # Remove the timeout duration argument
 echo "timeout called: $@" >> "$TIMEOUT_CALL_LOG"
 exec "$@"
 MOCK
     chmod +x "$MOCK_DIR/timeout"
 
-    # Default: gh pr checks exits 0
+    # Default: gh pr checks returns SUCCESS JSON
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
 if [[ "$1" == "pr" && "$2" == "checks" ]]; then
-    echo "All checks passed" >&2
+    echo '[{"name":"Run bats tests","state":"SUCCESS"}]'
     exit 0
 fi
 echo ""
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/gh"
+
+    # sleep mock: no-op to keep tests fast
+    cat > "$MOCK_DIR/sleep" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/sleep"
+
+    # jq wrapper: delegate to real jq (needed for restricted-PATH tests)
+    real_jq="$(type -P jq 2>/dev/null || echo "")"
+    if [[ -n "$real_jq" ]]; then
+        cat > "$MOCK_DIR/jq" <<MOCK
+#!/bin/bash
+exec "$real_jq" "\$@"
+MOCK
+        chmod +x "$MOCK_DIR/jq"
+    fi
+
+    # date wrapper: delegate to real date (needed for restricted-PATH tests)
+    real_date="$(type -P date 2>/dev/null || echo "")"
+    if [[ -n "$real_date" ]]; then
+        cat > "$MOCK_DIR/date" <<MOCK
+#!/bin/bash
+exec "$real_date" "\$@"
+MOCK
+        chmod +x "$MOCK_DIR/date"
+    fi
 }
 
 teardown() {
@@ -56,6 +84,7 @@ teardown() {
     run bash "$SCRIPT" 99
     [ "$status" -eq 0 ]
     grep -q "pr checks 99" "$TIMEOUT_CALL_LOG"
+    grep -q "\-\-json" "$TIMEOUT_CALL_LOG"
 }
 
 @test "success: uses WHOLEWORK_CI_TIMEOUT_SEC when set" {
@@ -73,22 +102,38 @@ teardown() {
 }
 
 @test "success: continues even when timeout exits non-zero (timeout occurred)" {
-    # Override timeout to exit 124 (the exit code timeout uses on timeout)
+    # Per-poll timeout exits 124; outer TIMEOUT_SEC elapses and loop breaks
     cat > "$MOCK_DIR/timeout" <<'MOCK'
 #!/bin/bash
 exit 124
 MOCK
     chmod +x "$MOCK_DIR/timeout"
 
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    echo '[{"name":"Run bats tests","state":"IN_PROGRESS"}]'
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    export WHOLEWORK_CI_TIMEOUT_SEC=2
     run bash "$SCRIPT" 88
     [ "$status" -eq 0 ]
     [[ "$output" == *"CI check wait complete for PR #88"* ]]
 }
 
 @test "success: continues even when gh pr checks fails" {
+    # gh exits 1 but prints [] so _in_progress=0 and loop breaks immediately
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
-exit 1
+if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    echo '[]'
+    exit 1
+fi
+exit 0
 MOCK
     chmod +x "$MOCK_DIR/gh"
 
@@ -178,6 +223,7 @@ MOCK
 #!/bin/bash
 echo "gh $@" >> "$GH_CALL_LOG"
 if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    echo '[{"name":"Run bats tests","state":"SUCCESS"}]'
     exit 0
 fi
 exit 0
@@ -197,12 +243,12 @@ MOCK
     emit_event_src="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/emit-event.sh"
     cp "$emit_event_src" "$EMIT_DIR/emit-event.sh"
 
-    # gh outputs text with no pass/success matches, causing grep -c to exit 1
+    # gh outputs FAILURE JSON: _in_progress=0 so loop breaks; checks_passed=0
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
 if [[ "$1" == "pr" && "$2" == "checks" ]]; then
-    echo "pending: check1 waiting" >&2
-    exit 1
+    echo '[{"name":"c1","state":"FAILURE"}]'
+    exit 0
 fi
 exit 0
 MOCK


### PR DESCRIPTION
## Summary

`scripts/wait-ci-checks.sh` の `gh pr checks --watch --interval 60` が CI 全 SUCCESS 後も終了せず長時間 hang する問題（PR #683 で 3h15m 観測）を解消する。

`--watch` 依存を廃止し、`--json name,state` を使った polling ループ（候補 C: A + B の両方）に置き換えた:

- 各 poll に `timeout --kill-after=10 30` を付与し、per-poll SIGKILL を保証
- 外側の `TIMEOUT_SEC` 経過チェック（elapsed >= TIMEOUT_SEC で break）により全体タイムアウトを保証
- `ci_wait` イベント emission を jq ベースの SUCCESS/FAILURE カウントに更新
- bats テストのモックを更新（sleep/jq/date ラッパー追加、timeout モックの --kill-after 対応）

## Verification (pre-merge)

- `scripts/wait-ci-checks.sh` に `gh pr checks ... --json name,state` および `--kill-after=10` が実装されていること
- rubric 基準（`--watch` 削除 + polling ループによる TIMEOUT_SEC 内終了ロジック）を満たすこと
- `tests/wait-ci-checks.bats` の全 bats テストが CI で PASS すること

## Verification (post-merge)

- 次回 pr route `/auto` 完走時に merge phase が TIMEOUT_SEC 内に完了することを確認（`event=auto-run` observation）

closes #685