### PR TITLE
auto: ## Consumed Comments セクション書き込みを bash post-processor で保証 (#811)

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（58 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（59 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -169,6 +169,7 @@ wholework/
 **Phase banner:**
 - `scripts/phase-banner.sh` — run-*.sh スクリプトで `print_start_banner` / `print_end_banner` 関数を提供する source 可能なヘルパー
 - `scripts/emit-event.sh` — `.tmp/auto-events.jsonl` への構造化 JSONL イベント emission を提供する source 可能なヘルパー; run-*.sh、claude-watchdog.sh、wait-ci-checks.sh が使用
+- `scripts/append-consumed-comments-section.sh` — post-processor フォールバック: LLM が Step 5 を silent skip した際に Spec へ `## Consumed Comments` を追記; run-spec.sh / run-code.sh (pre/post カウント比較) と verify SKILL.md (明示 bash call) が使用
 
 **GitHub API ユーティリティ:**
 - `scripts/gh-graphql.sh` — キャッシュ付き GraphQL クエリ実行

--- a/docs/spec/issue-811-consumed-comments-bash-fallback.md
+++ b/docs/spec/issue-811-consumed-comments-bash-fallback.md
@@ -118,3 +118,24 @@
 - `rubric` 条件 2 件とも PASS が AI 判定で確認できた (安定)
 - `command "bats ..."` は CI リファレンスフォールバックで PASS (local 実行不要)
 - UNCERTAIN 発生なし、verify command 品質は良好
+
+## Code Retrospective
+
+### 実装サマリ
+
+Candidate B (post-processor fallback) を採用した。`scripts/append-consumed-comments-section.sh` を新規作成し、`run-spec.sh` / `run-code.sh` に pre/post カウント比較ロジックを追加。`skills/verify/SKILL.md` には明示 bash call を追加して 3 フェーズ全てを網羅した。
+
+### 発見した技術的問題
+
+**`grep -c ... || echo 0` パターンのバグ**: `grep -c` はマッチなし時に `0` を stdout に出力して exit 1 する。`|| echo 0` を続けると command substitution が両方の出力を捕捉して `"0\n0"` を返し、`[[ "$count" -le 0 ]]` の整数比較が破綻してフォールバックが発火しない。修正: `|| true` に変更し `${COUNT:-0}` でデフォルト設定する形に統一。
+
+**git モックの引数位置ミス** (tests/run-verify.bats): `git -C /repo/path diff --quiet` の呼び出しで `$2` はパス、`$3` が `"diff"` になる。当初モックは `$2 == "diff"` を確認していたため diff 検出が機能せず test 68 が失敗。`$3 == "diff"` に修正。
+
+### テスト結果
+
+- 68 テスト全グリーン (run-code.bats, run-spec.bats, run-verify.bats)
+- 追加テスト: fallback 呼ばれる (2) + fallback 呼ばれない (2) + verify 動作 (6) = 計 10 新規テスト
+
+### PR
+
+https://github.com/saitoco/wholework/pull/813

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (58 files)
+├── scripts/             # Utility scripts used by skills and agents (59 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -176,6 +176,7 @@ Key modules:
 **Phase banner:**
 - `scripts/phase-banner.sh` — sourceable helper providing `print_start_banner` / `print_end_banner` functions for run-*.sh scripts
 - `scripts/emit-event.sh` — sourceable helper providing `emit_event()` for structured JSONL event emission to `.tmp/auto-events.jsonl`; used by run-*.sh, claude-watchdog.sh, and wait-ci-checks.sh
+- `scripts/append-consumed-comments-section.sh` — post-processor fallback: appends `## Consumed Comments` to Spec when LLM silently skips Step 5; used by run-spec.sh / run-code.sh (pre/post count comparison) and verify SKILL.md (explicit bash call)
 
 **GitHub API utilities:**
 - `scripts/gh-graphql.sh` — GraphQL query executor with caching

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -149,6 +149,15 @@ consumed comment:
 
 If no comments were consumed: write "No new comments since last phase."
 
+**Bash wrapper fallback (Issue #811):** This step is LLM-driven and may be silently skipped
+under context pressure or on fix-cycle paths. Two safety nets ensure the section is written:
+- `/spec` and `/code` phases (bash-wrapped via `run-spec.sh` / `run-code.sh`): a pre/post
+  `## Consumed Comments` count comparison triggers `append-consumed-comments-section.sh` as a
+  post-processor when the LLM did not write the section.
+- `/verify` phase (in-session): `SKILL.md` contains an explicit `bash` call to
+  `append-consumed-comments-section.sh` after the LLM's comment consumption step, ensuring
+  deterministic writeback regardless of prose execution.
+
 **Step 6 — Emit event (handled by bash wrapper in auto mode; LLM skip):**
 
 In `/auto` mode (invoked via `scripts/run-auto-sub.sh`), the bash wrapper calls

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# append-consumed-comments-section.sh - Fallback: append ## Consumed Comments to Spec
+# when the LLM phase did not write it (post-processor pattern, Candidate B).
+#
+# Usage: append-consumed-comments-section.sh <ISSUE_NUMBER> <PHASE_NAME>
+#
+# Best-effort: always exits 0. Failures are logged to stderr without blocking the caller.
+# Bash 3.2+ compatible.
+
+set -uo pipefail
+
+ISSUE_NUMBER="${1:-}"
+PHASE_NAME="${2:-}"
+
+if [[ -z "$ISSUE_NUMBER" || -z "$PHASE_NAME" ]]; then
+  echo "append-consumed-comments-section.sh: WARNING — skip (missing ISSUE_NUMBER or PHASE_NAME)" >&2
+  exit 0
+fi
+
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+_repo_root="$(dirname "$SCRIPT_DIR")"
+
+# Get spec directory (pass config path explicitly to avoid CWD sensitivity)
+SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="$_repo_root/.wholework.yml" \
+  "$SCRIPT_DIR/get-config-value.sh" spec-path docs/spec 2>/dev/null || echo "docs/spec")
+SPEC_DIR_ABS="$_repo_root/$SPEC_DIR"
+
+# Find spec file
+SPEC_FILE=$(ls "$SPEC_DIR_ABS/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+
+if [[ -z "$SPEC_FILE" ]]; then
+  TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title' 2>/dev/null \
+    || echo "Issue #${ISSUE_NUMBER}")
+  mkdir -p "$SPEC_DIR_ABS" 2>/dev/null || true
+  SPEC_FILE="$SPEC_DIR_ABS/issue-${ISSUE_NUMBER}-${PHASE_NAME}.md"
+  printf '%s\n' "# Issue #${ISSUE_NUMBER}: ${TITLE}" > "$SPEC_FILE" 2>/dev/null || {
+    echo "append-consumed-comments-section.sh: WARNING — skip (cannot create spec file)" >&2
+    exit 0
+  }
+fi
+
+# Check if section already exists; skip if present (deduplicate guard)
+if grep -q "^## Consumed Comments" "$SPEC_FILE" 2>/dev/null; then
+  exit 0
+fi
+
+# Get cutoff timestamp from GitHub Issue timeline (most recent phase/* label assignment)
+CUTOFF=$(gh api "repos/{owner}/{repo}/issues/${ISSUE_NUMBER}/timeline" --paginate \
+  --jq '[.[] | select(.event=="labeled" and (.label.name|startswith("phase/"))) | .created_at] | last // empty' \
+  2>/dev/null || true)
+
+# Fetch all comments from the Issue
+RAW_COMMENTS=$(gh issue view "$ISSUE_NUMBER" --json comments \
+  --jq '.comments' 2>/dev/null || echo "[]")
+
+# Filter comments since cutoff
+if [[ -n "$CUTOFF" ]]; then
+  SINCE_CUTOFF=$(echo "$RAW_COMMENTS" | \
+    jq --arg c "$CUTOFF" '[.[] | select(.createdAt > $c)]' 2>/dev/null || echo "[]")
+else
+  SINCE_CUTOFF="$RAW_COMMENTS"
+fi
+
+# Fetch verify-fail marker comments regardless of cutoff (defense in depth)
+VERIFYFAIL=$(echo "$RAW_COMMENTS" | \
+  jq '[.[] | select(.body | contains("<!-- wholework-event: type=verify-fail"))]' \
+  2>/dev/null || echo "[]")
+
+# Combine and deduplicate by URL
+ALL_COMMENTS=$(jq -n \
+  --argjson a "$SINCE_CUTOFF" \
+  --argjson b "$VERIFYFAIL" \
+  '($a + $b) | unique_by(.url)' 2>/dev/null || echo "[]")
+
+# Format entries applying trust boundary classification
+# Trust tiers: OWNER/MEMBER/COLLABORATOR = first-class, CONTRIBUTOR/NONE = external
+# Logins ending with [bot] = bot (skip), unless body contains <!-- wholework-event:
+ENTRIES=$(echo "$ALL_COMMENTS" | jq -r '
+  .[] |
+  ((.author.login) // "unknown") as $login |
+  (.authorAssociation // "NONE") as $assoc |
+  (.url // "") as $url |
+  (.body // "") as $body |
+  (if ($login | test("\\[bot\\]$"))
+   then (if ($body | contains("<!-- wholework-event:")) then "first-class" else "bot" end)
+   elif ($assoc == "OWNER" or $assoc == "MEMBER" or $assoc == "COLLABORATOR") then "first-class"
+   else "external"
+   end) as $tier |
+  if $tier == "bot" then empty
+  else
+    ($body | split("\n") | .[0] // "" | .[0:80]) as $summary |
+    "- \($login) / \($assoc) / \($tier) / \($summary) / \($url)"
+  end
+' 2>/dev/null || true)
+
+# Append section to spec file
+printf '\n%s\n' "## Consumed Comments" >> "$SPEC_FILE" 2>/dev/null || {
+  echo "append-consumed-comments-section.sh: WARNING — skip (cannot append to spec file)" >&2
+  exit 0
+}
+
+if [[ -z "$ENTRIES" ]]; then
+  printf '%s\n' "No new comments since last phase." >> "$SPEC_FILE" 2>/dev/null || true
+else
+  printf '%s\n' "$ENTRIES" >> "$SPEC_FILE" 2>/dev/null || true
+fi
+
+# Commit and push (best-effort; failures do not block caller)
+SPEC_REL="${SPEC_FILE#$_repo_root/}"
+if ! git -C "$_repo_root" diff --quiet "$SPEC_REL" 2>/dev/null; then
+  git -C "$_repo_root" add "$SPEC_REL" 2>/dev/null \
+    && git -C "$_repo_root" commit -s \
+         -m "Add consumed comments fallback for issue #${ISSUE_NUMBER} (${PHASE_NAME} phase)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" 2>/dev/null \
+    && git -C "$_repo_root" push origin HEAD 2>/dev/null \
+    || echo "append-consumed-comments-section.sh: WARNING — commit/push failed (best-effort)" >&2
+fi
+
+exit 0

--- a/scripts/emit-event.sh
+++ b/scripts/emit-event.sh
@@ -85,6 +85,16 @@ emit_event() {
   fi
 }
 
+# Bash-side Consumed Comments section appender. Issue #811 — post-processor
+# fallback: calls append-consumed-comments-section.sh to write the
+# ## Consumed Comments section when the LLM phase did not write it.
+# Always exits 0 (best-effort). Called by run-spec.sh and run-code.sh after
+# the claude subprocess exits when the pre/post count comparison shows no
+# section was added by the LLM.
+_append_consumed_comments_section() {
+  "$SCRIPT_DIR/append-consumed-comments-section.sh" "$@" 2>/dev/null || true
+}
+
 # Bash-side comments_consumed event emitter. Issue #705 — replaces the LLM
 # Step 6 in l0-surfaces.md Comment Consumption Procedure, which was not firing
 # reliably because the LLM skips the emit step. Extracted from run-auto-sub.sh

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -186,6 +186,14 @@ ${SKILL_BODY}
 ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 fi
 
+# Pre-count: capture ## Consumed Comments section count before claude runs.
+# Used by post-processor fallback to detect when LLM silently skipped writeback.
+_SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="$(dirname "$SCRIPT_DIR")/.wholework.yml" \
+  "$SCRIPT_DIR/get-config-value.sh" spec-path docs/spec 2>/dev/null || echo "docs/spec")
+_SPEC_FILE_PRE=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+_PRE_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_PRE:-/dev/null}" 2>/dev/null || true)
+_PRE_COUNT="${_PRE_COUNT:-0}"
+
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR" "code"
@@ -259,6 +267,17 @@ fi
 
 if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then
   emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
+fi
+
+# Post-processor fallback: if LLM did not append ## Consumed Comments, do it now.
+# Compare post-count with pre-count; trigger fallback when count did not increase.
+if [[ $EXIT_CODE -eq 0 ]]; then
+  _SPEC_FILE_POST=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+  _POST_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_POST:-/dev/null}" 2>/dev/null || true)
+  _POST_COUNT="${_POST_COUNT:-0}"
+  if [[ "$_POST_COUNT" -le "$_PRE_COUNT" ]]; then
+    _append_consumed_comments_section "$ISSUE_NUMBER" "code" || true
+  fi
 fi
 
 echo "---"

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -126,6 +126,14 @@ ${SKILL_BODY}
 
 ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 
+# Pre-count: capture ## Consumed Comments section count before claude runs.
+# Used by post-processor fallback to detect when LLM silently skipped writeback.
+_SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="$(dirname "$SCRIPT_DIR")/.wholework.yml" \
+  "$SCRIPT_DIR/get-config-value.sh" spec-path docs/spec 2>/dev/null || echo "docs/spec")
+_SPEC_FILE_PRE=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+_PRE_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_PRE:-/dev/null}" 2>/dev/null || true)
+_PRE_COUNT="${_PRE_COUNT:-0}"
+
 # Specify --model and ANTHROPIC_MODEL both (workaround for -p mode bug)
 # See: https://github.com/anthropics/claude-code/issues/22362
 load_watchdog_timeout "$SCRIPT_DIR" "spec"
@@ -156,6 +164,17 @@ fi
 
 if [[ $EXIT_CODE -eq 0 && -n "${_EMIT_PHASE_OWNED:-}" ]]; then
   emit_event "phase_complete" "phase=${EMIT_PHASE_NAME}"
+fi
+
+# Post-processor fallback: if LLM did not append ## Consumed Comments, do it now.
+# Compare post-count with pre-count; trigger fallback when count did not increase.
+if [[ $EXIT_CODE -eq 0 ]]; then
+  _SPEC_FILE_POST=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+  _POST_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_POST:-/dev/null}" 2>/dev/null || true)
+  _POST_COUNT="${_POST_COUNT:-0}"
+  if [[ "$_POST_COUNT" -le "$_PRE_COUNT" ]]; then
+    _append_consumed_comments_section "$ISSUE_NUMBER" "spec" || true
+  fi
 fi
 
 echo "---"

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -3,7 +3,7 @@ name: verify
 description: Acceptance test. Automatically verifies post-merge acceptance conditions and updates Issue checkboxes (`/verify 123`). Use after `/merge`. Reopens Issue on FAIL to return to the fix cycle.
 model: sonnet
 loop-paths-used: [A]
-allowed-tools: Bash(git checkout:*, git pull:*, git status:*, git stash:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh issue view:*, gh issue edit:*, gh issue list:*, gh issue close:*, gh issue reopen:*, gh issue create:*, gh pr list:*, gh label list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-verify-iteration.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-verify-dirty.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/collect-recovery-candidates.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, wc:*, diff:*, test:*, git log:*, git diff:*, npm:*, node:*, make:*, gh pr view:*, gh api:*, date:*, printf:*), Read, Write, Edit, Glob, Grep, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_close
+allowed-tools: Bash(git checkout:*, git pull:*, git status:*, git stash:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh issue view:*, gh issue edit:*, gh issue list:*, gh issue close:*, gh issue reopen:*, gh issue create:*, gh pr list:*, gh label list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-verify-iteration.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-verify-dirty.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/collect-recovery-candidates.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh:*, wc:*, diff:*, test:*, git log:*, git diff:*, npm:*, node:*, make:*, gh pr view:*, gh api:*, date:*, printf:*), Read, Write, Edit, Glob, Grep, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_playwright_playwright__browser_navigate, mcp__plugin_playwright_playwright__browser_snapshot, mcp__plugin_playwright_playwright__browser_take_screenshot, mcp__plugin_playwright_playwright__browser_close
 ---
 
 # Acceptance Test
@@ -116,6 +116,14 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/domain-loader.md` and follow the "Processing
 **Consume comments since the last phase (L0 input):**
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/l0-surfaces.md` and follow the "Comment Consumption Procedure" section with parameters: `ISSUE_NUMBER=$NUMBER`, `COMMENT_SCOPE=issue`, `PHASE_NAME=verify`. The cutoff resolves to the most recent `phase/verify` label assignment. Record results in the Spec's `## Consumed Comments` section.
+
+After completing the Comment Consumption Procedure, run the deterministic bash fallback to ensure the section was written even if the LLM skipped it:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER verify
+```
+
+(best-effort; always exits 0 — the call is mandatory but failures do not block the skill)
 
 **Phase Handoff read** (verify is the last execution phase — read only, no write):
 

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -87,6 +87,7 @@ MOCK
     cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
 emit_event() { return 0; }
 _emit_comments_consumed() { :; }
+_append_consumed_comments_section() { :; }
 MOCK
 
     # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
@@ -461,6 +462,7 @@ MOCK
     cat > "$MOCK_DIR/emit-event.sh" <<MOCK
 emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
 _emit_comments_consumed() { :; }
+_append_consumed_comments_section() { :; }
 MOCK
     run bash "$SCRIPT" 123 --pr
     [ "$status" -eq 0 ]
@@ -508,4 +510,53 @@ MOCK
     grep -q "heartbeat_called" "$HEARTBEAT_LOG"
     grep -q -- "--from spec" "$HEARTBEAT_LOG"
     grep -q -- "--to code" "$HEARTBEAT_LOG"
+}
+
+@test "fallback: no consumed comments section before and after claude → _append_consumed_comments_section called" {
+    # Create spec file without ## Consumed Comments section (simulates fresh spec)
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #123: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+
+    FALLBACK_LOG="$BATS_TEST_TMPDIR/fallback.log"
+    export FALLBACK_LOG
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { return 0; }
+_emit_comments_consumed() { :; }
+_append_consumed_comments_section() { echo "CALLED \$*" >> "${FALLBACK_LOG}"; }
+MOCK
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ -f "$FALLBACK_LOG" ]
+    grep -q "CALLED 123 code" "$FALLBACK_LOG"
+}
+
+@test "no fallback: consumed comments section added by claude (count increases) → _append_consumed_comments_section not called" {
+    # Create spec file without ## Consumed Comments section
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #123: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+
+    FALLBACK_LOG="$BATS_TEST_TMPDIR/fallback.log"
+    SPEC_FILE_IN_MOCK="$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+    export FALLBACK_LOG SPEC_FILE_IN_MOCK
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { return 0; }
+_emit_comments_consumed() { :; }
+_append_consumed_comments_section() { echo "CALLED \$*" >> "${FALLBACK_LOG}"; }
+MOCK
+
+    # Claude mock writes ## Consumed Comments to the spec file (simulates LLM writing it)
+    cat > "$MOCK_DIR/claude" <<MOCK
+#!/bin/bash
+printf '\n%s\n' "## Consumed Comments" >> "${SPEC_FILE_IN_MOCK}"
+printf '%s\n' "No new comments since last phase." >> "${SPEC_FILE_IN_MOCK}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ ! -f "$FALLBACK_LOG" ]
 }

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -111,6 +111,7 @@ MOCK
     # Mock emit-event.sh: no-op by default (tests that need capture override this)
     cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
 emit_event() { return 0; }
+_append_consumed_comments_section() { :; }
 MOCK
 
     # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
@@ -387,8 +388,56 @@ MOCK
     EMIT_LOG="$BATS_TEST_TMPDIR/emit.log"
     cat > "$MOCK_DIR/emit-event.sh" <<MOCK
 emit_event() { echo "\$@" >> "${EMIT_LOG}"; }
+_append_consumed_comments_section() { :; }
 MOCK
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
     grep -q "phase_complete" "$EMIT_LOG"
+}
+
+@test "fallback: no consumed comments section before and after claude → _append_consumed_comments_section called" {
+    # Create spec file without ## Consumed Comments section (simulates fresh spec)
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #123: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+
+    FALLBACK_LOG="$BATS_TEST_TMPDIR/fallback.log"
+    export FALLBACK_LOG
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { return 0; }
+_append_consumed_comments_section() { echo "CALLED \$*" >> "${FALLBACK_LOG}"; }
+MOCK
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ -f "$FALLBACK_LOG" ]
+    grep -q "CALLED 123 spec" "$FALLBACK_LOG"
+}
+
+@test "no fallback: consumed comments section added by claude (count increases) → _append_consumed_comments_section not called" {
+    # Create spec file without ## Consumed Comments section
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #123: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+
+    FALLBACK_LOG="$BATS_TEST_TMPDIR/fallback.log"
+    SPEC_FILE_IN_MOCK="$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+    export FALLBACK_LOG SPEC_FILE_IN_MOCK
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { return 0; }
+_append_consumed_comments_section() { echo "CALLED \$*" >> "${FALLBACK_LOG}"; }
+MOCK
+
+    # Claude mock writes ## Consumed Comments to the spec file (simulates LLM writing it)
+    cat > "$MOCK_DIR/claude" <<MOCK
+#!/bin/bash
+printf '\n%s\n' "## Consumed Comments" >> "${SPEC_FILE_IN_MOCK}"
+printf '%s\n' "No new comments since last phase." >> "${SPEC_FILE_IN_MOCK}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ ! -f "$FALLBACK_LOG" ]
 }

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -1,0 +1,174 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/append-consumed-comments-section.sh
+# Tests the verify-phase scenario: deterministic Consumed Comments writeback.
+# Mocks: gh, git, get-config-value.sh (via MOCK_DIR + WHOLEWORK_SCRIPT_DIR)
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/append-consumed-comments-section.sh"
+
+setup() {
+    cd "$BATS_TEST_TMPDIR"
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    # Mock get-config-value.sh: return default spec path
+    cat > "$MOCK_DIR/get-config-value.sh" <<'MOCK'
+#!/bin/bash
+KEY="$1"; DEFAULT="${2:-}"
+case "$KEY" in
+    spec-path) echo "docs/spec" ;;
+    *) echo "$DEFAULT" ;;
+esac
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-config-value.sh"
+
+    # Default gh mock: returns empty timeline cutoff and empty comments array
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json title"* ]]; then
+    echo "Test Issue Title"
+    exit 0
+fi
+if [[ "$1" == "api" ]]; then
+    # Timeline query: return empty (no cutoff)
+    echo ""
+    exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json comments"* ]]; then
+    # Comments: empty array
+    echo "[]"
+    exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    # Default git mock: no changes (diff --quiet exits 0 = no diff)
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "error: missing arguments → exit 0 with warning" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING"*"missing ISSUE_NUMBER"* ]] || [[ "$output" == "" ]]
+}
+
+@test "section absent: creates ## Consumed Comments with no-comments message" {
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #42: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+
+    run bash "$SCRIPT" 42 verify
+    [ "$status" -eq 0 ]
+
+    grep -q "^## Consumed Comments" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+    grep -q "No new comments since last phase." "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+}
+
+@test "spec absent: creates skeleton file with ## Consumed Comments section" {
+    # No spec file exists — script should create skeleton
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+
+    run bash "$SCRIPT" 99 verify
+    [ "$status" -eq 0 ]
+
+    # A spec file for issue 99 should have been created
+    CREATED=$(ls "$BATS_TEST_TMPDIR/docs/spec/issue-99-"*.md 2>/dev/null | head -1 || true)
+    [ -n "$CREATED" ]
+    grep -q "^## Consumed Comments" "$CREATED"
+}
+
+@test "section exists: skip and exit 0 without adding another section" {
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #42: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+    printf '\n%s\n' "## Consumed Comments" >> "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+    printf '%s\n' "No new comments since last phase." >> "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+
+    GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+    export GIT_LOG
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "GIT_CALLED: \$*" >> "${GIT_LOG}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash "$SCRIPT" 42 verify
+    [ "$status" -eq 0 ]
+
+    # Section count should remain 1 (not duplicated)
+    COUNT=$(grep -c "^## Consumed Comments" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md")
+    [ "$COUNT" -eq 1 ]
+
+    # git should not have been called (section already existed → skip before any write)
+    [ ! -f "$GIT_LOG" ]
+}
+
+@test "verify-fail marker comment included regardless of cutoff" {
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #42: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+
+    # gh mock: return a recent cutoff + one verify-fail bot comment before cutoff
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "api" ]]; then
+    # Return cutoff: 2026-06-01 (recent)
+    echo "2026-06-01T00:00:00Z"
+    exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json comments"* ]]; then
+    # One verify-fail bot comment with date before cutoff
+    printf '%s\n' '[{"author":{"login":"wholework-bot[bot]"},"authorAssociation":"NONE","body":"<!-- wholework-event: type=verify-fail phase=verify issue=42 -->\nFAIL on AC2","url":"https://github.com/test/issues/42#issuecomment-1","createdAt":"2026-05-01T00:00:00Z"}]'
+    exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 42 verify
+    [ "$status" -eq 0 ]
+
+    grep -q "^## Consumed Comments" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+    # verify-fail bot comment should be included (wholework-event exception)
+    grep -q "wholework-bot\[bot\]" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+}
+
+@test "git commit called when spec file is modified" {
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #42: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+
+    GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+    export GIT_LOG
+
+    # git mock: diff --quiet exits 1 (change detected), other calls log and exit 0
+    # Note: script calls "git -C /repo/root diff --quiet", so $3 == "diff"
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+if [[ "\$3" == "diff" && "\$*" == *"--quiet"* ]]; then
+    exit 1
+fi
+echo "GIT_CALLED: \$*" >> "${GIT_LOG}"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash "$SCRIPT" 42 verify
+    [ "$status" -eq 0 ]
+
+    [ -f "$GIT_LOG" ]
+    grep -q "GIT_CALLED:.*add" "$GIT_LOG"
+    grep -q "GIT_CALLED:.*commit" "$GIT_LOG"
+    grep -q "GIT_CALLED:.*push" "$GIT_LOG"
+}


### PR DESCRIPTION
## 概要

Issue #811 の実装。`## Consumed Comments` セクションが LLM に無言でスキップされても確実に Spec へ書き込まれるよう、Candidate B (bash post-processor fallback) を採用。

### 変更内容

- **`scripts/append-consumed-comments-section.sh`** (新規): post-processor fallback 本体。Spec ファイルにセクションが存在しない場合、GitHub コメントを取得・分類して追記し git commit/push する (best-effort、常に exit 0)
- **`scripts/emit-event.sh`**: `_append_consumed_comments_section()` wrapper 関数を追加
- **`scripts/run-spec.sh`**: claude 実行前後の `## Consumed Comments` カウント比較を追加。増えていない場合に fallback 起動
- **`scripts/run-code.sh`**: 同様の pre/post カウント比較と fallback 起動
- **`modules/l0-surfaces.md`**: Step 5 に bash wrapper fallback の注記を追加
- **`skills/verify/SKILL.md`**: Comment Consumption 後に明示 bash 呼び出し step を追加; allowed-tools に新スクリプトを追記
- **`tests/run-code.bats`**, **`tests/run-spec.bats`**: fallback 呼び出し / 非呼び出しテストを追加
- **`tests/run-verify.bats`** (新規): `append-consumed-comments-section.sh` の動作を直接テスト (6 テスト)
- **`docs/structure.md`**, **`docs/ja/structure.md`**: 新スクリプトのエントリを追加

### 検証結果

```
bats tests/run-code.bats tests/run-spec.bats tests/run-verify.bats
1..68
# 全68テスト green
```

### 根本バグの修正

実装中に `grep -c ... || echo 0` パターンの問題を発見・修正:
- `grep -c` はマッチなし時も "0" を stdout に出力して exit 1 する
- `|| echo 0` が続くと command substitution が "0\n0" を返し、整数比較が破綻する
- `|| true` に変更し `${COUNT:-0}` でデフォルト設定する形に統一

Closes #811