### PR TITLE
Issue #807: run-*.sh ラッパーに SIGTERM/SIGKILL 検出 + auto-retry-once 機構を追加

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（59 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（62 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -204,6 +204,7 @@ wholework/
 **プロセス管理:**
 - `scripts/auto-checkpoint.sh` — `/auto --resume` 用チェックポイントヘルパー: 単一 Issue の verify カウンタと batch 残リストの atomic 読み書き削除。BATCH_ID 名前空間化により並列 `--batch` セッション間の衝突を防止（サブコマンド: `read_single`、`write_single`、`delete_single`、`read_batch`、`write_batch`、`update_batch`、`delete_batch`、`list_active_batches`）
 - `scripts/watchdog-defaults.sh` — `WATCHDOG_TIMEOUT_DEFAULT` 定数と `load_watchdog_timeout` 関数を提供する run-*.sh 用 source 可能なヘルパー
+- `scripts/retry-on-kill.sh` — `run_with_retry_on_kill()` を提供する source 可能なヘルパー: SIGTERM/SIGKILL (exit 137/143) を early-kill ウィンドウ (<300s) 内で検出し自動 1 回リトライ。run-issue.sh、run-spec.sh、run-code.sh、run-auto-sub.sh が使用
 - `scripts/claude-watchdog.sh` — `claude -p` 呼び出し用の watchdog ラッパー（hang 検知 + 1 回リトライ）
 - `scripts/reconcile-phase-state.sh` — 全 phase の precondition チェックと completion チェックを行う汎用 state reconciler。`modules/phase-state.md` SSoT に基づく JSON v1 を出力（watchdog-reconcile.sh の後継）
 - `scripts/wait-ci-checks.sh` — claude 実行前に PR の全 CI チェック完了を待機

--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -196,6 +196,7 @@ Issue 本文の "Scope" または "Acceptance Criteria" セクションに以下
 | `WHOLEWORK_MAX_RECOVERY_SUBAGENTS` | `1` | `scripts/spawn-recovery-subagent.sh` が生成する Tier 3 recovery sub-agent の最大並列数。XL 並列実行時のコスト上限のためデフォルト 1 (逐次回復)。 |
 | `WHOLEWORK_PATCH_LOCK_TIMEOUT` | `300` | `scripts/worktree-merge-push.sh` の patch lock タイムアウト秒数。優先順位: env var > `.wholework.yml` `patch-lock-timeout` > 300。 |
 | `WHOLEWORK_PATCH_LOCK_LOG_INTERVAL` | `30` | `scripts/worktree-merge-push.sh` で patch lock 待機中のログ出力間隔秒数。 |
+| `WHOLEWORK_RETRY_ON_KILL_MAX_SEC` | `300` | `scripts/retry-on-kill.sh` の early-kill ウィンドウ (秒)。run-*.sh ラッパーが exit 137/143 でこのウィンドウ内に終了した場合、自動で 1 回リトライする。テストでは `0` を設定して late-kill (no-retry) ブランチを強制可能。最小 `WATCHDOG_TIMEOUT` (merge フェーズで 600s) より厳密に小さい値を維持し、watchdog hang-kill が自動リトライされないようにする必要がある。 |
 | `WHOLEWORK_YML` | `${CLAUDE_PROJECT_DIR:-}/.wholework.yml` | `scripts/hook-rename-on-auto.sh` が参照する `.wholework.yml` のパス。`CLAUDE_PROJECT_DIR` から導出され、オペレーター override パターン (`${WHOLEWORK_YML:-...}`) ではない (スクリプトが直接代入)。 |
 
 ### Capability フラグ

--- a/docs/spec/issue-807-wrapper-retry-on-kill.md
+++ b/docs/spec/issue-807-wrapper-retry-on-kill.md
@@ -180,3 +180,20 @@ No new comments since last phase.
 - scripts 数を `ls scripts/*.sh scripts/*.py | wc -l` (現状 61) で再計測し structure.md の "(N files)" を正確値に (既存 59 ドリフト是正)。
 - 既存 reconcile 143/0 branch は変更しない (137 へ拡張しない、保守的 escalation)。
 - `docs/ja/structure.md` / `docs/ja/tech.md` ミラーを translation-workflow.md に従い同期。
+
+## Code Retrospective
+
+### What went well
+- `"$@" || _exit=$?` パターンで `set -e` / `set +e` 両環境に安全な exit code キャプチャを実現できた
+- `env` 引数形式への移行 (`env -u CLAUDECODE NAME=VALUE ...`) により、関数ラッパー経由での環境変数伝播が確実になった
+- early-kill ウィンドウ 300s の選択: 最小 `WATCHDOG_TIMEOUT` (merge=600s) の半分以下を維持し、watchdog hang-kill (遅延) と外部 kill (早期) の非重複を保証できた
+- Layer A (claude 呼び出し) と Layer B (child runner) の 2 層構造で全 run-*.sh を網羅できた
+- カウンターファイル mock パターンが bats でのリトライ検証に有効だった
+
+### What was difficult
+- json ブランチ (`run-code.sh`) で stdout リダイレクト (`> "$TOKEN_USAGE_FILE"`) を関数ラッパー外に出す必要があり、ラッパー呼び出し側で `> file` を付ける形に変更が必要だった
+- `run-auto-sub.sh` の `_write_wrapper_retry_recovery` で python3 heredoc 内に bash 変数展開を混在させる構文が煩雑だった
+
+### Design decisions
+- `_RETRY_ON_KILL_FIRED` グローバルフラグで retry 発生を追跡し、`run-auto-sub.sh` が orchestration-recoveries.md への記録をトリガーする設計にした (ヘルパーと呼び出し側の責務分離)
+- 閾値超過 (Branch C) では retry せず as-is で返す — watchdog hang-kill は別経路 (watchdog 1回リトライ + tier 1/2/3 recovery) で処理されるため

--- a/docs/spec/issue-807-wrapper-retry-on-kill.md
+++ b/docs/spec/issue-807-wrapper-retry-on-kill.md
@@ -197,3 +197,33 @@ No new comments since last phase.
 ### Design decisions
 - `_RETRY_ON_KILL_FIRED` グローバルフラグで retry 発生を追跡し、`run-auto-sub.sh` が orchestration-recoveries.md への記録をトリガーする設計にした (ヘルパーと呼び出し側の責務分離)
 - 閾値超過 (Branch C) では retry せず as-is で返す — watchdog hang-kill は別経路 (watchdog 1回リトライ + tier 1/2/3 recovery) で処理されるため
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Spec handoff (phase-handoff.md) に「4 本すべての bats `setup()` で retry-on-kill.sh を cp」と注記されていたが、PR は主要 4 bats (`run-issue.bats`, `run-spec.bats`, `run-code.bats`, `run-auto-sub.bats`) のみ対応し、同じく `WHOLEWORK_SCRIPT_DIR=$MOCK_DIR` で `run-auto-sub.sh`/`run-code.sh` を実行する `auto-sub-observability.bats` と `run-code-mergeability.bats` の対応が漏れた。Spec の「4 本すべて」は main wrapper 4 本を指しており、周辺 bats ファイルまでスコープが広がっていなかった点が divergence の原因。
+
+### Recurring issues
+
+- sourceable helper (`retry-on-kill.sh`, `guard-prefix.sh`, `watchdog-defaults.sh`) を新規追加した際、`WHOLEWORK_SCRIPT_DIR` でオーバーライドされる可能性のある **全** bats ファイルへの cp 対応が漏れるパターンが今回初めて発生。guard-prefix.sh 追加時は `run-code-mergeability.bats` など周辺 bats で既に対応済みだったため表面化しなかった可能性がある。今後 sourceable helper 追加時は `grep -r "WHOLEWORK_SCRIPT_DIR" tests/` で影響 bats を全列挙するチェックが有効。
+
+### Acceptance criteria verification difficulty
+
+- AC2 の verify command (`bats tests/run-issue.bats tests/run-spec.bats tests/run-code.bats tests/run-auto-sub.bats`) は本 PR の新規テスト 5 本が PASS することを確認できるが、間接的に壊れる周辺 bats (auto-sub-observability.bats, run-code-mergeability.bats) は検出できない。AC として `bats tests/` 全体実行 or 特定 bats ファイル追加が望ましかった。verify command の範囲が狭すぎると、周辺ファイルへの波及バグが CI まで見逃される。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- `tests/auto-sub-observability.bats` と `tests/run-code-mergeability.bats` の `setup()` に `cp scripts/retry-on-kill.sh $MOCK_DIR/` を追加し CI 失敗 (6 tests) を修正した。
+- 実装本体 (retry-on-kill.sh、run-*.sh 統合、orchestration-fallbacks.md 文書化) は仕様通り正確に実装されており変更不要。
+- AC1/3/4/5/6 はすべて PASS、AC2 (bats) は修正後 PASS (130 tests)。
+
+### Deferred Items
+- sourceable helper 追加時に `grep -r "WHOLEWORK_SCRIPT_DIR" tests/` で影響 bats 全列挙するチェックリストは /auto-retrospective または CLAUDE.md への追記候補 (今回はレトロスペクティブ記録のみ)。
+- run-code.sh json branch の `--output-file` truncation 動作 (retry 時の partial write 上書き) は実観測が得られた場合のみ追加防御を検討 (Spec Uncertainty 記載済み)。
+
+### Notes for Next Phase
+- `/merge 816` を実行可能。修正コミット `dbc4ec2` が push 済み、CI 再実行を待って全 pass を確認してから merge 推奨。
+- post-merge AC: 次回 batch session の kill 発生時に orchestration-recoveries.md に記録されることを観察 (manual)。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (59 files)
+├── scripts/             # Utility scripts used by skills and agents (62 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -212,6 +212,7 @@ Key modules:
 **Process management:**
 - `scripts/auto-checkpoint.sh` — checkpoint helper for `/auto --resume`: atomic read/write/delete of single-Issue verify counter and batch remaining list; BATCH_ID-namespaced per-session state files prevent parallel `--batch` collisions (subcommands: `read_single`, `write_single`, `delete_single`, `read_batch`, `write_batch`, `update_batch`, `delete_batch`, `list_active_batches`)
 - `scripts/watchdog-defaults.sh` — sourceable helper providing `WATCHDOG_TIMEOUT_DEFAULT` constant and `load_watchdog_timeout` function for run-*.sh scripts
+- `scripts/retry-on-kill.sh` — sourceable helper providing `run_with_retry_on_kill()`: detects SIGTERM/SIGKILL (exit 137/143) in the early-kill window (<300s) and auto-retries once; used by run-issue.sh, run-spec.sh, run-code.sh, run-auto-sub.sh
 - `scripts/claude-watchdog.sh` — watchdog wrapper for `claude -p` invocations (hang detection + 1 retry)
 - `scripts/reconcile-phase-state.sh` — general-purpose state reconciler for precondition and completion checks across all phases; outputs JSON v1 per `modules/phase-state.md` SSoT (supersedes watchdog-reconcile.sh)
 - `scripts/wait-ci-checks.sh` — wait for all CI checks to complete on a PR before running claude

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -209,6 +209,7 @@ In gradual migration, there is a period where deprecated terms remain in the sam
 | `WHOLEWORK_MAX_RECOVERY_SUBAGENTS` | `1` | Maximum number of concurrent Tier 3 recovery sub-agents spawned by `scripts/spawn-recovery-subagent.sh`. Defaults to 1 (serial recovery) to bound cost during XL parallel runs. |
 | `WHOLEWORK_PATCH_LOCK_TIMEOUT` | `300` | Timeout seconds for the patch lock in `scripts/worktree-merge-push.sh`. Priority: env var > `patch-lock-timeout` in `.wholework.yml` > 300. |
 | `WHOLEWORK_PATCH_LOCK_LOG_INTERVAL` | `30` | Log output interval seconds while waiting for the patch lock in `scripts/worktree-merge-push.sh`. |
+| `WHOLEWORK_RETRY_ON_KILL_MAX_SEC` | `300` | Early-kill window in seconds for `scripts/retry-on-kill.sh`. If a run-*.sh wrapper exits 137 or 143 within this window, it retries once automatically. Set to `0` in tests to force the late-kill (no-retry) branch. Must stay strictly less than the minimum `WATCHDOG_TIMEOUT` (600s for merge phase) so watchdog hang-kills are never auto-retried. |
 | `WHOLEWORK_YML` | `${CLAUDE_PROJECT_DIR:-}/.wholework.yml` | Path to `.wholework.yml` resolved by `scripts/hook-rename-on-auto.sh`. Derived from `CLAUDE_PROJECT_DIR`; not an operator-override pattern (the script assigns directly rather than using `${WHOLEWORK_YML:-...}`). |
 
 ### Capability Flags

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -479,6 +479,39 @@ See also: `#async-external-commit` (reconcile-first authority — `matches_expec
 
 ---
 
+## wrapper-retry-on-kill
+
+### Symptom
+- A `run-*.sh` wrapper's child process (claude invocation or child runner script) exits with code `137` (SIGKILL) or `143` (SIGTERM) within the early-kill window (< `WHOLEWORK_RETRY_ON_KILL_MAX_SEC`, default 300s)
+- Typical cause: external resource pressure, OOM kill, or scheduler intervention during the first 60–180s of execution
+- Distinguishable from watchdog hang-kill (which fires after elapsed >= `WATCHDOG_TIMEOUT` >= 600s, always outside the 300s window)
+
+### Applicable Phases
+- Any phase whose runner is `run-issue.sh`, `run-spec.sh`, `run-code.sh`, or `run-auto-sub.sh`
+- Layer A: claude invocation inside leaf wrappers (run-issue.sh, run-spec.sh, run-code.sh)
+- Layer B: child runner invocation inside `run-auto-sub.sh run_phase_with_recovery()`
+
+### Fallback Steps
+1. `scripts/retry-on-kill.sh` `run_with_retry_on_kill()` detects exit code 137 or 143 and measures elapsed time
+2. If elapsed < `WHOLEWORK_RETRY_ON_KILL_MAX_SEC` (default 300s): log to stderr `"retry-on-kill: command killed (exit N) after Ms (< Ks); auto-retrying once"`, set `_RETRY_ON_KILL_FIRED=true`, and retry the command once
+3. If retry succeeds (exit 0): normal wrapper flow continues; `run-auto-sub.sh` records a `wrapper-retry-on-kill success` entry to `docs/reports/orchestration-recoveries.md`
+4. If elapsed >= threshold (Branch C): no retry — this is a watchdog hang-kill handled by the parent `json-mode-silent-hang` pattern
+
+### Escalation
+- If retry also exits 137 or 143 (Branch D): log `"retry-on-kill: retry also killed; escalating to recovery/manual"` and return the kill exit code to the caller
+- Leaf wrappers (run-issue/spec/code): the kill exit code propagates to the parent `/auto` session for manual recovery
+- `run-auto-sub.sh`: the kill exit code reaches `run_phase_with_recovery()` which proceeds to Tier 1/2/3 adaptive recovery
+- Automatic retry is 1 time only; no further looping
+
+### Rationale
+- Introduced in Issue #807: `/auto --batch` sessions observed `run-issue.sh` being killed at 60–120s (before watchdog could fire at >= 600s); manual retry succeeded on the second attempt; this mechanism automates that pattern at the wrapper level
+- Implementation uses shared sourceable helper `scripts/retry-on-kill.sh` (same pattern as `watchdog-defaults.sh`, `guard-prefix.sh`) sourced by all 4 wrapper scripts
+- Threshold 300s ensures non-overlap with watchdog hang-kill (minimum watchdog timeout is merge phase at 600s); see `scripts/watchdog-defaults.sh` for phase-specific values
+- Complementary to `json-mode-silent-hang` (which handles watchdog-timeout kills via parent-session retry); these two patterns cover orthogonal elapsed-time ranges (< 300s vs >= 600s)
+- Pointer comment `# See modules/orchestration-fallbacks.md#wrapper-retry-on-kill` is placed immediately above the `run_with_retry_on_kill` call in each script
+
+---
+
 ## Operational Notes
 
 This catalog is consumed by:

--- a/scripts/retry-on-kill.sh
+++ b/scripts/retry-on-kill.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# sourceable helper — do not execute directly
+# bash 3.2+ compatible: no associative arrays, no mapfile
+
+# Default early-kill window in seconds.
+# All production phase WATCHDOG_TIMEOUT defaults (see watchdog-defaults.sh) are >= 600s,
+# so only external/OOM kills (typically < 300s) trigger retry; watchdog hang-kills do not.
+RETRY_ON_KILL_MAX_SEC_DEFAULT=300
+
+# run_with_retry_on_kill <command> [args...]
+# Execute command; if killed early (SIGTERM=143 or SIGKILL=137) within the early-kill window,
+# retry once. Sets _RETRY_ON_KILL_FIRED=true when retry is attempted.
+# See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
+#
+# Branch A — non-kill exit:  exit code not 137 or 143 → return as-is, no retry
+# Branch B — early kill:     exit code 137/143 AND elapsed < max_sec → retry once
+# Branch C — late kill:      exit code 137/143 AND elapsed >= max_sec → return as-is (watchdog hang-kill)
+# Branch D — retry also kill: Branch B retry also exits 137/143 → log and escalate
+run_with_retry_on_kill() {
+  _RETRY_ON_KILL_FIRED=false
+  local _max_sec _start _end _elapsed _exit
+  _max_sec="${WHOLEWORK_RETRY_ON_KILL_MAX_SEC:-$RETRY_ON_KILL_MAX_SEC_DEFAULT}"
+  _start=$(date +%s)
+  _exit=0
+  "$@" || _exit=$?
+  # Branch A: non-kill exit (includes 0)
+  if [[ $_exit -ne 137 && $_exit -ne 143 ]]; then
+    return $_exit
+  fi
+  _end=$(date +%s)
+  _elapsed=$(( _end - _start ))
+  # Branch C: late kill — watchdog hang-kill (elapsed >= early-kill window), no retry
+  if [[ $_elapsed -ge $_max_sec ]]; then
+    return $_exit
+  fi
+  # Branch B: early kill — retry once
+  echo "retry-on-kill: command killed (exit ${_exit}) after ${_elapsed}s (< ${_max_sec}s); auto-retrying once" >&2
+  _RETRY_ON_KILL_FIRED=true
+  _exit=0
+  "$@" || _exit=$?
+  # Branch D: retry also killed — escalate to recovery/manual
+  if [[ $_exit -eq 137 || $_exit -eq 143 ]]; then
+    echo "retry-on-kill: retry also killed (exit ${_exit}); escalating to recovery/manual" >&2
+  fi
+  return $_exit
+}

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -46,6 +46,7 @@ export AUTO_SESSION_ID
 export EMIT_ISSUE_NUMBER="$SUB_NUMBER"
 
 source "$SCRIPT_DIR/emit-event.sh"
+source "$SCRIPT_DIR/retry-on-kill.sh"
 
 _maybe_emit_phase_complete() {
   local _exit_code=$?
@@ -191,6 +192,61 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
   fi
 }
 
+# _write_wrapper_retry_recovery ISSUE PHASE EXIT_CODE
+# Records a wrapper-retry-on-kill recovery event to orchestration-recoveries.md.
+# Skips silently if the file does not exist (file not in repo → return 0).
+# See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
+_write_wrapper_retry_recovery() {
+  local issue="$1"
+  local phase="$2"
+  local exit_code_arg="$3"
+  local _repo_root
+  _repo_root="$(dirname "$SCRIPT_DIR")"
+  local _recoveries_file="${_repo_root}/docs/reports/orchestration-recoveries.md"
+  if [[ ! -f "$_recoveries_file" ]]; then
+    return 0
+  fi
+  local _date _outcome
+  _date=$(date -u '+%Y-%m-%d %H:%M UTC')
+  if [[ "$exit_code_arg" -eq 0 ]]; then
+    _outcome="success"
+  else
+    _outcome="escalated (retry also killed)"
+  fi
+  python3 << PYEOF 2>/dev/null || true
+fpath = "${_recoveries_file}"
+marker = "<!-- Log entries appear below, newest first. -->"
+entry = (
+    "\n### wrapper-retry-on-kill (${phase})\n"
+    "- **Date**: ${_date}\n"
+    "- **Issue**: #${issue}, phase: ${phase}\n"
+    "- **Source**: retry-on-kill.sh\n"
+    "- **Exit code**: ${exit_code_arg}\n"
+    "- **Outcome**: ${_outcome}\n"
+)
+try:
+    content = open(fpath).read()
+    idx = content.find(marker)
+    if idx != -1:
+        pos = idx + len(marker)
+        content = content[:pos] + entry + content[pos:]
+        open(fpath, "w").write(content)
+except Exception:
+    pass
+PYEOF
+  if ! git -C "$_repo_root" diff --quiet "docs/reports/orchestration-recoveries.md" 2>/dev/null; then
+    if git -C "$_repo_root" add "docs/reports/orchestration-recoveries.md" \
+       && git -C "$_repo_root" commit -s -m "Record wrapper-retry-on-kill recovery for issue #${issue} ${phase}
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
+       && git -C "$_repo_root" push origin HEAD; then
+      echo "${LOG_PREFIX} [recovery] wrapper-retry-on-kill recovery log committed and pushed"
+    else
+      echo "${LOG_PREFIX} WARNING: could not commit/push wrapper-retry-on-kill recovery log" >&2
+    fi
+  fi
+}
+
 # _observe_code_milestone NUMBER
 # Probes observable git/GitHub state to determine the current code_phase_milestone value.
 # Used by the pr-route resume preamble to reconcile the checkpoint with live state.
@@ -260,9 +316,14 @@ run_phase_with_recovery() {
   emit_event "phase_start" "phase=${phase}"
 
   set +e
-  "$runner_script" "$issue" "$@" > "$log_file" 2>&1
+  # See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
+  run_with_retry_on_kill "$runner_script" "$issue" "$@" > "$log_file" 2>&1
   exit_code=$?
   set -e
+
+  if [[ "${_RETRY_ON_KILL_FIRED:-false}" == "true" ]]; then
+    _write_wrapper_retry_recovery "$issue" "$phase" "$exit_code"
+  fi
 
   emit_event "wrapper_exit" "phase=${phase}" "exit_code=${exit_code}"
 

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -176,6 +176,7 @@ if [[ -n "$BASE_FLAG" ]]; then
 fi
 
 source "$SCRIPT_DIR/guard-prefix.sh"
+source "$SCRIPT_DIR/retry-on-kill.sh"
 
 if [[ -n "$EXTRA_FLAGS" ]]; then
   PROMPT="${GUARD_PREFIX}
@@ -211,10 +212,11 @@ set +e
 if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
   TOKEN_USAGE_FILE=".tmp/token-usage-${ISSUE_NUMBER}.json"
   mkdir -p .tmp
-  ANTHROPIC_MODEL=sonnet \
+  # See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
+  run_with_retry_on_kill env -u CLAUDECODE ANTHROPIC_MODEL=sonnet \
     WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
     OUTPUT_FORMAT_JSON=1 \
-    env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
+    "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
       --model sonnet \
       --effort high \
       --output-format json \
@@ -223,9 +225,10 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
   EXIT_CODE=$?
   jq -r '.result // empty' "$TOKEN_USAGE_FILE" 2>/dev/null || true
 else
-  ANTHROPIC_MODEL=sonnet \
+  # See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
+  run_with_retry_on_kill env -u CLAUDECODE ANTHROPIC_MODEL=sonnet \
     WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
-    env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
+    "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
       --model sonnet \
       --effort high \
       $PERMISSION_FLAG

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -96,6 +96,7 @@ fi
 SKILL_BODY=$(tail -n +"$((FRONTMATTER_END + 1))" "$SKILL_FILE")
 
 source "$SCRIPT_DIR/guard-prefix.sh"
+source "$SCRIPT_DIR/retry-on-kill.sh"
 
 PROMPT="${GUARD_PREFIX}
 
@@ -109,9 +110,10 @@ load_watchdog_timeout "$SCRIPT_DIR" "issue"
 
 SECONDS=0
 set +e
-ANTHROPIC_MODEL=sonnet \
+# See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
+run_with_retry_on_kill env -u CLAUDECODE ANTHROPIC_MODEL=sonnet \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
-  env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
+  "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
     --model sonnet \
     --effort high \
     $PERMISSION_FLAG

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -120,6 +120,7 @@ fi
 SKILL_BODY=$(tail -n +"$((FRONTMATTER_END + 1))" "$SKILL_FILE")
 
 source "$SCRIPT_DIR/guard-prefix.sh"
+source "$SCRIPT_DIR/retry-on-kill.sh"
 
 PROMPT="${GUARD_PREFIX}
 
@@ -141,9 +142,10 @@ load_watchdog_timeout "$SCRIPT_DIR" "spec"
 
 SECONDS=0
 set +e
-ANTHROPIC_MODEL="${MODEL}" \
+# See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
+run_with_retry_on_kill env -u CLAUDECODE ANTHROPIC_MODEL="${MODEL}" \
   WATCHDOG_TIMEOUT="$WATCHDOG_TIMEOUT" \
-  env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
+  "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
     --model "${MODEL}" \
     --effort "${EFFORT}" \
     $PERMISSION_FLAG

--- a/tests/auto-sub-observability.bats
+++ b/tests/auto-sub-observability.bats
@@ -33,6 +33,9 @@ emit_event() {
 _emit_comments_consumed() { :; }
 MOCK
 
+    # Real retry-on-kill.sh (sourced via WHOLEWORK_SCRIPT_DIR; must be present or source fails)
+    cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
+
     # Mock phase-banner.sh (sourced by run-auto-sub.sh)
     cat > "$MOCK_DIR/phase-banner.sh" <<'MOCK'
 print_start_banner() { echo "Starting /$3 for issue #$2"; }

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -101,6 +101,9 @@ exit 1
 MOCK
     chmod +x "$MOCK_DIR/spawn-recovery-subagent.sh"
 
+    # Real retry-on-kill.sh (sourced via WHOLEWORK_SCRIPT_DIR; must be present or source fails)
+    cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
+
     # Mock auto-checkpoint.sh: no-op milestone operations so existing tests are unaffected
     cat > "$MOCK_DIR/auto-checkpoint.sh" <<'MOCK'
 #!/bin/bash
@@ -859,4 +862,31 @@ MOCK
     [ -f "$RUN_REVIEW_LOG" ]
     [ -f "$RUN_MERGE_LOG" ]
     [[ "$output" == *"[resume]"* ]]
+}
+
+@test "retry-on-kill: child runner killed once then succeeds, run-auto-sub exits 0" {
+    COUNTER_FILE="$BATS_TEST_TMPDIR/call_counter"
+    echo "0" > "$COUNTER_FILE"
+    export COUNTER_FILE
+    # XS route: only code-patch phase, shortest path
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+    # Counter mock: 1st call exits 143 (SIGTERM), 2nd call exits 0
+    cat > "$MOCK_DIR/run-code.sh" <<'MOCK'
+#!/bin/bash
+N=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "$COUNTER_FILE"
+if [[ $N -eq 1 ]]; then exit 143; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+    # orchestration-recoveries.md is absent in test env: _write_wrapper_retry_recovery skips
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
 }

--- a/tests/run-code-mergeability.bats
+++ b/tests/run-code-mergeability.bats
@@ -62,6 +62,7 @@ emit_event() { return 0; }
 MOCK
 
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
+    cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
 
     cat > "$MOCK_DIR/git" <<'MOCK'
 #!/bin/bash

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -90,8 +90,9 @@ _emit_comments_consumed() { :; }
 _append_consumed_comments_section() { :; }
 MOCK
 
-    # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
+    # Real guard-prefix.sh and retry-on-kill.sh (sourced via WHOLEWORK_SCRIPT_DIR)
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
+    cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
 
     cat > "$MOCK_DIR/git" <<'MOCK'
 #!/bin/bash
@@ -666,4 +667,22 @@ MOCK
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
     [[ "$output" != *"Warning:"*"Signed-off-by"* ]]
+}
+
+@test "retry-on-kill: retry-success - killed once then succeeds, wrapper exits 0" {
+    COUNTER_FILE="$BATS_TEST_TMPDIR/call_counter"
+    echo "0" > "$COUNTER_FILE"
+    export COUNTER_FILE
+    cat > "$MOCK_DIR/claude" <<'MOCK'
+#!/bin/bash
+N=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "$COUNTER_FILE"
+if [[ $N -eq 1 ]]; then exit 143; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
 }

--- a/tests/run-issue.bats
+++ b/tests/run-issue.bats
@@ -90,8 +90,9 @@ MOCK
 emit_event() { return 0; }
 MOCK
 
-    # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
+    # Real guard-prefix.sh and retry-on-kill.sh (sourced via WHOLEWORK_SCRIPT_DIR)
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
+    cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
 
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash
@@ -311,4 +312,58 @@ MOCK
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
     grep -q "phase_complete" "$EMIT_LOG"
+}
+
+@test "retry-on-kill: retry-success - killed once then succeeds, wrapper exits 0" {
+    COUNTER_FILE="$BATS_TEST_TMPDIR/call_counter"
+    echo "0" > "$COUNTER_FILE"
+    export COUNTER_FILE
+    cat > "$MOCK_DIR/claude" <<'MOCK'
+#!/bin/bash
+N=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "$COUNTER_FILE"
+if [[ $N -eq 1 ]]; then exit 143; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
+}
+
+@test "retry-on-kill: escalation - killed twice, wrapper exits 143" {
+    COUNTER_FILE="$BATS_TEST_TMPDIR/call_counter"
+    echo "0" > "$COUNTER_FILE"
+    export COUNTER_FILE
+    cat > "$MOCK_DIR/claude" <<'MOCK'
+#!/bin/bash
+N=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "$COUNTER_FILE"
+exit 143
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 143 ]
+    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
+}
+
+@test "retry-on-kill: over-threshold no-retry - immediate kill but WHOLEWORK_RETRY_ON_KILL_MAX_SEC=0" {
+    COUNTER_FILE="$BATS_TEST_TMPDIR/call_counter"
+    echo "0" > "$COUNTER_FILE"
+    export COUNTER_FILE
+    export WHOLEWORK_RETRY_ON_KILL_MAX_SEC=0
+    cat > "$MOCK_DIR/claude" <<'MOCK'
+#!/bin/bash
+N=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "$COUNTER_FILE"
+exit 143
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+    run bash "$SCRIPT" 123
+    unset WHOLEWORK_RETRY_ON_KILL_MAX_SEC
+    [ "$status" -eq 143 ]
+    [ "$(cat "$COUNTER_FILE")" -eq 1 ]
 }

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -114,8 +114,9 @@ emit_event() { return 0; }
 _append_consumed_comments_section() { :; }
 MOCK
 
-    # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
+    # Real guard-prefix.sh and retry-on-kill.sh (sourced via WHOLEWORK_SCRIPT_DIR)
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
+    cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
 
     # Mock reconcile-phase-state.sh: default returns empty (no false alarm)
     cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
@@ -440,4 +441,22 @@ MOCK
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
     [ ! -f "$FALLBACK_LOG" ]
+}
+
+@test "retry-on-kill: retry-success - killed once then succeeds, wrapper exits 0" {
+    COUNTER_FILE="$BATS_TEST_TMPDIR/call_counter"
+    echo "0" > "$COUNTER_FILE"
+    export COUNTER_FILE
+    cat > "$MOCK_DIR/claude" <<'MOCK'
+#!/bin/bash
+N=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "$COUNTER_FILE"
+if [[ $N -eq 1 ]]; then exit 143; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/claude"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
 }


### PR DESCRIPTION
## 概要

- `scripts/retry-on-kill.sh` を新規追加: `run_with_retry_on_kill()` 関数を提供する source 可能なヘルパー
- SIGTERM (exit 143) / SIGKILL (exit 137) を early-kill ウィンドウ内 (< 300s) で検出し、自動 1 回リトライする
- run-issue.sh / run-spec.sh / run-code.sh / run-auto-sub.sh の 4 本に統合
- `modules/orchestration-fallbacks.md` に `## wrapper-retry-on-kill` エントリを追加
- bats テスト 5 本追加 (retry-success / escalation / over-threshold 各バリアント)
- docs/structure.md (ja 含む) にファイル追記・カウント更新 (59→62)
- docs/tech.md (ja 含む) に `WHOLEWORK_RETRY_ON_KILL_MAX_SEC` 環境変数を追記

## 検証

- `bats tests/run-issue.bats tests/run-spec.bats tests/run-code.bats tests/run-auto-sub.bats` → 全 122 テスト pass
- `grep "137" modules/orchestration-fallbacks.md` → エントリ確認済み
- `grep "retry-on-kill.sh" docs/structure.md` → 記載確認済み
- `grep "WHOLEWORK_RETRY_ON_KILL_MAX_SEC" docs/tech.md` → 記載確認済み

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)