### PR TITLE
Issue #705: bash-driven comments_consumed emit (iteration 2)

### DIFF
--- a/docs/spec/issue-705-l0-surfaces-ssot-comments.md
+++ b/docs/spec/issue-705-l0-surfaces-ssot-comments.md
@@ -207,22 +207,21 @@ Output: inject 済み context + `## Consumed Comments` 記録 + (条件付き) `
 - post-merge AC 2 件 (manual + observation) は /verify フェーズで対応予定。
 
 ## Phase Handoff
-<!-- phase: merge -->
+<!-- phase: review -->
 
 ### Key Decisions
-- PR #712 を squash merge (`--squash --delete-branch`) で main に統合。CI 全ジョブ SUCCESS・全 pre-merge AC PASS を review フェーズで確認済み。
-- mergeable=true (reason=clean, review_status=approved) を `gh-pr-merge-status.sh` で確認し、conflict resolution フェーズ (Step 3) をスキップして直接 merge を実行。
-- BASE_BRANCH=main のため `closes #705` 記述により Issue が auto-close される。
+- iteration 2 (PR #786) の MUST issue を検出・修正: `_emit_comments_consumed()` を `phase_start` emit の前に移動し、backfill 検出を修復。
+- `modules/l0-surfaces.md` Step 6 のドキュメントを実装に合わせて更新 (「before `phase_start` emit」を明示)。
+- AC10 (`(37 files)`) は stale AC と判断 (PR #786 は structure.md を変更しない)。次 phase (merge) ではこの FAIL を無視して良い。
 
 ### Deferred Items
-- post-merge AC #11 (observation: `comments_consumed` イベントが `auto-events.jsonl` に記録されること) は /verify フェーズで実機観察が必要。
-- post-merge AC #12 (manual: 試験 Issue に user comment 追加後 `/spec N` を実行し Spec の "Consumed Comments" セクションに記録されることを確認) は /verify フェーズでの手動確認が必要。
-- run-spec.sh の `AUTO_EVENTS_LOG` export と worktree CWD 相対パス解決の実動作は /verify の実機確認で最終判断。
+- bats tests 11-15 (`append-loop-state-heartbeat.bats`) は pre-existing failures on main、本 PR と無関係。merge 後も継続して別途対処が必要。
+- post-merge AC #11/#12 は /verify フェーズで引き続き対応が必要。
 
-### Notes for Next Phase (/verify)
-- 全 pre-merge AC (1〜10) は review フェーズで PASS 確認済み; /verify では post-merge AC 2 件 (manual + observation) に集中。
-- `modules/l0-surfaces.md` が main に存在し、bot exception prefix 修正・jq `// empty` 修正が含まれた状態で merge 済み。
-- verify command で `docs/spec/issue-705-l0-surfaces-ssot-comments.md` の verify command セクションを参照してテストを実行すること。
+### Notes for Next Phase (/merge)
+- PR #786 の CI: test #98 regression は修正済み (commit 55b0986)。push 後の CI 結果が SUCCESS になることを confirm してから merge を実行すること。
+- tests 11-15 の pre-existing failures は merge ブロッカーではない (main でも失敗している)。
+- AC10 stale FAIL は regression ではないため merge ブロッカーではない。
 
 ## Verify Retrospective
 
@@ -270,3 +269,18 @@ run-spec.sh で `AUTO_EVENTS_LOG` export が欠けていた。他の run-*.sh wr
 **3. emit-event.sh cross-file validation の spec 反映 (Tier 3 / 一回限り)**
 
 spec 段階で `validate-skill-syntax.py` の cross-file validation 要件 (emit-event.sh source 元への allowed-tools 追加) を予見できなかった点は今後の spec 作成時に意識する。Tier 3 (Spec retro 記録のみ、Issue 起票不要)。
+
+## review retrospective (iteration 2)
+
+### Spec vs. implementation divergence patterns
+
+- `_emit_comments_consumed()` が `emit_event "phase_start"` の*後*に置かれた構造エラー。`_maybe_emit_phase_complete()` の backfill 検出条件 (`_last_event == "phase_start"`) を暗黙的に前提とするコードが既存しており、新たに追加した emit 呼び出しがその前提を破壊した。設計書 (l0-surfaces.md Step 6) には「before each phase runner script」と書かれていたが、実装は `phase_start` の後に配置されており spec と実装の齟齬が生じていた。
+- 同パターン教訓: イベントロギングの順序は明示的な順序制約として spec に記述する必要がある。「phase runner の前」という記述では `phase_start` emit の前後どちらなのかが曖昧。
+
+### Recurring issues
+
+- test #98 (backfill) は bats テストが既存の挙動 (`phase_start` が最後のイベント) を前提に書かれており、新規 emit 追加で自動的に失敗した。新しいイベント emit を追加する際は、テストで前提とされているイベント順序への影響を必ず確認すること。これは iteration 1 でも類似の順序問題 (jq `| last` の null 出力) が発生した再発例。
+
+### Acceptance criteria verification difficulty
+
+- AC10 (`file_contains "docs/structure.md" "(37 files)"`) が iteration 1 マージ後の後続開発で stale になっていた。iteration 2 のレビューでは PR 変更非対象ファイルの AC が FAIL となり、regression との区別に調査コストが発生。iteration 単位での PR レビュー時には、前 iteration の AC が stale になっていないかを最初に確認するか、iteration 2 用の新 AC セットを明示的に定義すべき。

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -152,9 +152,10 @@ If no comments were consumed: write "No new comments since last phase."
 **Step 6 — Emit event (handled by bash wrapper in auto mode; LLM skip):**
 
 In `/auto` mode (invoked via `scripts/run-auto-sub.sh`), the bash wrapper calls
-`_emit_comments_consumed()` before each phase runner script. This ensures the
-`comments_consumed` event is captured even when the LLM omits this step.
-**LLM action: skip this step** to avoid duplicate events.
+`_emit_comments_consumed()` before the `phase_start` emit for each code phase runner.
+Placing it before `phase_start` ensures the backfill detection in
+`_maybe_emit_phase_complete()` still sees `phase_start` as the last event when
+`phase_complete` is absent. **LLM action: skip this step** to avoid duplicate events.
 
 In non-auto interactive mode (`AUTO_EVENTS_LOG` not set): skip this step.
 

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -149,23 +149,21 @@ consumed comment:
 
 If no comments were consumed: write "No new comments since last phase."
 
-**Step 6 — Emit event (best-effort, only when `AUTO_EVENTS_LOG` is set):**
+**Step 6 — Emit event (handled by bash wrapper in auto mode; LLM skip):**
 
-```bash
-source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
-EMIT_ISSUE_NUMBER=$ISSUE_NUMBER emit_event "comments_consumed" \
-  "phase=$PHASE_NAME" \
-  "count=$N" \
-  "authors=$AUTHORS" \
-  "trust_breakdown=OWNER:$OWNER_N,MEMBER:$MEMBER_N,COLLABORATOR:$COLLAB_N,CONTRIBUTOR:$CONTRIB_N,NONE:$NONE_N"
-```
+In `/auto` mode (invoked via `scripts/run-auto-sub.sh`), the bash wrapper calls
+`_emit_comments_consumed()` before each phase runner script. This ensures the
+`comments_consumed` event is captured even when the LLM omits this step.
+**LLM action: skip this step** to avoid duplicate events.
 
-Skip this step entirely when `AUTO_EVENTS_LOG` is not set (normal in-session execution).
+In non-auto interactive mode (`AUTO_EVENTS_LOG` not set): skip this step.
+
 The `trust_breakdown` uses `KEY:n` flat format (not JSON) to avoid quoting issues with
-`emit_event()`'s value sanitization.
+`emit_event()`'s value sanitization. See `scripts/run-auto-sub.sh _emit_comments_consumed()`
+for the bash implementation.
 
 ## Output
 
 - Comments injected as context for the calling skill's current phase
 - `## Consumed Comments` section recorded in the Spec or retrospective
-- `comments_consumed` event emitted to `AUTO_EVENTS_LOG` when available (best-effort)
+- `comments_consumed` event emitted to `AUTO_EVENTS_LOG` by bash wrapper (best-effort)

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -88,6 +88,48 @@ _loop_state_to_phase() {
   esac
 }
 
+# Bash-side comments_consumed event emitter. Issue #705 — replaces the LLM
+# Step 6 in l0-surfaces.md Comment Consumption Procedure, which was not firing
+# reliably in batch mode because the LLM skips the emit step.
+# Called before each phase runner script so the event is captured even when
+# the LLM omits the bash emit.
+_emit_comments_consumed() {
+  local issue="$1"
+  local phase="$2"
+  [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
+  [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
+
+  # Fetch cutoff: timestamp of the last phase/* label assignment
+  local cutoff=""
+  cutoff=$(gh api "repos/{owner}/{repo}/issues/${issue}/timeline" --paginate \
+    --jq '[.[] | select(.event=="labeled" and (.label.name|startswith("phase/"))) | .created_at] | last // empty' \
+    2>/dev/null || true)
+
+  # Fetch all comments as JSON array, then filter since cutoff
+  local comments_json="[]"
+  comments_json=$(gh issue view "$issue" --json comments --jq '.comments' 2>/dev/null || echo "[]")
+  if [[ -n "$cutoff" ]]; then
+    comments_json=$(echo "$comments_json" \
+      | jq --arg c "$cutoff" '[.[] | select(.createdAt > $c)]' 2>/dev/null || echo "[]")
+  fi
+
+  local count=0 owner_n=0 member_n=0 collab_n=0 contrib_n=0 none_n=0 authors=""
+  count=$(echo "$comments_json" | jq 'length' 2>/dev/null || echo 0)
+  owner_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="OWNER")] | length' 2>/dev/null || echo 0)
+  member_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="MEMBER")] | length' 2>/dev/null || echo 0)
+  collab_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="COLLABORATOR")] | length' 2>/dev/null || echo 0)
+  contrib_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="CONTRIBUTOR")] | length' 2>/dev/null || echo 0)
+  none_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="NONE")] | length' 2>/dev/null || echo 0)
+  authors=$(echo "$comments_json" | jq -r '[.[] | .author.login] | unique | join(",")' 2>/dev/null || true)
+
+  EMIT_ISSUE_NUMBER="$issue" emit_event "comments_consumed" \
+    "phase=${phase}" \
+    "count=${count}" \
+    "authors=${authors:-}" \
+    "trust_breakdown=OWNER:${owner_n},MEMBER:${member_n},COLLABORATOR:${collab_n},CONTRIBUTOR:${contrib_n},NONE:${none_n}" \
+    2>/dev/null || true
+}
+
 # Best-effort heartbeat append. Never blocks the caller. Issue #701 — replaces
 # the LLM-driven inline procedure in skills/auto/SKILL.md that was not firing
 # in batch mode (which executes here through bash, bypassing the LLM steps).
@@ -153,6 +195,13 @@ run_phase_with_recovery() {
   local PHASE_START
   PHASE_START=$(date +%s)
   emit_event "phase_start" "phase=${phase}"
+
+  # Bash-side comments_consumed emit for code phases (issue-level comment consumption).
+  # run-auto-sub.sh handles this so the event is captured even when LLM skips
+  # Step 6 of l0-surfaces.md Comment Consumption Procedure. (Issue #705)
+  if [[ "$phase" == code* ]]; then
+    _emit_comments_consumed "$issue" "code" || true
+  fi
 
   set +e
   "$runner_script" "$issue" "$@" > "$log_file" 2>&1
@@ -292,6 +341,8 @@ emit_event "sub_start" "size=${SIZE}"
 LABELS=$(gh issue view "$SUB_NUMBER" --json labels -q '.labels[].name' 2>/dev/null || true)
 if ! echo "$LABELS" | grep -q "phase/ready"; then
   echo "${LOG_PREFIX} --- spec phase: issue #${SUB_NUMBER} ---"
+  # Bash-side comments_consumed emit for spec phase. (Issue #705)
+  _emit_comments_consumed "$SUB_NUMBER" "spec" || true
   if [[ "$SIZE" == "L" ]]; then
     "$SCRIPT_DIR/run-spec.sh" "$SUB_NUMBER" --opus
   else

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -192,16 +192,16 @@ run_phase_with_recovery() {
   export EMIT_ISSUE_NUMBER="$issue"
   export EMIT_PHASE_NAME="$phase"
 
-  local PHASE_START
-  PHASE_START=$(date +%s)
-  emit_event "phase_start" "phase=${phase}"
-
   # Bash-side comments_consumed emit for code phases (issue-level comment consumption).
-  # run-auto-sub.sh handles this so the event is captured even when LLM skips
-  # Step 6 of l0-surfaces.md Comment Consumption Procedure. (Issue #705)
+  # Emitted before phase_start so _maybe_emit_phase_complete backfill detection
+  # still sees phase_start as the last event when phase_complete is absent. (Issue #705)
   if [[ "$phase" == code* ]]; then
     _emit_comments_consumed "$issue" "code" || true
   fi
+
+  local PHASE_START
+  PHASE_START=$(date +%s)
+  emit_event "phase_start" "phase=${phase}"
 
   set +e
   "$runner_script" "$issue" "$@" > "$log_file" 2>&1


### PR DESCRIPTION
## Summary

Bash-driven `comments_consumed` event emit in `scripts/run-auto-sub.sh`, replacing the LLM-driven Step 6 in `modules/l0-surfaces.md` Comment Consumption Procedure that was not firing in batch mode (and inconsistently in parent /auto sessions).

Closes #705.

## Background

Iteration 1 of #705 added LLM-driven Step 6 emit instructions to `modules/l0-surfaces.md` and updated each skill (spec/code/verify) to invoke the Comment Consumption Procedure. However, `/verify` observation FAIL (2026-06-27) confirmed that the `comments_consumed` event count in `.tmp/auto-events.jsonl` was 0 across 1325 emitted events from multiple `/auto` sessions.

Root cause: the LLM-driven Step 6 was unreliably executed:
- batch mode (`run-auto-sub.sh`) does not invoke an LLM, so Step 6 never fires
- single-Issue parent `/auto` session: LLM tends to skip optional best-effort emit steps under context pressure

This is the same pattern that #701 iteration 2 addressed by moving the loop-state heartbeat from LLM prose to a bash helper. Iteration 2 of #705 applies the same defense-in-depth: move the emit to bash, keep the LLM step as no-op to avoid duplicates.

## Implementation

### Changes
- `scripts/run-auto-sub.sh`: add `_emit_comments_consumed()` helper that fetches comments since the most recent `phase/*` LabeledEvent and emits the `comments_consumed` event with `count`/`authors`/`trust_breakdown` payload. Called from `run_phase_with_recovery()` before each `code*` phase runner.
- `modules/l0-surfaces.md`: Step 6 rewritten — auto mode delegates to bash wrapper, LLM skips to avoid duplicate events.

### Divergence from original Spec

The Spec for #705 (iteration 1) specified a 10-file LLM-driven change (modifying each skill's SKILL.md to add Comment Consumption Procedure invocation + Step 6 emit). Iteration 2 deliberately diverges to a 2-file bash-driven approach for the reliability reason above. The verify retrospective should evaluate whether the Spec should be retroactively updated to reflect the new approach.

### Watchdog kill context

The `/code --pr 705` invocation was killed by watchdog at 1800s (silent for 30 min) — the worktree had 2 modified files staged but uncommitted. Tier 2 anomaly detector flagged `code-completed-no-pr`. Recovery: manual commit + rebase + push + PR creation (this PR).

## Test plan

- [x] Verify the helper function syntax is valid (bash 3.2+ compatible)
- [x] Confirm `run_phase_with_recovery()` calls the helper at the correct location (before each phase runner)
- [ ] Manual observation: next `/auto --batch` run should produce `comments_consumed` events in `.tmp/auto-events.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWrWzAFaD4Ev2pRtM1fZ2H