### PR TITLE
Issue #819: Suppress orphan spec stub on XS patch route

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -35,7 +35,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（90 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（91 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents

--- a/docs/spec/issue-819-xs-patch-orphan-spec-fix.md
+++ b/docs/spec/issue-819-xs-patch-orphan-spec-fix.md
@@ -70,3 +70,32 @@
 ## Consumed Comments
 
 - saito / MEMBER / first-class / ## Issue Retrospective / https://github.com/saitoco/wholework/issues/819#issuecomment-4826260581
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None. The Spec's Option B (early exit when no spec file) was implemented as specified. The 8-line stub creation block (title fetch, mkdir, file create, H1 write) was replaced with a 2-line early exit matching the Spec exactly.
+
+### Design Gaps/Ambiguities
+
+- The `WHOLEWORK_SCRIPT_DIR` env var override causes `_repo_root` to be derived as `dirname(MOCK_DIR)`. Tests must structure `MOCK_DIR` as `$BATS_TEST_TMPDIR/repo/mocks` so that `_repo_root` resolves to `$BATS_TEST_TMPDIR/repo` and spec files are found at the correct path. This path convention was not documented in the Spec but was discovered during test authoring.
+
+### Rework
+
+- None.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Adopted Option B (suppress stub creation entirely) over Option A (kebab-case naming fix). Option B is simpler, eliminates the gh title-fetch call for XS issues where no spec context is needed, and avoids any untracked file footprint.
+- Mocked `git` via PATH in BATS tests (not via WHOLEWORK_SCRIPT_DIR) because the script calls `git -C "$_repo_root"` using the system PATH, not the sibling-script resolver.
+
+### Deferred Items
+- Option A (correct kebab-case naming when a stub is intentionally needed) remains unimplemented. If a future use case requires creating a stub for XS issues, Option A could be revisited as a follow-up.
+
+### Notes for Next Phase
+- The fix is a pure deletion of 8 lines replaced by 2 — review should be straightforward.
+- All 43 bats tests pass; no test failures to investigate.
+- AC1 rubric passes because stub creation is fully suppressed (no file written when spec absent).

--- a/docs/spec/issue-819-xs-patch-orphan-spec-fix.md
+++ b/docs/spec/issue-819-xs-patch-orphan-spec-fix.md
@@ -85,17 +85,31 @@
 
 - None.
 
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- None. The implementation exactly matches the Spec's Option B (suppress stub creation entirely). The diff was a pure 8-line → 2-line replacement with no scope drift.
+
+### Recurring Issues
+
+- The code phase's "All 43 bats tests pass" log referred only to the new test file (`tests/append-consumed-comments-section.bats`), not the full suite. An existing test in `tests/run-verify.bats` ("spec absent: creates skeleton file") tested the old behavior and was not updated before committing. This produced a deterministic CI FAILURE that could have been caught with `bats tests/` (full suite run) locally. Recommendation: code phase should always run `bats tests/` (all tests) before committing behavioral changes to ensure no regression in existing tests.
+
+### Acceptance Criteria Verification Difficulty
+
+- AC3 `command "bats tests/run-code.bats tests/append-consumed-comments-section.bats"` was narrowly scoped to only the new/modified test files, which masked the broken existing test in `tests/run-verify.bats`. Broader verify commands (e.g., `command "bats tests/"`) would have caught this at AC verification time rather than at CI check time.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Adopted Option B (suppress stub creation entirely) over Option A (kebab-case naming fix). Option B is simpler, eliminates the gh title-fetch call for XS issues where no spec context is needed, and avoids any untracked file footprint.
-- Mocked `git` via PATH in BATS tests (not via WHOLEWORK_SCRIPT_DIR) because the script calls `git -C "$_repo_root"` using the system PATH, not the sibling-script resolver.
+- Updated `tests/run-verify.bats:88` test name from "spec absent: creates skeleton file with ## Consumed Comments section" to "spec absent: skips stub creation and exits 0", asserting the new behavior (exit 0, no file created).
+- No other changes needed; the implementation in `scripts/append-consumed-comments-section.sh` was correct.
 
 ### Deferred Items
-- Option A (correct kebab-case naming when a stub is intentionally needed) remains unimplemented. If a future use case requires creating a stub for XS issues, Option A could be revisited as a follow-up.
+- Option A (correct kebab-case naming when a stub is intentionally needed) remains unimplemented per the code phase decision.
+- AC3 verify command scope is narrow (`tests/run-code.bats tests/append-consumed-comments-section.bats` only); widening to `bats tests/` would improve regression coverage.
 
 ### Notes for Next Phase
-- The fix is a pure deletion of 8 lines replaced by 2 — review should be straightforward.
-- All 43 bats tests pass; no test failures to investigate.
-- AC1 rubric passes because stub creation is fully suppressed (no file written when spec absent).
+- CI should now pass after the `tests/run-verify.bats` fix was pushed.
+- Post-merge AC (orphan stub observation) is still pending; verify via `/auto N` on an XS issue.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -42,7 +42,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (90 files)
+├── tests/               # Bats test files for scripts (91 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -29,14 +29,8 @@ SPEC_DIR_ABS="$_repo_root/$SPEC_DIR"
 SPEC_FILE=$(ls "$SPEC_DIR_ABS/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
 
 if [[ -z "$SPEC_FILE" ]]; then
-  TITLE=$(gh issue view "$ISSUE_NUMBER" --json title -q '.title' 2>/dev/null \
-    || echo "Issue #${ISSUE_NUMBER}")
-  mkdir -p "$SPEC_DIR_ABS" 2>/dev/null || true
-  SPEC_FILE="$SPEC_DIR_ABS/issue-${ISSUE_NUMBER}-${PHASE_NAME}.md"
-  printf '%s\n' "# Issue #${ISSUE_NUMBER}: ${TITLE}" > "$SPEC_FILE" 2>/dev/null || {
-    echo "append-consumed-comments-section.sh: WARNING — skip (cannot create spec file)" >&2
-    exit 0
-  }
+  echo "append-consumed-comments-section.sh: no spec file for issue #${ISSUE_NUMBER}, skipping" >&2
+  exit 0
 fi
 
 # Check if section already exists; skip if present (deduplicate guard)

--- a/tests/append-consumed-comments-section.bats
+++ b/tests/append-consumed-comments-section.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/append-consumed-comments-section.sh
+# Mocks: get-config-value.sh (via WHOLEWORK_SCRIPT_DIR), gh and git (via PATH prepend)
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/append-consumed-comments-section.sh"
+
+setup() {
+    REPO_ROOT="$BATS_TEST_TMPDIR/repo"
+    MOCK_DIR="$REPO_ROOT/mocks"
+    mkdir -p "$MOCK_DIR"
+    mkdir -p "$REPO_ROOT/docs/spec"
+
+    export PATH="$MOCK_DIR:$PATH"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    cat > "$MOCK_DIR/get-config-value.sh" <<'MOCK'
+#!/bin/bash
+KEY="$1"; DEFAULT="${2:-}"
+case "$KEY" in
+    spec-path) echo "docs/spec" ;;
+    *) echo "$DEFAULT" ;;
+esac
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-config-value.sh"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "api" ]]; then
+    echo ""
+    exit 0
+fi
+echo "[]"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+if [[ " $* " == *" diff "* ]] && [[ " $* " == *" --quiet "* ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+}
+
+@test "no spec file: skips stub creation and exits 0" {
+    run "$SCRIPT" 42 code
+    [ "$status" -eq 0 ]
+    stub_count=$(find "$BATS_TEST_TMPDIR/repo/docs/spec" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
+    [ "$stub_count" -eq 0 ]
+}
+
+@test "spec file exists: appends Consumed Comments section" {
+    SPEC_FILE="$BATS_TEST_TMPDIR/repo/docs/spec/issue-42-some-title.md"
+    printf '# Issue #42: some title\n\n## Overview\nSome content.\n' > "$SPEC_FILE"
+
+    run "$SCRIPT" 42 code
+    [ "$status" -eq 0 ]
+    grep -q "^## Consumed Comments" "$SPEC_FILE"
+}
+
+@test "section already exists: dedup guard exits 0 without duplicate" {
+    SPEC_FILE="$BATS_TEST_TMPDIR/repo/docs/spec/issue-42-some-title.md"
+    printf '# Issue #42\n\n## Consumed Comments\nNo new comments since last phase.\n' > "$SPEC_FILE"
+
+    run "$SCRIPT" 42 code
+    [ "$status" -eq 0 ]
+    section_count=$(grep -c "^## Consumed Comments" "$SPEC_FILE")
+    [ "$section_count" -eq 1 ]
+}

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -76,17 +76,16 @@ teardown() {
     grep -q "No new comments since last phase." "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
 }
 
-@test "spec absent: creates skeleton file with ## Consumed Comments section" {
-    # No spec file exists — script should create skeleton
+@test "spec absent: skips stub creation and exits 0" {
+    # No spec file exists — script should exit 0 without creating a stub
     mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
 
     run bash "$SCRIPT" 99 verify
     [ "$status" -eq 0 ]
 
-    # A spec file for issue 99 should have been created
-    CREATED=$(ls "$BATS_TEST_TMPDIR/docs/spec/issue-99-"*.md 2>/dev/null | head -1 || true)
-    [ -n "$CREATED" ]
-    grep -q "^## Consumed Comments" "$CREATED"
+    # No stub file should be created
+    stub_count=$(ls "$BATS_TEST_TMPDIR/docs/spec/issue-99-"*.md 2>/dev/null | wc -l | tr -d ' ')
+    [ "$stub_count" -eq 0 ]
 }
 
 @test "section exists: skip and exit 0 without adding another section" {


### PR DESCRIPTION
## Summary

- `scripts/append-consumed-comments-section.sh` のスタブ作成ブロック (spec ファイルが存在しない場合) を早期 `exit 0` に置換し、非標準命名 `issue-N-code.md` の orphan stub 生成を抑制
- `tests/append-consumed-comments-section.bats` を新規作成 (no-spec skip / section append / dedup guard の 3 テスト)
- `docs/structure.md` / `docs/ja/structure.md` の tests ファイル数を 90→91 に更新

## Verification (pre-merge)

- orphan spec stub の発生が解消されている (スタブ作成ブロックを `exit 0` に置換)
- `tests/append-consumed-comments-section.bats` が新規作成されている
- `bats tests/run-code.bats tests/append-consumed-comments-section.bats` が成功する (43 tests PASS)

## Verification (post-merge)

- 次回 `/auto --batch` または `/auto N` (XS) 実行時に `docs/spec/issue-N-code.md` 形式の orphan stub が生成されないことを観察

closes #819