### PR TITLE
Issue #820: Suppress duplicate transition rows in append-loop-state-heartbeat.sh

### DIFF
--- a/docs/spec/issue-820-append-heartbeat-dedup.md
+++ b/docs/spec/issue-820-append-heartbeat-dedup.md
@@ -82,17 +82,32 @@
 ### Rework
 - None — 初回実装でテスト 10/10 all pass。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+Nothing to note. 実装は Spec の実装ステップと完全に一致している。dedup ロジックの挿入位置 (DETAIL 変数代入直後、printf 直前) も Spec 通り。
+
+### Recurring Issues
+
+Nothing to note. 4 観点レビューで MUST/SHOULD/CONSIDER いずれの課題も検出されず。
+
+### Acceptance Criteria Verification Difficulty
+
+Nothing to note. AC1 (rubric) はスクリプト本体の読み取りで確認。AC2 (bats) は CI reference fallback (CI job "Run bats tests" SUCCESS) で PASS 判定。UNCERTAIN 0 件。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Approach A (tail-based last-row dedup) を採用。Approach B (flock) は見送り — AC が OR 接続のため片方で十分、かつ実装コストが低い。
-- DETAIL 文字列 (`#N from→to snapshot:[...]`) 全体をパターンマッチ条件とし、timestamp と Phase column は判定対象外とした。
-- bats テストに新規ケースを追加 (AC2 上は任意だが品質向上のため実装)。
+- MUST 課題 0 件のため コード修正不要。PR はそのままマージ可能。
+- 軽量統合レビュー (light モード) で 4 観点を確認し、実装・テスト・ドキュメントすべてに問題なし。
+- CI 全ジョブ SUCCESS (DCO, bats, validate-skill-syntax, forbidden-expressions, macOS-compat)。
 
 ### Deferred Items
-- flock による並列 race condition 防止は未実装。AC は OR 条件で満たしているが、ハイ並列 batch での完全排除が必要になれば別 Issue で対応。
+- post-merge AC (observation event=auto-run) は `/verify` 自動検証対象外。次回 `/auto --batch` 後に手動観察で確認。
+- flock による並列 race condition 対策は別 Issue で対応 (既知の Deferred Item)。
 
 ### Notes for Next Phase
-- テスト 10/10 all pass、forbidden expressions check clean — CI は問題なく通るはず。
-- post-merge AC は observation event=auto-run 型 — `/verify` での自動検証対象外。次回 `/auto --batch` 実行後に手動観察で確認。
+- PR #828 は `/merge` 可能な状態。`/merge 828` を実行してよい。
+- Phase Handoff write: review フェーズ完了。

--- a/docs/spec/issue-820-append-heartbeat-dedup.md
+++ b/docs/spec/issue-820-append-heartbeat-dedup.md
@@ -70,3 +70,29 @@
 ## Consumed Comments
 
 - saito / MEMBER / first-class / ## Issue Retrospective (Auto-Resolve Log: approach A/B OR 接続の確認、bats テスト追加が任意であることの確認) / https://github.com/saitoco/wholework/issues/820#issuecomment-4826400420
+
+## Code Retrospective
+
+### Deviations from Design
+- None — Spec の実装ステップと完全に一致。dedup チェックは DETAIL 変数代入直後、printf append 直前に挿入した。
+
+### Design Gaps/Ambiguities
+- snapshot が異なる場合 (同 issue・同 transition だが snapshot 変化) はデュープとして検出されない。Spec Notes で "直前行のみ比較" と明記されており設計上の意図 — 連続する完全一致行のみが重複対象。
+
+### Rework
+- None — 初回実装でテスト 10/10 all pass。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Approach A (tail-based last-row dedup) を採用。Approach B (flock) は見送り — AC が OR 接続のため片方で十分、かつ実装コストが低い。
+- DETAIL 文字列 (`#N from→to snapshot:[...]`) 全体をパターンマッチ条件とし、timestamp と Phase column は判定対象外とした。
+- bats テストに新規ケースを追加 (AC2 上は任意だが品質向上のため実装)。
+
+### Deferred Items
+- flock による並列 race condition 防止は未実装。AC は OR 条件で満たしているが、ハイ並列 batch での完全排除が必要になれば別 Issue で対応。
+
+### Notes for Next Phase
+- テスト 10/10 all pass、forbidden expressions check clean — CI は問題なく通るはず。
+- post-merge AC は observation event=auto-run 型 — `/verify` での自動検証対象外。次回 `/auto --batch` 実行後に手動観察で確認。

--- a/scripts/append-loop-state-heartbeat.sh
+++ b/scripts/append-loop-state-heartbeat.sh
@@ -125,6 +125,15 @@ fi
 
 # Append row (best-effort). Detail packs issue, transition, and aggregated snapshot.
 DETAIL="#${ISSUE} ${FROM}→${TO} snapshot:[${SNAPSHOT}]"
+
+# Dedup: skip if last row already contains this transition (best-effort).
+if [[ -f "$FILE" ]]; then
+  LAST_ROW=$(tail -1 "$FILE" 2>/dev/null || true)
+  if [[ -n "$LAST_ROW" && "$LAST_ROW" == *"$DETAIL"* ]]; then
+    exit 0
+  fi
+fi
+
 printf '| %s | %s | %s | %s |\n' "$TS" "$PHASE_LABEL" "phase-transition" "$DETAIL" >> "$FILE" 2>/dev/null || true
 
 exit 0

--- a/tests/append-loop-state-heartbeat.bats
+++ b/tests/append-loop-state-heartbeat.bats
@@ -117,6 +117,17 @@ MOCK
     grep -q 'snapshot:\[snapshot-unavailable\]' "$file"
 }
 
+@test "duplicate transition: skips append when last row matches" {
+    fake_root="$BATS_TEST_TMPDIR/repo"
+    wrapper=$(_make_wrapper "$fake_root")
+    "$wrapper" --issue 701 --from spec --to code
+    "$wrapper" --issue 701 --from spec --to code
+    today=$(date -u +%Y-%m-%d)
+    file="$fake_root/docs/sessions/_daily/loop-state-$today.md"
+    count=$(grep -c '#701 spec→code' "$file")
+    [ "$count" -eq 1 ]
+}
+
 @test "phase-label override applies to the Phase column" {
     fake_root="$BATS_TEST_TMPDIR/repo"
     wrapper=$(_make_wrapper "$fake_root")


### PR DESCRIPTION
## Summary

- `scripts/append-loop-state-heartbeat.sh` に同一 transition の連続重複行を抑制する dedup チェックを追加
- DETAIL 文字列 (`#N from→to snapshot:[...]`) 構築後、`tail -1` で最終行を取得し一致する場合は `exit 0` で skip
- `tests/append-loop-state-heartbeat.bats` に新規テストケース "duplicate transition: skips append when last row matches" を追加

## Verification (pre-merge)

- append dedup ロジックが追加されている (rubric — PASS)
- bats テストが緑 (10/10 all pass)

## Verification (post-merge)

- 次回 `/auto --batch` 実行時に `docs/sessions/_daily/loop-state-*.md` に同 transition の重複行が出現しないことを観察

closes #820