### PR TITLE
Issue #791: parent /auto 単一 Issue path での bash 駆動 side effect 発火

### DIFF
--- a/docs/spec/issue-791-auto-single-issue-side-effects.md
+++ b/docs/spec/issue-791-auto-single-issue-side-effects.md
@@ -98,3 +98,26 @@
 - **heartbeat issue 番号**: `run-review.sh`/`run-merge.sh` は PR 番号しか持たないため `--issue $PR_NUMBER` で heartbeat を記録する。これは batch mode (run-auto-sub.sh) の既存挙動と一致する
 - **`docs/structure.md` の emit-event.sh 説明**: `_emit_comments_consumed()` 追加後は "providing `emit_event()` for structured JSONL event emission" の説明が不完全になるが、doc-checker の impact criteria では script 機能説明変更は SHOULD レベル (軽微) のため本 PR では更新を見送る
 - **verify command AC3 更新**: Issue body AC3 の `bats tests/run-auto-sub.bats tests/auto.bats` を新規テストファイル含む形 `bats tests/run-auto-sub.bats tests/auto.bats tests/run-code.bats tests/run-review.bats tests/run-merge.bats` に更新する
+
+## Code Retrospective
+
+**実施日**: 2026-06-28
+**PR**: #809
+**結果**: 実装完了・テスト全通過 (119/119)
+
+### 正常に機能したもの
+
+- `_emit_comments_consumed` の emit-event.sh 抽出は最小変更で DRY を実現。既存 `source "$SCRIPT_DIR/emit-event.sh"` 行があるすべての `run-*.sh` が自動的に取得できる設計で、テスト mock の追加 (`_emit_comments_consumed() { :; }`) パターンも明快だった
+- call-order 検証 (コメント消費イベントが claude 呼び出し前に発火) を bats で記録ファイル比較によって実装。LLM 遵守度に依存しない bash 保証の検証として有効
+- `run_phase_with_recovery()` からの抽出で既存 batch テストへの影響がない (mock 追加のみで挙動変わらず)
+
+### 改善余地
+
+- `run-review.sh`/`run-merge.sh` は issue 番号ではなく PR 番号を `--issue` に渡す。batch mode での既存挙動に合わせたが、heartbeat の意味的一貫性のためには将来的に PR→issue 番号変換が望ましいかもしれない
+- `_emit_comments_consumed` は `run-code.sh` のみで呼ばれる (code phase でコメントを消費するため)。関数は emit-event.sh に置いたが、review/merge では呼ばれない点は comment しておくと次の人が迷わない
+
+### フェーズ引継ぎ
+
+- 実装変更ファイル: `scripts/emit-event.sh`, `scripts/run-auto-sub.sh`, `scripts/run-code.sh`, `scripts/run-review.sh`, `scripts/run-merge.sh`
+- テスト変更ファイル: `tests/run-auto-sub.bats`, `tests/auto-sub-observability.bats`, `tests/run-code.bats`, `tests/run-review.bats`, `tests/run-merge.bats`
+- PR #809 (branch: `worktree-code+issue-791`) → review フェーズへ

--- a/docs/spec/issue-791-auto-single-issue-side-effects.md
+++ b/docs/spec/issue-791-auto-single-issue-side-effects.md
@@ -121,3 +121,44 @@
 - 実装変更ファイル: `scripts/emit-event.sh`, `scripts/run-auto-sub.sh`, `scripts/run-code.sh`, `scripts/run-review.sh`, `scripts/run-merge.sh`
 - テスト変更ファイル: `tests/run-auto-sub.bats`, `tests/auto-sub-observability.bats`, `tests/run-code.bats`, `tests/run-review.bats`, `tests/run-merge.bats`
 - PR #809 (branch: `worktree-code+issue-791`) → review フェーズへ
+
+## review retrospective
+
+**実施日**: 2026-06-28
+**PR**: #809
+**モード**: light (--light)
+
+### Spec vs. 実装差異パターン
+
+- 実装は Spec の設計計画と高い一致度。候補 A 採用・DRY 化・テスト追加の 3 点すべてが仕様通り実装されていた
+- DCO 失敗 (Signed-off-by 欠如) が唯一の MUST 指摘。Spec に記載なし。review フェーズで `git rebase --signoff` + force-push により解決
+
+### 繰り返しパターン (同種指摘)
+
+- DCO/sign-off 欠如は本 PR の 2 コミット両方に発生。code フェーズのコミット時に `-s` フラグが漏れると DCO CI が常に失敗するパターン。`run-*.sh` を通じた自動コミット (Claude Agent) では `-s` が付与されないケースがある
+
+### 受け入れ条件検証難易度
+
+- `rubric` 3 件はすべて PASS 判定が明快。Spec の "Alternatives Considered" テーブルが ac2 rubric の正確な判定を可能にした (Spec にトレードオフが構造化されている利点)
+- `command "bats ..."` は CI reference fallback で PASS 確認。安定していた
+- UNCERTAIN は 0 件。verify command の設計が適切だった
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+
+- DCO 失敗を review フェーズで修正 (git rebase --signoff + force-push)。merge フェーズでは DCO は既に通過済みになっている想定
+- SHOULD 指摘 (docs/structure.md) は Spec に defer 理由が記録されているためスキップ。merge フェーズでのアクション不要
+- 全 AC (Pre-merge 4 件) PASS、チェックボックス更新済み
+
+### Deferred Items
+
+- docs/structure.md の emit-event.sh 説明更新は SHOULD レベルとして defer (Spec 記録済み)。merge 後の follow-up Issue として残す候補
+- post-merge observation AC (auto-events.jsonl / loop-state heartbeat) は merge 後に観察が必要
+
+### Notes for Next Phase
+
+- CI は DCO 含め全ジョブ SUCCESS になる見込み (force-push 後に再実行される)
+- MUST 指摘はすべて解決済み。merge の前提条件を満たしている
+- `docs/structure.md` の SHOULD 更新は merge フェーズでは不要 (スキップ可)

--- a/scripts/emit-event.sh
+++ b/scripts/emit-event.sh
@@ -84,3 +84,44 @@ emit_event() {
     rmdir "${lock_dir}" 2>/dev/null || true
   fi
 }
+
+# Bash-side comments_consumed event emitter. Issue #705 — replaces the LLM
+# Step 6 in l0-surfaces.md Comment Consumption Procedure, which was not firing
+# reliably because the LLM skips the emit step. Extracted from run-auto-sub.sh
+# (Issue #791) so run-code.sh and other run-*.sh wrappers can call it on the
+# parent /auto single Issue path without going through run-auto-sub.sh.
+# Guard: exits early when AUTO_EVENTS_LOG or AUTO_SESSION_ID is unset.
+_emit_comments_consumed() {
+  local issue="$1"
+  local phase="$2"
+  [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
+  [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
+
+  local cutoff=""
+  cutoff=$(gh api "repos/{owner}/{repo}/issues/${issue}/timeline" --paginate \
+    --jq '[.[] | select(.event=="labeled" and (.label.name|startswith("phase/"))) | .created_at] | last // empty' \
+    2>/dev/null || true)
+
+  local comments_json="[]"
+  comments_json=$(gh issue view "$issue" --json comments --jq '.comments' 2>/dev/null || echo "[]")
+  if [[ -n "$cutoff" ]]; then
+    comments_json=$(echo "$comments_json" \
+      | jq --arg c "$cutoff" '[.[] | select(.createdAt > $c)]' 2>/dev/null || echo "[]")
+  fi
+
+  local count=0 owner_n=0 member_n=0 collab_n=0 contrib_n=0 none_n=0 authors=""
+  count=$(echo "$comments_json" | jq 'length' 2>/dev/null || echo 0)
+  owner_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="OWNER")] | length' 2>/dev/null || echo 0)
+  member_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="MEMBER")] | length' 2>/dev/null || echo 0)
+  collab_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="COLLABORATOR")] | length' 2>/dev/null || echo 0)
+  contrib_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="CONTRIBUTOR")] | length' 2>/dev/null || echo 0)
+  none_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="NONE")] | length' 2>/dev/null || echo 0)
+  authors=$(echo "$comments_json" | jq -r '[.[] | .author.login] | unique | join(",")' 2>/dev/null || true)
+
+  EMIT_ISSUE_NUMBER="$issue" emit_event "comments_consumed" \
+    "phase=${phase}" \
+    "count=${count}" \
+    "authors=${authors:-}" \
+    "trust_breakdown=OWNER:${owner_n},MEMBER:${member_n},COLLABORATOR:${collab_n},CONTRIBUTOR:${contrib_n},NONE:${none_n}" \
+    2>/dev/null || true
+}

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -89,47 +89,8 @@ _loop_state_to_phase() {
   esac
 }
 
-# Bash-side comments_consumed event emitter. Issue #705 — replaces the LLM
-# Step 6 in l0-surfaces.md Comment Consumption Procedure, which was not firing
-# reliably in batch mode because the LLM skips the emit step.
-# Called before each phase runner script so the event is captured even when
-# the LLM omits the bash emit.
-_emit_comments_consumed() {
-  local issue="$1"
-  local phase="$2"
-  [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
-  [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
-
-  # Fetch cutoff: timestamp of the last phase/* label assignment
-  local cutoff=""
-  cutoff=$(gh api "repos/{owner}/{repo}/issues/${issue}/timeline" --paginate \
-    --jq '[.[] | select(.event=="labeled" and (.label.name|startswith("phase/"))) | .created_at] | last // empty' \
-    2>/dev/null || true)
-
-  # Fetch all comments as JSON array, then filter since cutoff
-  local comments_json="[]"
-  comments_json=$(gh issue view "$issue" --json comments --jq '.comments' 2>/dev/null || echo "[]")
-  if [[ -n "$cutoff" ]]; then
-    comments_json=$(echo "$comments_json" \
-      | jq --arg c "$cutoff" '[.[] | select(.createdAt > $c)]' 2>/dev/null || echo "[]")
-  fi
-
-  local count=0 owner_n=0 member_n=0 collab_n=0 contrib_n=0 none_n=0 authors=""
-  count=$(echo "$comments_json" | jq 'length' 2>/dev/null || echo 0)
-  owner_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="OWNER")] | length' 2>/dev/null || echo 0)
-  member_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="MEMBER")] | length' 2>/dev/null || echo 0)
-  collab_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="COLLABORATOR")] | length' 2>/dev/null || echo 0)
-  contrib_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="CONTRIBUTOR")] | length' 2>/dev/null || echo 0)
-  none_n=$(echo "$comments_json" | jq '[.[] | select(.authorAssociation=="NONE")] | length' 2>/dev/null || echo 0)
-  authors=$(echo "$comments_json" | jq -r '[.[] | .author.login] | unique | join(",")' 2>/dev/null || true)
-
-  EMIT_ISSUE_NUMBER="$issue" emit_event "comments_consumed" \
-    "phase=${phase}" \
-    "count=${count}" \
-    "authors=${authors:-}" \
-    "trust_breakdown=OWNER:${owner_n},MEMBER:${member_n},COLLABORATOR:${collab_n},CONTRIBUTOR:${contrib_n},NONE:${none_n}" \
-    2>/dev/null || true
-}
+# _emit_comments_consumed() is now defined in emit-event.sh (Issue #791).
+# Sourced via: source "$SCRIPT_DIR/emit-event.sh" above.
 
 # Best-effort heartbeat append. Never blocks the caller. Issue #701 — replaces
 # the LLM-driven inline procedure in skills/auto/SKILL.md that was not firing

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -190,6 +190,8 @@ fi
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR" "code"
 
+_emit_comments_consumed "$ISSUE_NUMBER" "code" || true
+
 SECONDS=0
 set +e
 if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
@@ -249,6 +251,10 @@ if [[ "$ROUTE_FLAG" == "--pr" && $EXIT_CODE -eq 0 ]]; then
       echo "Recommended: resolve conflicts before /merge. See modules/orchestration-fallbacks.md#code-base-conflict for the recovery procedure." >&2
     fi
   fi
+fi
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  "$SCRIPT_DIR/append-loop-state-heartbeat.sh" --issue "$ISSUE_NUMBER" --from spec --to code >/dev/null 2>&1 || true
 fi
 
 if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -190,6 +190,10 @@ if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
   fi
 fi
 
+if [[ $EXIT_CODE -eq 0 ]]; then
+  "$SCRIPT_DIR/append-loop-state-heartbeat.sh" --issue "$PR_NUMBER" --from review --to merge >/dev/null 2>&1 || true
+fi
+
 if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then
   emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -156,6 +156,10 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
   fi
 fi
 
+if [[ $EXIT_CODE -eq 0 ]]; then
+  "$SCRIPT_DIR/append-loop-state-heartbeat.sh" --issue "$PR_NUMBER" --from code --to review >/dev/null 2>&1 || true
+fi
+
 if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then
   emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
 fi

--- a/tests/auto-sub-observability.bats
+++ b/tests/auto-sub-observability.bats
@@ -30,6 +30,7 @@ emit_event() {
     mkdir -p "$(dirname "${AUTO_EVENTS_LOG}")"
     printf '{"ts":"%s","issue":%s,"event":"%s"}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${EMIT_ISSUE_NUMBER:-0}" "${event_name}" >> "${AUTO_EVENTS_LOG}"
 }
+_emit_comments_consumed() { :; }
 MOCK
 
     # Mock phase-banner.sh (sourced by run-auto-sub.sh)
@@ -127,6 +128,7 @@ emit_event() {
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${EMIT_ISSUE_NUMBER:-0}" "${event_name}" \
         "${AUTO_SESSION_ID:-}" "${EMIT_PHASE_NAME:-}" >> "${AUTO_EVENTS_LOG}"
 }
+_emit_comments_consumed() { :; }
 MOCK
     export AUTO_SESSION_ID="test-session-backfill"
     run bash "$SCRIPT" 42
@@ -152,6 +154,7 @@ emit_event() {
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${EMIT_ISSUE_NUMBER:-0}" "${event_name}" \
         "${AUTO_SESSION_ID:-}" >> "${AUTO_EVENTS_LOG}"
 }
+_emit_comments_consumed() { :; }
 MOCK
 
     # Unset AUTO_SESSION_ID so run-auto-sub.sh reads from the pointer file

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -33,6 +33,7 @@ MOCK
     # Mock emit-event.sh (sourced by run-auto-sub.sh via emit-event.sh)
     cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
 emit_event() { :; }
+_emit_comments_consumed() { :; }
 MOCK
 
     # Mock phase-banner.sh (sourced by run-auto-sub.sh)
@@ -567,6 +568,7 @@ MOCK
 emit_event() {
   echo "emit_event \$*" >> "$BATS_TEST_TMPDIR/emit.log"
 }
+_emit_comments_consumed() { :; }
 MOCK
 
     # Make run-code.sh write a token usage JSON file
@@ -609,6 +611,7 @@ MOCK
 emit_event() {
   echo "emit_event \$*" >> "$BATS_TEST_TMPDIR/emit.log"
 }
+_emit_comments_consumed() { :; }
 MOCK
 
     # run-code.sh echoes bats output to stdout; run-auto-sub.sh captures it
@@ -647,6 +650,7 @@ MOCK
 emit_event() {
   echo "emit_event \$*" >> "$BATS_TEST_TMPDIR/emit.log"
 }
+_emit_comments_consumed() { :; }
 MOCK
 
     cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -86,6 +86,7 @@ MOCK
 
     cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
 emit_event() { return 0; }
+_emit_comments_consumed() { :; }
 MOCK
 
     # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
@@ -459,8 +460,52 @@ MOCK
     EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
     cat > "$MOCK_DIR/emit-event.sh" <<MOCK
 emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+_emit_comments_consumed() { :; }
 MOCK
     run bash "$SCRIPT" 123 --pr
     [ "$status" -eq 0 ]
     grep -q "phase_complete" "$EMIT_LOG"
+}
+
+@test "side-effect: _emit_comments_consumed called before claude invocation" {
+    CALL_ORDER_LOG="$BATS_TEST_TMPDIR/call-order.log"
+    export CALL_ORDER_LOG
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { :; }
+_emit_comments_consumed() { echo "comments_consumed_called" >> "${CALL_ORDER_LOG}"; }
+MOCK
+
+    cat > "$MOCK_DIR/claude" <<MOCK
+#!/bin/bash
+echo "claude_called" >> "${CALL_ORDER_LOG}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+
+    run bash "$SCRIPT" 123 --pr
+    [ "$status" -eq 0 ]
+    grep -q "comments_consumed_called" "$CALL_ORDER_LOG"
+    local cc_line claude_line
+    cc_line=$(grep -n "comments_consumed_called" "$CALL_ORDER_LOG" | head -1 | cut -d: -f1)
+    claude_line=$(grep -n "claude_called" "$CALL_ORDER_LOG" | head -1 | cut -d: -f1)
+    [ "${cc_line:-0}" -lt "${claude_line:-999}" ]
+}
+
+@test "side-effect: append-loop-state-heartbeat.sh called on code phase success" {
+    HEARTBEAT_LOG="$BATS_TEST_TMPDIR/heartbeat.log"
+    export HEARTBEAT_LOG
+
+    cat > "$MOCK_DIR/append-loop-state-heartbeat.sh" <<MOCK
+#!/bin/bash
+echo "heartbeat_called \$@" >> "${HEARTBEAT_LOG}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/append-loop-state-heartbeat.sh"
+
+    run bash "$SCRIPT" 123 --pr
+    [ "$status" -eq 0 ]
+    grep -q "heartbeat_called" "$HEARTBEAT_LOG"
+    grep -q -- "--from spec" "$HEARTBEAT_LOG"
+    grep -q -- "--to code" "$HEARTBEAT_LOG"
 }

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -90,6 +90,7 @@ MOCK
 
     cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
 emit_event() { return 0; }
+_emit_comments_consumed() { :; }
 MOCK
 
     # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
@@ -543,10 +544,29 @@ MOCK
     EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
     cat > "$MOCK_DIR/emit-event.sh" <<MOCK
 emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+_emit_comments_consumed() { :; }
 MOCK
     run bash "$SCRIPT" 88
     [ "$status" -eq 0 ]
     grep -q "phase_complete" "$EMIT_LOG"
+}
+
+@test "side-effect: append-loop-state-heartbeat.sh called on merge phase success" {
+    HEARTBEAT_LOG="$BATS_TEST_TMPDIR/heartbeat.log"
+    export HEARTBEAT_LOG
+
+    cat > "$MOCK_DIR/append-loop-state-heartbeat.sh" <<MOCK
+#!/bin/bash
+echo "heartbeat_called \$@" >> "${HEARTBEAT_LOG}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/append-loop-state-heartbeat.sh"
+
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "heartbeat_called" "$HEARTBEAT_LOG"
+    grep -q -- "--from review" "$HEARTBEAT_LOG"
+    grep -q -- "--to merge" "$HEARTBEAT_LOG"
 }
 
 @test "baseline-gate: pre-merge-check.sh exit 2 aborts merge with exit 1" {

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -86,6 +86,7 @@ MOCK
 
     cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
 emit_event() { return 0; }
+_emit_comments_consumed() { :; }
 MOCK
 
     # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
@@ -364,8 +365,27 @@ MOCK
     EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
     cat > "$MOCK_DIR/emit-event.sh" <<MOCK
 emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+_emit_comments_consumed() { :; }
 MOCK
     run bash "$SCRIPT" 88
     [ "$status" -eq 0 ]
     grep -q "phase_complete" "$EMIT_LOG"
+}
+
+@test "side-effect: append-loop-state-heartbeat.sh called on review phase success" {
+    HEARTBEAT_LOG="$BATS_TEST_TMPDIR/heartbeat.log"
+    export HEARTBEAT_LOG
+
+    cat > "$MOCK_DIR/append-loop-state-heartbeat.sh" <<MOCK
+#!/bin/bash
+echo "heartbeat_called \$@" >> "${HEARTBEAT_LOG}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/append-loop-state-heartbeat.sh"
+
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    grep -q "heartbeat_called" "$HEARTBEAT_LOG"
+    grep -q -- "--from code" "$HEARTBEAT_LOG"
+    grep -q -- "--to review" "$HEARTBEAT_LOG"
 }


### PR DESCRIPTION
Closes #791

## 概要

- `run-auto-sub.sh` のローカル定義だった `_emit_comments_consumed()` を `scripts/emit-event.sh` に抽出 (DRY)
- `run-code.sh` で claude 呼び出し前に `_emit_comments_consumed` を発火
- `run-code.sh` / `run-review.sh` / `run-merge.sh` の成功パスに `append-loop-state-heartbeat.sh` 呼び出しを追加

## 背景

batch/XL path は `run-auto-sub.sh` の `run_phase_with_recovery()` 経由で side effect を発火していた。
しかし M/L pr route (parent /auto 単一 Issue path) は `run-code.sh` 等を直接呼ぶため、
`comments_consumed` event と loop-state heartbeat が未発火だった。

## 検証

- [x] `bats tests/run-auto-sub.bats tests/auto.bats tests/run-code.bats tests/run-review.bats tests/run-merge.bats` → 119/119 green
- [x] `check-forbidden-expressions.sh` → クリーン
- [x] `validate-skill-syntax.py` → エラーなし (既存 warning のみ)