### PR TITLE
Issue #708: Add Spec exists precondition to reconcile-phase-state.sh code-patch/code-pr

### DIFF
--- a/docs/spec/issue-708-code-precondition-spec-check.md
+++ b/docs/spec/issue-708-code-precondition-spec-check.md
@@ -56,26 +56,41 @@
 
 - `skills/code/SKILL.md` の `!=` 修正により、2 つのコミットが生じた。commit メッセージで理由を明記し、追加プッシュで対処した。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- `actual.size` の JSON Schema ドキュメントが "Present when Spec is missing and Size check is performed" と記述しているが、実装では XS 成功パスで `size` フィールドが `actual_json` に含まれない (ミスマッチパスのみ)。表現が曖昧で CONSIDER 指摘を生じた。次回以降は "Present when ... mismatch occurs" など実装挙動を正確に反映した記述を推奨。
+- Phase Table の Implementation Status 列に括弧で Precondition を繰り返す冗長記述が発生。Spec でドキュメント更新内容を具体的に指定する (もしくは既存フォーマットを明示する) と、コードフェーズでの記述ぶれを防げる。
+
+### Recurring issues
+
+- Nothing to note. 今回は異なる種類の CONSIDER 指摘が 2 件のみで、繰り返しパターンなし。
+
+### Acceptance criteria verification difficulty
+
+- 承認基準 6 件全て PASS。`command "bats tests/reconcile-phase-state.bats"` は CI FAILURE だったが、失敗が `setup-labels.bats` (pre-existing) であることを CI ログで確認し PASS 判定できた。Safe mode では CI ログ解析が重要で、`reconcile-phase-state.bats` 新規テストの PASS ライン (ok 534-536) を明示確認できたのは有効。Spec の verify command を `bats tests/reconcile-phase-state.bats` に限定したことで CI ジョブ全体の FAILURE に惑わされなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- `SPEC_EXISTS` 変数名の採用: AC1 の verify command (`grep "SPEC_EXISTS"`) に合わせ、`spec_file` ではなく `SPEC_EXISTS` をリネームして使用。
-- `SIZE` の lazy fetch: SPEC_EXISTS が空の場合のみ `get-issue-size.sh` を呼ぶ設計を採用し、API コールを最小化。
-- 既存テスト `"same phase: precondition passes but completion not yet reached"` は `issue-42-spec.md` を touch する修正で対応。Spec の指示どおり。
-- `!=` → `is not` リネーム: `validate-skill-syntax.py` の forbidden expression ルール対応。
+- MUST/SHOULD 指摘なし: 全承認基準 PASS、CI の bats 失敗は `setup-labels.bats` pre-existing 問題 (main ブランチも同様)。
+- CONSIDER 2 件のみ: `actual.size` ドキュメント記述の曖昧さ、Phase Table 冗長記述。どちらも機能的影響なし、merge ブロックなし。
+- review-light (1 agent, light mode) を実行。SKIP_REVIEW_BUG=false だが REVIEW_DEPTH=light のため lightweight integrated review のみ。
 
 ### Deferred Items
 
-- post-merge 手動 AC (観察的 verify) は `/verify` フェーズで実施。
-- `docs/ja/` 翻訳ファイルへの同期は今回対象外 (`modules/phase-state.md` は `docs/` 以下ではないため翻訳ワークフロー非対象)。
+- `actual.size` JSON Schema の記述改善 (CONSIDER): merge 後の Improvement Proposal または次サイクルで対応。
+- Phase Table Implementation Status 列の整理 (CONSIDER): 同上。
+- `tests/setup-labels.bats` の pre-existing failures: 本 PR とは無関係、別 Issue で対応が必要。
 
 ### Notes for Next Phase
 
-- PR #730 に 2 コミット。1 つ目は実装、2 つ目は `!` 修正。レビュー時は両コミットをまとめて確認。
-- bats テスト: 57/60/59 の新規テストが Spec missing シナリオをカバー。既存テスト 51 番は Spec ファイル生成で修正済み。
-- `skills/code/SKILL.md` の `allowed-tools` に `reconcile-phase-state.sh:*` を追加済み。
+- PR #730 は APPROVED 状態で merge 可能。`/merge 730` を実行。
+- Post-merge AC (観察的 verify) が 2 件存在: `phase/ready` のみの M Issue での `matches_expected: false` 確認、XS Issue での `matches_expected: true` 確認。`/verify` フェーズで実施。
+- `setup-labels.bats` 失敗は main ブランチも同様なので merge ブロック理由にならない。
 
 ## Notes
 

--- a/docs/spec/issue-708-code-precondition-spec-check.md
+++ b/docs/spec/issue-708-code-precondition-spec-check.md
@@ -41,6 +41,42 @@
 - 試験的に `phase/ready` のみ付与・Spec 無しの M Issue に対して `reconcile-phase-state.sh --check-precondition code-pr N` を実行すると `matches_expected: false` を返すことを観察
 - 試験的に XS Issue (Spec 無し) に対して同コマンドを実行すると `matches_expected: true` を返すことを観察
 
+## Code Retrospective
+
+### Deviations from Design
+
+- `skills/code/SKILL.md` の `!=` を `is not` に変更: 実装直後に `validate-skill-syntax.py` が body 内の半角 `!` を forbidden expression として検出。Spec には修正方針の記載がなかったため、禁止文字のルール (docs/tech.md § Forbidden Expressions) に従い `!=` → `is not` に自動修正した。
+- SKILL.md 変更を 2 コミットに分割: 初回コミット後にバリデーション違反を発見したため、修正コミットを追加した。Spec は 1 コミットを想定していたが、この分割は許容範囲内の deviation。
+
+### Design Gaps/Ambiguities
+
+- `_precondition_code_common()` 内の既存変数 `spec_file` を `SPEC_EXISTS` にリネームした。Spec では「変数名は `SPEC_EXISTS` を使う」と明示されていたが、既存の `_completion_spec()` 等で `spec_file` が使用されている点との一貫性についての指定がなかった。今回は `_precondition_code_common()` のスコープ内のみでリネームし、他関数には影響しない実装を選択した。
+
+### Rework
+
+- `skills/code/SKILL.md` の `!=` 修正により、2 つのコミットが生じた。commit メッセージで理由を明記し、追加プッシュで対処した。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+
+- `SPEC_EXISTS` 変数名の採用: AC1 の verify command (`grep "SPEC_EXISTS"`) に合わせ、`spec_file` ではなく `SPEC_EXISTS` をリネームして使用。
+- `SIZE` の lazy fetch: SPEC_EXISTS が空の場合のみ `get-issue-size.sh` を呼ぶ設計を採用し、API コールを最小化。
+- 既存テスト `"same phase: precondition passes but completion not yet reached"` は `issue-42-spec.md` を touch する修正で対応。Spec の指示どおり。
+- `!=` → `is not` リネーム: `validate-skill-syntax.py` の forbidden expression ルール対応。
+
+### Deferred Items
+
+- post-merge 手動 AC (観察的 verify) は `/verify` フェーズで実施。
+- `docs/ja/` 翻訳ファイルへの同期は今回対象外 (`modules/phase-state.md` は `docs/` 以下ではないため翻訳ワークフロー非対象)。
+
+### Notes for Next Phase
+
+- PR #730 に 2 コミット。1 つ目は実装、2 つ目は `!` 修正。レビュー時は両コミットをまとめて確認。
+- bats テスト: 57/60/59 の新規テストが Spec missing シナリオをカバー。既存テスト 51 番は Spec ファイル生成で修正済み。
+- `skills/code/SKILL.md` の `allowed-tools` に `reconcile-phase-state.sh:*` を追加済み。
+
 ## Notes
 
 ### Auto-Resolve: AC5 ファイル名修正 (non-interactive mode)

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -35,8 +35,8 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 |-------|-------------|-------------------------------|----------------------|
 | issue | Issue exists and state != CLOSED | `triaged` label on issue | Implemented |
 | spec | `phase/issue` or `phase/spec` label on issue | `$SPEC_PATH/issue-N-*.md` exists AND `phase/(ready\|code\|review\|merge\|verify\|done)` label | Implemented |
-| code-patch | `phase/ready` label on issue, Spec exists | `git log origin/main --after=<reopen_ts> --grep="closes #N"` returns ≥1 fresh commit (reopen timestamp obtained via `get-last-reopen`); falls back to `git log origin/main --grep="closes #N"` when reopen timestamp unavailable | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
-| code-pr | `phase/ready` label on issue, Spec exists | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists — future scope. Completion: Implemented |
+| code-patch | `phase/ready` label on issue, Spec exists OR Size=XS | `git log origin/main --after=<reopen_ts> --grep="closes #N"` returns ≥1 fresh commit (reopen timestamp obtained via `get-last-reopen`); falls back to `git log origin/main --grep="closes #N"` when reopen timestamp unavailable | Precondition: `phase/ready` — Implemented; Spec exists OR Size=XS — Implemented (Spec exists OR Size=XS). Completion: Implemented |
+| code-pr | `phase/ready` label on issue, Spec exists OR Size=XS | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists OR Size=XS — Implemented (Spec exists OR Size=XS). Completion: Implemented |
 | review | PR is OPEN | PR has a comment containing `<!-- review-summary -->` marker (primary); or `## Review Response Summary` / `## レビュー回答サマリ` (fallback for marker-absent posts) | Implemented |
 | merge | PR is OPEN and reviewDecision is APPROVED | `gh pr view --json state == MERGED` | Implemented |
 | verify | Issue has `phase/verify` label or is CLOSED | Issue is CLOSED or has `phase/done` label | Implemented |
@@ -78,6 +78,7 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 | `actual.commits_found` | boolean | When git log is checked | `true` if matching commit found on origin/main |
 | `actual.spec_file` | string\|null | When spec is checked | Path to spec file, or `null` if not found |
 | `actual.issue_state` | string | When issue state is checked | `"OPEN"` or `"CLOSED"` |
+| `actual.size` | string | When spec precondition is checked with Size check | Issue size value (e.g., `"M"`, `"XS"`, `""`) returned by `get-issue-size.sh`. Present when Spec is missing and Size check is performed. |
 | `actual.hint_recent_commit` | string\|null | When phase label mismatch detected | Most recent git commit referencing the issue, or `null`. Added for phase label recovery. |
 | `actual.hint_pr_state` | string\|null | When phase label mismatch detected | PR state (`"OPEN"`, `"MERGED"`, `"CLOSED"`) if found, otherwise `null`. Added for phase label recovery. |
 | `diagnosis` | string | Always | One-line human-readable description |

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -373,18 +373,28 @@ _precondition_code_common() {
   local spec_path
   spec_path=$("$SCRIPT_DIR/get-config-value.sh" spec-path "docs/spec" 2>/dev/null) || spec_path="docs/spec"
 
-  local spec_file
-  spec_file=$(ls "${spec_path}/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1)
+  local SPEC_EXISTS
+  SPEC_EXISTS=$(ls "${spec_path}/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1)
 
   local labels_json
   labels_json=$(_labels_to_json_array "$labels")
   local spec_val="null"
-  [[ -n "$spec_file" ]] && spec_val="\"$(_escape_json "$spec_file")\""
+  [[ -n "$SPEC_EXISTS" ]] && spec_val="\"$(_escape_json "$SPEC_EXISTS")\""
   local actual_json="{\"labels\":${labels_json},\"spec_file\":${spec_val}}"
 
   if ! echo "$labels" | grep -q "^phase/ready$"; then
     _handle_mismatch "issue #${ISSUE_NUMBER} does not have phase/ready label (code phase precondition not met)" "$actual_json"
     return
+  fi
+
+  if [[ -z "$SPEC_EXISTS" ]]; then
+    local SIZE
+    SIZE=$("$SCRIPT_DIR/get-issue-size.sh" "$ISSUE_NUMBER" 2>/dev/null || true)
+    if [[ "$SIZE" != "XS" ]]; then
+      actual_json="{\"labels\":${labels_json},\"spec_file\":${spec_val},\"size\":\"$(_escape_json "$SIZE")\"}"
+      _handle_mismatch "Spec missing and Size != XS" "$actual_json"
+      return
+    fi
   fi
 
   _emit_result "true" "issue #${ISSUE_NUMBER} has phase/ready label (code phase precondition met)" "$actual_json"

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -2,7 +2,7 @@
 name: code
 description: Local implementation (`/code 123`). Size auto-detection routes XS/S→patch (direct commit to main), M/L→branch+PR. Override with `--patch`/`--pr`. Does not update CLAUDE.md, run session retrospectives, or manage memory.
 context: fork
-allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
+allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
 # Local Implementation
@@ -129,6 +129,18 @@ For sizes other than XS: run `gh issue view $NUMBER --json labels -q '.labels[].
   - Confirm via AskUserQuestion (non-interactive mode: auto-resolve — proceed without Spec; read requirements from Issue body directly and continue; record the decision in the Spec's `## Autonomous Auto-Resolve Log` subsection)
     - "Continue": proceed with execution
     - "Abort": stop processing and guide "run `/spec $NUMBER`", then exit
+
+**Spec precondition check (run after `phase/ready` passes, skip if Size is XS):**
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh --check-precondition code-patch $NUMBER
+# pr route: replace code-patch with code-pr
+```
+
+Parse the JSON output. If `matches_expected` is `false` (Spec missing and Size != XS):
+- Output: "Spec が見つかりません。`/spec $NUMBER` を実行してください"
+- **In non-interactive mode**: warn and continue (consistent with `--warn-only` default; Step 5 handles missing Spec by reading Issue body)
+- **In interactive mode**: abort recommended — guide user to run `/spec $NUMBER` first
 
 ### Step 4: Create Branch & Label Transition
 

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -137,7 +137,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh --check-precondition code
 # pr route: replace code-patch with code-pr
 ```
 
-Parse the JSON output. If `matches_expected` is `false` (Spec missing and Size != XS):
+Parse the JSON output. If `matches_expected` is `false` (Spec missing and Size is not XS):
 - Output: "Spec が見つかりません。`/spec $NUMBER` を実行してください"
 - **In non-interactive mode**: warn and continue (consistent with `--warn-only` default; Step 5 handles missing Spec by reading Issue body)
 - **In interactive mode**: abort recommended — guide user to run `/spec $NUMBER` first

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -817,6 +817,7 @@ MOCK_EOF
 
     export MOCK_SPEC_PATH="$BATS_TEST_TMPDIR/no-spec"
     mkdir -p "$BATS_TEST_TMPDIR/no-spec"
+    touch "$BATS_TEST_TMPDIR/no-spec/issue-42-spec.md"
 
     run bash "$SCRIPT" code-patch 42 --check-precondition --strict
     precondition_status=$status
@@ -986,6 +987,80 @@ MOCK_EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *'"matches_expected":true'* ]]
     [[ "$output" == *"async"* ]]
+}
+
+@test "code-patch precondition: Spec missing and Size != XS -> mismatch" {
+    export MOCK_SPEC_PATH="$BATS_TEST_TMPDIR/empty-spec-patch"
+    mkdir -p "$BATS_TEST_TMPDIR/empty-spec-patch"
+
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "phase/ready"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    cat > "$MOCK_DIR/get-issue-size.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "M"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" code-patch 42 --check-precondition --strict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"matches_expected":false'* ]]
+    [[ "$output" == *"Spec missing"* ]]
+}
+
+@test "code-patch precondition: Spec missing but Size XS -> matches_expected true" {
+    export MOCK_SPEC_PATH="$BATS_TEST_TMPDIR/empty-spec-xs"
+    mkdir -p "$BATS_TEST_TMPDIR/empty-spec-xs"
+
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "phase/ready"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    cat > "$MOCK_DIR/get-issue-size.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" code-patch 42 --check-precondition --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+}
+
+@test "code-pr precondition: Spec missing and Size != XS -> mismatch" {
+    export MOCK_SPEC_PATH="$BATS_TEST_TMPDIR/empty-spec-pr"
+    mkdir -p "$BATS_TEST_TMPDIR/empty-spec-pr"
+
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "phase/ready"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    cat > "$MOCK_DIR/get-issue-size.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "S"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" code-pr 42 --check-precondition --strict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"matches_expected":false'* ]]
+    [[ "$output" == *"Spec missing"* ]]
 }
 
 @test "spec completion: spec exists + no ready label -> mismatch includes hint_recent_commit and hint_pr_state" {


### PR DESCRIPTION
## Summary

- `reconcile-phase-state.sh` の `_precondition_code_common()` に Spec 存在チェックを追加。`phase/ready` チェック通過後に `SPEC_EXISTS` が空かつ `Size != XS` の場合は `_handle_mismatch "Spec missing and Size != XS"` で precondition mismatch を返す
- `modules/phase-state.md` の Phase Table から "future scope" 注記を削除し "Implemented (Spec exists OR Size=XS)" に更新。JSON Schema に `actual.size` フィールドを追加
- `tests/reconcile-phase-state.bats` に Spec missing シナリオ 3 件を追加 (code-patch mismatch / code-patch XS 例外 / code-pr mismatch)。"same phase" テストを Spec ファイル生成で修正
- `skills/code/SKILL.md` Step 3 に `reconcile-phase-state.sh --check-precondition` 呼び出しを追加。`allowed-tools` に同スクリプトを追加

## Verification (pre-merge)

- `grep "SPEC_EXISTS" "scripts/reconcile-phase-state.sh"` → PASS
- `grep "Size != XS" "scripts/reconcile-phase-state.sh"` → PASS
- `file_contains "modules/phase-state.md" "Implemented (Spec exists OR Size=XS)"` → PASS
- `bats tests/reconcile-phase-state.bats` → 60/60 PASS
- `file_contains "tests/reconcile-phase-state.bats" "Spec missing"` → PASS
- `grep "check-precondition" "skills/code/SKILL.md"` → PASS

## Verification (post-merge)

- `phase/ready` のみ付与・Spec 無しの M Issue に対して `reconcile-phase-state.sh --check-precondition code-pr N` を実行すると `matches_expected: false` を返すことを観察
- XS Issue (Spec 無し) に対して同コマンドを実行すると `matches_expected: true` を返すことを観察

closes #708