### PR TITLE
Issue #454: Auto-target all scripts in macOS shell CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,4 +67,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run shell scripts on macOS
-        run: bash scripts/check-translation-sync.sh
+        run: |
+          for f in scripts/*.sh; do
+            bash -n "$f"
+          done

--- a/docs/spec/issue-454-macos-shell-auto-target.md
+++ b/docs/spec/issue-454-macos-shell-auto-target.md
@@ -49,3 +49,36 @@
 - `bash scripts/check-translation-sync.sh` (実際の実行) から `bash -n` (構文チェックのみ) への切り替えにより、`check-translation-sync.sh` はこのジョブでは実行されなくなるが、macOS 互換性は引き続き構文チェックで担保される
 - `scripts/git-hooks/` 配下のスクリプトは `scripts/*.sh` グロブに含まれないため対象外
 - 変更後の run ブロックは bash 3.2+ (macOS システム bash) 互換: `for` ループ、glob 展開ともに 4.0+ 機能を使用しない
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A
+
+### Design Gaps/Ambiguities
+
+- Spec の実装ステップは 1 ステップのみで変更箇所が明確であり、曖昧な点はなかった
+
+### Rework
+
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+
+- `bash -n` による全 `scripts/*.sh` シンタックスチェックを採用 (実行副作用なし、新規スクリプト自動補足)
+- for ループは bash 3.2+ 互換 (`for f in scripts/*.sh; do bash -n "$f"; done`)
+- `scripts/git-hooks/` は `scripts/*.sh` グロブ対象外のため変更不要と確認
+
+### Deferred Items
+
+- CI の `macos-shell` ジョブ GREEN 確認 (AC4) は PR #692 のCI完了後に `/verify` で確認
+
+### Notes for Next Phase
+
+- 変更は `.github/workflows/test.yml` の 1 箇所のみ、シンプルな実装
+- pre-merge AC 1-3 は PASS 済み、AC4 (github_check) のみ CI 待ち
+- Post-merge AC は opportunistic verify で自動追跡される

--- a/docs/spec/issue-454-macos-shell-auto-target.md
+++ b/docs/spec/issue-454-macos-shell-auto-target.md
@@ -64,21 +64,35 @@
 
 - N/A
 
+## review retrospective
+
+### Spec と実装の乖離パターン
+
+- 乖離なし。Spec の実装ステップと PR diff が完全に一致しており、特記すべきパターンなし
+
+### 繰り返し問題
+
+- なし。今回の変更は1ファイル1箇所の最小限の変更であり、同種の問題は発生しなかった
+
+### 受け入れ条件の検証難易度
+
+- 全条件が verify command 付き。AC4 (`github_check`) は CI 完了まで検証不可だったが、CI SUCCESS 確認後に PASS を確定できた
+- UNCERTAIN なし。グロブ非マッチ時の挙動 (CONSIDER) は検証可能だったが実用上影響なし
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- `bash -n` による全 `scripts/*.sh` シンタックスチェックを採用 (実行副作用なし、新規スクリプト自動補足)
-- for ループは bash 3.2+ 互換 (`for f in scripts/*.sh; do bash -n "$f"; done`)
-- `scripts/git-hooks/` は `scripts/*.sh` グロブ対象外のため変更不要と確認
+- MUST/SHOULD 問題なし。CONSIDER 1件 (グロブ非マッチ時のガード) をスキップ判断: Spec が「シンプルな変更優先」を明示しており、追加ガード追加は範囲外
+- 全受け入れ条件 (AC1-4) PASS を確認。AC4 は CI SUCCESS による代替検証で確定
 
 ### Deferred Items
 
-- CI の `macos-shell` ジョブ GREEN 確認 (AC4) は PR #692 のCI完了後に `/verify` で確認
+- Post-merge AC (scripts/ に新規 .sh 追加時の自動チェック確認) は opportunistic verify で追跡
 
 ### Notes for Next Phase
 
-- 変更は `.github/workflows/test.yml` の 1 箇所のみ、シンプルな実装
-- pre-merge AC 1-3 は PASS 済み、AC4 (github_check) のみ CI 待ち
-- Post-merge AC は opportunistic verify で自動追跡される
+- 変更は `.github/workflows/test.yml` の 1 箇所のみ。merge 作業はシンプル
+- 全 CI ジョブ SUCCESS (DCO, bats, validate-skill-syntax, forbidden-expressions, macos-shell-compatibility)
+- MUST 問題なし → `/merge 692` で直接マージ可能


### PR DESCRIPTION
## Summary

- `.github/workflows/test.yml` の `macos-shell` ジョブを変更し、`scripts/*.sh` 全ファイルを `bash -n` でシンタックスチェックするよう自動化
- これにより `scripts/` に新規スクリプトが追加されても、`test.yml` を手動更新せずに macOS 互換性チェックが自動的に対象化される
- `bash -n` はシンタックス検証のみ (実行しない) のため、引数が必要なスクリプトも安全に検査できる

## Verification (pre-merge)

- `.github/workflows/test.yml` の `macos-shell` ジョブが `scripts/*.sh` グロブパターンを使用している
- `macos-shell` ジョブが `bash -n` でシンタックスチェックを実行する
- `scripts/check-eager-load-capability.sh` が macOS 互換の bash 構文であること
- CI の `macos-shell` ジョブが GREEN であること

## Verification (post-merge)

- `scripts/` に新たな `.sh` ファイルを追加した PR で macOS 互換性チェックが自動的に走ることを確認

closes #454