### PR TITLE
Issue #826: Add behavioral change detection guideline to code Step 9

### DIFF
--- a/docs/spec/issue-826-code-behavioral-change-bats.md
+++ b/docs/spec/issue-826-code-behavioral-change-bats.md
@@ -45,3 +45,35 @@
 ## Consumed Comments
 
 - saito (MEMBER / first-class): Issue Retrospective (auto-resolve log) — "behavioral change" の定義を `modules/verify-patterns.md` §24 に統一; Proposal A/C を統合して A/B 2択に整理; rubric を 3択→2択 (`skills/code/SKILL.md` または `modules/test-runner.md`) に絞り込み。これらの決定は Issue body に反映済み。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- None. Spec の実装ステップに従い、`skills/code/SKILL.md` Step 9 冒頭に「Behavioral Change Detection」サブセクションを追加した。挿入位置 (`Read test-runner.md` 行の直前) も Spec 通り。
+
+### Design Gaps/Ambiguities
+
+- `bats tests/` 実行後に `Read test-runner.md` も呼ぶかが Spec に明記されていなかった。Tier 0 / FAIL ハンドリングは test-runner.md 配下にあるため、behavioral change 検出時は「フルスイート実行 → その結果を Tier 0 フローに渡す」構造とし、`Read test-runner.md` はその後の処理 (FAIL 対応) として維持する構成を採用した。
+- Spec に「test-runner auto-detection を上書き」と記載されていたが、test-runner.md の Step 1 auto-detection が既に `bats tests/` を優先選択する。「上書き」は重複実行を避けるのではなく「明示的に誘導する」の意味と解釈し、behavioral change 時は full suite 実行を明確に指定するサブセクションを先置きする設計を採用した。
+
+### Rework
+
+- None.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `skills/code/SKILL.md` Step 9 冒頭に「Behavioral Change Detection」サブセクションを追加 (`modules/test-runner.md` には追加しない: code phase 固有問題のため)
+- behavioral change の定義は `modules/verify-patterns.md` §24 と統一 (既存ファイル変更 + cross-file test coupling の2段階チェック)
+- bash 3.2+ 互換の `grep -rl` を使用
+
+### Deferred Items
+- post-merge verification: 次回 /auto code phase 実行時に `bats tests/` が実行されることを観察 (verify-type: observation event=auto-run)
+- `modules/test-runner.md` 側への同等ガイドライン追加は今後のニーズ次第 (現時点は code phase 限定)
+
+### Notes for Next Phase
+- verify command (rubric) は code phase で PASS 確認済み、Issue #826 Pre-merge チェックボックス更新済み
+- post-merge AC は observation 型 (次回 /auto 実行後に観察)
+- 1 ファイル変更のシンプルな実装; review で注目すべき複雑度なし

--- a/docs/spec/issue-826-code-behavioral-change-bats.md
+++ b/docs/spec/issue-826-code-behavioral-change-bats.md
@@ -61,19 +61,31 @@
 
 - None.
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- 逸脱なし。Behavioral Change Detection の挿入位置、2段階チェック構造、`bats tests/` 呼び出し形式、bash 3.2+ 互換コマンドの選択、いずれも Spec と完全一致。
+
+### Recurring issues
+
+- SHOULD: `tests/` ディレクトリが存在しない場合の `grep -rl` エラーハンドリングが未定義 (skills/code/SKILL.md:294)。動作は常に「フルスイート実行」方向にフォールバックするため実害は小さいが、LLM 向けガイドラインとして明示すると堅牢性が上がる。
+
+### Acceptance criteria verification difficulty
+
+- 条件 1件、rubric 型 → PASS、UNCERTAIN なし。rubric 評価はシンプルで、Spec との一致確認のみで判断できた。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `skills/code/SKILL.md` Step 9 冒頭に「Behavioral Change Detection」サブセクションを追加 (`modules/test-runner.md` には追加しない: code phase 固有問題のため)
-- behavioral change の定義は `modules/verify-patterns.md` §24 と統一 (既存ファイル変更 + cross-file test coupling の2段階チェック)
-- bash 3.2+ 互換の `grep -rl` を使用
+- REVIEW_DEPTH=light (--light フラグ + Size M); review-light エージェントで 4観点全チェック実施
+- MUST 件数 0、CI 全ジョブ SUCCESS、AC PASS → merge 可能状態
 
 ### Deferred Items
-- post-merge verification: 次回 /auto code phase 実行時に `bats tests/` が実行されることを観察 (verify-type: observation event=auto-run)
-- `modules/test-runner.md` 側への同等ガイドライン追加は今後のニーズ次第 (現時点は code phase 限定)
+- `tests/` ディレクトリ存在チェック (SHOULD) → 作者判断でスキップ可; 必要なら follow-up Issue で対応
+- post-merge AC は observation 型 (verify-type: observation event=auto-run)
 
 ### Notes for Next Phase
-- verify command (rubric) は code phase で PASS 確認済み、Issue #826 Pre-merge チェックボックス更新済み
-- post-merge AC は observation 型 (次回 /auto 実行後に観察)
-- 1 ファイル変更のシンプルな実装; review で注目すべき複雑度なし
+- merge ブロッカーなし; `/merge 842` で進める
+- Phase Handoff (review) 更新済み

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -277,6 +277,29 @@ Skip this sub-step if no out-of-scope remediations are identified.
 
 ### Step 9: Run Tests
 
+#### Behavioral Change Detection
+
+Before delegating scope selection to test-runner, check whether this implementation includes behavioral changes. A behavioral change is a modification to an existing file that is referenced by tests beyond the file's directly-associated test (`modules/verify-patterns.md` §24).
+
+**Detection (2 checks):**
+
+1. **Does the implementation modify any existing file (not purely additive)?**
+   - Review the changed files in this implementation (use `git diff --name-only HEAD` or the staged-file list).
+   - If only new files were added with no modifications to existing files: skip this subsection and proceed to `Read test-runner.md` below — narrow scope is acceptable.
+   - If any existing file is modified: continue to check 2.
+
+2. **Are there existing tests that reference the modified file(s) outside the directly-associated test?**
+   - For each modified existing file, extract the filename (without path) and run (bash 3.2+ compatible):
+     ```bash
+     grep -rl "<filename>" tests/
+     ```
+   - If the only matching test file is the direct counterpart of the modified file (e.g., `tests/run-code.bats` for `scripts/run-code.sh`), or there are no matches: narrow scope is acceptable — proceed to `Read test-runner.md`.
+   - If additional test files reference the modified file: behavioral change confirmed — override test-runner auto-detection scope and run the full suite:
+     ```bash
+     bats tests/
+     ```
+   - Handle FAIL via Tier 0 structured recovery below. If PASS, continue with the remaining validations in this step.
+
 Read `${CLAUDE_PLUGIN_ROOT}/modules/test-runner.md` and follow the "Processing Steps" section to run tests.
 
 #### Tier 0: Structured Test-Failure Recovery


### PR DESCRIPTION
## Summary

`/code` フェーズの Step 9 (Run Tests) 冒頭に「Behavioral Change Detection」サブセクションを追加。既存ファイルを変更する behavioral change が検出された場合 (cross-file test coupling あり) に `bats tests/` フルスイートを実行するよう LLM を誘導するガイドラインを追加した。

- `skills/code/SKILL.md`: Step 9 冒頭に `#### Behavioral Change Detection` サブセクションを追加
- behavioral change の定義は `modules/verify-patterns.md` §24 と統一
- bash 3.2+ 互換の `grep -rl` を使用
- CI での `--non-interactive` モード含む全ルートで適用される (SKILL.md は `run-code.sh` が `-p` プロンプトとしてそのまま使用するため)

## Verification (pre-merge)

- `skills/code/SKILL.md` に「Behavioral Change Detection」サブセクションが追加され、既存ファイルを変更する behavioral change 時は `bats tests/` フルスイートを実行するガイドラインが含まれている
- rubric 評価: PASS (verify command 実行済み、Issue #826 Pre-merge チェックボックス更新済み)

## Verification (post-merge)

- 次回 code phase 実行時に behavioral changes を含む変更で `bats tests/` フルスイートが実行されることを観察 (verify-type: observation)

closes #826