### PR TITLE
Issue #693: Emit phase_start/phase_complete in run-*.sh for single-issue /auto

### DIFF
--- a/docs/spec/issue-693-run-scripts-phase-event-emit.md
+++ b/docs/spec/issue-693-run-scripts-phase-event-emit.md
@@ -137,3 +137,35 @@
 - ガード条件 `[[ -z "${EMIT_PHASE_NAME:-}" ]]` の根拠: `run-auto-sub.sh` は `export EMIT_PHASE_NAME="$phase"` 後にランナースクリプトを呼び出すため、この値が子プロセスに引き継がれる
 - `run-merge.sh` の phase_complete 明示 emit 必要性: test_result emit 後に exit するため、backfill trap が `_last_event == "phase_start"` をチェックする時点で last_event は `test_result` になり backfill 条件が不成立
 - Spec 簡易性ルール (light: 各 5 以内) について: 実装ステップは 4 ステップで規定内。Pre-merge 検証項目は Issue body の AC 定義に従い 15 項目となる (Issue body AC からの verbatim sync 優先)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None
+
+### Design Gaps/Ambiguities
+
+- `AUTO_SESSION_ID` 初期化の配置: Spec では `export AUTO_EVENTS_LOG` の直後に追加と明記されていたが、実際は `source emit-event.sh` の前 (同じ直後の位置) に挿入した — 同じ行ブロックなので実質同じ配置
+- `run-code.sh` の `else` ブランチ (フラグなしの場合 `EMIT_PHASE_NAME="code"`) は run-auto-sub.sh の命名規約に直接対応する phase 名がないが、直接呼び出しケースのフォールバックとして問題なし
+
+### Rework
+
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- EMIT ガードブロックは `trap '_maybe_emit_phase_complete' EXIT` の直後に配置した — trap 設定後すぐに phase_start を emit することで、crash/abort 時も backfill が機能する順序を維持
+- `phase_complete` の明示 emit は `echo "---"` の直前 (最終フッタ前) に追加 — EXIT_CODE が確定した後かつ出力が終わる前の自然な配置
+- `run-merge.sh` の phase_complete は CI test_result emit ブロックの直後に追加 — test_result → phase_complete の順序で emit されることで rollup の時系列が正しくなる
+
+### Deferred Items
+- `token_usage` event の run-*.sh への追加は別 Issue (#662) に委ねる
+- `code` (フラグなし) の phase 名は run-auto-sub.sh に対応するケースがないが、直接呼び出しケースのみ発生するため post-merge observation で確認する
+
+### Notes for Next Phase
+- bats テストで EMIT_PHASE_NAME の pre-set による二重 emit ガードを検証済み — review フェーズはこのテストの PASS を確認すればよい
+- section_contains "scripts/run-code.sh" "_maybe_emit_phase_complete" "EMIT_PHASE_NAME" で backfill 関数の EMIT_PHASE_NAME ガード保持を確認済み
+- PR #697 として作成済み、CI が通ることを確認してから merge へ進む

--- a/docs/spec/issue-693-run-scripts-phase-event-emit.md
+++ b/docs/spec/issue-693-run-scripts-phase-event-emit.md
@@ -153,19 +153,32 @@
 
 - None
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- `phase_complete` に `_EMIT_PHASE_OWNED` センチネルガードが必要だった点が Spec に明記されていなかった。Spec は phase_start のガード (`EMIT_PHASE_NAME` 未設定チェック) を説明しているが、phase_complete が同じガードを必要とするという対称性の記述が欠如していた。実装時に非対称な状態で実装されたためレビューで発見された。
+
+### Recurring Issues
+
+- 二重 emit ガードのパターン (フラグ/センチネルで emit を制御) が 3 スクリプト共通で必要だったが、Spec ではスクリプトごとに独立した説明になっており横断的な一貫性要件が明示されていなかった。今後同類のパターンは Spec に "全スクリプト共通で対称的に適用する" 旨を明記すると実装漏れが防げる。
+
+### Acceptance Criteria Verification Difficulty
+
+- AC 15 件すべて PASS、UNCERTAIN なし。bats テストは CI 参照 (Run bats tests SUCCESS) で代替検証した。`command` verify コマンドは safe mode で UNCERTAIN になるが CI 参照フォールバックが有効に機能した。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- EMIT ガードブロックは `trap '_maybe_emit_phase_complete' EXIT` の直後に配置した — trap 設定後すぐに phase_start を emit することで、crash/abort 時も backfill が機能する順序を維持
-- `phase_complete` の明示 emit は `echo "---"` の直前 (最終フッタ前) に追加 — EXIT_CODE が確定した後かつ出力が終わる前の自然な配置
-- `run-merge.sh` の phase_complete は CI test_result emit ブロックの直後に追加 — test_result → phase_complete の順序で emit されることで rollup の時系列が正しくなる
+- `phase_complete` の二重 emit 問題を `_EMIT_PHASE_OWNED` センチネル変数で解決。`run-auto-sub.sh` 経由時は `EMIT_PHASE_NAME` が pre-export されているため `_EMIT_PHASE_OWNED` が空のまま → `phase_complete` は emit されず二重 emit を防ぐ
+- bats テストの "no double emit" に `! grep -q "phase_complete"` アサーションを追加し、`phase_complete` の二重 emit 回帰を検出できるようにした
+- validate-skill-syntax.py: PASS (0 errors)
 
 ### Deferred Items
-- `token_usage` event の run-*.sh への追加は別 Issue (#662) に委ねる
-- `code` (フラグなし) の phase 名は run-auto-sub.sh に対応するケースがないが、直接呼び出しケースのみ発生するため post-merge observation で確認する
+- `token_usage` event の run-*.sh への追加は別 Issue (#662) — このレビューでは対象外
+- post-merge observation: 単一 Issue /auto 完走後の rollup Sessions テーブル確認
 
 ### Notes for Next Phase
-- bats テストで EMIT_PHASE_NAME の pre-set による二重 emit ガードを検証済み — review フェーズはこのテストの PASS を確認すればよい
-- section_contains "scripts/run-code.sh" "_maybe_emit_phase_complete" "EMIT_PHASE_NAME" で backfill 関数の EMIT_PHASE_NAME ガード保持を確認済み
-- PR #697 として作成済み、CI が通ることを確認してから merge へ進む
+- SHOULD 問題をすべて修正済み。MUST 問題なし。CI 再実行待ち
+- merge は CI 完了確認後に `/merge 697` で実施

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -47,6 +47,8 @@ fi
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
+AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat .tmp/auto-session-current 2>/dev/null || echo '')}"
+export AUTO_SESSION_ID
 source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
@@ -68,6 +70,18 @@ _maybe_emit_phase_complete() {
   fi
 }
 trap '_maybe_emit_phase_complete' EXIT
+
+if [[ -z "${EMIT_PHASE_NAME:-}" ]]; then
+  export EMIT_ISSUE_NUMBER="$ISSUE_NUMBER"
+  if [[ "$ROUTE_FLAG" == "--pr" ]]; then
+    export EMIT_PHASE_NAME="code-pr"
+  elif [[ "$ROUTE_FLAG" == "--patch" ]]; then
+    export EMIT_PHASE_NAME="code-patch"
+  else
+    export EMIT_PHASE_NAME="code"
+  fi
+  emit_event "phase_start" "phase=${EMIT_PHASE_NAME}"
+fi
 
 PERMISSION_MODE=$("$SCRIPT_DIR/get-config-value.sh" permission-mode auto 2>/dev/null || echo auto)
 if [[ "$PERMISSION_MODE" == "auto" ]]; then
@@ -232,6 +246,10 @@ if [[ "$ROUTE_FLAG" == "--pr" && $EXIT_CODE -eq 0 ]]; then
       echo "Recommended: resolve conflicts before /merge. See modules/orchestration-fallbacks.md#code-base-conflict for the recovery procedure." >&2
     fi
   fi
+fi
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi
 
 echo "---"

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -71,7 +71,9 @@ _maybe_emit_phase_complete() {
 }
 trap '_maybe_emit_phase_complete' EXIT
 
+_EMIT_PHASE_OWNED=""
 if [[ -z "${EMIT_PHASE_NAME:-}" ]]; then
+  _EMIT_PHASE_OWNED=1
   export EMIT_ISSUE_NUMBER="$ISSUE_NUMBER"
   if [[ "$ROUTE_FLAG" == "--pr" ]]; then
     export EMIT_PHASE_NAME="code-pr"
@@ -248,7 +250,7 @@ if [[ "$ROUTE_FLAG" == "--pr" && $EXIT_CODE -eq 0 ]]; then
   fi
 fi
 
-if [[ $EXIT_CODE -eq 0 ]]; then
+if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then
   emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi
 

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -14,6 +14,8 @@ fi
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
+AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat .tmp/auto-session-current 2>/dev/null || echo '')}"
+export AUTO_SESSION_ID
 source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
@@ -35,6 +37,12 @@ _maybe_emit_phase_complete() {
   fi
 }
 trap '_maybe_emit_phase_complete' EXIT
+
+if [[ -z "${EMIT_PHASE_NAME:-}" ]]; then
+  export EMIT_ISSUE_NUMBER="$PR_NUMBER"
+  export EMIT_PHASE_NAME="merge"
+  emit_event "phase_start" "phase=${EMIT_PHASE_NAME}"
+fi
 
 PERMISSION_MODE=$("$SCRIPT_DIR/get-config-value.sh" permission-mode auto 2>/dev/null || echo auto)
 if [[ "$PERMISSION_MODE" == "auto" ]]; then
@@ -167,6 +175,10 @@ if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
       echo "Warning: run-merge.sh: gh run view ${_run_id} --log: TAP plan line (1..N) not found" >&2
     fi
   fi
+fi
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi
 
 echo "---"

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -38,7 +38,9 @@ _maybe_emit_phase_complete() {
 }
 trap '_maybe_emit_phase_complete' EXIT
 
+_EMIT_PHASE_OWNED=""
 if [[ -z "${EMIT_PHASE_NAME:-}" ]]; then
+  _EMIT_PHASE_OWNED=1
   export EMIT_ISSUE_NUMBER="$PR_NUMBER"
   export EMIT_PHASE_NAME="merge"
   emit_event "phase_start" "phase=${EMIT_PHASE_NAME}"
@@ -177,7 +179,7 @@ if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
   fi
 fi
 
-if [[ $EXIT_CODE -eq 0 ]]; then
+if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then
   emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi
 

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -16,6 +16,8 @@ fi
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
+AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat .tmp/auto-session-current 2>/dev/null || echo '')}"
+export AUTO_SESSION_ID
 source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
@@ -37,6 +39,12 @@ _maybe_emit_phase_complete() {
   fi
 }
 trap '_maybe_emit_phase_complete' EXIT
+
+if [[ -z "${EMIT_PHASE_NAME:-}" ]]; then
+  export EMIT_ISSUE_NUMBER="$PR_NUMBER"
+  export EMIT_PHASE_NAME="review"
+  emit_event "phase_start" "phase=${EMIT_PHASE_NAME}"
+fi
 
 PERMISSION_MODE=$("$SCRIPT_DIR/get-config-value.sh" permission-mode auto 2>/dev/null || echo auto)
 if [[ "$PERMISSION_MODE" == "auto" ]]; then
@@ -143,6 +151,10 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
   else
     echo "reconcile-phase-state: could not extract issue number from PR #${PR_NUMBER}, skipping reconcile" >&2
   fi
+fi
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi
 
 echo "---"

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -40,7 +40,9 @@ _maybe_emit_phase_complete() {
 }
 trap '_maybe_emit_phase_complete' EXIT
 
+_EMIT_PHASE_OWNED=""
 if [[ -z "${EMIT_PHASE_NAME:-}" ]]; then
+  _EMIT_PHASE_OWNED=1
   export EMIT_ISSUE_NUMBER="$PR_NUMBER"
   export EMIT_PHASE_NAME="review"
   emit_event "phase_start" "phase=${EMIT_PHASE_NAME}"
@@ -153,7 +155,7 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
   fi
 fi
 
-if [[ $EXIT_CODE -eq 0 ]]; then
+if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then
   emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi
 

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -427,3 +427,36 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" != *"Warning:"* ]]
 }
+
+@test "emit: phase_start emitted when EMIT_PHASE_NAME is not set" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    run bash "$SCRIPT" 123 --pr
+    [ "$status" -eq 0 ]
+    grep -q "phase_start" "$EMIT_LOG"
+    grep -q "phase=code-pr" "$EMIT_LOG"
+}
+
+@test "emit: phase_start not emitted when EMIT_PHASE_NAME is pre-set (no double emit)" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    export EMIT_PHASE_NAME="code-pr"
+    run bash "$SCRIPT" 123 --pr
+    unset EMIT_PHASE_NAME
+    [ "$status" -eq 0 ]
+    ! grep -q "phase_start" "$EMIT_LOG"
+}
+
+@test "emit: phase_complete emitted on success" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    run bash "$SCRIPT" 123 --pr
+    [ "$status" -eq 0 ]
+    grep -q "phase_complete" "$EMIT_LOG"
+}

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -449,6 +449,7 @@ MOCK
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
     ! grep -q "phase_start" "$EMIT_LOG"
+    ! grep -q "phase_complete" "$EMIT_LOG"
 }
 
 @test "emit: phase_complete emitted on success" {

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -504,3 +504,36 @@ MOCK
     grep -q "\-\-status=success" "$RUN_LIST_LOG"
     grep -q "my-feature-branch" "$RUN_LIST_LOG"
 }
+
+@test "emit: phase_start emitted when EMIT_PHASE_NAME is not set" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "phase_start" "$EMIT_LOG"
+    grep -q "phase=merge" "$EMIT_LOG"
+}
+
+@test "emit: phase_start not emitted when EMIT_PHASE_NAME is pre-set (no double emit)" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    export EMIT_PHASE_NAME="merge"
+    run bash "$SCRIPT" 88
+    unset EMIT_PHASE_NAME
+    [ "$status" -eq 0 ]
+    ! grep -q "phase_start" "$EMIT_LOG"
+}
+
+@test "emit: phase_complete emitted on success" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "phase_complete" "$EMIT_LOG"
+}

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -526,6 +526,7 @@ MOCK
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
     ! grep -q "phase_start" "$EMIT_LOG"
+    ! grep -q "phase_complete" "$EMIT_LOG"
 }
 
 @test "emit: phase_complete emitted on success" {

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -332,3 +332,36 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" == *"skipping reconcile"* ]]
 }
+
+@test "emit: phase_start emitted when EMIT_PHASE_NAME is not set" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "phase_start" "$EMIT_LOG"
+    grep -q "phase=review" "$EMIT_LOG"
+}
+
+@test "emit: phase_start not emitted when EMIT_PHASE_NAME is pre-set (no double emit)" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    export EMIT_PHASE_NAME="review"
+    run bash "$SCRIPT" 88
+    unset EMIT_PHASE_NAME
+    [ "$status" -eq 0 ]
+    ! grep -q "phase_start" "$EMIT_LOG"
+}
+
+@test "emit: phase_complete emitted on success" {
+    EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+MOCK
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "phase_complete" "$EMIT_LOG"
+}

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -354,6 +354,7 @@ MOCK
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
     ! grep -q "phase_start" "$EMIT_LOG"
+    ! grep -q "phase_complete" "$EMIT_LOG"
 }
 
 @test "emit: phase_complete emitted on success" {


### PR DESCRIPTION
## Summary

`run-code.sh` / `run-review.sh` / `run-merge.sh` に `phase_start` / `phase_complete` イベントの emit を追加。

- `auto-events-rollup.sh` のセッション集計はこれらのイベントに依存するが、単一 Issue `/auto` では `run-auto-sub.sh` を経由しないため emit されていなかった
- EMIT ガードブロック (`EMIT_PHASE_NAME` 未設定の場合のみ emit) で `run-auto-sub.sh` 経由時の二重 emit を回避
- `run-merge.sh` は `test_result` emit 後に EXIT するため backfill 条件が不成立になる問題を明示 emit で解決
- 各スクリプトに bats テスト 3 件追加 (phase_start emit / 二重 emit ガード / phase_complete emit)

## Verification (pre-merge)

- `grep "emit_event.*phase_start" scripts/run-code.sh` PASS
- `grep "emit_event.*phase_complete" scripts/run-code.sh` PASS
- `grep "EMIT_ISSUE_NUMBER=" scripts/run-code.sh` PASS
- `grep "EMIT_PHASE_NAME=" scripts/run-code.sh` PASS
- 同様に `run-review.sh` / `run-merge.sh` も全 PASS
- rubric: 3 スクリプト全で EMIT ガード / phase_complete 明示 emit / phase 名一致 PASS
- `section_contains` で backfill 関数の EMIT_PHASE_NAME ガード保持確認 PASS
- `bats tests/run-code.bats tests/run-review.bats tests/run-merge.bats` → 74 tests PASS

## Verification (post-merge)

- 次回 単一 Issue pr-route `/auto` 完走後の rollup で Sessions テーブルが空でないことを確認

closes #693