### PR TITLE
Issue #770: session_id pointer の race condition を解消し parallel session 環境での event log isolation を保証

### DIFF
--- a/docs/spec/issue-770-auto-session-pgid-isolation.md
+++ b/docs/spec/issue-770-auto-session-pgid-isolation.md
@@ -57,3 +57,36 @@ Fix: ポインタファイル名に PGID を含めることで、同一 Claude C
 - `run-auto-sub.sh` は子プロセスとして run-code.sh, run-review.sh, run-merge.sh を呼び出す。`run-auto-sub.sh` が `AUTO_SESSION_ID` を `export` するため、XL サブ Issue 経路では子プロセスが PGID ファイルを読む機会はないが、M/L Issue の直接 Bash tool 呼び出し経路 (スキル SKILL.md から直接) では run-code.sh 等がポインタファイルを読む必要があるため、すべての run-*.sh を修正する。
 - PGID 取得コマンド `ps -o pgid= -p $$ | tr -d ' '` は macOS (bash 3.2) および Linux の両方で動作する。
 - Consumed Comments: saito (MEMBER) 2026-06-27T14:56:52Z — AC2 の verify command を BRE metacharacter (`\|`) を含む `grep` から `file_not_contains "scripts/run-auto-sub.sh" "auto-session-current"` に変更する自動解決ログ。この変更は Issue body の AC2 に既に反映済み。
+
+## review retrospective
+
+### Spec vs. 実装の乖離パターン
+
+- `skills/audit/SKILL.md` の「Session Boundary Identification」セクションが PR の変更ファイルに含まれておらず、古い `.tmp/auto-session-current` 参照が残留した。PR の変更ファイルが変更元 (Session ID 生成ロジック) に特化していたため、参照先ドキュメント (`audit/SKILL.md`) が Spec の "Changed Files" リストから漏れた典型パターン。対策: Issue #770 のような shared state 置換 Issue では、参照元だけでなく参照先ドキュメントも Spec の "Changed Files" に明示すること。
+
+### 繰り返し所見
+
+- 特になし。`skills/audit/SKILL.md` への参照漏れは今回固有の事例で、パターンとしての繰り返しではない。
+
+### 受け入れ基準検証の難しさ
+
+- `rubric` 条件 2 件はいずれも PASS で、verify command の精度に問題なし。AC2 の `file_not_contains` は明確で検証容易。UNCERTAIN なし。
+- Post-merge 条件 (2 つの `/auto --batch` 同時起動での観察) は手動検証が必要で自動化が難しいが、現状の verify command 種別 (`manual`) が適切に設定されている。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- SHOULD 所見 (`skills/audit/SKILL.md:991` の古い参照) をレビュー内で即時修正し、PR ブランチにコミット (`a21bc78`)
+- CONSIDER 所見 (負の isolation テスト, `.tmp` ファイル蓄積) はスキップ — マージブロッカーではない
+- CI 失敗 (tests 11-15) は main ブランチでも同様に失敗する既存不具合と確認。本 PR のブロッカーではない
+
+### Deferred Items
+- `tests/auto-sub-observability.bats` に wrong-PGID decoy テストの追加 (CONSIDER)
+- `.tmp/auto-session-${PGID}` ファイルの session 終了時クリーンアップ (CONSIDER)
+- `append-loop-state-heartbeat.bats` tests 11-15 の既存不具合修正 (別 Issue で対応)
+
+### Notes for Next Phase
+- MUST 所見なし。受け入れ基準 3/3 PASS。マージ可能な状態
+- CI 失敗は既存不具合 (main でも同様)。マージには影響しない
+- Post-merge: 2 つの `/auto --batch` を同時起動し、各 session の `/audit auto-session --full` report にクロスセッション混入がないことを手動確認すること

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -40,7 +40,8 @@ SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 LOG_PREFIX="[#${SUB_NUMBER}]"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
-AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat .tmp/auto-session-current 2>/dev/null || echo '')}"
+PGID=$(ps -o pgid= -p $$ | tr -d ' ')
+AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat ".tmp/auto-session-${PGID}" 2>/dev/null || echo '')}"
 export AUTO_SESSION_ID
 export EMIT_ISSUE_NUMBER="$SUB_NUMBER"
 

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -47,7 +47,8 @@ fi
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
-AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat .tmp/auto-session-current 2>/dev/null || echo '')}"
+PGID=$(ps -o pgid= -p $$ | tr -d ' ')
+AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat ".tmp/auto-session-${PGID}" 2>/dev/null || echo '')}"
 export AUTO_SESSION_ID
 source "$SCRIPT_DIR/emit-event.sh"
 

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -14,7 +14,8 @@ fi
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
-AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat .tmp/auto-session-current 2>/dev/null || echo '')}"
+PGID=$(ps -o pgid= -p $$ | tr -d ' ')
+AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat ".tmp/auto-session-${PGID}" 2>/dev/null || echo '')}"
 export AUTO_SESSION_ID
 source "$SCRIPT_DIR/emit-event.sh"
 

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -16,7 +16,8 @@ fi
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
-AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat .tmp/auto-session-current 2>/dev/null || echo '')}"
+PGID=$(ps -o pgid= -p $$ | tr -d ' ')
+AUTO_SESSION_ID="${AUTO_SESSION_ID:-$(cat ".tmp/auto-session-${PGID}" 2>/dev/null || echo '')}"
 export AUTO_SESSION_ID
 source "$SCRIPT_DIR/emit-event.sh"
 

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -988,7 +988,7 @@ This subcommand covers the post-session time scale of the `/audit` 3-axis model:
 
 `/auto` generates a `SESSION_ID` at startup using the format `PID-timestamp` (e.g., `12345-1718336400`). This identifier is recorded in:
 
-- `.tmp/auto-session-current` — pointer file read by `run-auto-sub.sh` to populate `session_id` in each emitted event
+- `.tmp/auto-session-${PGID}` — PGID-specific pointer file written by `/auto` and read by `run-auto-sub.sh`, `run-code.sh`, `run-review.sh`, `run-merge.sh` to populate `session_id` in each emitted event. Using the process group ID isolates parallel `/auto` sessions from overwriting each other's pointer
 - `.tmp/auto-session-${SESSION_ID}.json` — metadata file recording session start time
 
 Each event in `.tmp/auto-events.jsonl` includes a `session_id` field set to this value. The `auto-session` subcommand filters events by `session_id` to isolate exactly one session's activity, even when multiple sessions' events are mixed in the same log file.

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -31,13 +31,16 @@ Extract the Issue number from ARGUMENTS. Examples: `ARGUMENTS = "279"` → `NUMB
 
 **AUTO_SESSION_ID generation (run before all route detection):**
 
-Generate a session identifier and record it in a pointer file so sub-processes spawned by `run-auto-sub.sh` can read it:
+Generate a session identifier and record it in a PGID-specific pointer file so sub-processes spawned by `run-auto-sub.sh` can read it:
 
-1. Generate `SESSION_ID` and create the pointer file:
+**Session boundary isolation design**: Each `/auto` session uses its process group ID (PGID) as part of the pointer file name (`.tmp/auto-session-${PGID}`). This prevents parallel `/auto` sessions from overwriting each other's pointer file — each session's sub-processes (run-auto-sub.sh, run-code.sh, run-review.sh, run-merge.sh) share the same PGID as their parent, so they naturally read the correct session_id without cross-session contamination.
+
+1. Generate `SESSION_ID` and create the PGID-specific pointer file:
    ```bash
    mkdir -p .tmp
    SESSION_ID="$$-$(date +%s)"
-   printf '%s\n' "$SESSION_ID" > .tmp/auto-session-current
+   PGID=$(ps -o pgid= -p $$ | tr -d ' ')
+   printf '%s\n' "$SESSION_ID" > ".tmp/auto-session-${PGID}"
    ```
 2. Write `.tmp/auto-session-${SESSION_ID}.json` using the Write tool with session metadata:
    ```json

--- a/tests/auto-sub-observability.bats
+++ b/tests/auto-sub-observability.bats
@@ -133,3 +133,30 @@ MOCK
     [ "$status" -eq 0 ]
     grep -q '"backfilled":true' "$AUTO_EVENTS_LOG"
 }
+
+@test "session-isolation: PGID-specific pointer file is read when AUTO_SESSION_ID is unset" {
+    # Obtain the PGID of the current shell (same as run-auto-sub.sh will see)
+    local pgid
+    pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+
+    # Write a test session_id into the PGID-specific pointer file
+    mkdir -p "$BATS_TEST_TMPDIR/.tmp"
+    printf 'test-session-pgid\n' > "$BATS_TEST_TMPDIR/.tmp/auto-session-${pgid}"
+
+    # Override emit-event.sh to capture the session_id value
+    cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
+emit_event() {
+    local event_name="$1"
+    mkdir -p "$(dirname "${AUTO_EVENTS_LOG}")"
+    printf '{"ts":"%s","issue":%s,"event":"%s","session_id":"%s"}\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${EMIT_ISSUE_NUMBER:-0}" "${event_name}" \
+        "${AUTO_SESSION_ID:-}" >> "${AUTO_EVENTS_LOG}"
+}
+MOCK
+
+    # Unset AUTO_SESSION_ID so run-auto-sub.sh reads from the pointer file
+    unset AUTO_SESSION_ID
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q '"session_id":"test-session-pgid"' "$AUTO_EVENTS_LOG"
+}


### PR DESCRIPTION
closes #770