### PR TITLE
Issue #781: Add three-tier AC classification with pre-merge-preview layer

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -99,6 +99,7 @@ verify-max-iterations: 3
 capabilities:
   browser: true             # Enable Playwright-based verify commands
   workflow: true            # Enable Workflow-based multi-agent execution in /review --full
+  pr-preview: true          # Declare that PRs produce a preview URL (enables pre-merge-preview AC tier)
 ```
 
 All keys are optional. If `.wholework.yml` does not exist, all settings use their defaults.
@@ -122,6 +123,7 @@ This table is the **single source of truth (SSoT)** for all `.wholework.yml` con
 | `steering-docs-path` | string | `docs` | Where steering documents live |
 | `capabilities.browser` | boolean | `false` | Enable Playwright-based verify commands |
 | `capabilities.workflow` | boolean | `false` | Enable Workflow-based multi-agent execution in `/review --full` (opt-in; falls back to static Task fan-out when unset) |
+| `capabilities.pr-preview` | boolean | `false` | Declare PR preview availability; URL/UX ACs are classified as pre-merge-preview and executed at `/review` when the `PREVIEW_URL` env variable is set. Skipped in `/verify` post-merge to prevent double verification. |
 | `capabilities.mcp` | list | `[]` | MCP tool names available to skills |
 | `capabilities.{name}` | boolean | `false` | Dynamic capability mapping (e.g., `capabilities.invoice-api: true`) |
 | `watchdog-timeout-seconds` | integer | `2700` | Watchdog timeout in seconds before killing a silent `claude -p` process. Claude's extended thinking time on Size L+ tasks (especially Opus with high effort) can produce silent periods exceeding 2700 seconds; set to `3600` for meta-development or Size L+ work. Values ≤0 fall back to the default. |
@@ -146,6 +148,35 @@ This table is the **single source of truth (SSoT)** for all `.wholework.yml` con
 | `next-cycle-seed.enabled` | boolean | `false` | Enable next-cycle candidate seeding after batch completion. Emits `.tmp/next-cycle.json` with `audit/*` Issues created during the batch session (requires `autonomy: L2` or `L3`). When `false` or autonomy is `L1`, prints a recommendation instead. |
 
 For the full reference including implementation details and YAML parsing rules, see [`modules/detect-config-markers.md`](../../modules/detect-config-markers.md).
+
+### AC verification tiers
+
+Wholework classifies acceptance criteria into three verification tiers:
+
+| Tier | When executed | Typical ACs |
+|------|--------------|-------------|
+| **pre-merge-local** | `/review` safe mode (always) | File existence, text containment, code quality, test results |
+| **pre-merge-preview** | `/review` when `PREVIEW_URL` is set | `http_status`, `html_check`, `api_check`, `http_header`, `http_redirect`, `browser_check`, `browser_screenshot`, `lighthouse_check` |
+| **post-merge-production** | `/verify` full mode | Production deployment confirmation, production-only behavior |
+
+**Enabling pre-merge-preview:**
+
+Set `capabilities.pr-preview: true` in `.wholework.yml`. When `/issue` creates or refines an Issue with URL/UX-based verify commands, those ACs are placed in the `### Pre-merge (auto-verified)` section with a `<!-- ac-tier: preview -->` tag and a `--when="test -n \"$PREVIEW_URL\""` guard.
+
+**Resolving `PREVIEW_URL`:**
+
+The `PREVIEW_URL` environment variable must be exported before invoking `/review`. Wholework does not resolve it automatically — this is the responsibility of your CI pipeline or a project-side script. For example:
+
+```bash
+# In CI (e.g., GitHub Actions) — set before running /review
+export PREVIEW_URL="https://my-pr-123.example-preview.com"
+```
+
+**Behavior summary:**
+
+- `PREVIEW_URL` set at `/review` time: preview-tier ACs are executed against the preview URL.
+- `PREVIEW_URL` not set: preview-tier ACs are SKIPPED (the `--when` guard fires) and remain unchecked for human follow-up.
+- At `/verify` (post-merge): all `ac-tier: preview` ACs are skipped to prevent double verification. To also verify against production, duplicate the AC in the `### Post-merge` section without the tag.
 
 ## `.wholework/domains/`
 

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -88,6 +88,7 @@ verify-max-iterations: 3
 capabilities:
   browser: true             # Playwright ベースの verify command を有効化
   workflow: true            # /review --full で Workflow ベースのマルチエージェント実行を有効化
+  pr-preview: true          # PR が preview URL を生成することを宣言（pre-merge-preview AC 層を有効化）
 ```
 
 すべてのキーはオプションです。`.wholework.yml` が存在しない場合、すべての設定はデフォルトで動作します。
@@ -111,6 +112,7 @@ capabilities:
 | `steering-docs-path` | string | `docs` | steering document の配置先 |
 | `capabilities.browser` | boolean | `false` | Playwright ベースの verify command を有効化する |
 | `capabilities.workflow` | boolean | `false` | `/review --full` で Workflow ベースのマルチエージェント実行を有効化する（opt-in; 未設定時は static Task fan-out にフォールバック） |
+| `capabilities.pr-preview` | boolean | `false` | PR preview URL の存在を宣言する。URL/UX 系 AC を pre-merge-preview に分類し、`PREVIEW_URL` 環境変数が設定されている場合に `/review` 時に実行する。`/verify` post-merge では二重検証防止のため skip する。 |
 | `capabilities.mcp` | list | `[]` | スキルから利用できる MCP ツール名 |
 | `capabilities.{name}` | boolean | `false` | 動的 capability マッピング（例: `capabilities.invoice-api: true`） |
 | `watchdog-timeout-seconds` | integer | `2700` | watchdog が silent な `claude -p` プロセスを kill するまでのタイムアウト秒数。Size L+ タスク（特に Opus / xhigh effort）では claude の長い思考時間により 2700 秒を超える silent 期間が発生しうる。メタ開発や Size L+ 作業では `3600` を推奨。0 以下の値はデフォルトにフォールバック。 |
@@ -133,6 +135,30 @@ capabilities:
 | `verify-ignore-paths` | list | `[]` | `/verify` のダーティファイル検出から除外するパスの glob パターン（block list）。サポート: `dir/**` プレフィックスマッチ（ディレクトリ配下の任意ファイル）、単純 bash glob（`*`、`?`、`[...]`）によるフルパス完全一致。非対応: 中間 `**`（例: `a/**/b`）や否定パターン（`!`）。いずれかのパターンにマッチするファイルは除外され stderr に警告出力される。未設定時は除外なし。 |
 
 実装の詳細や YAML パースルールを含む完全なリファレンスは [`modules/detect-config-markers.md`](../../../modules/detect-config-markers.md) を参照してください。
+
+### AC 検証層
+
+Wholework は acceptance criteria を 3 層に分類します。
+
+| 層 | 実行タイミング | 対象 AC 例 |
+|---|---|---|
+| **pre-merge-local** | `/review` safe mode（常時） | ファイル存在・テキスト一致・コード品質・テスト結果 |
+| **pre-merge-preview** | `PREVIEW_URL` が設定された `/review` 時 | `http_status`、`html_check`、`api_check`、`http_header`、`http_redirect`、`browser_check`、`browser_screenshot`、`lighthouse_check` |
+| **post-merge-production** | `/verify` full mode | 本番デプロイ確認・本番固有の動作 |
+
+**pre-merge-preview の有効化:**
+
+`.wholework.yml` に `capabilities.pr-preview: true` を設定します。`/issue` が URL/UX 系 verify command を持つ AC を作成・更新する際、それらの AC は `### Pre-merge (auto-verified)` セクションに `<!-- ac-tier: preview -->` タグと `--when="test -n \"$PREVIEW_URL\""` ガードを付与して配置されます。
+
+**`PREVIEW_URL` の解決:**
+
+`PREVIEW_URL` 環境変数は `/review` 呼び出し前に export する必要があります。Wholework 側での自動解決は行いません — CI パイプラインまたはプロジェクト側スクリプトの責務です。
+
+**動作まとめ:**
+
+- `/review` 時に `PREVIEW_URL` が設定されている: preview 層 AC を preview URL に対して実行する。
+- `/review` 時に `PREVIEW_URL` が未設定: `--when` ガードが発動し preview 層 AC は SKIPPED になる（人間がフォローアップ）。
+- `/verify` (post-merge) 時: `ac-tier: preview` 付き AC はすべて skip される（二重検証防止）。本番でも同 AC を検証したい場合は、`### Post-merge` セクションへタグなしで複製する。
 
 ## `.wholework/domains/`
 

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -152,7 +152,12 @@ Wholework は acceptance criteria を 3 層に分類します。
 
 **`PREVIEW_URL` の解決:**
 
-`PREVIEW_URL` 環境変数は `/review` 呼び出し前に export する必要があります。Wholework 側での自動解決は行いません — CI パイプラインまたはプロジェクト側スクリプトの責務です。
+`PREVIEW_URL` 環境変数は `/review` 呼び出し前に export する必要があります。Wholework 側での自動解決は行いません — CI パイプラインまたはプロジェクト側スクリプトの責務です。例:
+
+```bash
+# CI (GitHub Actions 等) — /review 実行前に設定
+export PREVIEW_URL="https://my-pr-123.example-preview.com"
+```
 
 **動作まとめ:**
 

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -35,7 +35,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（87 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（89 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents

--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -207,6 +207,7 @@ Issue 本文の "Scope" または "Acceptance Criteria" セクションに以下
 | `HAS_BROWSER_CAPABILITY` | `capabilities.browser: true` | ブラウザ自動化 capability が有効なとき `true`。ブラウザ向け verify パターン（`verify/browser-verify-phase.md` など）を条件付きで読み込むために使用する |
 | `HAS_VISUAL_DIFF_CAPABILITY` | `capabilities.visual-diff: true` | ビジュアル差分 capability が有効なとき `true`。ビジュアル diff モジュール（`modules/visual-diff-adapter.md` など）を条件付きで読み込むために使用する |
 | `HAS_WORKFLOW_CAPABILITY` | `capabilities.workflow: true` | Workflow ツールが利用可能なとき `true`。`/review` での並列マルチエージェントレビューを条件付きで有効化するために使用する |
+| `HAS_PR_PREVIEW_CAPABILITY` | `capabilities.pr-preview: true` | プロジェクトの PR が preview URL を生成するとき `true`。`/issue` Step 4 の pre-merge-preview AC 分類のゲートとして機能する。URL/UX 系 AC に `ac-tier: preview` タグと `--when="test -n \"$PREVIEW_URL\""` ガードを付与し、`/review` 時に実行、`/verify` post-merge では二重検証防止のため skip する |
 | `MCP_TOOLS` | `capabilities.mcp` リスト | プロジェクトで有効化された MCP ツール名のカンマ区切りリスト（例: `"mf_list_quotes,mf_list_invoices"`）。注意: `capabilities.mcp` は直接 `MCP_TOOLS` にマッピングされる。動的な `HAS_*_CAPABILITY` マッピングの対象外のため、`HAS_MCP_CAPABILITY` は設定されない |
 
 ## Gotchas

--- a/docs/spec/issue-781-three-tier-ac-preview.md
+++ b/docs/spec/issue-781-three-tier-ac-preview.md
@@ -160,22 +160,39 @@ No new comments since last phase.
 - 分類ロジックは `/issue` Step 4 の LLM 実行ガイダンスのため、bats では決定論的な「ガイダンス文言の存在」(content 層) しか検証できない。実分類精度 (LLM 層) は post-merge observation AC でカバーする二層テスト戦略を採用 (skill-dev-constraints.md「LLM-assisted Skill Phase Test Strategy」準拠) → 解消。
 - `--when="test -n \"$PREVIEW_URL\""` env-var ガードと既存 Deployments API パスの相互作用は、`/review` Step 8.0 に env-var 直接利用パスを明記することで整合 (env 変数未設定時のみ Deployments API へフォールバック) → 解消。
 
+## Consumed Comments
+
+No new comments since last phase.
+
+## Code Retrospective
+
+### Deviations from Design
+- No deviations. All implementation steps followed the Spec exactly.
+
+### Design Gaps/Ambiguities
+- Spec Step 2 said to add `HAS_PR_PREVIEW_CAPABILITY` to "Step 2 の retain 文" without specifying which Step 2 (New Issue Creation vs. Existing Issue Refinement). Applied to both, which is correct since both sections read detect-config-markers and both reference Step 4/6 classification logic.
+- `docs/structure.md` had "87 files" in the tests/ comment but actual count was 88 (pre-existing drift noted in Spec). Updated to 89 (88 existing + 1 new `tests/issue.bats`).
+
+### Rework
+- None.
+
 ## Phase Handoff
+<!-- phase: code -->
 
 ### Key Decisions
-- `capabilities.pr-preview: true` を単一宣言シグナルとし、preview URL の env 変数名は `PREVIEW_URL` に標準化 (案B)。
-- AC tier は per-AC `<!-- ac-tier: preview -->` タグで表現し、既存 `### Pre-merge (auto-verified)` / `### Post-merge` のセクション構造は不変 (案2)。
-- 既定で `/verify` は `ac-tier: preview` AC を skip (二重検証防止)。本番再検証は post-merge セクションへの複製で opt-in。
-- URL/UX 系 verify command 集合を exhaustive 列挙し、`ac-tier: preview` タグの SSoT は `/issue` Step 4 とする (`/review`/`/verify` は参照のみ)。
+- All 9 implementation steps completed in a single commit. No deviations from Spec design.
+- `HAS_PR_PREVIEW_CAPABILITY` retain line added to both New Issue Creation Step 2 and Existing Issue Refinement Step 4 (both sections read detect-config-markers and both flow to classification logic).
+- pre-merge-preview guidance placed immediately after the classification decision sentence in Step 4, before the classification table — ensures the classifier reads the tier guidance before applying existing examples.
+- `/review` Step 8.0 fast-path added as a preamble before the numbered Deployments API steps (not inserted inline) — no risk of breaking existing step numbering references.
+- `/verify` Step 5 skip rule added as a note block directly under the Scope sentence — reads naturally as a scope extension.
 
 ### Deferred Items
-- Vercel / Netlify / Cloudflare Pages 用の preview URL 自動解決 adapter は follow-up Issue (Issue body「将来検討事項」)。
-- preview-tier AC が PREVIEW_URL 未解決のまま残った場合の UX は最小実装 (SKIPPED 記録のみ。phase/verify 残置で人手判断)。
-- `verify-classifier.md` への tier 概念統合は本 Issue スコープ外 (post-merge verify-type 専用モジュールのため)。
+- Vercel / Netlify / Cloudflare Pages preview URL auto-resolver adapter — follow-up Issue (scoped out in Spec).
+- `verify-classifier.md` tier concept integration — out of scope (post-merge verify-type module).
+- UX for PREVIEW_URL-unresolved preview ACs remains minimal (SKIPPED only).
 
 ### Notes for Next Phase
-- `skills/issue/SKILL.md` / `skills/review/SKILL.md` / `skills/verify/SKILL.md` 編集時、本文 (コードフェンス・inline code・HTML コメント外) に half-width `!` と triple backtick を新規追加しない (validate-skill-syntax.py MUST)。
-- `tests/issue.bats` は新規作成。参照は **リポジトリルート相対 path**、bats 3.2+ 互換構文のみ。CI は `tests/*.bats` を実行するため自動収集される。
-- `/issue` Step 4 に追加する URL/UX command 集合には `(exhaustive)` マーカーを付ける。
-- `docs/structure.md` の `tests/` ファイル数コメントは現状 87 表記だが実数は 88 (既存ドリフト)。`tests/issue.bats` 追加後の実数 89 に同期する。
-- ja ミラー同期: `docs/ja/structure.md` / `docs/ja/tech.md` は top-level docs で必須、`docs/ja/guide/customization.md` は consistency 目的。
+- `/review` should verify all 8 AC rubric and grep commands against the implementation; all should PASS without any fixup.
+- `bats tests/issue.bats` runs 4 content-assertion tests that confirm keyword presence — these are the mechanical safety net for the spec; confirm all 4 remain green in CI.
+- The `--when="test -n \"$PREVIEW_URL\""` guard in `skills/issue/SKILL.md` uses escaped double-quotes inside the SKILL.md prose — verify-executor parses this correctly (existing pattern from the pre-existing --when table row "Preview URL required").
+- Post-merge opportunistic ACs (review-run / verify-run) require a real project with `capabilities.pr-preview: true` and CI that exports `PREVIEW_URL`; no synthetic test exists.

--- a/docs/spec/issue-781-three-tier-ac-preview.md
+++ b/docs/spec/issue-781-three-tier-ac-preview.md
@@ -176,23 +176,34 @@ No new comments since last phase.
 ### Rework
 - None.
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- No structural divergences between Spec and PR diff. All 9 implementation steps were completed exactly as designed.
+- The Phase Handoff (code phase) accurately predicted that all 8 AC checks would PASS without fixup — confirmed during review.
+
+### Recurring issues
+- `tests/issue.bats` was created without the `PROJECT_ROOT` anchoring pattern used by all other 87 bats tests in the repository. This is a recurring gap: new test files don't inherit the project's established portability convention automatically. The issue was SHOULD-severity and fixed in this review. Consider adding a note to the test-writing guidance or a bats fixture template that includes the `setup()` pattern.
+- The JA mirror (`docs/ja/guide/customization.md`) omitted a bash code block present in the EN version. Translation drift in code examples is a recurring risk when adding code fences to documentation. Mitigation: the `docs/translation-workflow.md` sync procedure should explicitly check code blocks, not just text content.
+
+### Acceptance criteria verification difficulty
+- All 8 pre-merge ACs verified PASS without ambiguity. The mix of `rubric`, `grep`, and `command` verify commands provided good coverage at different verification depths.
+- The `command "bats tests/issue.bats"` AC was resolved via CI reference fallback (ok 441–444 in the CI log). The overall CI FAILURE in `Run bats tests` is caused by a pre-existing `append-loop-state-heartbeat.bats` issue unrelated to this PR. The AC verification correctly distinguished the specific test file result from the overall job status.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- All 9 implementation steps completed in a single commit. No deviations from Spec design.
-- `HAS_PR_PREVIEW_CAPABILITY` retain line added to both New Issue Creation Step 2 and Existing Issue Refinement Step 4 (both sections read detect-config-markers and both flow to classification logic).
-- pre-merge-preview guidance placed immediately after the classification decision sentence in Step 4, before the classification table — ensures the classifier reads the tier guidance before applying existing examples.
-- `/review` Step 8.0 fast-path added as a preamble before the numbered Deployments API steps (not inserted inline) — no risk of breaking existing step numbering references.
-- `/verify` Step 5 skip rule added as a note block directly under the Scope sentence — reads naturally as a scope extension.
+- All 8 pre-merge ACs PASS. Two SHOULD fixes applied (PROJECT_ROOT anchoring in bats, JA bash code block). Three CONSIDER issues skipped.
+- The Workflow path (capabilities.workflow: true) attempted but fell back to static fan-out because custom agentTypes (review-spec, review-bug) are not available as registered agent types in the worktree environment. Findings were collected via direct Agent tool calls instead.
+- No policy changes or acceptance criteria updates needed.
 
 ### Deferred Items
-- Vercel / Netlify / Cloudflare Pages preview URL auto-resolver adapter — follow-up Issue (scoped out in Spec).
-- `verify-classifier.md` tier concept integration — out of scope (post-merge verify-type module).
-- UX for PREVIEW_URL-unresolved preview ACs remains minimal (SKIPPED only).
+- CONSIDER: skills/review/SKILL.md Step 8.0 fast-path description scope ambiguity — the sentence "ac-tier: preview ACs ... are executed via this path" could mislead about ACs without {{base_url}}. Low risk, deferred to a future doc cleanup pass.
+- CONSIDER: skills/verify/SKILL.md "### Pre-merge" vs "### Pre-merge (auto-verified)" section name mismatch in skip rule prose. Low functional risk.
+- Vercel/Netlify/CF Pages preview URL auto-resolver adapter — already deferred from code phase.
 
 ### Notes for Next Phase
-- `/review` should verify all 8 AC rubric and grep commands against the implementation; all should PASS without any fixup.
-- `bats tests/issue.bats` runs 4 content-assertion tests that confirm keyword presence — these are the mechanical safety net for the spec; confirm all 4 remain green in CI.
-- The `--when="test -n \"$PREVIEW_URL\""` guard in `skills/issue/SKILL.md` uses escaped double-quotes inside the SKILL.md prose — verify-executor parses this correctly (existing pattern from the pre-existing --when table row "Preview URL required").
-- Post-merge opportunistic ACs (review-run / verify-run) require a real project with `capabilities.pr-preview: true` and CI that exports `PREVIEW_URL`; no synthetic test exists.
+- Two SHOULD fixes committed (PROJECT_ROOT in bats, JA code block). CI re-run expected to show same status (pre-existing append-loop-state-heartbeat.bats failures remain).
+- merge phase: no MUST issues to block merge. CI FAILURE is pre-existing on main too — merge can proceed if that's the project's accepted state.
+- Post-merge opportunistic ACs require a real project with `capabilities.pr-preview: true` and CI that exports `PREVIEW_URL`.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -42,7 +42,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (87 files)
+├── tests/               # Bats test files for scripts (89 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -220,6 +220,7 @@ The following variables are set by `detect-config-markers.md` from `.wholework.y
 | `HAS_BROWSER_CAPABILITY` | `capabilities.browser: true` | `true` when browser automation capability is enabled. Used to conditionally load browser-based verify patterns (e.g., `verify/browser-verify-phase.md`). |
 | `HAS_VISUAL_DIFF_CAPABILITY` | `capabilities.visual-diff: true` | `true` when visual diffing capability is enabled. Used to conditionally load visual diff modules (e.g., `modules/visual-diff-adapter.md`). |
 | `HAS_WORKFLOW_CAPABILITY` | `capabilities.workflow: true` | `true` when the Workflow tool is available. Used to conditionally enable parallel multi-agent review in `/review`. |
+| `HAS_PR_PREVIEW_CAPABILITY` | `capabilities.pr-preview: true` | `true` when the project's PRs produce a preview URL. Gates pre-merge-preview AC classification in `/issue` Step 4: URL/UX-based ACs are placed in the pre-merge section with `ac-tier: preview` tag and `--when="test -n \"$PREVIEW_URL\""` guard, executed at `/review` time, and skipped in `/verify` post-merge. |
 | `MCP_TOOLS` | `capabilities.mcp` list | Comma-separated list of MCP tool names enabled for the project (e.g., `"mf_list_quotes,mf_list_invoices"`). Note: `capabilities.mcp` maps to `MCP_TOOLS` directly — it is excluded from the dynamic `HAS_*_CAPABILITY` mapping, so `HAS_MCP_CAPABILITY` is never set. |
 
 ## Gotchas

--- a/modules/detect-config-markers.md
+++ b/modules/detect-config-markers.md
@@ -44,6 +44,7 @@ From the loaded content, search for each YAML key in the marker definition table
 | `capabilities.browser` | `HAS_BROWSER_CAPABILITY` | `true` | `false` |
 | `capabilities.visual-diff` | `HAS_VISUAL_DIFF_CAPABILITY` | `true` | `false` |
 | `capabilities.workflow` | `HAS_WORKFLOW_CAPABILITY` | `true` | `false` |
+| `capabilities.pr-preview` | `HAS_PR_PREVIEW_CAPABILITY` | `true` | `false` |
 | `capabilities.mcp` | `MCP_TOOLS` | Comma-separated tool name list | `""` |
 | `watchdog-timeout-seconds` | `WATCHDOG_TIMEOUT_SECONDS` | Integer string (extract as-is; use `1800` if ≤0 or non-numeric) | `1800` (see `scripts/watchdog-defaults.sh` `WATCHDOG_TIMEOUT_DEFAULT`) |
 | `watchdog-timeout-spec-seconds` | `WATCHDOG_TIMEOUT_SPEC_SECONDS` | Integer string (extract as-is; use phase-specific default if ≤0 or non-numeric) | `""` (unset; falls through to global key or phase default `1800`) |
@@ -65,6 +66,8 @@ From the loaded content, search for each YAML key in the marker definition table
 | `recoveries-auto-fire.enabled` | `RECOVERIES_AUTO_FIRE_ENABLED` | `true` | `false` |
 | `recoveries-auto-fire.threshold` | `RECOVERIES_AUTO_FIRE_THRESHOLD` | Integer string (extract as-is; use `3` if ≤0 or non-numeric) | `3` |
 | `next-cycle-seed.enabled` | `NEXT_CYCLE_SEED_ENABLED` | `true` | `false` |
+
+Note: `capabilities.pr-preview` is listed as an explicit row (rather than relying on Dynamic Capability Mapping alone) because it has dedicated classification logic in `/issue` Step 4 (pre-merge-preview AC tier).
 
 **Dynamic Capability Mapping:**
 
@@ -112,6 +115,7 @@ STEERING_DOCS_PATH: path string extracted from steering-docs-path (default: "doc
 HAS_BROWSER_CAPABILITY: true if capabilities.browser: true is set (default: false)
 HAS_VISUAL_DIFF_CAPABILITY: true if capabilities.visual-diff: true is set (default: false)
 HAS_WORKFLOW_CAPABILITY: true if capabilities.workflow: true is set (default: false)
+HAS_PR_PREVIEW_CAPABILITY: true if capabilities.pr-preview: true is set (default: false)
 MCP_TOOLS: tool name list from capabilities.mcp (comma-separated, default: "")
 WATCHDOG_TIMEOUT_SECONDS: integer from watchdog-timeout-seconds (default: "1800" (see `scripts/watchdog-defaults.sh` `WATCHDOG_TIMEOUT_DEFAULT`); falls back to "1800" if ≤0 or non-numeric)
 WATCHDOG_TIMEOUT_SPEC_SECONDS: integer from watchdog-timeout-spec-seconds (default: "" — unset; resolution handled by load_watchdog_timeout())

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -33,7 +33,7 @@ Use AskUserQuestion to collect:
 
 ### Step 2: Reference Steering Documents (if present)
 
-Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH` and `STEERING_DOCS_PATH` for use in subsequent steps.
+Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, and `HAS_PR_PREVIEW_CAPABILITY` for use in subsequent steps.
 
 Check whether the following steering documents exist using Glob, then read only those that exist:
 
@@ -64,6 +64,20 @@ If expressible via existing `adapter-resolver` patterns, prefer that approach ov
 Read `${CLAUDE_PLUGIN_ROOT}/modules/verify-patterns.md` and follow the "Processing Steps" section guidelines to design verify command patterns.
 
 After ambiguity detection, classify each acceptance criterion as "pre-merge" or "post-merge" and assign verify commands.
+
+**pre-merge-preview tier (URL/UX AC classification):**
+
+When `HAS_PR_PREVIEW_CAPABILITY` is `true` (i.e., `.wholework.yml` has `capabilities.pr-preview: true`), classify URL/UX-based verify commands into the **pre-merge-preview** tier instead of post-merge.
+
+URL/UX verify command set (exhaustive): `http_status`, `html_check`, `api_check`, `http_header`, `http_redirect`, `browser_check`, `browser_screenshot`, `lighthouse_check`.
+
+For each AC whose verify command belongs to the above set and `HAS_PR_PREVIEW_CAPABILITY=true`:
+- Place the AC in the `### Pre-merge (auto-verified)` section (not in Post-merge)
+- Append `<!-- ac-tier: preview -->` to the AC line (after the checkbox text, before any `<!-- verify-type: ... -->` tag)
+- Auto-append `--when="test -n \"$PREVIEW_URL\""` to the verify command so the check is SKIPPED when the `PREVIEW_URL` env variable is not set (see `--when` modifier table entry "Preview URL required")
+- `/review` will execute these ACs against the preview URL when `PREVIEW_URL` is exported; `/verify` will skip them post-merge to prevent double verification
+
+When `HAS_PR_PREVIEW_CAPABILITY` is `false` or unset: classify URL/UX-based ACs as post-merge as before (existing behavior unchanged).
 
 **Classification guidance (examples):**
 
@@ -356,7 +370,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh $NUMBER issue
 
 ### Step 4: Reference Steering Documents (if present)
 
-Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH` and `STEERING_DOCS_PATH` for use in subsequent steps.
+Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, and `HAS_PR_PREVIEW_CAPABILITY` for use in subsequent steps.
 
 Check whether the following steering documents exist using Glob, then read only those that exist:
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -212,6 +212,10 @@ After detection, follow `external-review-phase.md`'s Step 7 procedure for extern
 
 If any verify command contains `{{base_url}}`, resolve the Preview URL before passing to verify-executor:
 
+**Fast path — `PREVIEW_URL` env variable already set:**
+
+If the `PREVIEW_URL` environment variable is already exported (set by CI or a project-side script before invoking `/review`), use its value directly as the preview base URL and skip the GitHub Deployments API lookup (steps 1–4 below). Replace `{{base_url}}` with `$PREVIEW_URL` and proceed to step 5. `ac-tier: preview` ACs guarded with `--when="test -n \"$PREVIEW_URL\""` are executed via this path. If `PREVIEW_URL` is not set, fall through to the Deployments API path below.
+
 1. Get the PR branch name:
    ```bash
    gh pr view "$NUMBER" --json headRefName -q '.headRefName'

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -138,6 +138,12 @@ This is an early Spec read specifically for Phase Handoff context; SPEC_PATH is 
 
 **Scope**: This step processes **pre-merge conditions only**. Post-merge conditions (hint-based and manual) are processed in Steps 7–8, after pre-merge results are locked into the Issue. If the Issue has no section divisions, treat all conditions as pre-merge and process them here.
 
+**pre-merge-preview AC skip rule (double-verification prevention):**
+
+Within the `### Pre-merge` section, any AC line that carries a `<!-- ac-tier: preview -->` tag is classified as a preview-tier AC. These ACs were verified at `/review` time against the preview URL and must be skipped here to prevent double verification. Record each skipped AC as SKIPPED in the results table with the note "preview-tier AC; verified at /review against preview URL".
+
+If the same URL/UX verification is also needed against the production URL, duplicate the AC in the `### Post-merge` section without the `<!-- ac-tier: preview -->` tag; `/verify` will then execute it against `PRODUCTION_URL` (resolved via `{{base_url}}` and the `production-url` key in `.wholework.yml`).
+
 **Patch route detection (run before verification):**
 
 If PR_NUMBER (from Step 2) is empty and any acceptance condition contains `github_check "gh pr checks"`, treat those conditions as UNCERTAIN with the following guidance:

--- a/tests/issue.bats
+++ b/tests/issue.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+# Content-assertion tests for /issue skill pre-merge-preview tier guidance.
+# These tests verify that the required keywords and tags exist in the skill files
+# (script/content layer). The actual LLM-driven classification behavior is covered
+# by post-merge observation ACs.
+
+@test "issue skill Step 4 documents pre-merge-preview tier" {
+    grep -q 'pre-merge-preview' skills/issue/SKILL.md
+}
+
+@test "issue skill Step 4 tags preview-tier ACs with ac-tier preview" {
+    grep -q 'ac-tier: preview' skills/issue/SKILL.md
+}
+
+@test "issue skill Step 4 auto-appends PREVIEW_URL when-guard" {
+    grep -q 'test -n .*PREVIEW_URL' skills/issue/SKILL.md
+}
+
+@test "detect-config-markers documents pr-preview capability" {
+    grep -q 'pr-preview' modules/detect-config-markers.md && grep -q 'HAS_PR_PREVIEW_CAPABILITY' modules/detect-config-markers.md
+}

--- a/tests/issue.bats
+++ b/tests/issue.bats
@@ -4,18 +4,22 @@
 # (script/content layer). The actual LLM-driven classification behavior is covered
 # by post-merge observation ACs.
 
+setup() {
+    PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+}
+
 @test "issue skill Step 4 documents pre-merge-preview tier" {
-    grep -q 'pre-merge-preview' skills/issue/SKILL.md
+    grep -q 'pre-merge-preview' "$PROJECT_ROOT/skills/issue/SKILL.md"
 }
 
 @test "issue skill Step 4 tags preview-tier ACs with ac-tier preview" {
-    grep -q 'ac-tier: preview' skills/issue/SKILL.md
+    grep -q 'ac-tier: preview' "$PROJECT_ROOT/skills/issue/SKILL.md"
 }
 
 @test "issue skill Step 4 auto-appends PREVIEW_URL when-guard" {
-    grep -q 'test -n .*PREVIEW_URL' skills/issue/SKILL.md
+    grep -q 'test -n .*PREVIEW_URL' "$PROJECT_ROOT/skills/issue/SKILL.md"
 }
 
 @test "detect-config-markers documents pr-preview capability" {
-    grep -q 'pr-preview' modules/detect-config-markers.md && grep -q 'HAS_PR_PREVIEW_CAPABILITY' modules/detect-config-markers.md
+    grep -q 'pr-preview' "$PROJECT_ROOT/modules/detect-config-markers.md" && grep -q 'HAS_PR_PREVIEW_CAPABILITY' "$PROJECT_ROOT/modules/detect-config-markers.md"
 }


### PR DESCRIPTION
## Summary

- `modules/detect-config-markers.md` に `capabilities.pr-preview` / `HAS_PR_PREVIEW_CAPABILITY` 行を追加
- `skills/issue/SKILL.md` Step 4 に pre-merge-preview 層の分類ガイダンスを追加 (URL/UX 系 verify command の集合定義、`ac-tier: preview` タグ自動付与、`--when="test -n \"$PREVIEW_URL\""` ガード)
- `skills/review/SKILL.md` Step 8.0 に `PREVIEW_URL` env var 直接利用 fast path を追加 (Deployments API フォールバック前)
- `skills/verify/SKILL.md` Step 5 に `ac-tier: preview` AC の post-merge skip ルールを追加 (二重検証防止)
- `docs/guide/customization.md` に `capabilities.pr-preview` サンプルと三層分類説明セクションを追加
- `tests/issue.bats` を新規作成 (content-assertion テスト 4 件)
- `docs/tech.md` Capability Flags 表に `HAS_PR_PREVIEW_CAPABILITY` 行を追加
- `docs/structure.md` tests/ ファイル数を 89 に更新
- `docs/ja/` ミラー (structure.md、tech.md、guide/customization.md) を同期

## Verification (pre-merge)

- `detect-config-markers.md` マーカー定義表に `capabilities.pr-preview` と `HAS_PR_PREVIEW_CAPABILITY` が追加されている
- `detect-config-markers.md` に "preview" 関連エントリが追加されている
- `skills/issue/SKILL.md` Step 4 に pre-merge-preview 層分類ガイダンスが追加されている
- `skills/issue/SKILL.md` に "pre-merge-preview" キーワードが含まれている
- `skills/review/SKILL.md` に `PREVIEW_URL` env var 利用仕様が記述されている
- `skills/verify/SKILL.md` に `ac-tier: preview` AC skip 仕様が記述されている
- `docs/guide/customization.md` に三層分類の説明と `.wholework.yml` サンプルが追加されている
- `bats tests/issue.bats` が 4 件 green (CI で確認)

## Verification (post-merge)

- preview URL を持つ実プロジェクトで `/issue` → `/review` 実行時、URL 系 AC が preview URL 上で検証されることを観察
- 同プロジェクトで merge 後の `/verify` 実行時に `ac-tier: preview` AC が SKIPPED になることを観察

closes #781