### PR TITLE
Issue #687: Fix bats CI log parser to support TAP format

### DIFF
--- a/docs/spec/issue-687-run-merge-ci-tap-parser-fix.md
+++ b/docs/spec/issue-687-run-merge-ci-tap-parser-fix.md
@@ -106,3 +106,31 @@ passed/failed を計算する parser に置換する (Issue 本文 候補 A)。
   `|| echo 0` パターンだと stdout が `"0\n0"` になり算術エラーになるため `|| _failed=0` を使用。
   (auto-resolved: non-interactive mode, model judgment)
 - **doc-checker**: `scripts/` および `tests/` のみの変更のため docs/structure.md 等への文書更新不要。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- TAP plan line parser (`grep -oE "1\.\.[0-9]+"`) を採用。`^` anchor なしで `gh run view --log` のタイムスタンプ付き行にもマッチする
+- `grep -c "not ok "` + `|| _failed=0` で count=0 時の exit 1 を安全にハンドル
+- 既存テスト (`test_result: emit_event called with source=ci`) の gh mock を TAP 形式に更新し、新規 regression test を追加
+
+### Deferred Items
+- AC4 (`github_check "gh pr checks" "Run bats tests"`) は CI が green になった後に `/verify` で確認
+- Post-merge AC（次回 `/auto` 完走時の `source=ci` event 確認）は observation 型で `/verify` がスキップする
+
+### Notes for Next Phase
+- PR #688 が作成済み。`phase/code` → `phase/review` → `phase/merge` の通常フロー
+- AC1/AC2/AC3/AC5 は pre-merge でチェック済み。AC4 のみ CI green 待ち
+- `scripts/run-merge.sh` と `tests/run-merge.bats` の 2 ファイルのみ変更。スコープは狭い
+
+## Code Retrospective
+
+### Deviations from Design
+- None. Spec の実装ステップを忠実に実行した。Issue 本文提案の regex バグ (Spec Notes 参照) は Spec 段階で既に修正されており、コード実装時に改めて気づくことはなかった。
+
+### Design Gaps/Ambiguities
+- None. Spec Notes が `grep -c` + `|| _failed=0` パターンの理由を事前に説明しており、実装中に迷いは生じなかった。
+
+### Rework
+- None.

--- a/docs/spec/issue-687-run-merge-ci-tap-parser-fix.md
+++ b/docs/spec/issue-687-run-merge-ci-tap-parser-fix.md
@@ -108,21 +108,21 @@ passed/failed を計算する parser に置換する (Issue 本文 候補 A)。
 - **doc-checker**: `scripts/` および `tests/` のみの変更のため docs/structure.md 等への文書更新不要。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- TAP plan line parser (`grep -oE "1\.\.[0-9]+"`) を採用。`^` anchor なしで `gh run view --log` のタイムスタンプ付き行にもマッチする
-- `grep -c "not ok "` + `|| _failed=0` で count=0 時の exit 1 を安全にハンドル
-- 既存テスト (`test_result: emit_event called with source=ci`) の gh mock を TAP 形式に更新し、新規 regression test を追加
+- 全 5 つの Pre-merge AC が PASS。AC4 (`github_check "gh pr checks" "Run bats tests"`) はレビュー時に CI SUCCESS を確認し `[x]` に更新
+- MUST/SHOULD 課題なし。CONSIDER 1 件（`grep -c "not ok "` の全ステップ出力スコープ）は修正不要と判断
+- REVIEW_DEPTH=light（`--light` フラグ明示指定）で 1 エージェントの統合レビューを実施
 
 ### Deferred Items
-- AC4 (`github_check "gh pr checks" "Run bats tests"`) は CI が green になった後に `/verify` で確認
 - Post-merge AC（次回 `/auto` 完走時の `source=ci` event 確認）は observation 型で `/verify` がスキップする
+- CONSIDER 課題（grep スコープ）は実用上影響軽微なため未修正
 
 ### Notes for Next Phase
-- PR #688 が作成済み。`phase/code` → `phase/review` → `phase/merge` の通常フロー
-- AC1/AC2/AC3/AC5 は pre-merge でチェック済み。AC4 のみ CI green 待ち
+- 全 AC PASS、CI 全ジョブ SUCCESS、MUST 課題なし → merge 準備完了
 - `scripts/run-merge.sh` と `tests/run-merge.bats` の 2 ファイルのみ変更。スコープは狭い
+- レビューコメント投稿済み（COMMENT イベント、REQUEST_CHANGES なし）
 
 ## Code Retrospective
 
@@ -134,3 +134,17 @@ passed/failed を計算する parser に置換する (Issue 本文 候補 A)。
 
 ### Rework
 - None.
+
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Spec と実装の間に乖離なし。Spec Notes が `grep -c "not ok "` + `|| _failed=0` パターンの理由（`grep -c` は count=0 で exit 1 → `|| echo 0` だと stdout が二重になり算術エラー）を事前に記述しており、実装との齟齬が生じにくい構成だった。TAP 正規表現 (`grep -oE "1\.\.[0-9]+"`) も Issue 候補 A のバグを Spec 段階で修正済みで、コードレビューで再発見する必要がなかった。
+
+### Recurring Issues
+
+Nothing to note. 変更は `scripts/run-merge.sh` + `tests/run-merge.bats` の 2 ファイルに限定されており、単一パターンの parser 置換。繰り返し発生した問題はない。
+
+### Acceptance Criteria Verification Difficulty
+
+AC4 (`github_check "gh pr checks" "Run bats tests"`) のみ事前に `[ ]` であり、CI green 待ちとして deferred されていた。レビュー時に CI SUCCESS を確認して PASS に更新。他の 4 つの AC（`grep`/`rubric` 系）は verify コマンドが明確で UNCERTAIN なし。全体として verify コマンドの精度は高く、manual 判断不要だった。

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -153,13 +153,14 @@ fi
 if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
   _run_id=$(gh run list --workflow=test.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
   if [[ -n "$_run_id" ]]; then
-    _bats_summary=$(gh run view "$_run_id" --log 2>/dev/null | grep -E "[0-9]+ tests?, [0-9]+ failures?" | tail -1 || true)
-    if [[ -n "$_bats_summary" ]]; then
-      _passed=$(echo "$_bats_summary" | grep -oE "[0-9]+ tests?" | grep -oE "^[0-9]+" || echo 0)
-      _failed=$(echo "$_bats_summary" | grep -oE "[0-9]+ failures?" | grep -oE "^[0-9]+" || echo 0)
+    _log=$(gh run view "$_run_id" --log 2>/dev/null || true)
+    _total=$(echo "$_log" | grep -oE "1\.\.[0-9]+" | grep -oE "[0-9]+$" | head -1 || echo 0)
+    _failed=$(echo "$_log" | grep -c "not ok ") || _failed=0
+    if [[ "${_total:-0}" -gt 0 ]]; then
+      _passed=$((_total - _failed))
       emit_event "test_result" "phase=merge" "framework=bats" "source=ci" "passed=${_passed}" "failed=${_failed}" "run_id=${_run_id}"
     else
-      echo "Warning: run-merge.sh: gh run view ${_run_id} --log: no bats summary found" >&2
+      echo "Warning: run-merge.sh: gh run view ${_run_id} --log: TAP plan line (1..N) not found" >&2
     fi
   fi
 fi

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -389,7 +389,12 @@ if [[ "$1" == "run" && "$2" == "list" && "$*" == *"--workflow=test.yml"* ]]; the
   exit 0
 fi
 if [[ "$1" == "run" && "$2" == "view" && "$*" == *"--log"* ]]; then
-  echo "5 tests, 0 failures"
+  echo "1..5"
+  echo "ok 1 first test"
+  echo "ok 2 second test"
+  echo "ok 3 third test"
+  echo "ok 4 fourth test"
+  echo "ok 5 fifth test"
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
@@ -410,4 +415,45 @@ MOCK
     run bash "$SCRIPT" 88
     [ "$status" -eq 0 ]
     grep -q "source=ci" "$EMIT_LOG"
+}
+
+@test "test_result: TAP format with not ok lines counts failures correctly" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "run" && "$2" == "list" && "$*" == *"--workflow=test.yml"* ]]; then
+  echo "99999"
+  exit 0
+fi
+if [[ "$1" == "run" && "$2" == "view" && "$*" == *"--log"* ]]; then
+  echo "1..3"
+  echo "ok 1 passing test"
+  echo "not ok 2 failing test"
+  echo "ok 3 another passing test"
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  elif [[ "$*" == *"-q"* && "$*" == *".state"* ]]; then
+    echo "MERGED"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "source=ci" "$EMIT_LOG"
+    grep -q "failed=1" "$EMIT_LOG"
+    grep -q "passed=2" "$EMIT_LOG"
 }


### PR DESCRIPTION
## Summary

`scripts/run-merge.sh` の CI test_result emit ロジックが bats TAP 形式出力に対応していなかった問題を修正する。`bats --jobs N` による並列実行では summary 行 (`N tests, M failures`) が出力されないため、TAP plan line (`1..N`) と `not ok` 行から passed/failed を計算する parser に置換した。

- `scripts/run-merge.sh`: 旧 summary 行 grep parser を TAP plan + not ok count parser に置換
- `tests/run-merge.bats`: 既存テストの gh mock を TAP 形式に更新; TAP format regression test を追加

## Verification (pre-merge)

- `scripts/run-merge.sh` に TAP 形式 (`1..N` / `not ok`) parser が実装されている
- rubric 基準を満たす: CI log を TAP 形式で parse し `source=ci` 付き `test_result` event を emit する
- `emit_event` 呼び出しに `source=ci` が含まれている
- 既存 bats テストが CI で green
- CI log の TAP 形式 parse の regression test が追加されている

## Verification (post-merge)

- 次回 pr route `/auto` 完走時に `.tmp/auto-events.jsonl` で `source=ci` 付き `test_result` event が emit されることを確認

closes #687