### PR TITLE
Issue #839: Add polling backoff for mergeable=UNKNOWN in gh-pr-merge-status.sh

### DIFF
--- a/docs/spec/issue-839-merge-unknown-polling-backoff.md
+++ b/docs/spec/issue-839-merge-unknown-polling-backoff.md
@@ -66,19 +66,35 @@ polling backoff (初回 30s 待機 → 再確認 → 2 回目 60s 待機 → 再
 
 - N/A
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Spec と実装は完全一致。polling backoff ブロックの挿入位置、`RETRY_DELAYS=(30 60)`、`exit 2`、stateful mock ヘルパーのすべてが Spec 記載通りに実装されていた。divergence なし。
+
+### Recurring issues
+
+- なし。コードの変更範囲が小さく、各ファイルの変更が明確に分離されていた (script に機能追加、test にテスト追加)。
+
+### Acceptance criteria verification difficulty
+
+- `rubric` + `grep "sleep"` の 2 重 verify は効果的。ただし `grep "sleep"` 単独では `sleep` を使う他の用途と区別できないため、rubric の意味的判定が補完として重要だった。
+- `command "bats tests/gh-pr-merge-status.bats"` は safe mode で CI 代替検証 (SUCCESS) を使用できた。CI fallback が機能した事例。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- polling backoff を `gh-pr-merge-status.sh` 内部に閉じ込める設計を採用。merge/SKILL.md の routing ロジックを変更しないため regression リスクが低い。
-- exit 2 を polling timeout 専用とし、exit 1 を gh fetch error 専用に分離。両者を区別することで呼び出し元の error handling が精緻になる。
-- `RETRY_DELAYS=(30 60)` の 2 ステップのみ (合計待機 90s 上限)。GitHub metadata sync は通常 30〜60s 以内に解決するため、過度な待機を避けつつリスクを低減できる判断。
+- REVIEW_DEPTH=light (Size=M) で軽量統合レビューを実施。全 AC が PASS、CI が全 SUCCESS のため MUST/SHOULD 問題なし。
+- review-light エージェントタイプが未登録 (available agents に存在しない) のため、モジュールを読み込んで inline で 4 観点レビューを実施した。
+- CONSIDER 1 件 (bats abort テストの exit code 特定性不足) は skip。機能的に正しく regression リスクは低い。
 
 ### Deferred Items
-- polling 成功/abort をログ以外の手段 (exit code 以外の structured output 等) で呼び出し元に通知する仕組みは本 Issue スコープ外。merge/SKILL.md での error handling 改善は別途検討。
-- `RETRY_DELAYS` の値を `.wholework.yml` で設定可能にする拡張は現時点で不要だが、将来の要望に備えて Spec Notes に記録済み。
+- CONSIDER: bats abort テストで `[ "$status" -eq 2 ]` ではなく `[ "$status" -ne 0 ]` を使用中。exit code 精緻化は機能的に問題ないが、将来の変更時の regression 検知精度を高めるための改善候補。
+- merge/SKILL.md での exit 2 ハンドリングは本 PR スコープ外 (code フェーズより引き継ぎ)。
+- Post-merge AC は `verify-type: observation event=auto-run` のため次回 merge phase での実観察が必要。
 
 ### Notes for Next Phase
-- CI で `bats tests/` が全 11 件 PASS することを確認する (polling test も含む)。
-- `exit 2` が `merge/SKILL.md` または `run-merge.sh` 側で適切にハンドリングされているか確認推奨 (本 PR では変更なし)。
-- Post-merge AC は `verify-type: observation event=auto-run` のため次回 merge phase での実観察が必要。
+- 全 AC が PASS、全 CI が SUCCESS。MUST 問題なし。`/merge 845` を実行可能。
+- `exit 2` が `merge/SKILL.md` または `run-merge.sh` 側で適切にハンドリングされているかの確認推奨 (本 PR では変更なし。code フェーズからの引き継ぎ事項)。
+- Post-merge AC は `verify-type: observation event=auto-run` として設定済み。次回 merge phase で `mergeable=UNKNOWN` が観察された際に polling backoff の動作を確認。

--- a/docs/spec/issue-839-merge-unknown-polling-backoff.md
+++ b/docs/spec/issue-839-merge-unknown-polling-backoff.md
@@ -51,3 +51,34 @@ polling backoff (初回 30s 待機 → 再確認 → 2 回目 60s 待機 → 再
 - **exit 2 の意味**: polling timeout abort を示す。`exit 1` は gh fetch error 専用として残す
 - **sleep mock**: bats テストで `sleep` を no-op mock にしないと各テストが 90 秒かかるため、setup() に追加することで全テストに適用
 - **stateful gh mock**: counter file を `$BATS_TEST_TMPDIR` に置くことで各テスト run ごとにリセットされる (bats の tmpdir はテストごとに独立)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Spec の Implementation Steps どおりに実装した。polling backoff ブロックの挿入位置、RETRY_DELAYS の値、exit 2 の使用、stateful mock の counter file パスいずれも Spec 記載と一致。
+
+### Design Gaps/Ambiguities
+
+- `make_gh_mock_stateful` のヒアドキュメント内で `$counter_file` を展開する際、`<<MOCK` (unquoted) を使うことで変数が実際のパスに展開される。`<<'MOCK'` にすると展開されず mock が壊れる点は Spec 未記載だった (実装中に把握)。
+
+### Rework
+
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- polling backoff を `gh-pr-merge-status.sh` 内部に閉じ込める設計を採用。merge/SKILL.md の routing ロジックを変更しないため regression リスクが低い。
+- exit 2 を polling timeout 専用とし、exit 1 を gh fetch error 専用に分離。両者を区別することで呼び出し元の error handling が精緻になる。
+- `RETRY_DELAYS=(30 60)` の 2 ステップのみ (合計待機 90s 上限)。GitHub metadata sync は通常 30〜60s 以内に解決するため、過度な待機を避けつつリスクを低減できる判断。
+
+### Deferred Items
+- polling 成功/abort をログ以外の手段 (exit code 以外の structured output 等) で呼び出し元に通知する仕組みは本 Issue スコープ外。merge/SKILL.md での error handling 改善は別途検討。
+- `RETRY_DELAYS` の値を `.wholework.yml` で設定可能にする拡張は現時点で不要だが、将来の要望に備えて Spec Notes に記録済み。
+
+### Notes for Next Phase
+- CI で `bats tests/` が全 11 件 PASS することを確認する (polling test も含む)。
+- `exit 2` が `merge/SKILL.md` または `run-merge.sh` 側で適切にハンドリングされているか確認推奨 (本 PR では変更なし)。
+- Post-merge AC は `verify-type: observation event=auto-run` のため次回 merge phase での実観察が必要。

--- a/scripts/gh-pr-merge-status.sh
+++ b/scripts/gh-pr-merge-status.sh
@@ -14,6 +14,11 @@
 #   ci_failing     - CI checks failing
 #   behind_base    - branch is behind base branch
 #   unknown        - unable to determine
+#
+# exit codes:
+#   0  - success (merge status determined)
+#   1  - error (gh fetch failed or invalid arguments)
+#   2  - polling timeout (mergeable=UNKNOWN persisted after all retries)
 
 set -euo pipefail
 
@@ -46,6 +51,27 @@ JSON=$(gh pr view "$PR" --json mergeable,mergeStateStatus) || { echo "Error: fai
 
 MERGEABLE=$(echo "$JSON" | jq -r '.mergeable')
 STATE=$(echo "$JSON" | jq -r '.mergeStateStatus')
+
+# Polling backoff for UNKNOWN (GitHub metadata sync delay)
+# UNKNOWN+UNKNOWN indicates GitHub hasn't synced CI/review state yet, not a genuine failure.
+# Retry with exponential delays before aborting to avoid CI bypass risk.
+if [[ "$MERGEABLE" == "UNKNOWN" && "$STATE" == "UNKNOWN" ]]; then
+  RETRY_DELAYS=(30 60)
+  retry_count=0
+  while [[ "$MERGEABLE" == "UNKNOWN" && "$STATE" == "UNKNOWN" ]]; do
+    if [[ $retry_count -ge ${#RETRY_DELAYS[@]} ]]; then
+      echo "Error: PR #$PR mergeable=UNKNOWN persists after ${#RETRY_DELAYS[@]} retries — aborting to avoid CI bypass risk" >&2
+      exit 2
+    fi
+    delay="${RETRY_DELAYS[$retry_count]}"
+    echo "Info: mergeable=UNKNOWN (attempt $((retry_count + 1))) — waiting ${delay}s before retry..." >&2
+    sleep "$delay"
+    JSON=$(gh pr view "$PR" --json mergeable,mergeStateStatus) || { echo "Error: failed to fetch PR #$PR" >&2; exit 1; }
+    MERGEABLE=$(echo "$JSON" | jq -r '.mergeable')
+    STATE=$(echo "$JSON" | jq -r '.mergeStateStatus')
+    retry_count=$((retry_count + 1))
+  done
+fi
 
 # Determine merge readiness
 if [[ "$MERGEABLE" == "MERGEABLE" && "$STATE" == "CLEAN" ]]; then

--- a/tests/gh-pr-merge-status.bats
+++ b/tests/gh-pr-merge-status.bats
@@ -12,6 +12,13 @@ setup() {
     MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"
+
+    # no-op sleep mock (prevents real 30/60s delays in polling tests)
+    cat > "$MOCK_DIR/sleep" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/sleep"
 }
 
 make_gh_mock() {
@@ -19,6 +26,27 @@ make_gh_mock() {
     local state="$2"
     # Use printf to expand variables properly
     printf '#!/bin/bash\necho '"'"'{"mergeable": "%s", "mergeStateStatus": "%s"}'"'"'\n' "$mergeable" "$state" > "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# make_gh_mock_stateful: returns UNKNOWN/UNKNOWN for the first N calls, then the specified values
+# Usage: make_gh_mock_stateful <unknown_count> <final_mergeable> <final_state>
+make_gh_mock_stateful() {
+    local unknown_count="$1"
+    local final_mergeable="$2"
+    local final_state="$3"
+    local counter_file="$BATS_TEST_TMPDIR/gh_call_count"
+    echo "0" > "$counter_file"
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+count=\$(cat "$counter_file")
+if [ "\$count" -lt "$unknown_count" ]; then
+    echo '{"mergeable": "UNKNOWN", "mergeStateStatus": "UNKNOWN"}'
+    echo \$(( count + 1 )) > "$counter_file"
+else
+    echo '{"mergeable": "$final_mergeable", "mergeStateStatus": "$final_state"}'
+fi
+MOCK
     chmod +x "$MOCK_DIR/gh"
 }
 
@@ -92,4 +120,18 @@ make_gh_mock() {
     run bash "$SCRIPT" "123"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "Error" ]]
+}
+
+@test "polling: UNKNOWN twice then CLEAN resolves to clean" {
+    make_gh_mock_stateful 2 "MERGEABLE" "CLEAN"
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"mergeable": true'* ]]
+    [[ "$output" == *'"reason": "clean"'* ]]
+}
+
+@test "polling: max retries exceeded with UNKNOWN exits non-zero" {
+    make_gh_mock "UNKNOWN" "UNKNOWN"
+    run bash "$SCRIPT" "123"
+    [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Summary

- `scripts/gh-pr-merge-status.sh` に `MERGEABLE==UNKNOWN && STATE==UNKNOWN` ケースの polling backoff (30s → 60s → max retries で exit 2 abort) を追加
- GitHub metadata sync 遅延と CI failure/protection rule mismatch を区別し、CI bypass リスクを解消
- `tests/gh-pr-merge-status.bats` に sleep no-op mock、stateful gh mock helper、polling 成功/abort の 2 テストを追加

## Verification (pre-merge)

- `scripts/gh-pr-merge-status.sh` に `MERGEABLE==UNKNOWN` ケースで polling backoff (sleep + re-check) ロジックが追加されており、max retries 後に非ゼロ exit で abort する
- `tests/gh-pr-merge-status.bats` に polling 成功シナリオ (複数回の UNKNOWN 後に CLEAN になる) と max retries 後 abort シナリオが追加されている

## Verification (post-merge)

- 次回 merge phase で `mergeable=UNKNOWN` が観察された際、polling backoff が機能することを観察

closes #839