### PR TITLE
Issue #762: Add cross-link footer from data layer report to L3 session retrospective

### DIFF
--- a/docs/spec/issue-762-auto-session-cross-link.md
+++ b/docs/spec/issue-762-auto-session-cross-link.md
@@ -100,19 +100,35 @@
 
 - None. 1 パスで実装完了。全 8 テスト一発 PASS。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- None. 実装は Spec の Implementation Steps と完全に一致した。
+- SKILL.md step 3a の "Edit tool (or Write tool)" と Spec の "Write ツール" の違いは機能的に同等で、Edit 優先は改善であり divergence ではない。
+
+### Recurring Issues
+
+- Nothing to note. 単一パスでレビュー完了、MUST/SHOULD findings なし。
+- CI `Forbidden Expressions check` FAILURE は PR #766 の変更と無関係の pre-existing issue (check-forbidden-expressions.sh の単語境界バグに起因)。同スクリプトのバグ修正は別 Issue で追跡すること。
+
+### Acceptance Criteria Verification Difficulty
+
+- Nothing to note. 全 4 AC が PASS、UNCERTAIN ゼロ。rubric AC (AC1, AC4) は実装コードの読み取りで判定できた。grep AC (AC2, AC3) は直接的に確認できた。verify commands は適切に設計されていた。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `REPORT_EOF` 直後に cross-link ブロックを追加した。PERIOD_MODE 分岐は不要 (line 124 の早期 exit が既に分離している)。
-- `printf '\n---\n\n## See also\n\n- [L3 Session Retrospective](%s)\n'` で `>>` append にした。heredoc より printf の方が安全 (シェル変数展開が限定的)。
-- `skills/auto/SKILL.md` の追記は step 3a 形式で、既存の step 3 (Create session files) と step 4 (retro-proposals) の間に挿入した。
+- review-light エージェントが利用不可だったため、インラインで 4 視点レビューを実施した。結果は同等。
+- CI `Forbidden Expressions check` FAILURE は pre-existing issue と判定し、PR のマージブロックにしなかった (PR #766 変更ファイルに violations なし)。
+- MUST issues ゼロのため Step 12 (issue resolution) はスキップした。
 
 ### Deferred Items
-- 逆方向 cross-link (session.md → データ層レポート) は step 3a で手順を追加したが、実際の `/auto` 実行時に `docs/reports/auto-session-*.md` が未生成の場合は skip となる。これは意図的な設計 (`/audit auto-session` は事後生成のため)。
-- bats テストの `cross-link: See also footer appended` はサブシェル実行で CWD を BATS_TEST_TMPDIR に切り替える形だが、SESSION_DIR の glob マッチに `docs/sessions/session-xlink-2026-06-14/` を使用している。日付依存のテストではないが、固定日付であることに留意。
+- 逆方向 cross-link (session.md → データ層レポート) の実際の動作確認は Post-merge 検証 (次回 batch/XL session) で行う。
+- Forbidden Expressions check の単語境界バグ (単語境界なしパターンが `sub-issue Spec` 等の正当な記述を誤検知) は別 Issue での修正が必要。
 
 ### Notes for Next Phase
-- 変更ファイル: `scripts/get-auto-session-report.sh` (cross-link 追加)、`skills/auto/SKILL.md` (step 3a 追加)、`tests/get-auto-session-report.bats` (2 テスト追加)。
-- /verify では rubric AC が 2 個あるため、実装内容を git diff で grader に渡して判定させること。
-- 全テスト PASS (8/8)、forbidden expressions 違反なし (変更ファイル限定)。
+- 全 AC PASS、CI 主要ジョブ PASS (Forbidden Expressions check のみ pre-existing FAILURE)。
+- MUST issues なし。`/merge 766` で続行可。
+- /verify では rubric AC が 2 個あるため、実装内容を git diff で grader に渡して判定させること (code phase のメモを引き継ぎ)。

--- a/docs/spec/issue-762-auto-session-cross-link.md
+++ b/docs/spec/issue-762-auto-session-cross-link.md
@@ -84,3 +84,35 @@
 ## Consumed Comments
 
 - saito (MEMBER, first-class): Issue Retrospective — AC2 verify コマンドを `grep "docs/sessions/"` → `grep "session\.md"` に修正 (false positive 回避)、AC1 に supplementary `grep "See also"` を追加。これらは Issue 本文の Auto-Resolved Ambiguity Points に反映済み。(2026-06-27)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None. 実装は Spec の Implementation Steps と完全に一致した。
+
+### Design Gaps/Ambiguities
+
+- PERIOD_MODE での cross-link 不要の理由が Spec Notes に記載されていたため、コード上で `PERIOD_MODE` チェックを追加する必要がなかった (line 124 での早期 exit により report mode block は single session のみ実行される)。判断確認が不要で実装がシンプルになった。
+- bats テストの `cross-link: See also footer appended` は `cd "$BATS_TEST_TMPDIR"` でサブシェル実行が必要だった。スクリプトが CWD 相対パスで `docs/sessions/` を glob するため、テスト tmpdir を CWD にして session dir を作成した。
+
+### Rework
+
+- None. 1 パスで実装完了。全 8 テスト一発 PASS。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `REPORT_EOF` 直後に cross-link ブロックを追加した。PERIOD_MODE 分岐は不要 (line 124 の早期 exit が既に分離している)。
+- `printf '\n---\n\n## See also\n\n- [L3 Session Retrospective](%s)\n'` で `>>` append にした。heredoc より printf の方が安全 (シェル変数展開が限定的)。
+- `skills/auto/SKILL.md` の追記は step 3a 形式で、既存の step 3 (Create session files) と step 4 (retro-proposals) の間に挿入した。
+
+### Deferred Items
+- 逆方向 cross-link (session.md → データ層レポート) は step 3a で手順を追加したが、実際の `/auto` 実行時に `docs/reports/auto-session-*.md` が未生成の場合は skip となる。これは意図的な設計 (`/audit auto-session` は事後生成のため)。
+- bats テストの `cross-link: See also footer appended` はサブシェル実行で CWD を BATS_TEST_TMPDIR に切り替える形だが、SESSION_DIR の glob マッチに `docs/sessions/session-xlink-2026-06-14/` を使用している。日付依存のテストではないが、固定日付であることに留意。
+
+### Notes for Next Phase
+- 変更ファイル: `scripts/get-auto-session-report.sh` (cross-link 追加)、`skills/auto/SKILL.md` (step 3a 追加)、`tests/get-auto-session-report.bats` (2 テスト追加)。
+- /verify では rubric AC が 2 個あるため、実装内容を git diff で grader に渡して判定させること。
+- 全テスト PASS (8/8)、forbidden expressions 違反なし (変更ファイル限定)。

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -833,6 +833,18 @@ TBD — fill in after reviewing the session
 TBD — fill in after reviewing the session
 REPORT_EOF
 
+# Cross-link to L3 session retrospective if it exists
+_l3_session_found=""
+for _l3_dir in "docs/sessions/${SESSION_ID}-"*/; do
+  if [[ -f "${_l3_dir}session.md" ]]; then
+    _l3_session_found="${_l3_dir}session.md"
+    break
+  fi
+done
+if [[ -n "$_l3_session_found" ]]; then
+  printf '\n---\n\n## See also\n\n- [L3 Session Retrospective](%s)\n' "$_l3_session_found" >> "$OUTPUT_PATH"
+fi
+
 # Apply narrative draft if --narrative-draft was specified
 if [[ -n "$NARRATIVE_DRAFT_PATH" && -f "$NARRATIVE_DRAFT_PATH" ]]; then
   python3 - "$OUTPUT_PATH" "$NARRATIVE_DRAFT_PATH" << 'PYTHON_EOF'

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -641,6 +641,16 @@ After confirming phase completion (`reconcile-phase-state.sh` returns `matches_e
      jq -c 'select(.session_id == "'"$AUTO_SESSION_ID"'")' .tmp/auto-events.jsonl > "$SESSION_DIR/events.jsonl" 2>/dev/null || true
      ```
 
+3a. **Cross-link to data layer report**: if `docs/reports/auto-session-${AUTO_SESSION_ID}-*.md` exists, append the following to `$SESSION_DIR/session.md` using the Edit tool (or Write tool if Edit is not applicable):
+    ```
+    ---
+
+    ## See also
+
+    - [Data layer report](docs/reports/auto-session-{AUTO_SESSION_ID}-{DATE}.md)
+    ```
+    Use a glob to find the actual report file (the date suffix may differ from `$DATE`). If no matching file exists, skip this step.
+
 4. **Call `modules/retro-proposals.md`** — improvement Issue creation:
    - Create a bridge file for retro-proposals.md interface compatibility:
      - XL route (`ROUTE="sub_issue"`): `BRIDGE_NUMBER=$NUMBER`; write bridge file at `$SESSION_DIR/issue-${BRIDGE_NUMBER}-l3session.md` containing the `## Auto Retrospective > ### Improvement Proposals` section from `session.md`

--- a/tests/get-auto-session-report.bats
+++ b/tests/get-auto-session-report.bats
@@ -121,3 +121,32 @@ DRAFT_EOF
     [ -f "$OUTPUT_PATH" ]
     grep -q "Parallel execution completed without conflict" "$OUTPUT_PATH"
 }
+
+@test "cross-link: See also footer appended when L3 session.md exists" {
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-06-14T10:00:00Z","issue":100,"event":"sub_start","session_id":"session-xlink","size":"S"}
+{"ts":"2026-06-14T10:05:00Z","issue":100,"event":"sub_complete","session_id":"session-xlink","exit_code":"0"}
+FIXTURE_EOF
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/docs/sessions/session-xlink-2026-06-14"
+    mkdir -p "$SESSION_DIR"
+    echo "# L3 Session Retrospective: session-xlink" > "$SESSION_DIR/session.md"
+
+    (cd "$BATS_TEST_TMPDIR" && mkdir -p docs/reports && \
+        bash "$SCRIPT" "session-xlink" --output "$OUTPUT_PATH" --no-github)
+    [ -f "$OUTPUT_PATH" ]
+    grep -q "## See also" "$OUTPUT_PATH"
+    grep -q "session.md" "$OUTPUT_PATH"
+}
+
+@test "cross-link: no footer when L3 session.md absent" {
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-06-14T10:00:00Z","issue":100,"event":"sub_start","session_id":"session-noxlink","size":"S"}
+{"ts":"2026-06-14T10:05:00Z","issue":100,"event":"sub_complete","session_id":"session-noxlink","exit_code":"0"}
+FIXTURE_EOF
+
+    run bash "$SCRIPT" "session-noxlink" --output "$OUTPUT_PATH" --no-github
+    [ "$status" -eq 0 ]
+    [ -f "$OUTPUT_PATH" ]
+    ! grep -q "## See also" "$OUTPUT_PATH"
+}


### PR DESCRIPTION
## Summary

- `scripts/get-auto-session-report.sh` にデータ層レポート生成後の cross-link ブロックを追加: `docs/sessions/${SESSION_ID}-*/session.md` が存在する場合、レポート末尾に `## See also` フッターを追記する
- `skills/auto/SKILL.md` Step 5 L3 auto-retrospective に step 3a を追加: データ層レポートが存在すれば `session.md` 末尾に逆方向 cross-link を追記する手順
- `tests/get-auto-session-report.bats` に cross-link 動作のテストを 2 件追加 (session.md 存在時/不在時)

## Verification (pre-merge)

- get-auto-session-report.sh が L3 retrospective への cross-link を追記 (rubric)
- get-auto-session-report.sh に "See also:" フッター文字列の実装が追加されている (grep "See also")
- スクリプトに L3 session.md ファイルパスへの参照が追加されている (grep "session\.md")
- SKILL.md にも逆方向の cross-link 手順または運用注記が追加されている (rubric)

## Verification (post-merge)

- 次回 batch/XL session で両レポートが生成される際、データ層レポート末尾に L3 retrospective への See also: リンクが出力されることを観察

closes #762