### PR TITLE
Issue #738: Add explicit error handling to gh-*.sh scripts

### DIFF
--- a/docs/spec/issue-738-gh-scripts-error-handling.md
+++ b/docs/spec/issue-738-gh-scripts-error-handling.md
@@ -73,3 +73,35 @@
 - `gh-graphql.sh` の error メッセージは QUERY_NAME が空の場合もあるため "gh api graphql failed" というシンプルな形にする (QUERY_NAME を含めると空文字が混入する可能性)
 - `gh-label-transition.sh` line 68 は `ENTERED_WORKTREE` の "already set" パスの `gh issue edit` 呼び出し — 3 箇所すべて同じパターンで統一
 - `gh-check-blocking.sh` は audit report で「唯一 error handling があった」と記録されているが、現在は 3 個 (`gh-issue-edit.sh`, `gh-issue-comment.sh`, `gh-extract-issue-from-pr.sh`) も既に完全対応済み (Issue 記述時点から実装が進んだ)
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `gh-label-transition.sh` は 3 箇所の `gh issue edit` すべてに `if ! ...; then echo "Error..." >&2; exit 1; fi` パターンを採用し統一。
+- `gh-pr-review.sh` の heredoc パイプラインを変数キャプチャ方式にリファクタした後に `gh api` 呼び出しに error handling を追加。既存テストへの影響は最小限。
+- `gh-graphql.sh` の error メッセージは `QUERY_NAME` が空のケースを考慮して "gh api graphql failed" というシンプルな形にした。
+
+### Deferred Items
+- CI (github_check) の AC は PR 後に自動確認予定。
+- Spec の行番号指定は参照用であり正確ではないが、実装上の問題はなかった (実ファイルを読んで適用)。
+
+### Notes for Next Phase
+- 全 8 個の gh-*.sh に error handling が追加されており、rubric AC (7 個以上) は余裕を持って満たしている。
+- bats テスト 4 ファイルに "error: API failure" テストケースを追加済み。全 941 テスト PASS 確認済み。
+- PR #767 が CI 完了後 merge 可能になる。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- 設計では `gh-pr-review.sh` の `--with-line-comments` path が lines 91-93 に位置すると記載されているが、実際の行番号は正確ではなかった。Spec の行番号はあくまで参照用であり、実際のファイル内容を読んで適用した。
+- `gh-graphql.sh` の no-cache path (`gh api graphql "${GH_ARGS[@]}"`) は設計では単純な `|| { echo "Error..." >&2; exit 1; }` パターンで追加できるとされていたが、pipe 内の最終コマンドにあたるため set -e だけでは検出されないケースへの対処として明示的 error handling を追加した。これは設計意図と合致している。
+
+### Design Gaps/Ambiguities
+
+- Spec には `gh-label-transition.sh` の "already set" パス (line 68) が独立した branch であることが記載されているが、else ブランチの 2 箇所 (lines 90, 92) との区別が当初不明確だった。実装時にファイルを読んで 3 パターンに分けた。
+
+### Rework
+
+- None

--- a/docs/spec/issue-738-gh-scripts-error-handling.md
+++ b/docs/spec/issue-738-gh-scripts-error-handling.md
@@ -75,21 +75,20 @@
 - `gh-check-blocking.sh` は audit report で「唯一 error handling があった」と記録されているが、現在は 3 個 (`gh-issue-edit.sh`, `gh-issue-comment.sh`, `gh-extract-issue-from-pr.sh`) も既に完全対応済み (Issue 記述時点から実装が進んだ)
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `gh-label-transition.sh` は 3 箇所の `gh issue edit` すべてに `if ! ...; then echo "Error..." >&2; exit 1; fi` パターンを採用し統一。
-- `gh-pr-review.sh` の heredoc パイプラインを変数キャプチャ方式にリファクタした後に `gh api` 呼び出しに error handling を追加。既存テストへの影響は最小限。
-- `gh-graphql.sh` の error メッセージは `QUERY_NAME` が空のケースを考慮して "gh api graphql failed" というシンプルな形にした。
+- MUST/SHOULD 問題なし。CONSIDER 3 件 (bats テストカバレッジ 2 件 + Spec Code Retrospective 記述精度 1 件) はスキップ判断。
+- Forbidden Expressions check FAILURE は Issue #765 の pre-existing false positive と確認。PR #767 の変更とは無関係。
+- `github_check "gh run list ..."` が safe モード allowlist 外のため AC4 は UNCERTAIN だが、`gh pr checks` での "Run bats tests" SUCCESS で実質 PASS 相当を確認。
 
 ### Deferred Items
-- CI (github_check) の AC は PR 後に自動確認予定。
-- Spec の行番号指定は参照用であり正確ではないが、実装上の問題はなかった (実ファイルを読んで適用)。
+- AC4 の verify command を `gh pr checks` ベースに更新すると UNCERTAIN → PASS に改善できる (Spec 品質改善候補として review retrospective に記録)。
+- Forbidden Expressions check false positive は Issue #765 で追跡中。merge phase で auto-resolve 対象。
 
 ### Notes for Next Phase
-- 全 8 個の gh-*.sh に error handling が追加されており、rubric AC (7 個以上) は余裕を持って満たしている。
-- bats テスト 4 ファイルに "error: API failure" テストケースを追加済み。全 941 テスト PASS 確認済み。
-- PR #767 が CI 完了後 merge 可能になる。
+- MUST/SHOULD 問題なし → `/merge 767` で安全に進められる。
+- Forbidden Expressions check FAILURE は Issue #765 の既知バグ (pre-existing)。merge phase での判断対象となる。
 
 ## Code Retrospective
 
@@ -105,3 +104,23 @@
 ### Rework
 
 - None
+
+## review retrospective
+
+### Spec vs 実装の乖離パターン
+
+Code Retrospective に `gh-graphql.sh` の no-cache path が "pipe 内の最終コマンド" と記述されているが、実際は `else` ブロックの最終コマンドであり shell pipeline 内ではない。`set -euo pipefail` があれば単独でもエラー検出される。実装の正しさは問題ないが、Retrospective の説明が若干不正確。Spec 記述時に実装の詳細 (pipe vs 非 pipe) を明記すると今後の誤解を防げる。
+
+### 繰り返し問題のパターン
+
+CONSIDER のみ 3 件検出された:
+1. bats テストのエラーパスカバレッジが複数コードパスの一部のみをカバー (gh-graphql.bats, gh-label-transition.bats)
+2. Spec Code Retrospective の記述精度
+
+同一パターンの複数コードパスのうち一部のみテストするパターンが 2 件あった。複数コードパスがある場合 (特に `if-else` の各ブランチ)、少なくとも 1 パスがエラー経路をカバーしていれば実用上十分だが、「全パスカバー vs 代表パスのみカバー」の判断基準を Spec に明記するとコードレビューでの CONSIDER 指摘を減らせる。
+
+### 受け入れ条件の検証難易度
+
+- rubric + grep + command (CI reference) で3件の pre-merge 条件を PASS 判定できた。
+- `github_check "gh run list ..."` は safe モードの allowlist 外のため UNCERTAIN だったが、`gh pr checks` での CI 状態確認で実質的に PASS 相当を確認。
+- `gh run list` を `gh pr checks` で代替できるよう verify command を更新すると UNCERTAIN を PASS に変換できる (Spec 品質改善候補)。

--- a/scripts/gh-graphql.sh
+++ b/scripts/gh-graphql.sh
@@ -271,7 +271,7 @@ if [ "$CACHE_ENABLED" = true ]; then
 
     # Cache miss: execute API call without --jq to get raw response
     GH_ARGS=("-f" "query=$QUERY" "${F_ARGS[@]}")
-    RAW_RESPONSE=$(gh api graphql "${GH_ARGS[@]}")
+    RAW_RESPONSE=$(gh api graphql "${GH_ARGS[@]}") || { echo "Error: gh api graphql failed" >&2; exit 1; }
     echo "$RAW_RESPONSE" > "$CACHE_FILE"
 
     # Apply --jq filter if specified
@@ -288,5 +288,5 @@ else
         GH_ARGS+=("--jq" "$JQ_EXPR")
     fi
 
-    gh api graphql "${GH_ARGS[@]}"
+    gh api graphql "${GH_ARGS[@]}" || { echo "Error: gh api graphql failed" >&2; exit 1; }
 fi

--- a/scripts/gh-label-transition.sh
+++ b/scripts/gh-label-transition.sh
@@ -65,7 +65,10 @@ if [ -n "$TARGET_PHASE" ] && echo "$CURRENT_LABELS" | grep -qx "$TARGET_LABEL"; 
             REMOVE_ARGS+=(--remove-label "$label")
         fi
     done
-    gh issue edit "$ISSUE_NUMBER" "${REMOVE_ARGS[@]}"
+    if ! gh issue edit "$ISSUE_NUMBER" "${REMOVE_ARGS[@]}"; then
+        echo "Error: failed to update labels for issue #$ISSUE_NUMBER" >&2
+        exit 1
+    fi
 else
     # Build --remove-label flags for all phase/* labels except the target label
     REMOVE_ARGS=()
@@ -87,8 +90,14 @@ else
 
     # Add target phase label if specified
     if [ -n "$TARGET_PHASE" ]; then
-        gh issue edit "$ISSUE_NUMBER" "${REMOVE_ARGS[@]}" --add-label "phase/$TARGET_PHASE"
+        if ! gh issue edit "$ISSUE_NUMBER" "${REMOVE_ARGS[@]}" --add-label "phase/$TARGET_PHASE"; then
+            echo "Error: failed to update labels for issue #$ISSUE_NUMBER" >&2
+            exit 1
+        fi
     else
-        gh issue edit "$ISSUE_NUMBER" "${REMOVE_ARGS[@]}"
+        if ! gh issue edit "$ISSUE_NUMBER" "${REMOVE_ARGS[@]}"; then
+            echo "Error: failed to update labels for issue #$ISSUE_NUMBER" >&2
+            exit 1
+        fi
     fi
 fi

--- a/scripts/gh-pr-merge-status.sh
+++ b/scripts/gh-pr-merge-status.sh
@@ -42,7 +42,7 @@ if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
 fi
 
 # Fetch PR mergeable and mergeStateStatus
-JSON=$(gh pr view "$PR" --json mergeable,mergeStateStatus)
+JSON=$(gh pr view "$PR" --json mergeable,mergeStateStatus) || { echo "Error: failed to fetch PR #$PR" >&2; exit 1; }
 
 MERGEABLE=$(echo "$JSON" | jq -r '.mergeable')
 STATE=$(echo "$JSON" | jq -r '.mergeStateStatus')

--- a/scripts/gh-pr-review.sh
+++ b/scripts/gh-pr-review.sh
@@ -88,8 +88,7 @@ PYEOF
     fi
 
     # Build payload: exclude severity field, filter invalid entries, then POST
-    python3 - "$REVIEW_BODY_FILE" "$LINE_COMMENTS_FILE" "$EVENT" <<'PYEOF' | \
-        gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input -
+    REVIEW_PAYLOAD=$(python3 - "$REVIEW_BODY_FILE" "$LINE_COMMENTS_FILE" "$EVENT" <<'PYEOF'
 import sys, json
 review_body_file = sys.argv[1]
 line_comments_file = sys.argv[2]
@@ -116,10 +115,14 @@ if clean_comments:
     payload['comments'] = clean_comments
 print(json.dumps(payload))
 PYEOF
+    )
+    echo "$REVIEW_PAYLOAD" | gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input - || {
+        echo "Error: failed to post review for PR #$PR_NUMBER" >&2
+        exit 1
+    }
 else
     # No line comments: post review body only
-    python3 - "$REVIEW_BODY_FILE" "$EVENT" <<'PYEOF' | \
-        gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input -
+    REVIEW_PAYLOAD=$(python3 - "$REVIEW_BODY_FILE" "$EVENT" <<'PYEOF'
 import sys, json
 with open(sys.argv[1]) as f:
     body = f.read()
@@ -127,4 +130,9 @@ event = sys.argv[2]
 payload = {'body': body, 'event': event}
 print(json.dumps(payload))
 PYEOF
+    )
+    echo "$REVIEW_PAYLOAD" | gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --method POST --input - || {
+        echo "Error: failed to post review for PR #$PR_NUMBER" >&2
+        exit 1
+    }
 fi

--- a/tests/gh-graphql.bats
+++ b/tests/gh-graphql.bats
@@ -278,6 +278,27 @@ cache_teardown() {
     cache_teardown
 }
 
+@test "error: gh api graphql failure exits with code 1 and Error message" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GH_CALL_LOG"
+if [[ "$1" == "repo" && "$2" == "view" ]]; then
+    printf "testowner\ttestrepo\n"
+    exit 0
+fi
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+    echo "error: rate limit exceeded" >&2
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 'query{viewer{login}}'
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error" ]]
+}
+
 @test "cache: --jq filter applied on cache hit" {
     cache_setup
     # First run without --jq to populate cache

--- a/tests/gh-label-transition.bats
+++ b/tests/gh-label-transition.bats
@@ -251,6 +251,36 @@ MOCK
     grep -q -- "--add-label phase/code" "$GH_CALL_LOG"
 }
 
+@test "error: gh issue edit failure exits with code 1 and Error message" {
+    # gh mock: label list succeeds, issue view returns nothing, issue edit fails
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GH_CALL_LOG"
+if [ "\$1" = "label" ] && [ "\$2" = "list" ]; then
+    echo "phase/issue"
+    echo "phase/spec"
+    echo "phase/ready"
+    echo "phase/code"
+    echo "phase/review"
+    echo "phase/verify"
+    echo "phase/done"
+    exit 0
+fi
+if [ "\$1" = "issue" ] && [ "\$2" = "view" ]; then
+    exit 0
+fi
+if [ "\$1" = "issue" ] && [ "\$2" = "edit" ]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 123 code
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error" ]]
+}
+
 @test "bootstrap: gh-label-transition.sh continues with warning when setup-labels.sh fails" {
     # gh mock: label list returns empty (triggers bootstrap), label create fails
     cat > "$MOCK_DIR/gh" <<MOCK

--- a/tests/gh-pr-merge-status.bats
+++ b/tests/gh-pr-merge-status.bats
@@ -85,3 +85,11 @@ make_gh_mock() {
     [[ "$output" == *'"reason": "ci_failing"'* ]]
     [[ "$output" == *'"ci_status": "failing"'* ]]
 }
+
+@test "error: gh pr view failure exits with code 1 and Error message" {
+    printf '#!/bin/bash\nexit 1\n' > "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh"
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error" ]]
+}

--- a/tests/gh-pr-review.bats
+++ b/tests/gh-pr-review.bats
@@ -188,3 +188,25 @@ for c in comments:
     [ "$status" -eq 1 ]
     [[ "$output" == *"invalid line comments JSON"* ]]
 }
+
+@test "error: gh api POST failure exits with code 1 and Error message" {
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+echo "ARGS: \$@" >> "$GH_CALL_LOG"
+if [ "\$1" = "repo" ] && [ "\$2" = "view" ]; then
+    echo "owner/repo"
+    exit 0
+fi
+if [ "\$1" = "api" ]; then
+    echo "error: rate limit exceeded" >&2
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    echo "review body text" > "$BATS_TEST_TMPDIR/review.md"
+    run bash "$SCRIPT" 159 "$BATS_TEST_TMPDIR/review.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error" ]]
+}


### PR DESCRIPTION
## Summary

- `gh-pr-merge-status.sh`: `gh pr view` 失敗時に `Error: failed to fetch PR #N` を stderr 出力して exit 1
- `gh-label-transition.sh`: `gh issue edit` 3 箇所を `if ! ...; then echo "Error..." >&2; exit 1; fi` パターンに変更
- `gh-graphql.sh`: `gh api graphql` 2 箇所 (cache/no-cache パス) に `|| { echo "Error: gh api graphql failed" >&2; exit 1; }` を追加
- `gh-pr-review.sh`: heredoc パイプライン (`python3 <<'PYEOF' | gh api`) を変数キャプチャ方式にリファクタし `gh api` 呼び出しに error handling を追加
- 上記 4 スクリプトのテスト (bats) に "error: API failure" テストケースを追加

## Verification (pre-merge)

- [x] 7 個以上の gh-*.sh が API failure を観察可能にする error handling を持つ (全 8 個が対応済み)
- [x] gh-check-blocking.sh が API failure 時に明示的な stderr エラーメッセージを持つ
- [x] 主要 gh-*.sh の syntax check 通過
- CI bats 全件 green (回帰検出) — CI 完了後に確認

## Verification (post-merge)

- 次回 GitHub API rate limit / permission error が発生した際、silent pass through せず stderr で発見可能になっていることを観察 (手動)

closes #738