### PR TITLE
Issue #802: Extend backfill to SIGTERM (exit 143) in _maybe_emit_phase_complete

### DIFF
--- a/docs/spec/issue-802-event-emission-backfill-guard.md
+++ b/docs/spec/issue-802-event-emission-backfill-guard.md
@@ -76,7 +76,7 @@ The `### phase_complete (backfilled)` description was written to reflect intende
 - **Exit 143 = SIGTERM**: `_exit_code=143` corresponds to SIGTERM (128+15). Only SIGTERM is special-cased; other non-zero exits (e.g., 1 from claude failure, 127 from command-not-found) continue to skip backfill — they are tracked by `wrapper_exit` events instead.
 - **Test approach**: The bats test uses an inline helper script written to `$BATS_TEST_TMPDIR` rather than running the full `run-auto-sub.sh`, because triggering actual SIGTERM on a complex script in a bats test is timing-sensitive and flaky. The helper script directly exercises the updated `_maybe_emit_phase_complete()` logic.
 - **No `docs/structure.md` update needed**: `modules/event-emission.md` is already listed in Key Files; its description ("event emission contract SSoT") remains accurate.
-- **Count alignment warning**: Issue body has 2 pre-merge AC checkboxes; Spec has 3 verification lines (AC 2 carries 2 verify commands). This mismatch is expected — one AC item has two verify hints.
+- **Count alignment warning**: Issue body has 2 pre-merge AC checkboxes; Spec has 3 verification lines (AC 2 carries 2 verify commands). This mismatch is expected — one AC item has two verify commands.
 
 ## Consumed Comments
 

--- a/docs/spec/issue-802-event-emission-backfill-guard.md
+++ b/docs/spec/issue-802-event-emission-backfill-guard.md
@@ -96,19 +96,36 @@ No new comments since last phase.
 
 - N/A
 
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- The Spec's "Changed Files" list said "all 4 `run-*.sh`" but actually 6 scripts (`run-issue.sh`, `run-spec.sh`, `run-code.sh`, `run-auto-sub.sh`, `run-review.sh`, `run-merge.sh`) have `_maybe_emit_phase_complete()`. The code phase only updated 4; `run-review.sh` and `run-merge.sh` were missed. This was caught by the review phase and fixed (guard updated in both scripts). Root cause: the Spec Background and Changed Files sections counted wrappers inconsistently — the Wrapper Coverage Table in `event-emission.md` lists 6 wrappers, but the Spec text said "all 4."
+- Improvement: When listing affected files in a Spec, cross-check with the implementation source (e.g., `grep -l "_maybe_emit_phase_complete"`) rather than relying on a mental count. A `find`/`grep` step in the Spec's Changed Files enumeration would catch this earlier.
+
+### Recurring Issues
+
+- Nothing to note.
+
+### Acceptance Criteria Verification Difficulty
+
+- All 3 pre-merge conditions were verifiable at review time: 2 rubric checks (PASS) and 1 github_check (CI job conclusion). No UNCERTAIN results.
+- The `rubric` verify commands were effective for this PR — the semantic check confirmed doc-vs-code alignment without ambiguity.
+- The test for SIGTERM (exit 143) backfill uses an inline helper script that duplicates the guard logic rather than exercising the actual run scripts. This is an acknowledged tradeoff (avoids timing-sensitive SIGTERM in bats); the gap (no negative test for exit 1 → no backfill) was noted as CONSIDER.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Chose Option 2 (code extension): extended all 4 `run-*.sh` guards to allow exit 143 (SIGTERM) through to backfill logic, rather than Option 1 (doc fix only). Rationale: SIGTERM backfill improves post-merge AC observability in Tier 3 recovery.
-- bats test uses an inline helper script written to `$BATS_TEST_TMPDIR` (not running full `run-auto-sub.sh`) because SIGTERM on a complex script is timing-sensitive and flaky in bats context.
-- The Spec also had a deprecated term (旧称: verify hints) remaining in the Notes section, fixed to "verify commands" in a separate commit.
+- All pre-merge ACs verified PASS (rubric × 2, github_check CI × 1); all CI jobs SUCCESS.
+- SHOULD finding: `run-review.sh` and `run-merge.sh` had stale guard; fixed in this review phase by extending the guard to match the other 4 wrappers.
+- No MUST issues; review posted as COMMENT event (not REQUEST_CHANGES).
 
 ### Deferred Items
-- AC2 github_check ("Run bats tests" CI job) is UNCERTAIN at code time (CI not yet run). Will resolve after CI runs on PR #812.
-- Post-merge AC (observation event=watchdog-kill) deferred to natural occurrence of next Tier 3 recovery.
+- Post-merge AC (observation event=watchdog-kill) deferred to natural occurrence of next Tier 3 recovery — no action needed in merge phase.
+- CONSIDER finding (negative test for exit 1) not fixed — low priority.
 
 ### Notes for Next Phase
-- PR #812 created. Wait for CI to confirm bats tests pass before merging.
-- All 982 bats tests pass locally. The guard change is minimal (one `&& "$_exit_code" -ne 143` addition per script).
-- The `modules/event-emission.md` SSoT now correctly documents exit 0 or 143 backfill behavior — the `/review` phase should verify the rubric ACs confirm this alignment.
+- PR #812 is ready to merge. All ACs PASS, CI SUCCESS, SHOULD fix applied.
+- New commits on `worktree-code+issue-802`: guard update for `run-review.sh` and `run-merge.sh`.
+- Run `/merge 812` to proceed.

--- a/docs/spec/issue-802-event-emission-backfill-guard.md
+++ b/docs/spec/issue-802-event-emission-backfill-guard.md
@@ -81,3 +81,34 @@ The `### phase_complete (backfilled)` description was written to reflect intende
 ## Consumed Comments
 
 No new comments since last phase.
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A (implementation followed the Spec exactly)
+
+### Design Gaps/Ambiguities
+
+- The Spec's bats test description used HEREDOC with escaped variables (`\$?`, `\$_exit_code`), but in the actual bats file, the HEREDOC delimiter needed `HELPER` (unquoted) to allow variable expansion for `$MOCK_DIR` and `$AUTO_EVENTS_LOG` references, while inner function variables required `\$` escaping — minor shell quoting subtlety not captured in the Spec description.
+
+### Rework
+
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Chose Option 2 (code extension): extended all 4 `run-*.sh` guards to allow exit 143 (SIGTERM) through to backfill logic, rather than Option 1 (doc fix only). Rationale: SIGTERM backfill improves post-merge AC observability in Tier 3 recovery.
+- bats test uses an inline helper script written to `$BATS_TEST_TMPDIR` (not running full `run-auto-sub.sh`) because SIGTERM on a complex script is timing-sensitive and flaky in bats context.
+- The Spec also had a deprecated term (旧称: verify hints) remaining in the Notes section, fixed to "verify commands" in a separate commit.
+
+### Deferred Items
+- AC2 github_check ("Run bats tests" CI job) is UNCERTAIN at code time (CI not yet run). Will resolve after CI runs on PR #812.
+- Post-merge AC (observation event=watchdog-kill) deferred to natural occurrence of next Tier 3 recovery.
+
+### Notes for Next Phase
+- PR #812 created. Wait for CI to confirm bats tests pass before merging.
+- All 982 bats tests pass locally. The guard change is minimal (one `&& "$_exit_code" -ne 143` addition per script).
+- The `modules/event-emission.md` SSoT now correctly documents exit 0 or 143 backfill behavior — the `/review` phase should verify the rubric ACs confirm this alignment.

--- a/modules/event-emission.md
+++ b/modules/event-emission.md
@@ -44,7 +44,7 @@ Emitted after a phase completes successfully (`EXIT_CODE=0` and `_EMIT_PHASE_OWN
 ### phase_complete (backfilled)
 
 When the EXIT trap fires and the last event for the issue is `phase_start`, a backfill entry
-is written with `"backfilled": true`. This covers abnormal exits (SIGTERM / watchdog timeout).
+is written with `"backfilled": true`. This covers exit code 0 (clean exit) and exit code 143 (SIGTERM / watchdog timeout).
 
 ```json
 {
@@ -127,15 +127,14 @@ stays empty and `phase_start` / `phase_complete` are not emitted — preventing 
 `_maybe_emit_phase_complete()` is registered as an EXIT trap in each wrapper. On exit, it checks
 whether the last event for the current issue (in the session) was `phase_start`. If so, it writes
 a `phase_complete` entry with `"backfilled": true`. This covers cases where `phase_start` was
-emitted but `phase_complete` was not, on clean (exit code 0) exits only.
+emitted but `phase_complete` was not, on exit code 0 (clean exit) or exit code 143 (SIGTERM / watchdog timeout).
 
 Guard conditions (all must be set and non-empty for backfill to fire):
 - `AUTO_SESSION_ID`
 - `EMIT_ISSUE_NUMBER`
 - `EMIT_PHASE_NAME`
 - `AUTO_EVENTS_LOG`
-- Exit code must be 0 (backfill only on clean exit; non-zero exits — including SIGTERM (143) —
-  are not backfilled; they are tracked via `wrapper_exit` events emitted by `run-auto-sub.sh`)
+- Exit code must be 0 or 143 (SIGTERM): other non-zero exits are not backfilled (non-SIGTERM failures tracked by `wrapper_exit` events from `run-auto-sub.sh`)
 
 ## How to Reference
 

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -49,7 +49,7 @@ source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
   local _exit_code=$?
-  [[ "$_exit_code" -ne 0 ]] && return 0
+  [[ "$_exit_code" -ne 0 && "$_exit_code" -ne 143 ]] && return 0
   [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
   [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "${EMIT_ISSUE_NUMBER:-}" ]] && return 0

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -54,7 +54,7 @@ source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
   local _exit_code=$?
-  [[ "$_exit_code" -ne 0 ]] && return 0
+  [[ "$_exit_code" -ne 0 && "$_exit_code" -ne 143 ]] && return 0
   [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
   [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "${EMIT_ISSUE_NUMBER:-}" ]] && return 0

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -29,7 +29,7 @@ source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
   local _exit_code=$?
-  [[ "$_exit_code" -ne 0 ]] && return 0
+  [[ "$_exit_code" -ne 0 && "$_exit_code" -ne 143 ]] && return 0
   [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
   [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "${EMIT_ISSUE_NUMBER:-}" ]] && return 0

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -21,7 +21,7 @@ source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
   local _exit_code=$?
-  [[ "$_exit_code" -ne 0 ]] && return 0
+  [[ "$_exit_code" -ne 0 && "$_exit_code" -ne 143 ]] && return 0
   [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
   [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "${EMIT_ISSUE_NUMBER:-}" ]] && return 0

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -23,7 +23,7 @@ source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
   local _exit_code=$?
-  [[ "$_exit_code" -ne 0 ]] && return 0
+  [[ "$_exit_code" -ne 0 && "$_exit_code" -ne 143 ]] && return 0
   [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
   [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "${EMIT_ISSUE_NUMBER:-}" ]] && return 0

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -51,7 +51,7 @@ source "$SCRIPT_DIR/emit-event.sh"
 
 _maybe_emit_phase_complete() {
   local _exit_code=$?
-  [[ "$_exit_code" -ne 0 ]] && return 0
+  [[ "$_exit_code" -ne 0 && "$_exit_code" -ne 143 ]] && return 0
   [[ -z "${AUTO_EVENTS_LOG:-}" ]] && return 0
   [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "${EMIT_ISSUE_NUMBER:-}" ]] && return 0

--- a/tests/auto-sub-observability.bats
+++ b/tests/auto-sub-observability.bats
@@ -136,6 +136,43 @@ MOCK
     grep -q '"backfilled":true' "$AUTO_EVENTS_LOG"
 }
 
+@test "backfill-emit: SIGTERM (exit 143) with phase_start emits phase_complete with backfilled" {
+    export AUTO_SESSION_ID="test-session-sigterm"
+    export EMIT_ISSUE_NUMBER="42"
+    export EMIT_PHASE_NAME="code-pr"
+    mkdir -p "$(dirname "$AUTO_EVENTS_LOG")"
+    printf '{"ts":"2026-01-01T00:00:00Z","issue":42,"event":"phase_start","session_id":"test-session-sigterm","phase":"code-pr"}\n' \
+        >> "$AUTO_EVENTS_LOG"
+
+    cat > "$BATS_TEST_TMPDIR/sigterm-helper.sh" <<HELPER
+#!/usr/bin/env bash
+source "$MOCK_DIR/emit-event.sh"
+_maybe_emit_phase_complete() {
+  local _exit_code=\$?
+  [[ "\$_exit_code" -ne 0 && "\$_exit_code" -ne 143 ]] && return 0
+  [[ -z "\${AUTO_EVENTS_LOG:-}" ]] && return 0
+  [[ -z "\${AUTO_SESSION_ID:-}" ]] && return 0
+  [[ -z "\${EMIT_ISSUE_NUMBER:-}" ]] && return 0
+  [[ -z "\${EMIT_PHASE_NAME:-}" ]] && return 0
+  local _last_event
+  _last_event=\$(grep "\\"session_id\\":\\"\${AUTO_SESSION_ID}\\"" "\${AUTO_EVENTS_LOG}" 2>/dev/null \
+      | jq -rs --argjson n "\${EMIT_ISSUE_NUMBER}" \
+        '[.[] | select(.issue == \$n)] | last // empty | .event // ""' 2>/dev/null || true)
+  if [[ "\${_last_event}" == "phase_start" ]]; then
+    local _ts; _ts=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    printf '%s\n' \
+      "{\\"ts\\":\\"\${_ts}\\",\\"issue\\":\${EMIT_ISSUE_NUMBER},\\"event\\":\\"phase_complete\\",\\"session_id\\":\\"\${AUTO_SESSION_ID}\\",\\"phase\\":\\"\${EMIT_PHASE_NAME}\\",\\"backfilled\\":true}" \
+      >> "\${AUTO_EVENTS_LOG}" 2>/dev/null || true
+  fi
+}
+trap '_maybe_emit_phase_complete' EXIT
+exit 143
+HELPER
+    run bash "$BATS_TEST_TMPDIR/sigterm-helper.sh"
+    [ "$status" -eq 143 ]
+    grep -q '"backfilled":true' "$AUTO_EVENTS_LOG"
+}
+
 @test "session-isolation: PGID-specific pointer file is read when AUTO_SESSION_ID is unset" {
     # Obtain the PGID of the current shell (same as run-auto-sub.sh will see)
     local pgid


### PR DESCRIPTION
## Summary

- `_maybe_emit_phase_complete()` の exit_code guard を `[[ "$_exit_code" -ne 0 && "$_exit_code" -ne 143 ]] && return 0` に変更し、SIGTERM (exit 143) 経路でも backfill event が emit されるよう拡張 (all 4 `run-*.sh`)
- `modules/event-emission.md` の `### phase_complete (backfilled)` セクションと `## Backfill` セクションの記述を実動作 (exit 0 or exit 143) に合わせて修正
- `tests/auto-sub-observability.bats` に SIGTERM (exit 143) backfill テスト追加

## Verification (pre-merge)

- `modules/event-emission.md` Backfill セクション記述と `_maybe_emit_phase_complete()` 動作が一致 (exit 0 or 143 で明記)
- bats test `backfill-emit: SIGTERM (exit 143) with phase_start emits phase_complete with backfilled` が新規追加・PASS
- 全 982 bats テスト PASS (ローカル確認済)
- CI bats tests pass (PR 作成後に確認)

## Verification (post-merge)

- 次回 Tier 3 recovery 発生時に data-layer report が SIGTERM 経路の `phase_complete (backfilled)` を反映していることを観察

closes #802