### PR TITLE
Issue #822: Add --write-manual-recovery subcommand for Spec Auto Retrospective

### DIFF
--- a/docs/spec/issue-822-manual-recovery-auto-retrospective.md
+++ b/docs/spec/issue-822-manual-recovery-auto-retrospective.md
@@ -246,18 +246,34 @@ Note: 既存 Tier 2 anomaly detector がパターンを追記済みの場合は 
 ### Rework
 - N/A
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Spec の 5 実装ファイルはすべて PR diff に反映されており、構造的な乖離なし
+- `_write_manual_recovery_to_spec()` の配置 (set -euo pipefail 直後) も Spec 記述と一致
+
+### Recurring issues
+- `git diff --quiet` が untracked ファイルを検出できない問題が `scripts/run-auto-sub.sh` の `_write_manual_recovery_to_spec()` (line 46) に存在。既存の `_write_tier2_recovery_to_spec()` (line 196)、`_write_tier3_recovery_to_spec()` (line 243) にも同じパターンが繰り返されており、共通ヘルパー関数化または `git status --porcelain` への統一修正が効果的。後続 Issue として起票を推奨
+- `_write_manual_recovery_to_spec()` に `$issue` の数値バリデーションがなく、フォールバックパスでパストラバーサルが可能 (SHOULD)。既存 Tier 2/3 も同様であり、横断的な修正 Issue の余地あり
+
+### Acceptance criteria verification difficulty
+- rubric + grep の組み合わせで AC 検証が機械的に実施でき、UNCERTAIN なし
+- bats test の verify command (grep "manual.*recovery") が実装を直接確認できており verify command の品質は良好
+- POST-MERGE 観察条件 1 件は verify phase が担当
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `_write_manual_recovery_to_spec()` を `set -euo pipefail` 直後 (line 8 の前) に配置することで、`--write-manual-recovery` dispatch が `SUB_NUMBER` 代入前に実行されるようにした — これにより `bash run-auto-sub.sh --write-manual-recovery 42 code push-only` が正常動作する
-- `skills/auto/SKILL.md` Step 6 の更新は Step 4a 参照を削除し `--write-manual-recovery` 呼び出し一本に統一した
-- `skills/verify/SKILL.md` Step 12 の "Tier 2/3" → "Tier 2/3/Manual" 拡張で `### Manual recovery` エントリも "already recorded" として扱われる
+- MUST 問題は検出されず。SHOULD 4 件、CONSIDER 1 件をラインコメントとして記録
+- `git diff --quiet` vs untracked files バグ (SHOULD) は Tier 2/3 にも共通する既知パターンであるため、本 PR のブロッカーとはしない判断
+- セキュリティ所見 (path traversal via `$issue`) は内部ツール文脈 + `-recovery.md` 固定サフィックスの制約から SHOULD 止まりとした
 
 ### Deferred Items
-- `orchestration-recoveries.md` への同時書き込み (Tier 2/3 は書き込む) は今回スコープ外。manual recovery の session-level SSoT は引き続き手動で `orchestration-recoveries.md` に書くか省略する
-- `allowed-tools` への追加は不要 (既存 `run-auto-sub.sh:*` でカバー)
+- `git diff --quiet` → `git status --porcelain` の横断修正は別 Issue で対応推奨
+- `$issue` / `$phase` / `$recovery_type` の入力バリデーション追加も別 Issue 候補
+- "Manual automatic recovery" の表現矛盾は次回 cleanup で修正
 
 ### Notes for Next Phase
-- PR #830 の CI が通過すること、特に bats テスト全 32 件が PASS していることを確認
-- `--write-manual-recovery` の引数順は `ISSUE PHASE RECOVERY_TYPE` (全て位置引数) — PR body の verify サンプルを含めて review 担当が確認すると良い
+- CI 全 SUCCESS、MUST 未検出につき `/merge 830` で直接 merge 可能
+- merge 後は next-cycle-seed または verify セッションで上記 SHOULD 問題の起票を検討

--- a/docs/spec/issue-822-manual-recovery-auto-retrospective.md
+++ b/docs/spec/issue-822-manual-recovery-auto-retrospective.md
@@ -235,19 +235,29 @@ Note: 既存 Tier 2 anomaly detector がパターンを追記済みの場合は 
 ### Uncertainty resolution
 - Nothing to note
 
+## Code Retrospective
+
+### Deviations from Design
+- `_write_manual_recovery_to_spec()` は Spec に記述の通り `set -euo pipefail` 直後に配置した。設計と一致
+
+### Design Gaps/Ambiguities
+- `skills/auto/SKILL.md` の更新で "then follow Step 4a (after all phases are done)" という旧文が `--write-manual-recovery` 呼び出しに完全置換された。Step 4a の `### Orchestration Anomalies` / `### Improvement Proposals` 参照が失われる懸念があったが、`--write-manual-recovery` は recovery record のみ書き込む機能に特化しており、Improvement Proposals は verify phase が担当するという役割分担で整合している
+
+### Rework
+- N/A
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
-- `_write_manual_recovery_to_spec()` を `run-auto-sub.sh` の `set -euo pipefail` 直後に配置し、`SUB_NUMBER` 代入前に `--write-manual-recovery` dispatch を実装する設計を採用。`WHOLEWORK_SCRIPT_DIR` 環境変数でテスト可能にする
-- `skills/verify/SKILL.md` Step 12 skip 判定の更新も必要と判断 (Issue body 未記載だが目的達成のため必須)
-- Size: L (5ファイル + script argument handling 変更 → +1)、ROUTE=pr
+- `_write_manual_recovery_to_spec()` を `set -euo pipefail` 直後 (line 8 の前) に配置することで、`--write-manual-recovery` dispatch が `SUB_NUMBER` 代入前に実行されるようにした — これにより `bash run-auto-sub.sh --write-manual-recovery 42 code push-only` が正常動作する
+- `skills/auto/SKILL.md` Step 6 の更新は Step 4a 参照を削除し `--write-manual-recovery` 呼び出し一本に統一した
+- `skills/verify/SKILL.md` Step 12 の "Tier 2/3" → "Tier 2/3/Manual" 拡張で `### Manual recovery` エントリも "already recorded" として扱われる
 
 ### Deferred Items
-- `_write_manual_recovery_to_spec()` を `_write_tier3` と同じ場所 (line 148 近傍) に配置する alternative は見送り (関数定義を SUB_NUMBER より後に置けない制約があるため)
-- `orchestration-recoveries.md` への同時書き込みは今回スコープ外 (spec のみ対象)
+- `orchestration-recoveries.md` への同時書き込み (Tier 2/3 は書き込む) は今回スコープ外。manual recovery の session-level SSoT は引き続き手動で `orchestration-recoveries.md` に書くか省略する
+- `allowed-tools` への追加は不要 (既存 `run-auto-sub.sh:*` でカバー)
 
 ### Notes for Next Phase
-- `scripts/run-auto-sub.sh` への変更は `set -euo pipefail` 直後 (line 7 と line 8 の間) に挿入する必要がある — 間違って `SUB_NUMBER` 代入後に置かないよう注意
-- bats テストは `WHOLEWORK_SCRIPT_DIR=$MOCK_DIR` を使うため `_repo_root=$(dirname $MOCK_DIR)=$BATS_TEST_TMPDIR` になる。テスト内の `docs/spec/` ディレクトリは `$BATS_TEST_TMPDIR/docs/spec/` に作成すること
-- `skills/auto/SKILL.md` の変更で半角 `!` を使わないよう注意 (forbidden expression)
+- PR #830 の CI が通過すること、特に bats テスト全 32 件が PASS していることを確認
+- `--write-manual-recovery` の引数順は `ISSUE PHASE RECOVERY_TYPE` (全て位置引数) — PR body の verify サンプルを含めて review 担当が確認すると良い

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -512,6 +512,34 @@ See also: `#async-external-commit` (reconcile-first authority — `matches_expec
 
 ---
 
+## manual-recovery-spec-write
+
+### Symptom
+- Parent session manually called `worktree-merge-push.sh`, `gh pr create`, or `run-*.sh` to recover a sub-issue from a kill or mid-run failure — independent of Tier 1/2/3 automatic recovery
+- The sub-issue Spec's `## Auto Retrospective` section does not have a recovery entry for this manual intervention
+
+### Applicable Phases
+- code, review, merge (XL sub-issue parent session manual recovery)
+
+### Fallback Steps
+1. After the manual recovery action completes successfully, run:
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh --write-manual-recovery ISSUE PHASE RECOVERY_TYPE
+   ```
+   where `RECOVERY_TYPE` is a short string describing the action taken (e.g., `push-only`, `pr-create`, `review-rerun`)
+2. The subcommand calls `_write_manual_recovery_to_spec()` which appends a `### Manual recovery (PHASE)` entry to the Spec's `## Auto Retrospective` section and commits/pushes immediately
+3. The entry includes: date, issue/phase, source (`parent session manual recovery`), recovery type, and outcome (`success`)
+
+### Escalation
+- If the script exits non-zero (commit/push failure), a WARNING is logged to stderr and execution continues — spec write failure is non-fatal; the `/verify` session can still record the anomaly manually
+
+### Rationale
+- Introduced in Issue #822: `_write_tier2_recovery_to_spec()` and `_write_tier3_recovery_to_spec()` (Issue #800) only cover automatic recovery paths; manual recovery by the parent session left `## Auto Retrospective` incomplete, requiring verify-session manual supplementation
+- Symmetric with Tier 2/3 paths: same `## Auto Retrospective` section, same `### <type> recovery (phase)` heading format
+- `/verify` Step 12's skip-judgment now includes `### Manual recovery` entries as "already recorded" (alongside Tier 2/Tier 3), eliminating the need for manual supplementation
+
+---
+
 ## Operational Notes
 
 This catalog is consumed by:
@@ -535,6 +563,18 @@ Mechanism:
 - `_write_tier2_recovery_to_spec()` appends the metadata to the Spec's `## Auto Retrospective` section and commits/pushes immediately
 
 This write happens during the sub-issue execution phase, before the parent `/auto` Step 4a runs. When Step 4a Source 1 (`fallback-catalog`) runs later, the sub-issue Spec Auto Retrospective is already up to date. The parent session's Step 4a writes `orchestration-recoveries.md` as the session-level SSoT; the Spec write here serves the per-Issue paper trail.
+
+### Manual path: Spec Auto Retrospective write
+
+When the parent session performs a manual recovery (e.g., `worktree-merge-push.sh` re-run, `gh pr create` manual call, or `run-*.sh` re-execution), there is no automatic bash path to write the recovery record. The operator must explicitly call:
+
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh --write-manual-recovery ISSUE PHASE RECOVERY_TYPE
+```
+
+This invokes `_write_manual_recovery_to_spec()`, which appends a `### Manual recovery (PHASE)` entry to the sub-issue Spec's `## Auto Retrospective` section and commits/pushes immediately — symmetric with the Tier 2 and Tier 3 bash paths described below. `/verify` Step 12 treats `### Manual recovery` entries as "already recorded" and skips redundant retrospective writing.
+
+See also: `modules/orchestration-fallbacks.md#manual-recovery-spec-write`
 
 ### Tier 3 bash path: Spec Auto Retrospective write
 

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -5,6 +5,67 @@
 # Usage: run-auto-sub.sh <sub-issue-number> [--base <branch>]
 
 set -euo pipefail
+
+# --write-manual-recovery subcommand: write manual recovery record to sub-issue Spec.
+# Usage: run-auto-sub.sh --write-manual-recovery ISSUE [PHASE] [RECOVERY_TYPE]
+# See modules/orchestration-fallbacks.md#manual-recovery-spec-write
+_write_manual_recovery_to_spec() {
+  local issue="$1"
+  local phase="${2:-unknown}"
+  local recovery_type="${3:-unspecified}"
+  local _script_dir="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+  local _repo_root
+  _repo_root="$(dirname "$_script_dir")"
+  local spec_dir="$_repo_root/docs/spec"
+  local spec_file
+  spec_file=$(ls "$spec_dir/issue-${issue}-"*.md 2>/dev/null | head -1 || true)
+
+  if [[ -z "$spec_file" ]]; then
+    local title
+    title=$(gh issue view "$issue" --json title -q '.title' 2>/dev/null || echo "Issue #${issue}")
+    mkdir -p "$spec_dir"
+    spec_file="$spec_dir/issue-${issue}-recovery.md"
+    printf '%s\n' "# Issue #${issue}: ${title}" > "$spec_file"
+  fi
+
+  if ! grep -q "^## Auto Retrospective" "$spec_file" 2>/dev/null; then
+    printf '\n%s\n' "## Auto Retrospective" >> "$spec_file"
+  fi
+
+  local _date
+  _date=$(date -u '+%Y-%m-%d %H:%M UTC')
+  printf '\n%s\n' "### Manual recovery (${phase})" >> "$spec_file"
+  printf '%s\n' "- **Date**: ${_date}" >> "$spec_file"
+  printf '%s\n' "- **Issue**: #${issue}, phase: ${phase}" >> "$spec_file"
+  printf '%s\n' "- **Source**: parent session manual recovery" >> "$spec_file"
+  printf '%s\n' "- **Recovery type**: ${recovery_type}" >> "$spec_file"
+  printf '%s\n' "- **Outcome**: success" >> "$spec_file"
+
+  local spec_rel_path="${spec_file#$_repo_root/}"
+
+  if ! git -C "$_repo_root" diff --quiet "$spec_rel_path" 2>/dev/null; then
+    if git -C "$_repo_root" add "$spec_rel_path" \
+       && git -C "$_repo_root" commit -s -m "Record manual recovery in auto retrospective for issue #${issue}
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
+       && git -C "$_repo_root" push origin HEAD; then
+      echo "[#${issue}] [recovery] spec auto retrospective updated for issue #${issue} (manual recovery)"
+    else
+      echo "[#${issue}] WARNING: could not commit/push manual recovery to spec; continuing" >&2
+    fi
+  fi
+}
+
+if [[ "${1:-}" == "--write-manual-recovery" ]]; then
+  shift
+  if [[ -z "${1:-}" ]]; then
+    echo "Error: --write-manual-recovery requires: ISSUE [PHASE] [RECOVERY_TYPE]" >&2
+    exit 1
+  fi
+  _write_manual_recovery_to_spec "$@"
+  exit 0
+fi
+
 SUB_NUMBER="${1:?Usage: run-auto-sub.sh <sub-issue-number> [--base <branch>]}"
 shift
 

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -890,7 +890,7 @@ Do not invoke subsequent phases.
 - merge phase failure: invalid PR state (not approved, CI failure), conflict resolution failure
 - verify phase failure: acceptance condition FAIL, Issue reopened
 
-**Manual recovery hand-off**: If the parent session manually recovers and continues to subsequent phases instead of stopping here, complete the remaining phases via manual recovery first, then follow Step 4a (after all phases are done) to append anomaly details and improvement proposals to the Spec's `## Auto Retrospective > ### Orchestration Anomalies` and `### Improvement Proposals` sections, then proceed to Step 5. Note: if the Tier 2 anomaly detector already appended a known pattern, skip the `### Orchestration Anomalies` / `### Improvement Proposals` append in Step 4a to avoid duplicate entries.
+**Manual recovery hand-off**: If the parent session manually recovers and continues to subsequent phases instead of stopping here, complete the remaining phases via manual recovery first, then call `bash ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh --write-manual-recovery ISSUE PHASE RECOVERY_TYPE` to automatically write the recovery record to the sub-issue Spec's `## Auto Retrospective` section (where RECOVERY_TYPE describes the action taken, e.g., `push-only`, `pr-create`, `review-rerun`). Skip this call if the Tier 2 anomaly detector already appended a recovery entry for this event to avoid duplicate entries. Then proceed to Step 5.
 
 Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "Processing Steps" section with:
 - `SKILL_NAME=auto`

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -650,11 +650,11 @@ As the final step of the workflow, verify conducts a retrospective of the entire
    - Zero improvement proposals were identified in step 2
    - Spec does not exist OR all phases in the lifecycle review (step 2) had no observations worth recording
 
-   **Tier 2/3 automatic recovery handling**: When evaluating the third condition, apply the following rule for orchestration recovery observations:
-   - If the Spec's `## Auto Retrospective` section already records the Tier 2 or Tier 3 recovery that occurred for this Issue, those recovery observations are considered "already recorded" — they do not count as notable content for the verify retrospective. Treat them as non-notable when evaluating the third condition above.
-   - If a Tier 2 or Tier 3 recovery occurred but is NOT recorded in `## Auto Retrospective` (e.g., the auto route was not used, or the recovery predates Auto Retrospective), it qualifies as notable content. Do not skip; record it in the verify retrospective.
+   **Tier 2/3/Manual automatic recovery handling**: When evaluating the third condition, apply the following rule for orchestration recovery observations:
+   - If the Spec's `## Auto Retrospective` section already records the Tier 2, Tier 3, or Manual recovery that occurred for this Issue, those recovery observations are considered "already recorded" — they do not count as notable content for the verify retrospective. Treat them as non-notable when evaluating the third condition above. `_write_manual_recovery_to_spec()` writes `### Manual recovery (phase)` entries that qualify as "already recorded" under this rule.
+   - If a Tier 2, Tier 3, or Manual recovery occurred but is NOT recorded in `## Auto Retrospective` (e.g., the auto route was not used, the recovery predates Auto Retrospective, or `--write-manual-recovery` was not called), it qualifies as notable content. Do not skip; record it in the verify retrospective.
 
-   This rule makes the skip determination mechanical: check whether `## Auto Retrospective` exists and contains "Tier 2" or "Tier 3" recovery records. If yes, those records are already the SSoT — no duplication in the verify retrospective.
+   This rule makes the skip determination mechanical: check whether `## Auto Retrospective` exists and contains "Tier 2", "Tier 3", or "Manual recovery" records. If yes, those records are already the SSoT — no duplication in the verify retrospective.
 
    If ALL conditions hold: output `retrospective skipped: no notable content` to terminal and skip step 4. Proceed to Step 13.
 4. **Persist retrospective results to Spec**:

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -795,6 +795,29 @@ MOCK
     grep -qE "commit.*Tier 3 recovery" "$GIT_LOG"
 }
 
+@test "run-auto-sub: manual recovery: writes Auto Retrospective to spec file" {
+    export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    echo "# Issue #42: test spec" > "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GIT_LOG"
+if [[ "$*" == *"diff"* && "$*" == *"issue-42"* ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash "$SCRIPT" --write-manual-recovery 42 code push-only
+    [ "$status" -eq 0 ]
+    grep -q "Auto Retrospective" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+    grep -q "Manual recovery" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+    grep -qE "commit.*manual recovery" "$GIT_LOG"
+}
+
 @test "post-spec size unchanged XS->XS: Post-spec is not logged" {
     cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
 #!/bin/bash


### PR DESCRIPTION
## Summary

- `scripts/run-auto-sub.sh` に `_write_manual_recovery_to_spec()` 関数と `--write-manual-recovery ISSUE PHASE RECOVERY_TYPE` サブコマンドを追加。parent session が manual recovery (push, pr-create, review-rerun 等) を実行した際に sub-issue Spec の `## Auto Retrospective` に自動追記できるようになった
- `modules/orchestration-fallbacks.md` に `## manual-recovery-spec-write` カタログエントリと `## Operational Notes` の "Manual path" 小節を追加し、Tier 2/3 と対称的な設計を文書化
- `tests/run-auto-sub.bats` に `--write-manual-recovery` の bats test を追加 (32/32 PASS)
- `skills/auto/SKILL.md` Step 6 の Manual recovery hand-off 注釈を `--write-manual-recovery` 呼び出し形式に更新
- `skills/verify/SKILL.md` Step 12 の skip 判定を更新し、`### Manual recovery` エントリも "already recorded" として扱うようにした

## Verification (pre-merge)

- `_write_manual_recovery_to_spec()` が `scripts/run-auto-sub.sh` に実装されており、`_write_tier3_recovery_to_spec` と対称的な構造 (spec_dir 参照、git add+commit+push、セクション存在確認) を持つ
- `modules/orchestration-fallbacks.md` に `manual-recovery-spec-write` エントリが存在し、Tier 3 path との対称性が記述されている
- `tests/run-auto-sub.bats` に manual recovery → Spec write を assert するテストが追加されている

## Verification (post-merge)

- 次回 manual recovery 発生時に対象 sub-issue の Spec に `## Auto Retrospective` が自動追記されることを観察

closes #822