### PR TITLE
Issue #702: Add recoveries-auto-fire to verify retrospective tail

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -88,6 +88,12 @@ verify-max-iterations: 3
 #   max_iterations: 3
 #   budget_tokens: 500000
 
+# Auto-file improvement Issues when orchestration-recoveries.md symptom count exceeds threshold
+# (opt-in; requires autonomy: L2 or L3)
+# recoveries-auto-fire:
+#   enabled: true
+#   threshold: 3
+
 # Optional capabilities
 capabilities:
   browser: true             # Enable Playwright-based verify commands
@@ -133,6 +139,8 @@ This table is the **single source of truth (SSoT)** for all `.wholework.yml` con
 | `auto-retry-on-fail.enabled` | boolean | `false` | Enable automatic `/code` re-fire + `/verify` retry on FAIL (requires `autonomy: L2` or `L3`). When `false` (or autonomy is `L1`), only advisory guidance is printed. |
 | `auto-retry-on-fail.max_iterations` | integer | `3` | Maximum number of auto-retry iterations before stopping and returning to the user. Values ≤0 or non-numeric fall back to `3`. |
 | `auto-retry-on-fail.budget_tokens` | integer | `500000` | Approximate token budget for auto-retry iterations. Initial implementation uses iteration count only; budget tracking is a future improvement. Values ≤0 or non-numeric fall back to `500000`. |
+| `recoveries-auto-fire.enabled` | boolean | `false` | Auto-file improvement Issues when orchestration-recoveries.md symptom count exceeds threshold (requires `autonomy: L2` or `L3`). When `false` or autonomy is `L1`, prints a recommendation instead. |
+| `recoveries-auto-fire.threshold` | integer | `3` | Symptom occurrence count threshold for auto-filing. Values ≤0 or non-numeric fall back to `3`. |
 
 For the full reference including implementation details and YAML parsing rules, see [`modules/detect-config-markers.md`](../../modules/detect-config-markers.md).
 

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -78,6 +78,12 @@ verify-max-iterations: 3
 #   max_iterations: 3
 #   budget_tokens: 500000
 
+# orchestration-recoveries.md の symptom 数が閾値を超えた際に改善 Issue を自動起票
+# （opt-in; autonomy: L2 または L3 が必要）
+# recoveries-auto-fire:
+#   enabled: true
+#   threshold: 3
+
 # オプション capability
 capabilities:
   browser: true             # Playwright ベースの verify command を有効化
@@ -120,6 +126,8 @@ capabilities:
 | `auto-retry-on-fail.enabled` | boolean | `false` | verify FAIL 時の自動 `/code` 再発火 + `/verify` リトライを有効化する（`autonomy: L2` または `L3` が必要）。`false` または autonomy が `L1` の場合はアドバイザリーガイダンスのみ出力。 |
 | `auto-retry-on-fail.max_iterations` | integer | `3` | 自動リトライの最大試行回数。上限到達後はユーザーに制御を戻す。0 以下または非数値の場合は `3` にフォールバック。 |
 | `auto-retry-on-fail.budget_tokens` | integer | `500000` | 自動リトライのトークン予算概算。初期実装は試行回数カウントのみ; トークン追跡は将来の改善項目。0 以下または非数値の場合は `500000` にフォールバック。 |
+| `recoveries-auto-fire.enabled` | boolean | `false` | `orchestration-recoveries.md` の symptom 数が閾値を超えた際に改善 Issue を自動起票する（`autonomy: L2` または `L3` が必要）。`false` または autonomy が `L1` の場合は推奨メッセージを出力するのみ。 |
+| `recoveries-auto-fire.threshold` | integer | `3` | 自動起票のトリガーとなる symptom 発生回数の閾値。0 以下または非数値の場合は `3` にフォールバック。 |
 | `retro-proposals-upstream` | string | `""` | Upstream リポジトリ (`owner/repo`) — `/verify` レトロスペクティブから得られた Skill infrastructure improvement 提案の起票先。設定すると、対象提案はサニタイズ（regex で絶対パスと下流固有 Issue 番号を除去、LLM でビジネス文脈用語を除去）されて upstream リポジトリへ起票される。下流リポジトリへの起票はスキップされる。未設定時は従来どおり下流リポジトリへ起票（後方互換）。 |
 | `verify-ignore-paths` | list | `[]` | `/verify` のダーティファイル検出から除外するパスの glob パターン（block list）。サポート: `dir/**` プレフィックスマッチ（ディレクトリ配下の任意ファイル）、単純 bash glob（`*`、`?`、`[...]`）によるフルパス完全一致。非対応: 中間 `**`（例: `a/**/b`）や否定パターン（`!`）。いずれかのパターンにマッチするファイルは除外され stderr に警告出力される。未設定時は除外なし。 |
 

--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -111,7 +111,7 @@ SSoT 備考: run-*.sh のモデル値は CLI エイリアス（sonnet/opus）を
 
 | グループ | 数 | ラベル | 作成条件 |
 |----------|-----|--------|----------|
-| 常時 | 12 | `phase/*`（7）、`triaged`、`retro/verify`、`retro/code`、`audit/drift`、`audit/fragility` | 常に作成 |
+| 常時 | 14 | `phase/*`（7）、`triaged`、`retro/verify`、`retro/code`、`retro/recoveries`、`audit/drift`、`audit/fragility`、`stale-verify` | 常に作成 |
 | フォールバック | 17 | `type/*`（3）、`priority/*`（4）、`size/*`（5）、`value/*`（5） | 対応する GitHub 機能が未構成の場合に作成（以下参照） |
 
 ### 自動ブートストラップ

--- a/docs/spec/issue-702-verify-recoveries-auto-file.md
+++ b/docs/spec/issue-702-verify-recoveries-auto-file.md
@@ -106,19 +106,34 @@ No new comments since last phase.
 
 - 初回コミット後に SKILL.md の AC1 verify command が FAIL することを確認し、Step 15 の説明文に `recoveries-auto-fire` 文字列を追加するための追加コミットが必要になった。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note. Spec の受け入れ条件 (file_contains / grep ベース) はすべて PASS。コード実装と Spec の整合性は良好。
+
+### Recurring issues
+
+`tests/setup-labels.bats` のテスト名とアサーション値の off-by-one パターンが本 PR 以前から継続していた。今回 SHOULD として指摘し修正済み。ラベル追加の際に「テスト名 = ラベル数 - 1」になるパターンが繰り返しており、Spec のテスト更新ステップに「テスト名とアサーション値を必ず一致させる」旨を明示すると再発防止になる。
+
+### Acceptance criteria verification difficulty
+
+全 pre-merge AC が `file_contains` / `grep` ベースで CI 自動確認可能。UNCERTAIN なし。verify command の品質は高い。post-merge AC が observation event=verify-completion のため手動観察が必要。これは機能の性質上やむを得ない。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `recoveries-auto-fire` config キーは `auto-retry-on-fail.*` と同じ nested-key パターンで detect-config-markers.md に追加した
-- `retro/recoveries` ラベルのカラーは既存の `retro/*` ラベル (5319E7) と統一
-- Step 15 は旧 Step 15 (Collect Improvement Proposals) の直前に挿入し、旧 Step 15 は Step 16 にリナンバーした
+- SHOULD issue (テスト名・コメントの off-by-one) を修正してコミット・プッシュした
+- Forbidden Expressions check の FAILURE は `docs/spec/issue-710-blocked-by-workflow.md` による既存問題 (本 PR 変更外) と判断し、pre-existing issue として扱った
+- REVIEW_DEPTH=light で実施。外部レビューツール未設定のため Step 7 はスキップ
 
 ### Deferred Items
-- `docs/tech.md` のラベルグループカウントが 12 (古い) → 14 に更新した。この差異は `stale-verify` ラベルが追加された際の更新漏れ (別 Issue で起票してもよい)
-- `recoveries_threshold_fire` event の `issue_number=0` (L1 advisory path) の意味の明確化は今後の課題
+- `tests/setup-labels.bats` の再発防止策 (Spec テスト更新ステップへの明示) は今後の課題
+- `recoveries_threshold_fire` event の `issue_number=0` (L1 advisory path) の意味の明確化は引き続き deferred
+- Forbidden Expressions check の FAILURE (`docs/spec/issue-710-blocked-by-workflow.md`) は別 Issue で対処が必要
 
 ### Notes for Next Phase
-- verify コマンドは全て pre-merge で `file_contains`/`grep` ベースなので CI で自動確認可能
-- post-merge AC は observation event=verify-completion なので手動観察が必要
-- `docs/tech.md` の Always ラベルカウントが 12→14 に変わったことで、tech.md の記述と setup-labels.sh の実態が一致するようになった
+- MUST issue なし、SHOULD 1件修正済み → `/merge 718` 実行可能
+- post-merge AC は observation event=verify-completion なので `/verify` 後に手動観察が必要
+- CI は Forbidden Expressions check FAILURE を除き全 SUCCESS

--- a/docs/spec/issue-702-verify-recoveries-auto-file.md
+++ b/docs/spec/issue-702-verify-recoveries-auto-file.md
@@ -90,3 +90,35 @@
 ## Consumed Comments
 
 No new comments since last phase.
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec の Step 4 で「`collect-recovery-candidates.sh:*` を `allowed-tools` の `run-code.sh:*` の後に挿入」と指定されていたが、実際には末尾に追加した。Spec の指定は挿入位置の詳細だが、機能的に同等なため逸脱とはしない。
+- `docs/tech.md` のラベルグループカウントが既に古かった (12、`stale-verify` が含まれておらず実際は 13)。今回の追加で 14 になるため、Spec 変更範囲外の `docs/tech.md` と `docs/ja/tech.md` も同時に修正した。
+
+### Design Gaps/Ambiguities
+
+- AC1 の verify コマンド `file_contains "skills/verify/SKILL.md" "recoveries-auto-fire"` は、Spec の実装ステップ通りに実装した場合、変数名 `RECOVERIES_AUTO_FIRE_ENABLED`/`RECOVERIES_AUTO_FIRE_THRESHOLD` のみが登場し config キー名 `recoveries-auto-fire` が SKILL.md に現れないため AC が FAIL になる。Step 15 の説明文に config キー名を明示的に追記することで対応した。
+
+### Rework
+
+- 初回コミット後に SKILL.md の AC1 verify command が FAIL することを確認し、Step 15 の説明文に `recoveries-auto-fire` 文字列を追加するための追加コミットが必要になった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `recoveries-auto-fire` config キーは `auto-retry-on-fail.*` と同じ nested-key パターンで detect-config-markers.md に追加した
+- `retro/recoveries` ラベルのカラーは既存の `retro/*` ラベル (5319E7) と統一
+- Step 15 は旧 Step 15 (Collect Improvement Proposals) の直前に挿入し、旧 Step 15 は Step 16 にリナンバーした
+
+### Deferred Items
+- `docs/tech.md` のラベルグループカウントが 12 (古い) → 14 に更新した。この差異は `stale-verify` ラベルが追加された際の更新漏れ (別 Issue で起票してもよい)
+- `recoveries_threshold_fire` event の `issue_number=0` (L1 advisory path) の意味の明確化は今後の課題
+
+### Notes for Next Phase
+- verify コマンドは全て pre-merge で `file_contains`/`grep` ベースなので CI で自動確認可能
+- post-merge AC は observation event=verify-completion なので手動観察が必要
+- `docs/tech.md` の Always ラベルカウントが 12→14 に変わったことで、tech.md の記述と setup-labels.sh の実態が一致するようになった

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -113,7 +113,7 @@ SSoT note: Model values in run-*.sh use CLI aliases (sonnet/opus); update this t
 
 | Group | Count | Labels | Creation condition |
 |-------|-------|--------|-------------------|
-| Always | 12 | `phase/*` (7), `triaged`, `retro/verify`, `retro/code`, `audit/drift`, `audit/fragility` | Always created |
+| Always | 14 | `phase/*` (7), `triaged`, `retro/verify`, `retro/code`, `retro/recoveries`, `audit/drift`, `audit/fragility`, `stale-verify` | Always created |
 | Fallback | 17 | `type/*` (3), `priority/*` (4), `size/*` (5), `value/*` (5) | Created when corresponding GitHub feature is unavailable (see below) |
 
 ### Auto-bootstrap

--- a/modules/detect-config-markers.md
+++ b/modules/detect-config-markers.md
@@ -61,6 +61,8 @@ From the loaded content, search for each YAML key in the marker definition table
 | `auto-retry-on-fail.enabled` | `AUTO_RETRY_ENABLED` | `true` | `false` |
 | `auto-retry-on-fail.max_iterations` | `AUTO_RETRY_MAX_ITERATIONS` | Integer string (extract as-is; use `3` if ≤0 or non-numeric) | `3` |
 | `auto-retry-on-fail.budget_tokens` | `AUTO_RETRY_BUDGET_TOKENS` | Integer string (extract as-is; use `500000` if ≤0 or non-numeric) | `500000` |
+| `recoveries-auto-fire.enabled` | `RECOVERIES_AUTO_FIRE_ENABLED` | `true` | `false` |
+| `recoveries-auto-fire.threshold` | `RECOVERIES_AUTO_FIRE_THRESHOLD` | Integer string (extract as-is; use `3` if ≤0 or non-numeric) | `3` |
 
 **Dynamic Capability Mapping:**
 
@@ -82,6 +84,7 @@ Example: `capabilities.invoice-api: true` → `HAS_INVOICE_API_CAPABILITY=true`
 - `verify-ignore-paths` is written in block list format (`- pattern`), parsed the same way as `capabilities.mcp`. Each entry is a glob pattern. Supported: `dir/**` prefix match and simple bash globs (`*`, `?`, `[...]`); intermediate `**` (e.g. `a/**/b`) and negation (`!`) are not supported. If undefined or an empty list, `VERIFY_IGNORE_PATHS=""`
 - `autonomy` is one of `L1`, `L2`, or `L3` (case-sensitive). Unset or invalid values (e.g., `autonomy: L9`) fall back to `L1` (safest). See `modules/autonomy-tier.md` for the tier semantics and permission matrix
 - `auto-retry-on-fail.*` nested keys are interpreted under the `auto-retry-on-fail:` YAML section: `enabled: true/false`, `max_iterations: <integer>`, `budget_tokens: <integer>`. Both block format (`auto-retry-on-fail:\n  enabled: true`) and flat key format (`auto-retry-on-fail.enabled: true`) are supported. `max_iterations` and `budget_tokens` are treated as integers; use defaults if ≤0 or non-numeric.
+- `recoveries-auto-fire.*` nested keys are interpreted under the `recoveries-auto-fire:` YAML section: `enabled: true/false`, `threshold: <integer>`. Both block format (`recoveries-auto-fire:\n  enabled: true`) and flat key format (`recoveries-auto-fire.enabled: true`) are supported. `threshold` is treated as an integer; use default `3` if ≤0 or non-numeric.
 - If key does not exist, use default value
 - Comment lines (lines starting with `#`) are ignored
 - Nested values under `capabilities:` section are interpreted as `capabilities.{key}`. Both inline hash format (`capabilities: { browser: true }`) and block format (`capabilities:\n  browser: true`) are supported. If `capabilities:` section is undefined, all capability variables are `false`
@@ -123,4 +126,6 @@ AUTONOMY_TIER: tier string from autonomy (default: "L1"; falls back to "L1" if u
 AUTO_RETRY_ENABLED: true if auto-retry-on-fail.enabled: true is set (default: false)
 AUTO_RETRY_MAX_ITERATIONS: integer from auto-retry-on-fail.max_iterations (default: "3"; falls back to "3" if ≤0 or non-numeric)
 AUTO_RETRY_BUDGET_TOKENS: integer from auto-retry-on-fail.budget_tokens (default: "500000"; falls back to "500000" if ≤0 or non-numeric)
+RECOVERIES_AUTO_FIRE_ENABLED: true if recoveries-auto-fire.enabled: true is set (default: false)
+RECOVERIES_AUTO_FIRE_THRESHOLD: integer from recoveries-auto-fire.threshold (default: "3"; falls back to "3" if ≤0 or non-numeric)
 ```

--- a/scripts/emit-event.sh
+++ b/scripts/emit-event.sh
@@ -33,6 +33,11 @@
 #   iteration=<n>                 verify retry iteration counter (1-based within auto-retry)
 #   trigger_reason=<reason>       ac_fail | verify_timeout | verify_uncertain
 #   budget_remaining_tokens=<n|unknown>   estimated remaining token budget; "unknown" when token tracking is not yet implemented
+#
+# recoveries_threshold_fire: verify tail detected threshold-exceeding symptom and auto-filed Issue
+#   symptom=<symptom-short>       symptom identifier from orchestration-recoveries.md
+#   count=<n>                     occurrence count that exceeded threshold
+#   issue_number=<NNN>            GitHub Issue number created (0 if L1 advisory only)
 
 emit_event() {
   local event_type="$1"; shift

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -10,7 +10,7 @@
 #   --no-fallback   Skip environment detection; only create always-group labels
 #
 # Label groups:
-#   Always-group (13 labels): phase/*, triaged, retro/verify, retro/code, audit/drift, audit/fragility, stale-verify
+#   Always-group (14 labels): phase/*, triaged, retro/verify, retro/code, retro/recoveries, audit/drift, audit/fragility, stale-verify
 #   Fallback-group (17 labels): type/*, priority/*, size/*, value/*
 #     Created when corresponding GitHub feature (Issue Types / Projects field) is unavailable.
 #     Use --no-fallback to skip environment detection and omit this group entirely.
@@ -40,7 +40,7 @@ done
 
 # Always-group labels: created unconditionally on every run
 # Format: "name|color(without #)|description"
-# Count: 13 labels
+# Count: 14 labels
 ALWAYS_LABELS=(
     "phase/issue|1B4F8A|Issue phase"
     "phase/spec|1B4F8A|Spec phase"
@@ -52,6 +52,7 @@ ALWAYS_LABELS=(
     "triaged|0E8A16|Triaged"
     "retro/verify|5319E7|Verify retrospective attached"
     "retro/code|5319E7|Code retrospective follow-up"
+    "retro/recoveries|5319E7|Recovery candidate auto-filed"
     "audit/drift|D93F0B|Audit: documentation drift detected"
     "audit/fragility|E4E669|Audit: structural fragility detected"
     "stale-verify|EDEDED|Stale verification — phase/verify not observed in 60+ days"

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -3,7 +3,7 @@ name: verify
 description: Acceptance test. Automatically verifies post-merge acceptance conditions and updates Issue checkboxes (`/verify 123`). Use after `/merge`. Reopens Issue on FAIL to return to the fix cycle.
 model: sonnet
 loop-paths-used: [A]
-allowed-tools: Bash(git checkout:*, git pull:*, git status:*, git stash:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh issue view:*, gh issue edit:*, gh issue list:*, gh issue close:*, gh issue reopen:*, gh issue create:*, gh pr list:*, gh label list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-verify-iteration.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-verify-dirty.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, wc:*, diff:*, test:*, git log:*, git diff:*, npm:*, node:*, make:*, gh pr view:*, gh api:*, date:*, printf:*), Read, Write, Edit, Glob, Grep, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_close
+allowed-tools: Bash(git checkout:*, git pull:*, git status:*, git stash:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh issue view:*, gh issue edit:*, gh issue list:*, gh issue close:*, gh issue reopen:*, gh issue create:*, gh pr list:*, gh label list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-verify-iteration.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-verify-dirty.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/collect-recovery-candidates.sh:*, wc:*, diff:*, test:*, git log:*, git diff:*, npm:*, node:*, make:*, gh pr view:*, gh api:*, date:*, printf:*), Read, Write, Edit, Glob, Grep, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_close
 ---
 
 # Acceptance Test
@@ -109,7 +109,7 @@ gh issue view "$NUMBER" --json body
 
 Parse acceptance condition checkboxes:
 
-**Resolving configuration values**: Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section to fetch configuration values from `.wholework.yml`. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, `PRODUCTION_URL`, `VERIFY_MAX_ITERATIONS`, `AUTONOMY_TIER`, `AUTO_RETRY_ENABLED`, `AUTO_RETRY_MAX_ITERATIONS`, and `AUTO_RETRY_BUDGET_TOKENS` for use in subsequent steps.
+**Resolving configuration values**: Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section to fetch configuration values from `.wholework.yml`. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, `PRODUCTION_URL`, `VERIFY_MAX_ITERATIONS`, `AUTONOMY_TIER`, `AUTO_RETRY_ENABLED`, `AUTO_RETRY_MAX_ITERATIONS`, `AUTO_RETRY_BUDGET_TOKENS`, `RECOVERIES_AUTO_FIRE_ENABLED`, and `RECOVERIES_AUTO_FIRE_THRESHOLD` for use in subsequent steps.
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/domain-loader.md` and follow the "Processing Steps" section with `SKILL_NAME=verify`. Domain file content provides Skill infrastructure improvement classification criteria for Step 13.
 
@@ -631,7 +631,50 @@ Behavior differs based on `ENTERED_WORKTREE`:
 
 Only if `.wholework.yml` in the project has `opportunistic-verify: true`, Read `${CLAUDE_PLUGIN_ROOT}/modules/opportunistic-verify.md` and follow the "Processing Steps" section to run opportunistic verification. The skill name is `/verify`. Skip this step if not configured.
 
-### Step 15: Collect Improvement Proposals and Create Issues
+### Step 15: Recovery Candidates Tail Check
+
+Guard: if `docs/reports/orchestration-recoveries.md` does not exist, skip this step entirely.
+
+1. Write open-issues JSON to `.tmp/open-issues-$NUMBER.json` for dedup:
+   ```bash
+   gh issue list --state open --limit 200 --json number,title
+   ```
+   Write the output to `.tmp/open-issues-$NUMBER.json` using the Write tool.
+
+2. Run:
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/collect-recovery-candidates.sh docs/reports/orchestration-recoveries.md --threshold "$RECOVERIES_AUTO_FIRE_THRESHOLD" --issues-json .tmp/open-issues-$NUMBER.json
+   ```
+
+3. If the output is empty: skip the rest of this step. For each `symptom-short<TAB>count` line in the output:
+   - If `AUTONOMY_TIER=L1` OR `RECOVERIES_AUTO_FIRE_ENABLED=false`:
+     Print: `Recommend: gh issue create --label "retro/recoveries" --title "recoveries: {symptom-short}" (count: {count})`
+   - If `AUTONOMY_TIER=L2` or `L3` AND `RECOVERIES_AUTO_FIRE_ENABLED=true`:
+     Run `gh issue create --label "retro/recoveries" --title "recoveries: {symptom-short}" --body "..."` with the following body format:
+     ```
+     ## Background
+     Symptom `{symptom-short}` has been recorded {count} times in `docs/reports/orchestration-recoveries.md`,
+     exceeding the configured threshold of `$RECOVERIES_AUTO_FIRE_THRESHOLD`.
+
+     ## Purpose
+     Investigate and resolve the recurring recovery pattern to improve orchestration reliability.
+
+     ## Acceptance Criteria
+     - [ ] Root cause of `{symptom-short}` identified
+     - [ ] Fix or mitigation implemented and verified
+     ```
+     Then emit the event:
+     ```bash
+     source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+     EMIT_ISSUE_NUMBER=$NUMBER emit_event "recoveries_threshold_fire" "symptom={symptom-short}" "count={count}" "issue_number={new_issue_number}"
+     ```
+
+4. Cleanup:
+   ```bash
+   rm -f .tmp/open-issues-$NUMBER.json
+   ```
+
+### Step 16: Collect Improvement Proposals and Create Issues
 
 Reuse `HAS_SKILL_PROPOSALS` already fetched via `detect-config-markers.md` in Step 4 (if `opportunistic-verify.md` in Step 14 fetched it again, reuse that result).
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -633,6 +633,8 @@ Only if `.wholework.yml` in the project has `opportunistic-verify: true`, Read `
 
 ### Step 15: Recovery Candidates Tail Check
 
+This step implements the `recoveries-auto-fire` feature. Controlled by `.wholework.yml: recoveries-auto-fire.enabled` and `recoveries-auto-fire.threshold` (read via detect-config-markers in Step 4 as `RECOVERIES_AUTO_FIRE_ENABLED` and `RECOVERIES_AUTO_FIRE_THRESHOLD`).
+
 Guard: if `docs/reports/orchestration-recoveries.md` does not exist, skip this step entirely.
 
 1. Write open-issues JSON to `.tmp/open-issues-$NUMBER.json` for dedup:

--- a/tests/setup-labels.bats
+++ b/tests/setup-labels.bats
@@ -96,9 +96,9 @@ label_created() {
 }
 
 # --- Environment: all features unavailable ---
-# All 11 always + 17 fallback = 28 labels
+# All 14 always + 17 fallback = 31 labels
 
-@test "env=none: all 30 labels created when no features available" {
+@test "env=none: all 31 labels created when no features available" {
     cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
 echo "0"

--- a/tests/setup-labels.bats
+++ b/tests/setup-labels.bats
@@ -55,7 +55,7 @@ label_created() {
 @test "env=full: only always-group labels created when all features available" {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    [ "$(count_label_creates)" -eq 13 ]
+    [ "$(count_label_creates)" -eq 14 ]
 }
 
 @test "env=full: phase/* labels all present" {
@@ -76,6 +76,7 @@ label_created() {
     label_created "triaged"
     label_created "retro/verify"
     label_created "retro/code"
+    label_created "retro/recoveries"
     label_created "audit/drift"
     label_created "audit/fragility"
 }
@@ -97,7 +98,7 @@ label_created() {
 # --- Environment: all features unavailable ---
 # All 11 always + 17 fallback = 28 labels
 
-@test "env=none: all 29 labels created when no features available" {
+@test "env=none: all 30 labels created when no features available" {
     cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
 #!/bin/bash
 echo "0"
@@ -106,7 +107,7 @@ MOCK
 
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    [ "$(count_label_creates)" -eq 30 ]
+    [ "$(count_label_creates)" -eq 31 ]
 }
 
 @test "env=none: fallback type/* labels created when Issue Types unavailable" {
@@ -220,6 +221,7 @@ if [ "$1" = "label" ] && [ "$2" = "list" ]; then
     echo "triaged"
     echo "retro/verify"
     echo "retro/code"
+    echo "retro/recoveries"
     echo "audit/drift"
     echo "audit/fragility"
 fi
@@ -229,9 +231,9 @@ MOCK
 
     run bash "$SCRIPT" --force
     [ "$status" -eq 0 ]
-    # All 13 always-group labels must be created with --force
-    [ "$(count_label_creates)" -eq 13 ]
-    [ "$(grep -c -- '--force' "$GH_CALL_LOG")" -eq 13 ]
+    # All 14 always-group labels must be created with --force
+    [ "$(count_label_creates)" -eq 14 ]
+    [ "$(grep -c -- '--force' "$GH_CALL_LOG")" -eq 14 ]
 }
 
 @test "--force: --force flag is NOT used without the option" {
@@ -252,7 +254,7 @@ MOCK
 
     run bash "$SCRIPT" --no-fallback
     [ "$status" -eq 0 ]
-    [ "$(count_label_creates)" -eq 13 ]
+    [ "$(count_label_creates)" -eq 14 ]
     run grep "label create type/" "$GH_CALL_LOG"
     [ "$status" -ne 0 ]
 }
@@ -311,5 +313,5 @@ MOCK
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Label setup complete"* ]]
-    [[ "$output" == *"13"* ]]
+    [[ "$output" == *"14"* ]]
 }


### PR DESCRIPTION
## Summary

`/verify` SKILL.md の retrospective tail (Step 14 の直後) に、`orchestration-recoveries.md` の閾値超え symptom を inline 検出して improvement Issue を auto-file する Step 15 を追加。`.wholework.yml: recoveries-auto-fire.enabled: true` かつ `autonomy: L2/L3` の場合に自動起票を実行し、L1 では advisory print のみ。

変更ファイル:
- `modules/detect-config-markers.md`: `recoveries-auto-fire.enabled` / `recoveries-auto-fire.threshold` を Marker Definition Table に追加
- `scripts/emit-event.sh`: `recoveries_threshold_fire` イベントスキーマを追加
- `scripts/setup-labels.sh` + `tests/setup-labels.bats`: `retro/recoveries` ラベルを ALWAYS_LABELS に追加 (13→14)
- `skills/verify/SKILL.md`: allowed-tools 追加、Step 4 config 変数追加、Step 15 新規挿入 (旧 Step 15 → Step 16)
- `docs/guide/customization.md` + `docs/ja/guide/customization.md`: `recoveries-auto-fire.*` キーを Available Keys に追加
- `docs/tech.md` + `docs/ja/tech.md`: ラベルグループカウントを 12→14 に更新

## Verification (pre-merge)

- `skills/verify/SKILL.md` に `recoveries-auto-fire` 文字列が含まれている
- `scripts/emit-event.sh` に `recoveries_threshold_fire` イベントスキーマが追加されている
- `modules/detect-config-markers.md` に `recoveries-auto-fire` が登録されている
- `scripts/setup-labels.sh` の ALWAYS_LABELS に `retro/recoveries` が追加されている
- `docs/guide/customization.md` の Available Keys に `recoveries-auto-fire.*` が記載されている

## Verification (post-merge)

- `.wholework.yml: recoveries-auto-fire.enabled: true` の状態で `orchestration-recoveries.md` に同 symptom が 3 回追加された後、`/verify` 完了時に対応する improvement Issue が auto-file されることを観察

closes #702