### PR TITLE
Issue #798: Exempt loop-state heartbeat from verify dirty check

### DIFF
--- a/docs/spec/issue-798-heartbeat-dirty-state-fix.md
+++ b/docs/spec/issue-798-heartbeat-dirty-state-fix.md
@@ -84,17 +84,31 @@
 - None. 1 回目のコミットで実装が完了し、全 12 テスト PASS。リワークは発生しなかった。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- 案 B (verify 側 dirty check 特例) を採用。Case A は commit 履歴肥大・push race リスクがあり採用しない。
-- `ignore_patterns` 配列への追加方式を選択。`_is_ignored()` 関数のシグネチャを変えず、既存 user-config パターンと同一の判定ロジックを共有する。
-- 警告メッセージは変更しない ("excluded by verify-ignore-paths" のまま)。既存テスト行 95・121 のアサートが同文字列を期待しており、変更コストを避ける。
+- 全 4 観点のライトレビューで MUST / SHOULD / CONSIDER 問題なし。外部レビューツール (Copilot/CodeRabbit) は未設定のため Step 7 スキップ。
+- Forbidden Expressions check の FAILURE は `docs/spec/issue-432-out-of-tree-file-verify-guide.md` の既存問題で、このPRの変更とは無関係と確認。
+- 警告メッセージが "excluded by verify-ignore-paths" を built-in パターンにも使用する設計は、Spec で明示的に決定されたもので問題なし。
 
 ### Deferred Items
 - Post-merge: 次回 `/auto --batch` 実行時に heartbeat dirty state が verify を block しないことを観察 (verify-type: observation event=auto-run)。
 
 ### Notes for Next Phase
-- `/review` では `scripts/check-verify-dirty.sh` の変更点 (built-in 免除パターン追加) と `tests/verify-dirty-detection.bats` の新規テストケース 2 件を重点的に確認すること。
-- 案 A を採用しなかった理由が Script コメントおよび Spec Notes に記録されている。
+- `/merge` では CI SUCCESS (Run bats tests × 2、Validate skill syntax × 2) を確認のうえマージ可能。
+- Forbidden Expressions check の FAILURE は既存問題のため merge ブロック要因ではない。
 - Post-merge AC は `observation event=auto-run` なので verify フェーズでは SKIPPED 扱い。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- None. Spec と実装の間に乖離なし。`ignore_patterns+=` の挿入位置、テストケースの assertionパターン、警告メッセージの維持、いずれも Spec の設計通りに実装されていた。
+
+### Recurring issues
+
+- None. 同種の問題は検出されなかった。4 観点すべてでクリーン。
+
+### Acceptance criteria verification difficulty
+
+- 全 AC が PASS (Post-merge は SKIPPED)。verify command (`bats` command) は CI "Run bats tests" SUCCESS を代替検証として使用 (safe mode)。rubric AC も diff から直接確認可能で UNCERTAIN なし。verify command の品質は良好。

--- a/docs/spec/issue-798-heartbeat-dirty-state-fix.md
+++ b/docs/spec/issue-798-heartbeat-dirty-state-fix.md
@@ -68,3 +68,33 @@
 
 - saito (MEMBER / first-class) — 2026-06-28T03:56:24Z: Issue Retrospective 記録: AC2 分割 (append-loop-state-heartbeat.bats と verify-dirty-detection.bats を明示) および Post-merge AC の verify-type を `observation event=auto-run` に修正
   URL: https://github.com/saitoco/wholework/issues/798#issuecomment-4824704355
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None. 実装ステップは Spec の通りに実行した。`verify-ignore-paths` ロードブロックの直後に built-in 免除パターンを追加し、テストケースも Spec 通りの 2 件を追加した。
+
+### Design Gaps/Ambiguities
+
+- 警告メッセージが built-in パターン経由でも "excluded by verify-ignore-paths" と表示されることは Spec Notes に明記されていたため問題なし。`_is_ignored()` 関数が `ignore_patterns` 配列を共通で使うため、built-in パターンと user-config パターンで同一メッセージが出力される設計は既存の期待に合致していた。
+
+### Rework
+
+- None. 1 回目のコミットで実装が完了し、全 12 テスト PASS。リワークは発生しなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- 案 B (verify 側 dirty check 特例) を採用。Case A は commit 履歴肥大・push race リスクがあり採用しない。
+- `ignore_patterns` 配列への追加方式を選択。`_is_ignored()` 関数のシグネチャを変えず、既存 user-config パターンと同一の判定ロジックを共有する。
+- 警告メッセージは変更しない ("excluded by verify-ignore-paths" のまま)。既存テスト行 95・121 のアサートが同文字列を期待しており、変更コストを避ける。
+
+### Deferred Items
+- Post-merge: 次回 `/auto --batch` 実行時に heartbeat dirty state が verify を block しないことを観察 (verify-type: observation event=auto-run)。
+
+### Notes for Next Phase
+- `/review` では `scripts/check-verify-dirty.sh` の変更点 (built-in 免除パターン追加) と `tests/verify-dirty-detection.bats` の新規テストケース 2 件を重点的に確認すること。
+- 案 A を採用しなかった理由が Script コメントおよび Spec Notes に記録されている。
+- Post-merge AC は `observation event=auto-run` なので verify フェーズでは SKIPPED 扱い。

--- a/scripts/check-verify-dirty.sh
+++ b/scripts/check-verify-dirty.sh
@@ -57,6 +57,10 @@ if [[ -f ".wholework.yml" ]]; then
   done < ".wholework.yml"
 fi
 
+# Built-in exempt: loop-state heartbeat files are exempt from the dirty check.
+# Case B adopted (#798): verify-side exemption avoids commit/push overhead in append-loop-state-heartbeat.sh
+ignore_patterns+=("docs/sessions/_daily/loop-state-*.md")
+
 # Check if a file matches any ignore pattern
 # Handles both "file/path" and "dir/" (trailing slash from untracked directory entries)
 _is_ignored() {

--- a/tests/verify-dirty-detection.bats
+++ b/tests/verify-dirty-detection.bats
@@ -133,3 +133,21 @@ EOF
     [ "$status" -eq 2 ]
     [[ "$output" == *"docs/spec/issue-999-unrelated.md"* ]]
 }
+
+@test "loop-state heartbeat only dirty: exit 0 (built-in exempt)" {
+    cd "$REPO_DIR"
+    mkdir -p "docs/sessions/_daily"
+    make_dirty "docs/sessions/_daily/loop-state-2026-06-28.md"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Warning: ignoring dirty file excluded by verify-ignore-paths" ]]
+}
+
+@test "loop-state mixed with non-spec dirty: exit 1" {
+    cd "$REPO_DIR"
+    mkdir -p "docs/sessions/_daily"
+    make_dirty "docs/sessions/_daily/loop-state-2026-06-28.md"
+    make_dirty "scripts/some-script.sh"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
## Summary

- `scripts/check-verify-dirty.sh` に `docs/sessions/_daily/loop-state-*.md` の built-in 免除パターンを追加 (Case B 採用)
- heartbeat-only dirty state で `/verify` が exit 0 (clean 扱い) で起動できるようになる
- `tests/verify-dirty-detection.bats` に新規テストケース 2 件を追加 (heartbeat-only → exit 0、heartbeat + 非 spec → exit 1)

## Verification (pre-merge)

- `scripts/check-verify-dirty.sh` に loop-state 免除パターンが追加されている (`ignore_patterns+=("docs/sessions/_daily/loop-state-*.md")`)
- Script コメントで Case B 採用理由が記述されている
- `bats tests/append-loop-state-heartbeat.bats` (9 tests PASS)
- `bats tests/verify-dirty-detection.bats` (12 tests PASS — 新規 2 件を含む)

## Verification (post-merge)

- 次回 `/auto --batch` 実行時に heartbeat による dirty state が verify を block しないことを観察

closes #798