### PR TITLE
Issue #690: Fix run-merge.sh CI run query to use PR branch with --status=success

### DIFF
--- a/docs/spec/issue-690-run-merge-in-progress-ci-fix.md
+++ b/docs/spec/issue-690-run-merge-in-progress-ci-fix.md
@@ -58,3 +58,35 @@
 - Candidate A を採用: `PR_NUMBER` は `run-merge.sh` の引数として既知なので `gh pr view "$PR_NUMBER"` でブランチ名を取得できる。Candidate B (`--status=success` で main を query) は semantic がずれる（他 PR の merge 結果を参照する可能性）
 - `_branch` が空の場合（PR 削除済み等）は graceful にスキップ（`_run_id=""` → emit 非実行）
 - 既存テストの `gh` mock は headRefName を処理しないため、実装変更後に既存 test_result テストが FAIL する。Step 2 で既存テストの mock 更新も必須
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec では `--jq '.headRefName'` を使用する例示があったが、既存コード (line 143) が `-q` 形式を使っているため `-q '.headRefName'` に統一した。両者は `gh` CLI 上では同義だが、テスト mock の条件マッチが `-q` を想定しており `--jq` では FAIL した。
+
+### Design Gaps/Ambiguities
+
+- Spec の headRefName 取得例示 (`--jq`) と既存コードの慣用 (`-q`) が不一致だった。Spec が `-q` と明示していれば第1コミットでのバグを防げた。
+
+### Rework
+
+- `scripts/run-merge.sh` を 2 回コミット: 初回に `--jq` で実装したが bats テストが FAIL したため `-q` に修正。1 回のコミットで済ませるためには Spec に慣用形を明示すべきだった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Candidate A (PR branch から headRefName 取得 + `--status=success` filter) を採用。既存 `PR_NUMBER` 変数を再利用できるため追加引数不要
+- `-q` フラグを使用（`--jq` でなく）: 既存コード (line 143) の慣用に合わせ、テスト mock の互換を維持
+- `_branch` が空の場合は graceful skip (`_run_id=""` → emit 非実行): PR 削除済み等の edge case をエラーなく処理
+
+### Deferred Items
+- post-merge AC: 次回 `/auto` 完走時に `source=ci` 付き `test_result` event が emit されるか観測 (observation event=auto-run)
+- 関連 Issues #679 / #662 / #630 の observation chain が本 PR merge 後に trigger されるか確認
+
+### Notes for Next Phase
+- PR #691 branch: `worktree-code+issue-690`
+- AC3 (`github_check "gh pr checks" "Run bats tests"`) は CI 完了後に PASS/FAIL が確定する
+- Spec の実装ステップと実際の実装は一致（`-q` vs `--jq` の細部のみ相違し retrospective に記録済み）
+- テスト: 全 20 件 PASS 確認済み

--- a/docs/spec/issue-690-run-merge-in-progress-ci-fix.md
+++ b/docs/spec/issue-690-run-merge-in-progress-ci-fix.md
@@ -74,19 +74,32 @@
 - `scripts/run-merge.sh` を 2 回コミット: 初回に `--jq` で実装したが bats テストが FAIL したため `-q` に修正。1 回のコミットで済ませるためには Spec に慣用形を明示すべきだった。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Candidate A (PR branch から headRefName 取得 + `--status=success` filter) を採用。既存 `PR_NUMBER` 変数を再利用できるため追加引数不要
-- `-q` フラグを使用（`--jq` でなく）: 既存コード (line 143) の慣用に合わせ、テスト mock の互換を維持
-- `_branch` が空の場合は graceful skip (`_run_id=""` → emit 非実行): PR 削除済み等の edge case をエラーなく処理
+- REVIEW_DEPTH=light（Size M + `--light` フラグ）: 全4視点チェックで問題なし
+- MUST イシューなし → Step 12（コード修正）スキップ
+- 全 pre-merge AC（4件）が PASS: AC3（`github_check "gh pr checks" "Run bats tests"`）も CI SUCCESS 確認
 
 ### Deferred Items
 - post-merge AC: 次回 `/auto` 完走時に `source=ci` 付き `test_result` event が emit されるか観測 (observation event=auto-run)
 - 関連 Issues #679 / #662 / #630 の observation chain が本 PR merge 後に trigger されるか確認
 
 ### Notes for Next Phase
-- PR #691 branch: `worktree-code+issue-690`
-- AC3 (`github_check "gh pr checks" "Run bats tests"`) は CI 完了後に PASS/FAIL が確定する
-- Spec の実装ステップと実際の実装は一致（`-q` vs `--jq` の細部のみ相違し retrospective に記録済み）
-- テスト: 全 20 件 PASS 確認済み
+- 全 CI SUCCESS、MUST イシューなし、ready to merge
+- `scripts/run-merge.sh` 変更: `--branch=main --limit=1` → PR branch の `--status=success` な最新 run を参照
+- validate-skill-syntax.py: PASS（0 error, 0 warning）
+
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+- Nothing to note. Spec と実装の整合性は良好。Code phase の retrospective に記録された `-q` vs `--jq` の差異は既に解消済みで、Spec の example に慣用形を明示すれば防げた軽微な事案。
+
+### 再発イシュー
+
+- Nothing to note. 同種のイシューは見当たらない。
+
+### 受け入れ基準検証難易度
+
+- Nothing to note. AC3 (`github_check "gh pr checks" "Run bats tests"`) は CI 完了待ちが必要だが、実行時点で既に SUCCESS だったため問題なし。全 4 pre-merge AC が PASS で UNCERTAIN なし。verify command の syntax は適切。

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -151,7 +151,11 @@ fi
 
 # CI test_result emit (pr route, EXIT_CODE=0 + AUTO_EVENTS_LOG set)
 if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
-  _run_id=$(gh run list --workflow=test.yml --branch=main --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+  _branch=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+  _run_id=""
+  if [[ -n "$_branch" ]]; then
+    _run_id=$(gh run list --workflow=test.yml --branch="$_branch" --status=success --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+  fi
   if [[ -n "$_run_id" ]]; then
     _log=$(gh run view "$_run_id" --log 2>/dev/null || true)
     _total=$(echo "$_log" | grep -oE "1\.\.[0-9]+" | grep -oE "[0-9]+$" | head -1 || echo 0)

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -151,7 +151,7 @@ fi
 
 # CI test_result emit (pr route, EXIT_CODE=0 + AUTO_EVENTS_LOG set)
 if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
-  _branch=$(gh pr view "$PR_NUMBER" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+  _branch=$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName' 2>/dev/null || true)
   _run_id=""
   if [[ -n "$_branch" ]]; then
     _run_id=$(gh run list --workflow=test.yml --branch="$_branch" --status=success --limit=1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -398,7 +398,9 @@ if [[ "$1" == "run" && "$2" == "view" && "$*" == *"--log"* ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
-  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".headRefName"* ]]; then
+    echo "pr-feature-branch"
+  elif [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
     echo "test PR title"
   elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
     echo "https://github.com/test/repo/pull/88"
@@ -437,7 +439,9 @@ if [[ "$1" == "run" && "$2" == "view" && "$*" == *"--log"* ]]; then
   exit 0
 fi
 if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
-  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".headRefName"* ]]; then
+    echo "pr-feature-branch"
+  elif [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
     echo "test PR title"
   elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
     echo "https://github.com/test/repo/pull/88"
@@ -456,4 +460,47 @@ MOCK
     grep -q "source=ci" "$EMIT_LOG"
     grep -q "failed=1" "$EMIT_LOG"
     grep -q "passed=2" "$EMIT_LOG"
+}
+
+@test "test_result: SUCCESS run query uses PR branch with --status=success" {
+    RUN_LIST_LOG="$BATS_TEST_TMPDIR/run-list-args.log"
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { :; }
+MOCK
+
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+if [[ "\$1" == "run" && "\$2" == "list" && "\$*" == *"--workflow=test.yml"* ]]; then
+  echo "\$@" >> "${RUN_LIST_LOG}"
+  echo "77777"
+  exit 0
+fi
+if [[ "\$1" == "run" && "\$2" == "view" && "\$*" == *"--log"* ]]; then
+  echo "1..2"
+  echo "ok 1 first"
+  echo "ok 2 second"
+  exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "view" && "\$*" == *"--json"* ]]; then
+  if [[ "\$*" == *"-q"* && "\$*" == *".headRefName"* ]]; then
+    echo "my-feature-branch"
+  elif [[ "\$*" == *"-q"* && "\$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "\$*" == *"-q"* && "\$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  elif [[ "\$*" == *"-q"* && "\$*" == *".state"* ]]; then
+    echo "MERGED"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "\-\-status=success" "$RUN_LIST_LOG"
+    grep -q "my-feature-branch" "$RUN_LIST_LOG"
 }


### PR DESCRIPTION
## Summary

- `scripts/run-merge.sh` の CI test_result emit ブロックで `--branch=main --limit=1` (in-progress run を取得してしまう) を、`gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName'` で取得した PR branch に `--status=success` filter を付けて query するよう変更
- merge 前に既に SUCCESS している PR の run を直接参照することで、TAP plan line のない不完全な log を掴む問題を解消し `source=ci` 付き `test_result` event の emit を確実化
- `tests/run-merge.bats` の既存 test_result テスト mock に `headRefName` 分岐を追加し、新規 regression test `test_result: SUCCESS run query uses PR branch with --status=success` を追加

## Verification (pre-merge)

- `scripts/run-merge.sh` に `headRefName` 取得と `--status=success` filter が実装されていることを grep で確認 (PASS)
- rubric: `--status=success` filter により in-progress run ではなく SUCCESS run を query している (PASS)
- bats テストが CI で green
- `tests/run-merge.bats` に `headRefName` / `--status` / `SUCCESS` keyword が含まれる regression test が追加されていることを grep で確認 (PASS)

## Verification (post-merge)

- 次回 pr route `/auto` 完走時に `.tmp/auto-events.jsonl` で `source=ci` 付き `test_result` event が emit されることを確認

closes #690