### PR TITLE
Issue #760: Surface Tier 2 recoveries in auto-session Improvement Candidates

### DIFF
--- a/docs/spec/issue-760-tier2-improvement-candidates.md
+++ b/docs/spec/issue-760-tier2-improvement-candidates.md
@@ -49,3 +49,34 @@
 ### Consumed Comments
 
 - saito (MEMBER / first-class): Issue Retrospective コメント (2026-06-26T23:16:04Z) — AC2 削除 (always-PASS 修正)、AC1 に `file_contains "recoveries-auto-fire"` 補足追加、AC3 に `file_contains "Tier 2"` 補足追加、rubric+file_contains パターン統一。コメント内容を反映して AC 構造を設計。
+
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+特記事項なし。Spec の実装ステップが PR diff と高い一致度で対応。`file_contains` による verify command も実装と正確に一致しており、PASS 判定が容易だった。
+
+### 繰り返し問題
+
+- Tier 2 bats テストが "approaching threshold" ケースのみでバウンダリ対称 (threshold reached) が欠落するパターンは、新機能追加テストで起こりやすい。AC に threshold/approaching 両方の test case を明記すると /review での検出が不要になる。
+
+### 受け入れ基準検証の難易度 (UNCERTAIN 分析)
+
+- Pre-merge 条件 2 つは `file_contains` で確実に検証可能。UNCERTAIN は 0 件。
+- verify command のシンプルな設計 (rubric + file_contains の組み合わせ) により、完全自動判定ができた。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- Forbidden Expressions check CI failure は本 PR 変更に起因しない既存 main 問題 (`docs/reports/auto-session-3480-1782440098-2026-06-27-ja.md` が commit `7071bb2` 由来) と判断し、マージブロッカーとして扱わない
+- SHOULD 問題 (threshold reached テスト欠落) を修正としてコミット済み (commit `1831b47`)
+
+### Deferred Items
+- awk regex `in_section && /threshold:/` の精度向上 (CONSIDER、現 `.wholework.yml` では問題なし) — 起票不要、将来のリファクタ機会に対応
+- Forbidden Expressions check が `docs/reports/` の日本語テキストに反応する既存 main 問題 — 別 Issue で対応予定 (#760 スコープ外)
+
+### Notes for Next Phase
+- 全 CI チェック SUCCESS (Forbidden Expressions 除く)、bats テスト 6/6 PASS
+- PR をマージ可能な状態。`/merge 763` で進める
+- Post-merge AC (次回 batch session での観察) は merge 後に手動確認

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -105,6 +105,22 @@ if [[ -n "$PERIOD_DAY" || -n "$PERIOD_SINCE_DAYS" || -n "$PERIOD_RANGE_START" ]]
   PERIOD_MODE=true
 fi
 
+# Read recoveries-auto-fire.threshold from .wholework.yml (awk for nested YAML; get-config-value.sh lacks nested key support)
+_config_path="${WHOLEWORK_CONFIG_PATH:-.wholework.yml}"
+RECOVERIES_THRESHOLD=3
+if [[ -f "$_config_path" ]]; then
+  _raw=$(awk '
+    /^recoveries-auto-fire:/ { in_section=1; next }
+    /^[^ ]/ { in_section=0 }
+    /^recoveries-auto-fire\.threshold:/ { gsub(/.*threshold:[[:space:]]*/, ""); print; exit }
+    in_section && /threshold:/ { gsub(/.*threshold:[[:space:]]*/, ""); print; exit }
+  ' "$_config_path" 2>/dev/null || true)
+  if [[ "$_raw" =~ ^[0-9]+$ ]] && [[ "$_raw" -gt 0 ]]; then
+    RECOVERIES_THRESHOLD="$_raw"
+  fi
+fi
+RECOVERIES_APPROACH=$(( RECOVERIES_THRESHOLD - 1 ))
+
 if [[ "$PERIOD_MODE" == "true" ]]; then
   if [[ ! -f "$AUTO_EVENTS_LOG" ]]; then
     echo "No event log found at: $AUTO_EVENTS_LOG"
@@ -590,14 +606,34 @@ else
   CONCURRENT_SECTION="(none detected)"
 fi
 
-# Improvement candidates from anomaly events
-IMPROVEMENT_CANDIDATES=$(echo "$EVENTS_JSON" | jq -r '
+# Improvement candidates from anomaly events (Tier 2 approaching threshold + Tier 3)
+TIER3_CANDIDATES=$(echo "$EVENTS_JSON" | jq -r '
   [.[] | select(.event == "recovery" and .tier == "3")] |
-  if length == 0 then "(none — no Tier 3 recoveries)"
-  else
-    "- Tier 3 recovery occurred in " + (.[] | "phase=" + (.phase // "?")) + " — investigate root cause"
+  if length == 0 then ""
+  else .[] |
+    "- Tier 3 recovery occurred in phase=" + (.phase // "?") + " — investigate root cause"
   end
-' 2>/dev/null || echo "(none)")
+' 2>/dev/null || true)
+
+TIER2_CANDIDATES=$(echo "$EVENTS_JSON" | jq -r --argjson approach "$RECOVERIES_APPROACH" --argjson threshold "$RECOVERIES_THRESHOLD" '
+  [.[] | select(.event == "recovery" and .tier == "2" and .phase != null)] |
+  group_by(.phase) |
+  map({phase: .[0].phase, count: length}) |
+  .[] | select(.count >= $approach) |
+  if .count >= $threshold
+  then "- Tier 2 recovery in phase=" + .phase + " (count=" + (.count | tostring) + ", threshold reached) — review recoveries-auto-fire.threshold"
+  else "- Tier 2 recovery in phase=" + .phase + " (count=" + (.count | tostring) + ", approaching threshold) — review recoveries-auto-fire.threshold"
+  end
+' 2>/dev/null || true)
+
+if [[ -z "$TIER2_CANDIDATES" && -z "$TIER3_CANDIDATES" ]]; then
+  IMPROVEMENT_CANDIDATES="(none — no Tier 3 recoveries or Tier 2 approaching recoveries-auto-fire threshold)"
+else
+  IMPROVEMENT_CANDIDATES=""
+  [[ -n "$TIER2_CANDIDATES" ]] && IMPROVEMENT_CANDIDATES+="${TIER2_CANDIDATES}"$'\n'
+  [[ -n "$TIER3_CANDIDATES" ]] && IMPROVEMENT_CANDIDATES+="${TIER3_CANDIDATES}"$'\n'
+  IMPROVEMENT_CANDIDATES="${IMPROVEMENT_CANDIDATES%$'\n'}"
+fi
 
 # GitHub state lookups (best-effort, skipped with --no-github)
 FULLY_CLOSED=0

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1006,7 +1006,7 @@ The generated report (`docs/reports/auto-session-{session-id}-{date}.md`) contai
 3. **Recovery Events** — chronological list of Tier 1/2/3 recovery events (phase, tier, result, affected issue)
 4. **Verify Phase Residuals** — issues that entered verify but did not complete it in this session
 5. **Concurrent Sessions Detected** — events where another session committed to main during a phase
-6. **Improvement Candidates Surfaced** — anomaly-derived improvement candidates (Tier 3 recoveries, unknown patterns)
+6. **Improvement Candidates Surfaced** — anomaly-derived improvement candidates (Tier 3 recoveries, Tier 2 recoveries approaching or reaching recoveries-auto-fire.threshold, unknown patterns)
 7. **Narrative Section (skeleton)** — TBD placeholders for "What worked", "Limits and gaps", "Improvement candidates surfaced", "Conclusion" (manual fill, or `--full` for LLM-assisted draft)
 
 ### Argument Parsing

--- a/tests/get-auto-session-report.bats
+++ b/tests/get-auto-session-report.bats
@@ -75,6 +75,35 @@ FIXTURE_EOF
     grep -q "approaching threshold" "$OUTPUT_PATH"
 }
 
+@test "Tier 2 candidate surfacing: threshold reached when count equals threshold" {
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-06-14T10:00:00Z","issue":100,"event":"sub_start","session_id":"session-t3","size":"S"}
+{"ts":"2026-06-14T10:01:00Z","issue":100,"event":"phase_start","session_id":"session-t3","phase":"code-patch"}
+{"ts":"2026-06-14T10:05:00Z","issue":100,"event":"recovery","session_id":"session-t3","phase":"code-patch","tier":"2","result":"recovered"}
+{"ts":"2026-06-14T10:06:00Z","issue":100,"event":"phase_complete","session_id":"session-t3","phase":"code-patch"}
+{"ts":"2026-06-14T10:07:00Z","issue":100,"event":"sub_complete","session_id":"session-t3","exit_code":"0"}
+{"ts":"2026-06-14T10:10:00Z","issue":101,"event":"sub_start","session_id":"session-t3","size":"S"}
+{"ts":"2026-06-14T10:11:00Z","issue":101,"event":"phase_start","session_id":"session-t3","phase":"code-patch"}
+{"ts":"2026-06-14T10:15:00Z","issue":101,"event":"recovery","session_id":"session-t3","phase":"code-patch","tier":"2","result":"recovered"}
+{"ts":"2026-06-14T10:16:00Z","issue":101,"event":"phase_complete","session_id":"session-t3","phase":"code-patch"}
+{"ts":"2026-06-14T10:17:00Z","issue":101,"event":"sub_complete","session_id":"session-t3","exit_code":"0"}
+{"ts":"2026-06-14T10:20:00Z","issue":102,"event":"sub_start","session_id":"session-t3","size":"S"}
+{"ts":"2026-06-14T10:21:00Z","issue":102,"event":"phase_start","session_id":"session-t3","phase":"code-patch"}
+{"ts":"2026-06-14T10:25:00Z","issue":102,"event":"recovery","session_id":"session-t3","phase":"code-patch","tier":"2","result":"recovered"}
+{"ts":"2026-06-14T10:26:00Z","issue":102,"event":"phase_complete","session_id":"session-t3","phase":"code-patch"}
+{"ts":"2026-06-14T10:27:00Z","issue":102,"event":"sub_complete","session_id":"session-t3","exit_code":"0"}
+FIXTURE_EOF
+
+    # WHOLEWORK_CONFIG_PATH=/dev/null forces default threshold=3 -> RECOVERIES_APPROACH=2
+    # 3 Tier 2 events in phase=code-patch -> count=3 >= threshold=3 -> should appear as "threshold reached"
+    export WHOLEWORK_CONFIG_PATH=/dev/null
+    run bash "$SCRIPT" "session-t3" --output "$OUTPUT_PATH" --no-github
+    [ "$status" -eq 0 ]
+    [ -f "$OUTPUT_PATH" ]
+    grep -q "Tier 2 recovery" "$OUTPUT_PATH"
+    grep -q "threshold reached" "$OUTPUT_PATH"
+}
+
 @test "--narrative-draft: draft content inserted into report" {
     cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
 {"ts":"2026-06-14T10:00:00Z","issue":100,"event":"sub_start","session_id":"session-draft","size":"S"}

--- a/tests/get-auto-session-report.bats
+++ b/tests/get-auto-session-report.bats
@@ -51,6 +51,30 @@ FIXTURE_EOF
     grep -q "Issues processed | 0" "$OUTPUT_PATH"
 }
 
+@test "Tier 2 candidate surfacing: approaching threshold appears in Improvement Candidates" {
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-06-14T10:00:00Z","issue":100,"event":"sub_start","session_id":"session-t2","size":"S"}
+{"ts":"2026-06-14T10:01:00Z","issue":100,"event":"phase_start","session_id":"session-t2","phase":"code-patch"}
+{"ts":"2026-06-14T10:05:00Z","issue":100,"event":"recovery","session_id":"session-t2","phase":"code-patch","tier":"2","result":"recovered"}
+{"ts":"2026-06-14T10:06:00Z","issue":100,"event":"phase_complete","session_id":"session-t2","phase":"code-patch"}
+{"ts":"2026-06-14T10:07:00Z","issue":100,"event":"sub_complete","session_id":"session-t2","exit_code":"0"}
+{"ts":"2026-06-14T10:10:00Z","issue":101,"event":"sub_start","session_id":"session-t2","size":"S"}
+{"ts":"2026-06-14T10:11:00Z","issue":101,"event":"phase_start","session_id":"session-t2","phase":"code-patch"}
+{"ts":"2026-06-14T10:15:00Z","issue":101,"event":"recovery","session_id":"session-t2","phase":"code-patch","tier":"2","result":"recovered"}
+{"ts":"2026-06-14T10:16:00Z","issue":101,"event":"phase_complete","session_id":"session-t2","phase":"code-patch"}
+{"ts":"2026-06-14T10:17:00Z","issue":101,"event":"sub_complete","session_id":"session-t2","exit_code":"0"}
+FIXTURE_EOF
+
+    # WHOLEWORK_CONFIG_PATH=/dev/null forces default threshold=3 -> RECOVERIES_APPROACH=2
+    # 2 Tier 2 events in phase=code-patch -> count=2 >= approach=2 -> should appear as "approaching threshold"
+    export WHOLEWORK_CONFIG_PATH=/dev/null
+    run bash "$SCRIPT" "session-t2" --output "$OUTPUT_PATH" --no-github
+    [ "$status" -eq 0 ]
+    [ -f "$OUTPUT_PATH" ]
+    grep -q "Tier 2 recovery" "$OUTPUT_PATH"
+    grep -q "approaching threshold" "$OUTPUT_PATH"
+}
+
 @test "--narrative-draft: draft content inserted into report" {
     cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
 {"ts":"2026-06-14T10:00:00Z","issue":100,"event":"sub_start","session_id":"session-draft","size":"S"}


### PR DESCRIPTION
## Summary

`/audit auto-session` の session レポートの Improvement Candidates Surfaced セクションを拡張し、Tier 2 fallback catalog リカバリも candidate として浮上させる。

- `scripts/get-auto-session-report.sh`: `.wholework.yml` から `recoveries-auto-fire.threshold` を awk で読み取り、session 内の Tier 2 リカバリを phase 別に集計。count ≥ threshold-1 の場合に「approaching threshold」、count ≥ threshold の場合に「threshold reached」として Improvement Candidates に出力する
- `skills/audit/SKILL.md`: §6 (Improvement Candidates Surfaced) の説明に Tier 2 candidates を追記
- `tests/get-auto-session-report.bats`: Tier 2 candidate surfacing の bats テスト追加 (2 events ≥ threshold-1=2 → approaching threshold)

## Verification (pre-merge)

- `scripts/get-auto-session-report.sh` に `recoveries-auto-fire` 参照が追加されており、Tier 2 candidates を Improvement Candidates に含めるロジックが実装されている
- `skills/audit/SKILL.md` §6 に `Tier 2 recoveries approaching or reaching recoveries-auto-fire.threshold` が明記されている

## Verification (post-merge)

- 次回 batch session で Tier 2 リカバリが発生した際、`/audit auto-session <id>` レポートの Improvement Candidates Surfaced に当該 symptom が表示されることを観察

closes #760