### PR TITLE
Issue #727: Add code-patch-silent-no-op Tier 2 handler to apply-fallback.sh

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -200,7 +200,7 @@ wholework/
 - `scripts/detect-wrapper-anomaly.sh` — shell wrapper 出力の既知失敗パターンを検出し、Auto Retrospective の markdown 断片を生成
 - `scripts/test-failure-classify.sh` — テスト失敗出力を回復カテゴリに分類（snapshot/mock/fixture/logic/infra）。exit 0 = 修復可、exit 1 = 修復不可
 - `scripts/validate-recovery-plan.sh` — orchestration-recovery sub-agent が出力する recovery plan JSON を検証（schema チェック + forbidden ops ガード）
-- `scripts/apply-fallback.sh` — `modules/orchestration-fallbacks.md` の Tier 2 bash projection。wrapper ログから既知の symptom anchor を検出し recovery handler を dispatch する（初期 full-impl: dco-signoff-missing-autofix）
+- `scripts/apply-fallback.sh` — `modules/orchestration-fallbacks.md` の Tier 2 bash projection。wrapper ログから既知の symptom anchor を検出し recovery handler を dispatch する（ハンドラ: dco-signoff-missing-autofix、code-patch-silent-no-op）
 - `scripts/spawn-recovery-subagent.sh` — `run-auto-sub.sh` が呼び出す Tier 3 recovery オーケストレーター。`claude -p` で `agents/orchestration-recovery` を spawn し、`validate-recovery-plan.sh` で plan を検証し、`WHOLEWORK_MAX_RECOVERY_SUBAGENTS` による mkdir-based スロットロックで並列性を制御し、成功時に `write_recovery_entry()` で `docs/reports/orchestration-recoveries.md` にエントリを記録する
 
 **Skill runners:**

--- a/docs/reports/orchestration-recoveries.md
+++ b/docs/reports/orchestration-recoveries.md
@@ -106,7 +106,7 @@ This file records cross-Issue recovery events, fallback applications, and diagno
 - success
 
 ### Improvement Candidate
-- 未起票
+- 起票済み #727
 
 ---
 
@@ -129,7 +129,7 @@ This file records cross-Issue recovery events, fallback applications, and diagno
 - success
 
 ### Improvement Candidate
-- 未起票
+- 起票済み #727
 
 ---
 
@@ -152,7 +152,7 @@ This file records cross-Issue recovery events, fallback applications, and diagno
 - success
 
 ### Improvement Candidate
-- 未起票
+- 起票済み #727
 
 ---
 

--- a/docs/spec/issue-727-resolve-code-patch-tier3-recovery.md
+++ b/docs/spec/issue-727-resolve-code-patch-tier3-recovery.md
@@ -70,3 +70,31 @@
 ## Consumed Comments
 
 - saito (MEMBER, first-class) — Issue Retrospective + Autonomous Auto-Resolve Log: AC 分割、verify command 設計の決定記録。spec フェーズへの引継ぎ情報として利用。
+
+## Code Retrospective
+
+### Deviations from Design
+- `docs/structure.md` と `docs/ja/structure.md` の `apply-fallback.sh` 記述更新を追加実装した。Spec の Changed Files には含まれていなかったが、doc-checker が "(initial full-impl: dco-signoff-missing-autofix)" 記述を stale と検出したため更新した。
+
+### Design Gaps/Ambiguities
+- None
+
+### Rework
+- None
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `detect_symptom_anchor()` でのパターンマッチは `grep -q "silent no-op"` を使用した。Spec Notes の指示通り、`run-code.sh` が出力する `"silent no-op"` は安定した識別子であり、regex なしで十分。
+- watchdog kill (原因グループ 2) の Tier 2 ハンドラは Spec の方針通りスコープ外とし、文書化のみで AC2 を充足した。
+- `apply_code_patch_silent_no_op_retry()` では `"$SCRIPT_DIR/run-code.sh" "$ISSUE" --patch` を呼び出す。`SCRIPT_DIR` は `WHOLEWORK_SCRIPT_DIR` 環境変数で上書き可能なため BATS テストで hermetic な実行が確保できる。
+
+### Deferred Items
+- watchdog kill (原因グループ 2) の Tier 2 ハンドラ (`code-patch-watchdog-kill-retry`) は follow-up Issue で検討予定。
+- `write_recovery_entry()` が常に `- 未起票` を書き込む仕様の改修は本 Issue のスコープ外。
+
+### Notes for Next Phase
+- bats tests 全 9 件 PASS、forbidden expressions チェック PASS、validate-skill-syntax.py エラーなし (既存警告 1 件のみ)。
+- PR #741 が作成済み。CI が通過した後 `/merge 741` を実行できる状態。
+- AC1/AC2 は `rubric` 検証。`rubric` は PR ブランチのファイル内容を参照するため、review フェーズで正確に評価される。

--- a/docs/spec/issue-727-resolve-code-patch-tier3-recovery.md
+++ b/docs/spec/issue-727-resolve-code-patch-tier3-recovery.md
@@ -82,19 +82,32 @@
 ### Rework
 - None
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Spec と実装の構造的乖離なし。Spec の実装ステップ 1–4 がすべて PR diff に存在した。
+- `docs/structure.md` / `docs/ja/structure.md` の更新は Spec の Changed Files 外だが、code 回顧録に記載済みで妥当な追加。
+
+### Recurring issues
+- 特になし。4 観点すべてで問題未検出。CI `Run bats tests` 失敗は systemic (main ブランチも同一障害) であり、本 PR の変更と無関係。
+
+### Acceptance criteria verification difficulty
+- AC3 (`grep "起票済み #727"`) と AC4 (`file_contains`) は自動検証で PASS 判定容易。
+- AC1/AC2 (`rubric`) は Spec ファイルとメインブランチの差分から判定可能。`rubric` が worktree-safe にファイル内容を参照できたため問題なし。
+- `verify command` の品質は高く、UNCERTAIN なし。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `detect_symptom_anchor()` でのパターンマッチは `grep -q "silent no-op"` を使用した。Spec Notes の指示通り、`run-code.sh` が出力する `"silent no-op"` は安定した識別子であり、regex なしで十分。
-- watchdog kill (原因グループ 2) の Tier 2 ハンドラは Spec の方針通りスコープ外とし、文書化のみで AC2 を充足した。
-- `apply_code_patch_silent_no_op_retry()` では `"$SCRIPT_DIR/run-code.sh" "$ISSUE" --patch` を呼び出す。`SCRIPT_DIR` は `WHOLEWORK_SCRIPT_DIR` 環境変数で上書き可能なため BATS テストで hermetic な実行が確保できる。
+- `Run bats tests` CI 失敗を CI インフラ起因と判定した。根拠: main ブランチ (sha 4200c9b9, run 27880896413) でも同一ジョブが FAILURE。ローカル全 9 件 PASS。
+- MUST 問題なし。COMMENT イベントで PR review を投稿した (REQUEST_CHANGES 不要)。
+- Step 12 (issue resolution) と Step 13 (AC consistency check) はスキップ (変更なし、policy change なし)。
 
 ### Deferred Items
-- watchdog kill (原因グループ 2) の Tier 2 ハンドラ (`code-patch-watchdog-kill-retry`) は follow-up Issue で検討予定。
-- `write_recovery_entry()` が常に `- 未起票` を書き込む仕様の改修は本 Issue のスコープ外。
+- `Run bats tests` の systemic CI 障害は別途調査が必要。本 PR のブロッカーではないが、CI が安定していない状態は問題。
+- watchdog kill (原因グループ 2) の Tier 2 ハンドラは別 Issue で検討予定 (code フェーズから引継ぎ)。
 
 ### Notes for Next Phase
-- bats tests 全 9 件 PASS、forbidden expressions チェック PASS、validate-skill-syntax.py エラーなし (既存警告 1 件のみ)。
-- PR #741 が作成済み。CI が通過した後 `/merge 741` を実行できる状態。
-- AC1/AC2 は `rubric` 検証。`rubric` は PR ブランチのファイル内容を参照するため、review フェーズで正確に評価される。
+- すべての受け入れ条件が PASS。MUST 問題なし。`/merge 741` で merge 可能な状態。
+- CI `Run bats tests` 失敗は systemic 障害。merge 前に CI が復帰するか確認すること。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -208,7 +208,7 @@ Key modules:
 - `scripts/detect-wrapper-anomaly.sh` — detect known failure patterns in shell wrapper output and generate Auto Retrospective markdown fragments
 - `scripts/test-failure-classify.sh` — classify test failure output into recovery categories (snapshot/mock/fixture/logic/infra); exit 0 = repairable, exit 1 = not repairable
 - `scripts/validate-recovery-plan.sh` — validate recovery plan JSON from orchestration-recovery sub-agent (schema check + forbidden ops guard)
-- `scripts/apply-fallback.sh` — Tier 2 bash projection of `modules/orchestration-fallbacks.md`; detects known symptom anchors from wrapper logs and dispatches recovery handlers (initial full-impl: dco-signoff-missing-autofix)
+- `scripts/apply-fallback.sh` — Tier 2 bash projection of `modules/orchestration-fallbacks.md`; detects known symptom anchors from wrapper logs and dispatches recovery handlers (handlers: dco-signoff-missing-autofix, code-patch-silent-no-op)
 - `scripts/spawn-recovery-subagent.sh` — Tier 3 recovery orchestrator invoked by `run-auto-sub.sh`; spawns `agents/orchestration-recovery` via `claude -p`, validates the returned plan with `validate-recovery-plan.sh`, enforces concurrency via `WHOLEWORK_MAX_RECOVERY_SUBAGENTS` mkdir-based slot locks, and records successful recoveries to `docs/reports/orchestration-recoveries.md` via `write_recovery_entry()`
 
 **Skill runners:**

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -447,6 +447,31 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 
 ---
 
+## code-patch-silent-no-op
+
+### Symptom
+- `run-code.sh` exits 1; wrapper log contains `"silent no-op"` warning
+- `reconcile-phase-state.sh code-patch <issue> --check-completion` confirms `commits_found:false`
+- Claude exited 0 (no crash, no watchdog kill) but produced no commit on origin/main
+
+### Applicable Phases
+- code (patch route)
+
+### Fallback Steps
+1. Retry `run-code.sh <issue> --patch` once
+2. If the second run also exits 1 (still no commit detected by reconcile) → escalate to Tier 3
+
+### Escalation
+- If the retry itself exits non-zero and reconcile still reports `commits_found:false`, escalate to Tier 3 (recovery sub-agent)
+- Do not retry more than once automatically; a second silent no-op may indicate a structural issue requiring human investigation
+
+### Rationale
+- First observed in Issues #658 and #489; cataloged in Issue #727
+- When `reconcile-phase-state.sh` confirms `commits_found:false`, the working tree is known-clean and a single retry is always safe on the patch route (no partial commit can exist)
+- Handling this in Tier 2 avoids the overhead of spawning a Tier 3 `claude -p` recovery sub-agent for a pattern that is trivially safe to retry
+
+---
+
 ## Operational Notes
 
 This catalog is consumed by:

--- a/scripts/apply-fallback.sh
+++ b/scripts/apply-fallback.sh
@@ -52,6 +52,11 @@ detect_symptom_anchor() {
     echo "dco-signoff-missing-autofix"
     return 0
   fi
+  # See modules/orchestration-fallbacks.md#code-patch-silent-no-op
+  if [[ "$PHASE" == "code-patch" ]] && grep -q "silent no-op" "$log" 2>/dev/null; then
+    echo "code-patch-silent-no-op"
+    return 0
+  fi
   # See modules/orchestration-fallbacks.md#gh-pr-list-head-glob (not yet implemented)
   # See modules/orchestration-fallbacks.md#ff-only-merge-fallback (not yet implemented)
   # See modules/orchestration-fallbacks.md#conflict-marker-residual (not yet implemented)
@@ -76,11 +81,23 @@ apply_dco_signoff_autofix() {
   echo "[apply-fallback] dco-signoff-missing-autofix: done"
 }
 
+# Handler: code-patch-silent-no-op
+# Retries run-code.sh --patch once when a silent no-op is detected on the patch route.
+# Safe because reconcile confirms commits_found:false (clean state, no partial commit).
+apply_code_patch_silent_no_op_retry() {
+  echo "[apply-fallback] code-patch-silent-no-op: retrying run-code.sh --patch for issue $ISSUE"
+  "$SCRIPT_DIR/run-code.sh" "$ISSUE" --patch
+  echo "[apply-fallback] code-patch-silent-no-op: done"
+}
+
 symptom_anchor=$(detect_symptom_anchor "$LOG_FILE")
 
 case "$symptom_anchor" in
   dco-signoff-missing-autofix)
     apply_dco_signoff_autofix
+    ;;
+  code-patch-silent-no-op)
+    apply_code_patch_silent_no_op_retry
     ;;
   *)
     exit 1

--- a/tests/apply-fallback.bats
+++ b/tests/apply-fallback.bats
@@ -116,3 +116,30 @@ MOCK
     run bash "$SCRIPT"
     [ "$status" -ne 0 ]
 }
+
+@test "code-patch-silent-no-op pattern triggers run-code.sh retry" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    echo "Warning: claude exited 0 but code-patch phase did not complete (silent no-op)." > "$LOG_FILE"
+
+    RUN_CODE_LOG="$BATS_TEST_TMPDIR/run-code.log"
+    cat > "$MOCK_DIR/run-code.sh" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$RUN_CODE_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+
+    run bash "$SCRIPT" code-patch 42 --log "$LOG_FILE"
+    [ "$status" -eq 0 ]
+
+    grep -q "42" "$RUN_CODE_LOG"
+    grep -q -- "--patch" "$RUN_CODE_LOG"
+}
+
+@test "code-patch-silent-no-op pattern does not fire for non-code-patch phase" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    echo "Warning: claude exited 0 but code-patch phase did not complete (silent no-op)." > "$LOG_FILE"
+
+    run bash "$SCRIPT" verify 42 --log "$LOG_FILE"
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

- `docs/reports/orchestration-recoveries.md` の 3 件の `code-patch-tier3-recovery` エントリの `Improvement Candidate` を `未起票` → `起票済み #727` に更新
- `modules/orchestration-fallbacks.md` に `code-patch-silent-no-op` エントリを追加 (サイレント no-op パターンの根本原因と対処手順を文書化)
- `scripts/apply-fallback.sh` に `code-patch-silent-no-op` ハンドラを追加 — patch route でサイレント no-op が発生した場合に `run-code.sh --patch` をリトライする Tier 2 ハンドラ
- `tests/apply-fallback.bats` に 2 件のテストを追加
- `docs/structure.md` / `docs/ja/structure.md` の `apply-fallback.sh` 説明を更新

## Verification (pre-merge)

- Spec / Issue #727 に両原因グループ (サイレント no-op: Issues #658, #489; watchdog kill: Issue #486) の根本原因が文書化されている
- `apply-fallback.sh` コード変更により少なくとも 1 原因グループへの修正が実装されている
- 既存 3 件の `code-patch-tier3-recovery` エントリの `Improvement Candidate` が `起票済み #727` に更新されている
- `scripts/apply-fallback.sh` に `code-patch-silent-no-op` ハンドラが追加されている
- bats tests 全 9 件 PASS

## Verification (post-merge)

- 2026-06-21 以降に `code-patch-tier3-recovery` かつ `Improvement Candidate: 未起票` のエントリが `docs/reports/orchestration-recoveries.md` に現れないこと (opportunistic)

closes #727