### PR TITLE
Issue #436: Skip retrospective when no notable content

### DIFF
--- a/docs/spec/issue-436-retro-skip-when-no-notable.md
+++ b/docs/spec/issue-436-retro-skip-when-no-notable.md
@@ -38,3 +38,32 @@
 - SPEC_DEPTH=light で pre-merge verification が 7 件 (上限 5 件超) だが、Issue body の AC を verbatim でコピーするため全件含む
 - `/verify` の skip 条件は Issue body の `## Auto-Resolved Ambiguity Points` で auto-resolve 済み: 「全AC PASS かつ改善提案ゼロかつ Spec 未存在（または lifecycle review に観察事項なし）」を採用
 - `docs/workflow.md` の `/verify` 説明 ("Performs a cross-phase retrospective review") は変更後も意味的に正確 (skip はあくまで注記事項がない場合のみ) なので更新不要
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+特筆事項なし。diff がSpec の実装ステップ3件と完全に一致。verify/SKILL.md の旧ステップ3→新ステップ4へのリナンバリングも正確。
+
+### Recurring issues
+
+特筆事項なし。全4観点 (Spec divergence / Edge cases / Security / Documentation consistency) で MUST/SHOULD/CONSIDER 指摘ゼロ。SKILL.md テキスト変更のみのため構造的リスクが低く、高品質な実装。
+
+### Acceptance criteria verification difficulty
+
+特筆事項なし。全7件 PASS、UNCERTAIN ゼロ。`rubric` 条件はPRブランチ上のSKILL.mdを直接参照して判定可能。`section_contains` / `github_check` は機械的に確認。verify commandの設計が変更内容に対して適切で検証フリクションが低かった。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- 全 AC PASS (7件)、MUST/SHOULD/CONSIDER 指摘ゼロのため Step 12 修正スキップを判断
+- `review-light` subagent type が未登録のため、同等ロジックを直接実行 (結果は同一)
+- Step 13 ポリシー変更なし (外部レビューも Claude レビュー修正もなし)
+
+### Deferred Items
+- Post-merge: サンプル XS Issue で `/issue` `/verify` を実機実行して retrospective skipped を確認 (AC #8)
+
+### Notes for Next Phase
+- 全 CI ジョブ SUCCESS、MUST 指摘なし — merge 可能な状態
+- `closes #436` がコミットメッセージに含まれており、merge 時に Issue が自動クローズされる

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -297,7 +297,14 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query add-blocked-by -F issueId="$
 
 ### Step 10: Issue Retrospective
 
-Post a retrospective comment to the issue covering: judgment rationale for ambiguity resolution, key policy decisions from Q&A, and reasons for acceptance criteria changes. Always create the section (write "Nothing to note" if no content).
+**Skip condition**: Skip posting this retrospective comment if ALL of the following hold:
+- Zero ambiguity auto-resolutions were made
+- Zero acceptance criteria changes were made
+- No surprising policy decisions were made
+
+When skipping: output `retrospective skipped: no notable content` to terminal and proceed to the next step without posting a comment.
+
+When NOT skipping: post a retrospective comment covering: judgment rationale for ambiguity resolution, key policy decisions from Q&A, and reasons for acceptance criteria changes.
 
 The comment body must use `## Issue Retrospective` as the top-level heading (canonical key used by `/auto` Step 4b and `/verify`).
 
@@ -449,7 +456,14 @@ Run the standard sub-issue creation flow (New Issue Creation Step 9, procedures 
 
 ### Step 12: Issue Retrospective
 
-Post a retrospective comment to the issue covering: judgment rationale for ambiguity resolution, key policy decisions from Q&A, and reasons for acceptance criteria changes. Always create the section (write "Nothing to note" if no content).
+**Skip condition**: Skip posting this retrospective comment if ALL of the following hold:
+- Zero ambiguity auto-resolutions were made
+- Zero acceptance criteria changes were made
+- No surprising policy decisions were made
+
+When skipping: output `retrospective skipped: no notable content` to terminal and proceed to the next step without posting a comment.
+
+When NOT skipping: post a retrospective comment covering: judgment rationale for ambiguity resolution, key policy decisions from Q&A, and reasons for acceptance criteria changes.
 
 The comment body must use `## Issue Retrospective` as the top-level heading (canonical key used by `/auto` Step 4b and `/verify`).
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -530,7 +530,13 @@ As the final step of the workflow, verify conducts a retrospective of the entire
 2. Detect improvements across the 6 phases above:
    - Integrate content from each phase's retrospective
    - Cross-reference information sources in the retrospective dimensions table with collected retrospective information to detect improvement patterns across the entire workflow
-3. **Persist retrospective results to Spec**:
+3. **Skip condition check**: Before persisting, evaluate whether ALL of the following hold:
+   - All acceptance conditions resulted in PASS or SKIPPED (zero FAIL or UNCERTAIN among auto-verification targets)
+   - Zero improvement proposals were identified in step 2
+   - Spec does not exist OR all phases in the lifecycle review (step 2) had no observations worth recording
+
+   If ALL conditions hold: output `retrospective skipped: no notable content` to terminal and skip step 4. Proceed to Step 13.
+4. **Persist retrospective results to Spec**:
    - If Spec (`$SPEC_PATH/issue-$NUMBER-*.md`) does not exist: skip persistence and output to terminal only
    - If Spec exists, add `## Verify Retrospective` section at the end
    - Include improvement proposals if any, or "N/A" if none


### PR DESCRIPTION
## Summary

Adds skip conditions to `/issue` and `/verify` retrospective steps so that empty comments are not posted when there is nothing notable to record.

### Changes
- `skills/issue/SKILL.md` Step 10 / Step 12: skip when ambiguity auto-resolutions = 0, AC changes = 0, no surprising policy decisions
- `skills/verify/SKILL.md` Step 12: skip when all ACs PASS, zero improvement proposals, and Spec has no observations

closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)