### PR TITLE
chore: strip empty Narrative Section skeleton from existing data-layer reports

### DIFF
--- a/docs/sessions/13998-1782562514-2026-06-27/data-layer-ja.md
+++ b/docs/sessions/13998-1782562514-2026-06-27/data-layer-ja.md
@@ -109,19 +109,3 @@ Session 終了時に `phase/verify` に留まる Issue (post-merge AC が observ
 | `/verify` Step 8b の executability rubric 拡張 | source code 由来 observation を executable 例に追加 | **#780 起票済み + fix merged** |
 
 **全 retro Issue 完了**: 本 batch session で起票された 9 件の retro Issue は全て本 session 内で実装・merge 完了。recovery 自動化機構の self-improvement loop が機能した実例。
-
-## Narrative セクション (skeleton)
-
-### うまくいったこと
-- TBD (本 session の Spec retrospective + verify retrospective を全 Issue で記録済み。各 Spec の `## Verify Retrospective` を参照)
-
-### 限界と gap
-- TBD
-
-### 改善候補 (浮上分)
-- TBD
-
-### 結論
-- TBD
-
-> 注: `--full` mode の LLM narrative draft 経路は #776 で削除済み (`scripts/get-auto-session-report.sh --narrative-draft` および `auto-session-narrative-prompts.md` 撤去)。本レポートは #776 後の thin reader 仕様に従い data layer のみを記録。Narrative は本 session 中に生成された `session.md` (notable 判定で生成されていれば) または各 Spec の retrospective セクションを参照。

--- a/docs/sessions/13998-1782562514-2026-06-27/data-layer.md
+++ b/docs/sessions/13998-1782562514-2026-06-27/data-layer.md
@@ -109,19 +109,3 @@ This is expected for a single-user, single-parent-session batch run with manual 
 | `/verify` Step 8b executability rubric 拡張 | source code 由来 observation を executable 例として追加 | **#780 起票済み + fix merged** |
 
 **全 retro Issue 完了**: 本 batch session で起票された 9 件の retro Issue は全て本 session 内で実装・merge 完了。recovery 自動化機構の self-improvement loop が機能した実例。
-
-## Narrative Section (skeleton)
-
-### What worked
-- TBD (本 session の Spec retrospective + verify retrospective を全 Issue で記録済み; 各 Spec の `## Verify Retrospective` 参照)
-
-### Limits and gaps
-- TBD
-
-### Improvement candidates surfaced
-- TBD
-
-### Conclusion
-- TBD
-
-> Note: --full mode の LLM narrative draft 経路は #776 で削除済み (`scripts/get-auto-session-report.sh --narrative-draft` および `auto-session-narrative-prompts.md` 撤去)。本 report は #776 後の thin reader 仕様に従い data layer のみ。narrative は本 session 中に作成された `session.md` (もし notable 判定で生成されていれば) または各 Spec の retrospective セクションを参照。

--- a/docs/sessions/62650-1782653419-2026-06-28/data-layer.md
+++ b/docs/sessions/62650-1782653419-2026-06-28/data-layer.md
@@ -65,19 +65,3 @@
 ## Improvement Candidates Surfaced
 
 (none — no Tier 3 recoveries or Tier 2 approaching recoveries-auto-fire threshold)
-
----
-
-## Narrative Section (skeleton)
-
-### What worked
-TBD — fill in after reviewing the session
-
-### Limits and gaps
-TBD — fill in after reviewing the session
-
-### Improvement candidates surfaced
-TBD — fill in after reviewing the session
-
-### Conclusion
-TBD — fill in after reviewing the session

--- a/docs/sessions/64057-1782615135-2026-06-28/data-layer.md
+++ b/docs/sessions/64057-1782615135-2026-06-28/data-layer.md
@@ -45,19 +45,3 @@
 ## Improvement Candidates Surfaced
 
 (none — no Tier 3 recoveries or Tier 2 approaching recoveries-auto-fire threshold)
-
----
-
-## Narrative Section (skeleton)
-
-### What worked
-TBD — fill in after reviewing the session
-
-### Limits and gaps
-TBD — fill in after reviewing the session
-
-### Improvement candidates surfaced
-TBD — fill in after reviewing the session
-
-### Conclusion
-TBD — fill in after reviewing the session

--- a/docs/sessions/_daily/loop-state-2026-06-29.md
+++ b/docs/sessions/_daily/loop-state-2026-06-29.md
@@ -15,3 +15,4 @@ date: 2026-06-29
 | 01:05:10 | code | phase-transition | #543 spec→code snapshot:[issue:1 spec:0 code:0 review:0 verify:2] |
 | 01:20:46 | code | phase-transition | #834 spec→code snapshot:[issue:4 spec:0 code:0 review:0 verify:2] |
 | 01:53:22 | code | phase-transition | #841 spec→code snapshot:[issue:4 spec:0 code:0 review:0 verify:2] |
+| 02:07:23 | verify | phase-transition | #543 code→verify snapshot:[issue:1 spec:0 code:0 review:0 verify:2] |


### PR DESCRIPTION
## Summary

- Follow-up to 54bb5a4f (Narrative skeleton 出力停止) で、既に commit 済みの 4 ファイルから redundant な `## Narrative Section (skeleton)` block を削除。
- TBD placeholder のみの skeleton で実コンテンツなし。Narrative ownership は同ディレクトリの `session.md` (L3 retrospective) に集約済。

## Files

- `docs/sessions/62650-1782653419-2026-06-28/data-layer.md`
- `docs/sessions/13998-1782562514-2026-06-27/data-layer.md`
- `docs/sessions/13998-1782562514-2026-06-27/data-layer-ja.md`
- `docs/sessions/64057-1782615135-2026-06-28/data-layer.md`

## Preserved (not touched)

旧型式 `## Narrative Section (manual / --full LLM-assist)` を持つ 4 セッション (`22753`, `3480`, `58975`, `98315`) は手書き narrative の実コンテンツ入りで歴史的分析価値があるため untouched。

## Test plan

- [x] cleanup 対象 4 ファイルから `## Narrative` 行が消えていることを確認
- [x] preserved 4 ファイルの narrative 実コンテンツが変更されていないことを確認
- [x] 直前 commit 54bb5a4f の bats 16 件 PASS は維持済 (skeleton 不在を assert する変更を含む)