### PR TITLE
Issue #693: Add phase_start/phase_complete fallback to Sessions in auto-events-rollup

### DIFF
--- a/docs/spec/issue-693-rollup-sessions-fallback.md
+++ b/docs/spec/issue-693-rollup-sessions-fallback.md
@@ -83,19 +83,35 @@
 
 - None
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Phases / Recoveries 集計列が `$own` (session スコープ) ではなく `$ev[]` (issue 全体) で実装されていた。Spec が "現行を踏襲" と明示したため実装は Spec どおりだが、session_id 別行が生成される新構造では同一 issue が複数セッションで実行された際にクロス汚染が発生する。Spec 記述が "現行を踏襲" という短縮形で将来の含意を隠蔽した典型。次回類似改修では "session スコープ vs. issue スコープ" を明示的に書くこと。
+
+### Recurring Issues
+
+- Nothing to note
+
+### Acceptance Criteria Verification Difficulty
+
+- `command "bats tests/auto-events-rollup.bats"` は safe mode では UNCERTAIN 扱いだが、CI reference fallback (Run bats tests SUCCESS) で PASS に解決できた。verify command 品質に問題なし。
+- `rubric` 基準は AI 判断で PASS。3 スクリプトの symmetry (phase_start emit ガード + phase_complete on success) を rubric が適切に捉えていた。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Sessions jq クエリを `sub_start` 起点から `{issue, session_id}` 全列挙に変更し fallback 追加 (Spec どおり)
-- `session_id` が欠落した legacy event を `.session_id // ""` で正規化してから `unique` に渡す設計を採用
-- `$own` 変数で同一 `(issue, session_id)` のイベント列を絞り、`sub_start`/`phase_start` の優先順位を `//` 演算子で表現
+- MUST 指摘なし → COMMENT 投稿 (REQUEST_CHANGES 不要)
+- SHOULD #1 (Phases/Recoveries クロス汚染): Spec "現行を踏襲" に従い修正スキップ。次 Issue 候補として記録
+- SHOULD #2 (混在ケーステスト不足): SHOULD #1 の修正前提のためスキップ
 
 ### Deferred Items
-- post-merge observation: 単一 Issue /auto 完走後の rollup Sessions テーブルに行が出力されることを確認 (Post-merge verification)
-- `token_usage` event の run-*.sh への追加は別 Issue (#662)
+- Phases/Recoveries 列を `$own` スコープに変更する改善 (SHOULD 級、別 Issue で検討)
+- 同一 issue 複数セッション混在ケースのテスト追加 (上記に連動)
+- post-merge observation: 単一 Issue /auto 完走後の rollup Sessions テーブルに行が出力されることを確認
 
 ### Notes for Next Phase
-- テストは 7 件全て PASS (新規 2 件含む)
-- PR #698 を review → merge フローで進める
-- `bats tests/auto-events-rollup.bats` が 7 件 green であることを CI で確認
+- MUST 指摘なし。`/merge 698` で進行可
+- CI 全ジョブ SUCCESS 確認済み
+- Acceptance Criteria 20 件 PASS、Post-merge 2 件は観察待ち

--- a/docs/spec/issue-693-rollup-sessions-fallback.md
+++ b/docs/spec/issue-693-rollup-sessions-fallback.md
@@ -68,3 +68,34 @@
 - Phases 列の現行ロジック (`select(.event == "phase_complete" and .issue == $iss) | .phase | join("→")`) は単一 Issue 経路でも phase_complete が emit されるため変更不要
 - Recoveries 列の `recovery` event 集計は単一 Issue 経路では発生しないため `—` 表示 (現行通り)
 - bash 3.2+ 互換: jq 内の変更のみで、シェル組み込みは現行のまま使用
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None
+
+### Design Gaps/Ambiguities
+
+- Spec の jq クエリ疑似コードでは `$own` を `($ev | map(select(.issue == $iss and ...)))` で絞るが、`session_id` の正規化 (`.session_id // ""`) を `unique` 前と `$own` 絞り込み時の両方に適用する必要があった。Spec では明示されていなかったが実装時に統一した
+
+### Rework
+
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Sessions jq クエリを `sub_start` 起点から `{issue, session_id}` 全列挙に変更し fallback 追加 (Spec どおり)
+- `session_id` が欠落した legacy event を `.session_id // ""` で正規化してから `unique` に渡す設計を採用
+- `$own` 変数で同一 `(issue, session_id)` のイベント列を絞り、`sub_start`/`phase_start` の優先順位を `//` 演算子で表現
+
+### Deferred Items
+- post-merge observation: 単一 Issue /auto 完走後の rollup Sessions テーブルに行が出力されることを確認 (Post-merge verification)
+- `token_usage` event の run-*.sh への追加は別 Issue (#662)
+
+### Notes for Next Phase
+- テストは 7 件全て PASS (新規 2 件含む)
+- PR #698 を review → merge フローで進める
+- `bats tests/auto-events-rollup.bats` が 7 件 green であることを CI で確認

--- a/scripts/auto-events-rollup.sh
+++ b/scripts/auto-events-rollup.sh
@@ -119,31 +119,41 @@ fi
 # Build Sessions table rows
 SESSIONS_ROWS=$(printf '%s\n' "$FILTERED" | jq -rs '
   . as $ev |
-  [$ev[] | select(.event == "sub_start")] | sort_by(.ts) |
+  [$ev[] | {issue, session_id: (.session_id // "")}] | unique | sort_by(.issue) |
   map(
     .issue as $iss |
-    (.size // "-") as $sz |
-    .ts as $start_ts |
-    ($start_ts | split("T")[1] | rtrimstr("Z")) as $start_time |
-    ($ev | map(select(.event == "sub_complete" and .issue == $iss)) | last) as $comp |
-    (if $comp then $comp.ts | split("T")[1] | rtrimstr("Z") else "-" end) as $end_time |
-    (if $comp then
-      (($comp.ts | split("T")[1] | rtrimstr("Z") | split(":") |
-          (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber)) -
-       ($start_ts | split("T")[1] | rtrimstr("Z") | split(":") |
-          (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber))) as $sec |
-      if $sec < 0 then "\(($sec + 86400) / 60 | floor)m"
-      else if $sec >= 60 then "\($sec / 60 | floor)m"
-      else "\($sec)s"
-      end end
-    else "-" end) as $dur |
-    ([$ev[] | select(.event == "phase_complete" and .issue == $iss) | .phase] | join("→")) as $phases |
-    ([$ev[] | select(.event == "recovery" and .issue == $iss)] | length) as $rec_count |
-    (if $rec_count == 0 then "—" else ($rec_count | tostring) end) as $recs |
-    (if $comp then
-      if (($comp.exit_code // "0") == "0") then "success" else "failure" end
-    else "incomplete" end) as $outcome |
-    "| #\($iss) | \($sz) | \($start_time) | \($end_time) | \($dur) | \($phases) | \($recs) | \($outcome) |"
+    .session_id as $sid |
+    ($ev | map(select(.issue == $iss and (.session_id // "") == $sid))) as $own |
+    ($own | map(select(.event == "sub_start")) | first) as $sub_start |
+    ($own | map(select(.event == "phase_start")) | first) as $first_phase_start |
+    ($sub_start // $first_phase_start) as $start |
+    if $start == null then empty else
+      ($sub_start.size // "-") as $sz |
+      $start.ts as $start_ts |
+      ($start_ts | split("T")[1] | rtrimstr("Z")) as $start_time |
+      ($own | map(select(.event == "sub_complete")) | last) as $sub_complete |
+      ($own | map(select(.event == "phase_complete")) | last) as $last_phase_complete |
+      ($sub_complete // $last_phase_complete) as $end |
+      (if $end then $end.ts | split("T")[1] | rtrimstr("Z") else "-" end) as $end_time |
+      (if $end then
+        (($end.ts | split("T")[1] | rtrimstr("Z") | split(":") |
+            (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber)) -
+         ($start_ts | split("T")[1] | rtrimstr("Z") | split(":") |
+            (.[0]|tonumber)*3600 + (.[1]|tonumber)*60 + (.[2]|tonumber))) as $sec |
+        if $sec < 0 then "\(($sec + 86400) / 60 | floor)m"
+        else if $sec >= 60 then "\($sec / 60 | floor)m"
+        else "\($sec)s"
+        end end
+      else "-" end) as $dur |
+      ([$ev[] | select(.event == "phase_complete" and .issue == $iss) | .phase] | join("→")) as $phases |
+      ([$ev[] | select(.event == "recovery" and .issue == $iss)] | length) as $rec_count |
+      (if $rec_count == 0 then "—" else ($rec_count | tostring) end) as $recs |
+      (if $sub_complete then
+        if (($sub_complete.exit_code // "0") == "0") then "success" else "failure" end
+      elif $last_phase_complete then "success"
+      else "incomplete" end) as $outcome |
+      "| #\($iss) | \($sz) | \($start_time) | \($end_time) | \($dur) | \($phases) | \($recs) | \($outcome) |"
+    end
   ) | join("\n")
 ' 2>/dev/null || true)
 

--- a/tests/auto-events-rollup.bats
+++ b/tests/auto-events-rollup.bats
@@ -96,6 +96,47 @@ EOF
     grep -q "| 1 |" "docs/reports/auto-events-rollup-2026-06-14.md"
 }
 
+# (e) phase_start/phase_complete only (no sub_*) produces session row
+@test "auto-events-rollup: phase_start/phase_complete only (no sub_*) produces session row" {
+    cat > .tmp/events.jsonl << 'EOF'
+{"ts":"2026-06-14T08:00:00Z","issue":684,"event":"phase_start","phase":"code-patch"}
+{"ts":"2026-06-14T08:30:00Z","issue":684,"event":"phase_complete","phase":"code-patch"}
+EOF
+
+    run bash "$SCRIPT" --date 2026-06-14 --input .tmp/events.jsonl --output-dir docs/reports
+    [ "$status" -eq 0 ]
+    [ -f "docs/reports/auto-events-rollup-2026-06-14.md" ]
+
+    # Sessions table should have a row for #684
+    grep -q "^| #684" "docs/reports/auto-events-rollup-2026-06-14.md"
+
+    # Size should be "-" (no sub_start)
+    grep "^| #684" "docs/reports/auto-events-rollup-2026-06-14.md" | grep -q "| - |"
+
+    # Outcome should be success (phase_complete present)
+    grep "^| #684" "docs/reports/auto-events-rollup-2026-06-14.md" | grep -q "success"
+
+    # Phase column should show code-patch
+    grep "^| #684" "docs/reports/auto-events-rollup-2026-06-14.md" | grep -q "code-patch"
+}
+
+# (f) phase_start without phase_complete produces incomplete outcome
+@test "auto-events-rollup: phase_start without phase_complete produces incomplete outcome" {
+    cat > .tmp/events.jsonl << 'EOF'
+{"ts":"2026-06-14T09:00:00Z","issue":685,"event":"phase_start","phase":"code-pr"}
+EOF
+
+    run bash "$SCRIPT" --date 2026-06-14 --input .tmp/events.jsonl --output-dir docs/reports
+    [ "$status" -eq 0 ]
+    [ -f "docs/reports/auto-events-rollup-2026-06-14.md" ]
+
+    # Sessions table should have a row for #685
+    grep -q "^| #685" "docs/reports/auto-events-rollup-2026-06-14.md"
+
+    # Outcome should be incomplete (no phase_complete)
+    grep "^| #685" "docs/reports/auto-events-rollup-2026-06-14.md" | grep -q "incomplete"
+}
+
 # (d) Cleanup rotation: target date entries removed, other dates preserved
 @test "auto-events-rollup: cleanup removes target date entries and preserves others" {
     cat > .tmp/events.jsonl << 'EOF'


### PR DESCRIPTION
## Summary

- `scripts/auto-events-rollup.sh` の Sessions jq クエリを修正し、`sub_start` がない `(issue, session_id)` ペアについて `phase_start`/`phase_complete` から合成する fallback を追加
- 単一 Issue `/auto` (run-*.sh 直接実行パス) では `sub_start`/`sub_complete` が emit されないため Sessions テーブルが空になっていた問題を解消
- `tests/auto-events-rollup.bats` に 2 件のテストケースを追加 (phase_start/phase_complete のみのケース + phase_start のみ incomplete のケース)

## Verification (pre-merge)

- `scripts/auto-events-rollup.sh` が `phase_start` / `phase_complete` を参照している
- `tests/auto-events-rollup.bats` に fallback 用テストと incomplete outcome テストが追加されている
- `bats tests/auto-events-rollup.bats` が 7 件 green

## Verification (post-merge)

- 次回 単一 Issue `/auto` 完走後の rollup で Sessions テーブルに `| #N` 行が出力されることを確認

closes #693