### PR TITLE
Issue #831: Fix git diff --quiet silent failure for untracked spec files

### DIFF
--- a/docs/spec/issue-831-recovery-change-detection-fix.md
+++ b/docs/spec/issue-831-recovery-change-detection-fix.md
@@ -68,19 +68,32 @@
 
 - 既存 tier2/tier3/manual recovery テストの git mock を最初の commit では更新しなかったため、全テスト実行 (bats tests/) で tests 26-28 が FAIL した。2 回目の edit で修正した。新テスト追加時は既存テストへの影響を同時に確認すべきだった。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+
+- Nothing to note. 実装は Spec の設計通りで乖離なし。`_spec_has_changes()` の引数名・配置位置・`grep -q .` 判定方式いずれも Spec Notes と一致。
+
+### Recurring Issues
+
+- Nothing to note. review-light の 4観点すべてで問題なし。Bug type の特徴である regression tests も AC に含まれており、3件が適切に追加されている。
+
+### Acceptance Criteria Verification Difficulty
+
+- AC2 の verify command (`github_check "gh pr checks" "Run bats tests"`) は CI 完了後でないと判定できない構造。AC2 のチェックボックスが `[ ]` のまま PR が提出されたが、CI SUCCESS を確認後に `[x]` に更新した。この遅延検証は `github_check` verify の想定動作であり問題ない。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `_spec_has_changes()` を `set -euo pipefail` 直後に配置し、`_write_manual_recovery_to_spec()` の直前に置いた。スコープ的に最も近い位置であり、script の早期定義として読みやすい。
-- `git status --porcelain "$spec_rel_path"` の出力を `grep -q .` で non-empty 判定する方式を選択。`wc -l` や変数展開より簡潔で bash 3.2+ 互換。
-- 既存テストの git mock を `status --porcelain` 対応に更新した。これにより `git diff --quiet` の旧モックが残らず、テストが新ロジックのみを検証することが確認できる。
+- REVIEW_DEPTH=light (--light 指定かつ Size M)。review-light の 4観点で問題なし。MUST 問題なし → COMMENT イベントで投稿。
+- AC2 のチェックボックスを `[x]` に更新 (`gh-issue-edit.sh` 経由)。CI SUCCESS を確認済み。
 
 ### Deferred Items
-- `orchestration-recoveries.md` の `git diff --quiet` (lines 298, 486) はスコープ外のまま。これらは常に tracked ファイルへの書き込みなので問題なし。
-- AC2 の `github_check "gh pr checks" "Run bats tests"` は CI 実行後に確認。ローカル bats 全 1031 件 PASS 済み。
+- Post-merge AC: 「次回 recovery 発生時に初回 Spec 作成 (untracked) ケースで commit が漏れないことを観察」は `/verify` のポストマージ観察に委ねる。
+- Spec Notes に記載された `orchestration-recoveries.md` の `git diff --quiet` (スコープ外) は将来の関連 Issue で対応。
 
 ### Notes for Next Phase
-- PR #838 で CI が通ることを `/verify` 前に確認すること。`Run bats tests` ジョブが最重要。
-- `_spec_has_changes()` は bash script の先頭部 (line 9-15) に定義済み。`/review` はこの位置を確認してコメント位置の適切性を評価してよい。
-- Spec Notes の verify command と実装の結合度についてはレビューコメント不要 (設計上の意図的な依存)。
+- MUST 問題なし、CI SUCCESS → `/merge 838` で即マージ可能。
+- Post-merge AC は `verify-type: observation event=auto-run` のため `/verify` の観察スコープ。
+- review-light エージェントが利用不可のためインライン実行した。次サイクルでエージェント登録を検討してもよい (Improvement Proposal 候補)。

--- a/docs/spec/issue-831-recovery-change-detection-fix.md
+++ b/docs/spec/issue-831-recovery-change-detection-fix.md
@@ -53,3 +53,34 @@
 ## Consumed Comments
 
 - **saito** (MEMBER, first-class) — bats verify command 形式の修正・rubric 補足 verify 追加・bats test AC 補足 grep 追加の Auto-Resolve Log: https://github.com/saitoco/wholework/issues/831#issuecomment-4827005414
+
+## Code Retrospective
+
+### Deviations from Design
+
+- 既存の 3 テスト (tier2/tier3/manual recovery) の git mock を更新する必要があった。Spec の実装計画には新 3 テストの追加のみ記載されていたが、既存テストも `git diff --quiet` 前提の mock だったため、`git status --porcelain` を返すよう合わせて更新した。これは実装の自然な副作用であり、スコープ変更ではなくテスト整合性の維持。
+
+### Design Gaps/Ambiguities
+
+- `_spec_has_changes()` の引数名 `spec_rel_path` は AC verify command の grep パターンに依存するため Spec Notes に明記されており、実装に迷いはなかった。ただし、Notes がなければ引数名が異なった可能性があるため、verify command と実装の結合度の高さは将来の rename 時に注意が必要。
+
+### Rework
+
+- 既存 tier2/tier3/manual recovery テストの git mock を最初の commit では更新しなかったため、全テスト実行 (bats tests/) で tests 26-28 が FAIL した。2 回目の edit で修正した。新テスト追加時は既存テストへの影響を同時に確認すべきだった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `_spec_has_changes()` を `set -euo pipefail` 直後に配置し、`_write_manual_recovery_to_spec()` の直前に置いた。スコープ的に最も近い位置であり、script の早期定義として読みやすい。
+- `git status --porcelain "$spec_rel_path"` の出力を `grep -q .` で non-empty 判定する方式を選択。`wc -l` や変数展開より簡潔で bash 3.2+ 互換。
+- 既存テストの git mock を `status --porcelain` 対応に更新した。これにより `git diff --quiet` の旧モックが残らず、テストが新ロジックのみを検証することが確認できる。
+
+### Deferred Items
+- `orchestration-recoveries.md` の `git diff --quiet` (lines 298, 486) はスコープ外のまま。これらは常に tracked ファイルへの書き込みなので問題なし。
+- AC2 の `github_check "gh pr checks" "Run bats tests"` は CI 実行後に確認。ローカル bats 全 1031 件 PASS 済み。
+
+### Notes for Next Phase
+- PR #838 で CI が通ることを `/verify` 前に確認すること。`Run bats tests` ジョブが最重要。
+- `_spec_has_changes()` は bash script の先頭部 (line 9-15) に定義済み。`/review` はこの位置を確認してコメント位置の適切性を評価してよい。
+- Spec Notes の verify command と実装の結合度についてはレビューコメント不要 (設計上の意図的な依存)。

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -6,6 +6,14 @@
 
 set -euo pipefail
 
+# Returns true if spec_rel_path has any changes (modified or untracked).
+# Uses git status --porcelain so untracked files are detected (unlike git diff --quiet).
+_spec_has_changes() {
+  local repo_root="$1"
+  local spec_rel_path="$2"
+  git -C "$repo_root" status --porcelain "$spec_rel_path" 2>/dev/null | grep -q .
+}
+
 # --write-manual-recovery subcommand: write manual recovery record to sub-issue Spec.
 # Usage: run-auto-sub.sh --write-manual-recovery ISSUE [PHASE] [RECOVERY_TYPE]
 # See modules/orchestration-fallbacks.md#manual-recovery-spec-write
@@ -43,7 +51,7 @@ _write_manual_recovery_to_spec() {
 
   local spec_rel_path="${spec_file#$_repo_root/}"
 
-  if ! git -C "$_repo_root" diff --quiet "$spec_rel_path" 2>/dev/null; then
+  if _spec_has_changes "$_repo_root" "$spec_rel_path"; then
     if git -C "$_repo_root" add "$spec_rel_path" \
        && git -C "$_repo_root" commit -s -m "Record manual recovery in auto retrospective for issue #${issue}
 
@@ -193,7 +201,7 @@ _write_tier2_recovery_to_spec() {
 
   local spec_rel_path="${spec_file#$_repo_root/}"
 
-  if ! git -C "$_repo_root" diff --quiet "$spec_rel_path" 2>/dev/null; then
+  if _spec_has_changes "$_repo_root" "$spec_rel_path"; then
     if git -C "$_repo_root" add "$spec_rel_path" \
        && git -C "$_repo_root" commit -s -m "Record Tier 2 recovery in auto retrospective for issue #${issue}
 
@@ -240,7 +248,7 @@ _write_tier3_recovery_to_spec() {
 
   local spec_rel_path="${spec_file#$_repo_root/}"
 
-  if ! git -C "$_repo_root" diff --quiet "$spec_rel_path" 2>/dev/null; then
+  if _spec_has_changes "$_repo_root" "$spec_rel_path"; then
     if git -C "$_repo_root" add "$spec_rel_path" \
        && git -C "$_repo_root" commit -s -m "Record Tier 3 recovery in auto retrospective for issue #${issue}
 

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -703,8 +703,9 @@ MOCK
     cat > "$MOCK_DIR/git" <<'MOCK'
 #!/bin/bash
 echo "$@" >> "$GIT_LOG"
-if [[ "$*" == *"diff"* && "$*" == *"issue-42"* ]]; then
-    exit 1
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo " M docs/spec/issue-42-test.md"
+    exit 0
 fi
 exit 0
 MOCK
@@ -755,8 +756,9 @@ MOCK
     cat > "$MOCK_DIR/git" <<'MOCK'
 #!/bin/bash
 echo "$@" >> "$GIT_LOG"
-if [[ "$*" == *"diff"* && "$*" == *"issue-42"* ]]; then
-    exit 1
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo " M docs/spec/issue-42-test.md"
+    exit 0
 fi
 exit 0
 MOCK
@@ -804,8 +806,9 @@ MOCK
     cat > "$MOCK_DIR/git" <<'MOCK'
 #!/bin/bash
 echo "$@" >> "$GIT_LOG"
-if [[ "$*" == *"diff"* && "$*" == *"issue-42"* ]]; then
-    exit 1
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo " M docs/spec/issue-42-test.md"
+    exit 0
 fi
 exit 0
 MOCK
@@ -815,6 +818,132 @@ MOCK
     [ "$status" -eq 0 ]
     grep -q "Auto Retrospective" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
     grep -q "Manual recovery" "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+    grep -qE "commit.*manual recovery" "$GIT_LOG"
+}
+
+@test "run-auto-sub: tier2 recovery: commits when spec file is untracked" {
+    export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+
+    # No pre-existing spec file: simulates untracked (initial creation) state
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GIT_LOG"
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo "?? docs/spec/issue-42-recovery.md"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    cat > "$MOCK_DIR/apply-fallback.sh" <<'MOCK'
+#!/bin/bash
+printf '%s\n' \
+  "### Orchestration Anomalies" \
+  "- **[code-patch-silent-no-op]** Tier 2 fallback applied: result=recovered."
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/apply-fallback.sh"
+
+    cat > "$MOCK_DIR/run-code.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":false}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "Auto Retrospective" "$BATS_TEST_TMPDIR/docs/spec/issue-42-recovery.md"
+    grep -qE "commit.*Tier 2 recovery" "$GIT_LOG"
+}
+
+@test "run-auto-sub: tier3 recovery: commits when spec file is untracked" {
+    export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+
+    # No pre-existing spec file: simulates untracked (initial creation) state
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GIT_LOG"
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo "?? docs/spec/issue-42-recovery.md"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    cat > "$MOCK_DIR/spawn-recovery-subagent.sh" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$SPAWN_RECOVERY_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/spawn-recovery-subagent.sh"
+
+    cat > "$MOCK_DIR/run-code.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":false}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "Auto Retrospective" "$BATS_TEST_TMPDIR/docs/spec/issue-42-recovery.md"
+    grep -qE "commit.*Tier 3 recovery" "$GIT_LOG"
+}
+
+@test "run-auto-sub: manual recovery: commits when spec file is untracked" {
+    export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+
+    # No pre-existing spec file: simulates untracked (initial creation) state
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GIT_LOG"
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo "?? docs/spec/issue-42-recovery.md"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash "$SCRIPT" --write-manual-recovery 42 code push-only
+    [ "$status" -eq 0 ]
+    grep -q "Auto Retrospective" "$BATS_TEST_TMPDIR/docs/spec/issue-42-recovery.md"
+    grep -q "Manual recovery" "$BATS_TEST_TMPDIR/docs/spec/issue-42-recovery.md"
     grep -qE "commit.*manual recovery" "$GIT_LOG"
 }
 


### PR DESCRIPTION
## Summary

- `scripts/run-auto-sub.sh` の 3 つの recovery 関数 (`_write_manual_recovery_to_spec`, `_write_tier2_recovery_to_spec`, `_write_tier3_recovery_to_spec`) で変更検知に `git diff --quiet` を使用していたが、untracked ファイル (初回 Spec 作成時) を検出できない silent failure があった
- 共通ヘルパー関数 `_spec_has_changes()` を追加し、`git status --porcelain` ベースに統一することで untracked ファイルも確実に検出するように修正
- `tests/run-auto-sub.bats` に 3 関数それぞれの untracked ケースを assert するテストを追加し、既存 3 テストの git mock も新ロジックに対応

## Verification (pre-merge)

- `scripts/run-auto-sub.sh` に `_spec_has_changes()` ヘルパーが追加され、3 関数の `git diff --quiet` 呼び出しが置換されていること
- `grep "status --porcelain.*spec_rel_path" "scripts/run-auto-sub.sh"` にマッチすること
- CI の `Run bats tests` ジョブが pass すること (1031 tests expected)
- `grep "untracked" "tests/run-auto-sub.bats"` にマッチすること

## Verification (post-merge)

- 次回 recovery 発生時に初回 Spec 作成 (untracked) ケースで commit が漏れないことを観察

closes #831