### PR TITLE
Issue #837: Add §23 non-contiguous git invocation heuristic to verify-patterns.md

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -35,7 +35,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（91 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（93 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents

--- a/docs/spec/issue-837-git-contiguous-heuristic.md
+++ b/docs/spec/issue-837-git-contiguous-heuristic.md
@@ -78,19 +78,32 @@ No new comments since last phase.
 ### Rework
 - None.
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+- AC1 の rubric verify command は対象ファイルを 4 件列挙しているが、実装は `modules/verify-patterns.md` 1 件のみに追加された。rubric の "のいずれかに" 条件は満たされており、PASS。将来の Issue で同様の複数候補 rubric を書く場合、実装ターゲットを 1 件に絞る判断は code phase で行うため rubric は候補列挙で問題ない。
+
+### Recurring Issues
+- §23 の Decision Procedure (step 1) が `git commit` に限定されており、§23 本文の「汎化」と矛盾していた。ガイドライン文書では、本文での「汎化します」という宣言と手順書の具体例が一致しているか review phase で意識的にチェックすることを推奨。
+- ssh の例示に placeholder 文字列 (`host command`) を使っており、ガイドラインの実用性が低下していた。例示には常に実在するリテラル文字列を使うべきというルールを verify-patterns.md 自体が自己適用できていなかった。
+
+### Acceptance Criteria Verification Difficulty
+- pre-merge AC2 の `command "bats tests/verify-heuristics.bats"` は safe mode で CI reference fallback を使用した。CI `Run bats tests` SUCCESS で PASS を確認 — verify command と CI ジョブ名の対応が明確であり、fallback が正常に機能した。
+- AC1 の rubric は adversarial grader なしに AI judgment で PASS 判定した。対象ファイルが diff に明示的に含まれており、verify command 検証が容易だった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- §23 を `modules/verify-patterns.md` の `## Output` 直前に挿入した。他の候補ファイル (skills/issue/SKILL.md、verify-classifier.md、ambiguity-detector.md) より SSoT として最適。
-- `tests/verify-heuristics.bats` は Spec の指定通り 3 テスト (non-contiguous keyword / contiguous keyword / git -C example) で構成した。
-- `docs/structure.md` の tests/ カウントを 91 → 93 に更新し、translation sync として `docs/ja/structure.md` も同期した。
+- MUST 問題なし (全 SHOULD/CONSIDER を修正)。event = COMMENT で投稿。
+- SHOULD 3 件を修正: Decision Procedure 汎化、ssh placeholder 例の差し替え、commit -s vs commit -m の使い分け明示。
+- CONSIDER 1 件 (bats test anchor の specificity 向上) も合わせて修正。
 
 ### Deferred Items
-- Post-merge observation AC (次回 /auto または /issue 実行時の verify command 生成観察) は verify phase に委ねる。
-- `/issue` SKILL.md や他モジュールへの同 heuristic の追記は本 Issue スコープ外 (Proposal A は実施せず; verify-patterns.md SSoT で十分)。
+- Post-merge observation AC は verify phase が担当 (`verify-type: observation event=auto-run`)。
+- Step 13 ポリシー変更なし — AC の更新不要。
 
 ### Notes for Next Phase
-- PR #840 が CI を通過することを確認してから merge を進めること。
-- post-merge AC は `verify-type: observation event=auto-run` であり、機械的な検証は不要 — verify phase では SKIPPED/post-merge manual として扱う。
-- 全 pre-merge AC は code phase でチェック済み (AC1: rubric PASS、AC2: bats 3/3 PASS)。
+- 修正コミット `047d29a` を含む PR #840 が merge 可能な状態。
+- post-merge AC は verify phase で SKIPPED/post-merge manual として扱うこと。
+- CI は全ジョブ SUCCESS 確認済み。

--- a/docs/spec/issue-837-git-contiguous-heuristic.md
+++ b/docs/spec/issue-837-git-contiguous-heuristic.md
@@ -62,3 +62,35 @@
 - **docs/structure.md count**: tests/ カウントが既に 91 (structure.md) vs 92 (実際) と 1 ずれている。本 Issue で verify-heuristics.bats を追加後は 93 になるため 93 に更新する。ただし Issue body に AC なし — /code フェーズで合わせて修正すること
 - **implementation placement**: §23 は `## Output` の直前に挿入する。§22 の最終行 (`Do not force...`) の後に改行を挟んで追加
 - **git -C example**: `scripts/append-loop-state-heartbeat.sh` line 142 の `git -C "$REPO_ROOT" commit -s -m "chore: loop-state heartbeat auto-commit $DATE [skip ci]"` がリファレンス例として使用可能 (非連続形式が実在することを確認済み)
+
+## Consumed Comments (code phase)
+
+No new comments since last phase.
+
+## Code Retrospective
+
+### Deviations from Design
+- None. Spec の実装ステップを設計通りに実行した。
+
+### Design Gaps/Ambiguities
+- `docs/ja/structure.md` の translation sync が Spec の Changed Files に明示されていなかったが、`docs/translation-workflow.md` のルールに従い `docs/structure.md` 更新に対応して同期した。
+
+### Rework
+- None.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- §23 を `modules/verify-patterns.md` の `## Output` 直前に挿入した。他の候補ファイル (skills/issue/SKILL.md、verify-classifier.md、ambiguity-detector.md) より SSoT として最適。
+- `tests/verify-heuristics.bats` は Spec の指定通り 3 テスト (non-contiguous keyword / contiguous keyword / git -C example) で構成した。
+- `docs/structure.md` の tests/ カウントを 91 → 93 に更新し、translation sync として `docs/ja/structure.md` も同期した。
+
+### Deferred Items
+- Post-merge observation AC (次回 /auto または /issue 実行時の verify command 生成観察) は verify phase に委ねる。
+- `/issue` SKILL.md や他モジュールへの同 heuristic の追記は本 Issue スコープ外 (Proposal A は実施せず; verify-patterns.md SSoT で十分)。
+
+### Notes for Next Phase
+- PR #840 が CI を通過することを確認してから merge を進めること。
+- post-merge AC は `verify-type: observation event=auto-run` であり、機械的な検証は不要 — verify phase では SKIPPED/post-merge manual として扱う。
+- 全 pre-merge AC は code phase でチェック済み (AC1: rubric PASS、AC2: bats 3/3 PASS)。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -42,7 +42,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (91 files)
+├── tests/               # Bats test files for scripts (93 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents

--- a/modules/verify-patterns.md
+++ b/modules/verify-patterns.md
@@ -801,6 +801,45 @@ The first condition verifies installation (mechanical, dependency-free). The sec
 
 Do not force `command` hints onto authentication-dependent or external-service-dependent commands. If the command fails in CI due to missing credentials or an offline service, the condition produces FAIL/UNCERTAIN noise. Classify such conditions as `verify-type: opportunistic` from the start and add a lightweight `command "tool --version"` check as the automatable portion where available.
 
+### 23. Non-Contiguous Git Invocation — Prefer Contiguous Sub-strings
+
+When verifying git invocations with `file_contains` or `grep`, the full form `"git commit"` may not appear as a contiguous substring when the implementation inserts flags between `git` and the sub-command (e.g., `git -C "$REPO_ROOT" commit`). Use a sub-string that is guaranteed to appear contiguously on one line.
+
+**Anti-pattern:**
+
+```
+file_contains "scripts/foo.sh" "git commit"
+```
+
+This FAILs when the actual code is `git -C "$REPO_ROOT" commit -s -m "..."` — `git commit` is split by the `-C "$REPO_ROOT"` flag and does not appear on any single line.
+
+**Recommended patterns:**
+
+```
+file_contains "scripts/foo.sh" "commit -s"
+file_contains "scripts/foo.sh" "commit -m"
+```
+
+Both `commit -s` and `commit -m` are contiguous sub-strings regardless of what precedes `commit` on the line.
+
+**Real example:** `scripts/append-loop-state-heartbeat.sh` contains `git -C "$REPO_ROOT" commit -s -m "chore: ..."` — the contiguous anchor is `commit -s`, not `git commit`.
+
+**Generalizes to any command with inserted flags:**
+
+This pattern applies whenever option flags are inserted between a command name and its sub-command:
+
+| Full form (non-contiguous) | Contiguous anchor |
+|---------------------------|-------------------|
+| `git -C "$REPO_ROOT" commit` | `commit -s` / `commit -m` |
+| `git -C "$REPO_ROOT" push` | `push origin` |
+| `ssh -i key host command` | `host command` (the host+command part) |
+
+**Decision procedure:**
+
+1. Before writing `file_contains "path" "git commit"`, check whether the implementation may use `git -C` or other inserted flags
+2. If yes (or uncertain): use `commit -s`, `commit -m`, or another contiguous sub-string anchor instead
+3. Verify the chosen anchor appears literally in the implementation file (cross-reference procedure from §3)
+
 ## Output
 
 Design verify commands following these guidelines and apply them to acceptance criteria.

--- a/modules/verify-patterns.md
+++ b/modules/verify-patterns.md
@@ -820,7 +820,7 @@ file_contains "scripts/foo.sh" "commit -s"
 file_contains "scripts/foo.sh" "commit -m"
 ```
 
-Both `commit -s` and `commit -m` are contiguous sub-strings regardless of what precedes `commit` on the line.
+Both `commit -s` and `commit -m` are contiguous sub-strings regardless of what precedes `commit` on the line. Use `commit -s` for projects that require signed-off commits (DCO); use `commit -m` otherwise — always choose the anchor that matches what the implementation actually contains.
 
 **Real example:** `scripts/append-loop-state-heartbeat.sh` contains `git -C "$REPO_ROOT" commit -s -m "chore: ..."` — the contiguous anchor is `commit -s`, not `git commit`.
 
@@ -832,11 +832,11 @@ This pattern applies whenever option flags are inserted between a command name a
 |---------------------------|-------------------|
 | `git -C "$REPO_ROOT" commit` | `commit -s` / `commit -m` |
 | `git -C "$REPO_ROOT" push` | `push origin` |
-| `ssh -i key host command` | `host command` (the host+command part) |
+| `ssh -i key myserver "deploy.sh"` | `"deploy.sh"` (the literal command string) |
 
 **Decision procedure:**
 
-1. Before writing `file_contains "path" "git commit"`, check whether the implementation may use `git -C` or other inserted flags
+1. Before writing `file_contains "path" "<command> <subcommand>"` (e.g., `"git commit"`, `"git push"`), check whether the implementation may insert flags between the command name and sub-command (e.g., `git -C`, `ssh -i key host`)
 2. If yes (or uncertain): use `commit -s`, `commit -m`, or another contiguous sub-string anchor instead
 3. Verify the chosen anchor appears literally in the implementation file (cross-reference procedure from §3)
 

--- a/tests/verify-heuristics.bats
+++ b/tests/verify-heuristics.bats
@@ -4,7 +4,7 @@ PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 VERIFY_PATTERNS="$PROJECT_ROOT/modules/verify-patterns.md"
 
 @test "verify-heuristics: non-contiguous heuristic section exists in verify-patterns.md" {
-    grep -q "non-contiguous" "$VERIFY_PATTERNS"
+    grep -q "Non-Contiguous Git Invocation" "$VERIFY_PATTERNS"
 }
 
 @test "verify-heuristics: contiguous sub-string guidance is documented" {

--- a/tests/verify-heuristics.bats
+++ b/tests/verify-heuristics.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+# Structural regression tests for verify command heuristic guidelines.
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+VERIFY_PATTERNS="$PROJECT_ROOT/modules/verify-patterns.md"
+
+@test "verify-heuristics: non-contiguous heuristic section exists in verify-patterns.md" {
+    grep -q "non-contiguous" "$VERIFY_PATTERNS"
+}
+
+@test "verify-heuristics: contiguous sub-string guidance is documented" {
+    grep -q "contiguous" "$VERIFY_PATTERNS"
+}
+
+@test "verify-heuristics: git -C example is present in verify-patterns.md" {
+    grep -q 'git -C' "$VERIFY_PATTERNS"
+}


### PR DESCRIPTION
## Summary

- `modules/verify-patterns.md` に §23「Non-Contiguous Git Invocation — Prefer Contiguous Sub-strings」を追加
- `file_contains` / `grep` で `git -C "$REPO_ROOT" commit` 等の非連続 git invocation を検証する際に `git commit` がマッチしない問題に対するガイドラインを文書化
- `tests/verify-heuristics.bats` を新規作成し、§23 ガイドラインの structural regression test を追加 (3 テスト)
- `docs/structure.md` および `docs/ja/structure.md` の tests/ ファイル数を 91 → 93 に更新

## Verification (pre-merge)

- modules/verify-patterns.md に §23 が追加され、non-contiguous シンボルの contiguous sub-string 選択ガイドラインが文書化されている
- `bats tests/verify-heuristics.bats` が 3/3 PASS (structural regression test)

## Verification (post-merge)

- 次回 `/auto` または `/issue` 実行時、git invocation を含む実装の verify command が contiguous sub-string で生成されることを観察

closes #837