### PR TITLE
Issue #829: Add flock race guard to append-loop-state-heartbeat.sh

### DIFF
--- a/docs/spec/issue-829-heartbeat-flock-race-guard.md
+++ b/docs/spec/issue-829-heartbeat-flock-race-guard.md
@@ -113,3 +113,32 @@ flock 実装パターンは既存の `scripts/emit-event.sh` の `command -v flo
 - **クリティカルセクション範囲の拡大**: 従来は dedup+append のみ。file-creation (mkdir -p + header write) もアトミックに含めることで、並列起動時のヘッダー重複を防ぐ
 - **test assertion**: `[ "$count" -le 1 ]` — macOS システム bash (3.2) には flock がないため mkdir fallback 動作。並列 2プロセスが同時に mkdir に成功するエッジケースは極めてレアだが、CI 環境での flakiness を避けるため strict `[ -eq 1 ]` でなく `[ -le 1 ]` とする。flock 有環境では必ず 1 行
 - **auto-resolve (macOS flock 可用性)**: rubric が "flock または file-based mutual exclusion" と許容しており、Issue Retrospective に記録済み (自動解決)。実装は flock + mkdir fallback の両方を含むため、どちらの環境でも rubric が pass する
+
+## Code Retrospective
+
+### 実装サマリ
+
+`scripts/append-loop-state-heartbeat.sh` に flock ベースの排他制御を追加し、並列 batch worker による duplicate row race condition を構造的に防御した。
+
+主な変更点:
+1. `_do_append` 関数を定義し、file-creation・dedup・append を 1 つのアトミックな単位に集約
+2. `command -v flock` ディスパッチで flock (Linux/macOS with Homebrew) と mkdir-lock fallback (bash 3.2+) を切り替え
+3. `flock -n` (non-blocking) を採用し、ロック取得失敗時はスキップして best-effort 設計を維持
+4. `mkdir -p "$SESSIONS_DAILY_DIR"` をロック試行前に追加し、親ディレクトリ不在による lock ファイル/ディレクトリ作成失敗を解消
+
+### 発生した問題と修正
+
+**Test 21 FAIL: `[ "$header_count" -eq 1 ]`**
+
+- 原因: `$SESSIONS_DAILY_DIR` が存在しない場合、`flock` の `9>"$LOCK_FILE"` も `mkdir "$LOCK_DIR"` も親ディレクトリ不在で失敗 → 両並列プロセスが lock を取得できずタイムアウト後に無ロックで `_do_append` を呼び出し → ヘッダー重複
+- 修正: ロックディスパッチブロック前に `mkdir -p "$SESSIONS_DAILY_DIR" 2>/dev/null || true` を追加
+- 教訓: flock と mkdir-lock はどちらも親ディレクトリの存在を前提とする。`_do_append` 内部の `mkdir -p` は「ファイルが存在しない場合のみ」実行されるため、lock 取得前には別途 `mkdir -p` が必要
+
+### 設計判断
+
+- `flock -n` vs `flock -x`: heartbeat は best-effort なため non-blocking を選択。ロック競合時にスキップしても次回 phase transition で再 emit されるため、データ損失リスクは許容範囲内
+- `_do_append` 関数化: クリティカルセクションのスコープを明確にし、flock ブランチと mkdir-lock ブランチの両方から同一関数を呼び出す設計により、実装の重複を排除
+
+### Phase Handoff
+
+PR #844 (branch: `worktree-code+issue-829`) をマージ後、post-merge AC として次回 `/auto --batch` での重複行不発生を観察する。

--- a/docs/spec/issue-829-heartbeat-flock-race-guard.md
+++ b/docs/spec/issue-829-heartbeat-flock-race-guard.md
@@ -142,3 +142,33 @@ flock 実装パターンは既存の `scripts/emit-event.sh` の `command -v flo
 ### Phase Handoff
 
 PR #844 (branch: `worktree-code+issue-829`) をマージ後、post-merge AC として次回 `/auto --batch` での重複行不発生を観察する。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note. Spec の実装ステップと PR diff が完全に一致しており、divergence なし。rubric + grep による AC 検証も期待通りに機能した。
+
+### Recurring issues
+
+Nothing to note. 今回の PR では review-light の 4 観点すべてで MUST/SHOULD issues が発生しなかった。CONSIDER 1 件 (stale mkdir-lock) は設計上許容済みのトレードオフであり、繰り返し問題ではない。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note. `rubric` + `grep` の 2 段構えの verify command が機能的だった。`command "bats tests/"` は safe mode のため CI reference fallback を使用したが、`Run bats tests` ジョブが明確に特定できスムーズに PASS 判定できた。Post-merge observation AC (verify-type: observation) は SKIPPED として正しく処理された。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- `REVIEW_DEPTH=light` を適用 (--light フラグ明示) — 1 agent (review-light) で 4 観点を統合カバー
+- MUST/SHOULD issues なし → 修正フェーズ (Step 12) をスキップし直接 merge へ
+- CONSIDER 1 件 (stale mkdir-lock) は設計上許容済みとして skip 記録
+
+### Deferred Items
+- Post-merge 観察 AC: 次回 `/auto --batch` 実行後に `docs/sessions/_daily/loop-state-*.md` の重複行不発生を確認
+- verify-type: observation event=auto-run での自動評価
+
+### Notes for Next Phase
+- All pre-merge AC PASS、CI 全ジョブ SUCCESS → merge に支障なし
+- `review-light` エージェントタイプが未登録 (available agents に存在しない) — インライン分析で代替した。次回 /auto 実行時に review-light の登録状態を確認することを推奨

--- a/scripts/append-loop-state-heartbeat.sh
+++ b/scripts/append-loop-state-heartbeat.sh
@@ -103,38 +103,60 @@ if command -v gh >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
 fi
 [[ -z "$SNAPSHOT" ]] && SNAPSHOT="snapshot-unavailable"
 
-# Create file with unified header if it does not yet exist.
-if [[ ! -f "$FILE" ]]; then
-  mkdir -p "$SESSIONS_DAILY_DIR" 2>/dev/null || true
-  {
-    printf '%s\n' '---'
-    printf '%s\n' 'type: report'
-    printf '%s\n' "description: Loop state log for $DATE (phase-transition heartbeats and next-cycle seeds)"
-    printf '%s\n' "date: $DATE"
-    printf '%s\n' '---'
-    printf '\n'
-    printf '%s\n' "# Loop State — $DATE"
-    printf '\n'
-    printf '%s\n' '| Time (UTC) | Phase | Event | Detail |'
-    printf '%s\n' '|------------|-------|-------|--------|'
-  } >> "$FILE" 2>/dev/null || {
-    echo "append-loop-state-heartbeat.sh: WARNING — skip (cannot create $FILE)" >&2
-    exit 0
-  }
-fi
-
-# Append row (best-effort). Detail packs issue, transition, and aggregated snapshot.
+# Detail packs issue, transition, and aggregated snapshot.
 DETAIL="#${ISSUE} ${FROM}→${TO} snapshot:[${SNAPSHOT}]"
 
-# Dedup: skip if last row already contains this transition (best-effort).
-if [[ -f "$FILE" ]]; then
-  LAST_ROW=$(tail -1 "$FILE" 2>/dev/null || true)
-  if [[ -n "$LAST_ROW" && "$LAST_ROW" == *"$DETAIL"* ]]; then
-    exit 0
+# _do_append: file-creation + dedup + append as one atomic unit.
+# Called inside a flock or mkdir-lock critical section.
+# Uses return 0 (not exit) for flow control inside the function.
+_do_append() {
+  if [[ ! -f "$FILE" ]]; then
+    mkdir -p "$SESSIONS_DAILY_DIR" 2>/dev/null || true
+    {
+      printf '%s\n' '---'
+      printf '%s\n' 'type: report'
+      printf '%s\n' "description: Loop state log for $DATE (phase-transition heartbeats and next-cycle seeds)"
+      printf '%s\n' "date: $DATE"
+      printf '%s\n' '---'
+      printf '\n'
+      printf '%s\n' "# Loop State — $DATE"
+      printf '\n'
+      printf '%s\n' '| Time (UTC) | Phase | Event | Detail |'
+      printf '%s\n' '|------------|-------|-------|--------|'
+    } >> "$FILE" 2>/dev/null || {
+      echo "append-loop-state-heartbeat.sh: WARNING — skip (cannot create $FILE)" >&2
+      return 0
+    }
   fi
-fi
+  local last_row
+  last_row=$(tail -1 "$FILE" 2>/dev/null || true)
+  if [[ -n "$last_row" && "$last_row" == *"$DETAIL"* ]]; then
+    return 0
+  fi
+  printf '| %s | %s | %s | %s |\n' "$TS" "$PHASE_LABEL" "phase-transition" "$DETAIL" >> "$FILE" 2>/dev/null || true
+}
 
-printf '| %s | %s | %s | %s |\n' "$TS" "$PHASE_LABEL" "phase-transition" "$DETAIL" >> "$FILE" 2>/dev/null || true
+# Acquire a file lock before running _do_append so that parallel batch workers
+# cannot interleave file-creation, dedup, and append — preventing duplicate rows.
+# flock -n (non-blocking): if the lock is held, skip gracefully (best-effort).
+LOCK_FILE="${FILE}.lock"
+if command -v flock >/dev/null 2>&1; then
+  (flock -n 9 || exit 0; _do_append) 9>"$LOCK_FILE" 2>/dev/null || true
+else
+  # mkdir-lock fallback (bash 3.2+ compatible, no flock required)
+  LOCK_DIR="${FILE}.lockdir"
+  tries=0
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    tries=$((tries + 1))
+    if (( tries > 50 )); then
+      _do_append
+      tries=-1
+      break
+    fi
+    sleep 0.1
+  done
+  [[ "$tries" != -1 ]] && { _do_append; rmdir "$LOCK_DIR" 2>/dev/null || true; }
+fi
 
 # Best-effort auto-commit: commit the heartbeat file immediately so verify workers see a clean state.
 # Failure is non-fatal — the verify-side exempt in check-verify-dirty.sh (#824) acts as fallback.

--- a/scripts/append-loop-state-heartbeat.sh
+++ b/scripts/append-loop-state-heartbeat.sh
@@ -136,6 +136,11 @@ _do_append() {
   printf '| %s | %s | %s | %s |\n' "$TS" "$PHASE_LABEL" "phase-transition" "$DETAIL" >> "$FILE" 2>/dev/null || true
 }
 
+# Ensure the parent directory exists before creating the lock file/dir.
+# Both flock (9>"$LOCK_FILE") and mkdir-lock ("$LOCK_DIR") require the parent
+# to exist. mkdir -p is idempotent so parallel calls are safe.
+mkdir -p "$SESSIONS_DAILY_DIR" 2>/dev/null || true
+
 # Acquire a file lock before running _do_append so that parallel batch workers
 # cannot interleave file-creation, dedup, and append — preventing duplicate rows.
 # flock -n (non-blocking): if the lock is held, skip gracefully (best-effort).

--- a/tests/append-loop-state-heartbeat.bats
+++ b/tests/append-loop-state-heartbeat.bats
@@ -138,6 +138,23 @@ MOCK
     grep -q '| code-patch | phase-transition |' "$file"
 }
 
+@test "parallel append: lock prevents duplicate rows from concurrent calls" {
+    fake_root="$BATS_TEST_TMPDIR/repo"
+    wrapper=$(_make_wrapper "$fake_root")
+    # Run two instances with the same transition in parallel
+    "$wrapper" --issue 701 --from spec --to code &
+    "$wrapper" --issue 701 --from spec --to code &
+    wait
+    today=$(date -u +%Y-%m-%d)
+    file="$fake_root/docs/sessions/_daily/loop-state-$today.md"
+    # Header must appear exactly once (no parallel file-creation race)
+    header_count=$(grep -c '| Time (UTC) | Phase | Event | Detail |' "$file")
+    [ "$header_count" -eq 1 ]
+    # Transition row must appear at most once (dedup inside critical section)
+    count=$(grep -c '#701 spec→code' "$file")
+    [ "$count" -le 1 ]
+}
+
 @test "auto-commit: git add and git commit are called after heartbeat append" {
     GIT_LOG="$BATS_TEST_TMPDIR/git-calls.log"
     cat > "$MOCK_DIR/git" <<MOCK


### PR DESCRIPTION
## Summary

`scripts/append-loop-state-heartbeat.sh` に flock ベースの排他制御 (macOS 向け mkdir-lock fallback 付き) を追加し、並列 batch worker による同時 append race condition を構造的に防ぐ。

- `_do_append` ヘルパー関数を定義し、file-creation / dedup / append を一つのアトミックなクリティカルセクションに統合
- `flock -n` (non-blocking) で lock 取得: 取得失敗時は skip (best-effort 設計を維持)
- `flock` 不在時は `mkdir` lock dir fallback (bash 3.2+ compatible)
- lock file/dir 作成前に親ディレクトリを `mkdir -p` で確保
- 並列 append 重複防止テストケースを追加

## Verification (pre-merge)

- flock または相当のロック機構が `scripts/append-loop-state-heartbeat.sh` に追加されている (rubric AC)
- `grep "flock" "scripts/append-loop-state-heartbeat.sh"` で flock キーワードが確認できる
- `bats tests/` で全テストスイートが緑 (並列 append テストを含む)

## Verification (post-merge)

- 次回 `/auto --batch` (並列 batch) または XL Issue 並列実行で `docs/sessions/_daily/loop-state-*.md` に重複行が発生しないことを観察

closes #829