### PR TITLE
Issue #859: Extend check-verify-dirty.sh to session-aware classification

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -229,7 +229,7 @@ wholework/
 - `scripts/validate-permissions.sh` — skill ディレクトリと name: フィールドの一貫性を検証
 - `scripts/validate-skill-syntax.py` — SKILL.md frontmatter と構文を検証
 - `scripts/check-file-overlap.sh` — リポジトリ間のファイル重複検出
-- `scripts/check-verify-dirty.sh` — dirty ファイルを unrelated spec または other に分類する /verify Step 1 ヘルパー
+- `scripts/check-verify-dirty.sh` — /verify Step 1 用 session-aware dirty file 分類スクリプト (self-worktree / other-worktree / other-session / parent-main の 4 分類; classify=... を stderr 出力)
 - `scripts/check-translation-sync.sh` — docs/ja/* と docs/* の翻訳同期状況を確認
 - `scripts/check-forbidden-expressions.sh` — docs/product.md § Terms の deprecated terms を検出
 - `scripts/setup-labels.sh` — ワークフロー用 GitHub ラベルを作成

--- a/docs/spec/issue-859-session-aware-dirty-classifier.md
+++ b/docs/spec/issue-859-session-aware-dirty-classifier.md
@@ -92,3 +92,35 @@ dirty file を以下 4 分類で判定し、`self-worktree` / `other-worktree` /
 - `.claude/worktrees/` は `.gitignore` で除外されているが、テスト用リポジトリには `.gitignore` がないため bats テストでは問題なく dirty として検出される。本番での `.claude/worktrees/` パスは `docs/sessions/` とは異なり現在は git status に現れないが、将来的な use case (verify が worktree 内から呼ばれる場合等) のために基礎機構として追加する。
 - `other-worktree` と `other-session` は blocking しない (exit 0 → no-op) が、stderr への出力は残す。後続 Issue で各 run-*.sh の冒頭 check がこの出力を利用できるようにするための基礎。
 - bash 3.2 互換: `=~` と `case`/glob パターン (`== glob`) は両方 bash 3.2 以上で動作。`[[ "$f" == .claude/worktrees/*+issue-${NUMBER}/* ]]` の glob マッチは bash 3.2+ 互換。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- SHOULD issue (`setup()` missing `git config core.excludesFile /dev/null`) was fixed inline during review (not deferred) — the fix is 2 lines and low risk
+- CONSIDER issue (`docs/sessions/*-*/*` over-matching) was skipped — current usage has no `-` in non-numeric dirs, real harm is nil
+- Review depth: light (Size M PR, explicit `--light` flag)
+
+### Deferred Items
+- CONSIDER: add comment to `check-verify-dirty.sh` line 111 to document that `*-*` means `{pid}-{timestamp}` numeric-only pattern intent — deferred to follow-up or merge-phase judgment
+- Post-merge observation: verify that self-worktree/other-worktree classification works correctly when called from a worktree context in a real parallel session
+
+### Notes for Next Phase
+- All CI checks passed (5/5 SUCCESS), PR is merge-ready
+- One additional commit pushed (`b630f4e`) addressing the bats test environment fix — merge should include this commit
+- No MUST issues; no REQUEST_CHANGES event posted
+
+## review retrospective
+
+### Spec vs. 実装乖離パターン
+
+- 乖離なし。実装はSpec定義の4分類ロジック・stderr出力フォーマット・exit codeポリシーと完全に一致している。
+
+### 繰り返し発生するIssue
+
+- **テスト環境依存の想定漏れ**: Specの Notes に「テスト用リポジトリには `.gitignore` がないため bats テストでは問題なく dirty として検出される」と記述されていたが、グローバル gitignore (`~/.gitignore_global`) の影響を考慮していなかった。`git config core.excludesFile /dev/null` の設定は、`.claude/` を含む任意のパスを test repo で使用するすべてのテストファイルで必要になる可能性がある。verify-dirty-detection.bats 以外のテストがこのパスを使用する場合は同様の修正が必要。
+
+### 受入条件の検証困難度
+
+- `bats tests/` の検証は CI では PASS (Ubuntu runner にはグローバル gitignore がない) だが、macOS 開発者環境では FAIL する潜在的な環境依存がある。bats テストで `.claude/` 配下パスを使用する際は `git config core.excludesFile /dev/null` が標準パターンとして必要であることを今後の Issue/Spec で周知するとよい。
+- verify command `bats tests/` は適切で UNCERTAIN なし。他の verify commands (grep 系) もすべて確実に PASS を判定できた。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -237,7 +237,7 @@ Key modules:
 - `scripts/validate-permissions.sh` — validate skill directory ↔ name: field consistency
 - `scripts/validate-skill-syntax.py` — validate SKILL.md frontmatter and syntax
 - `scripts/check-file-overlap.sh` — detect file overlap between repos
-- `scripts/check-verify-dirty.sh` — classify dirty files as unrelated spec or other for /verify Step 1
+- `scripts/check-verify-dirty.sh` — session-aware dirty file classifier for /verify Step 1 (self-worktree / other-worktree / other-session / parent-main 4-way classification; outputs classify=... to stderr)
 - `scripts/check-translation-sync.sh` — check translation sync status of docs/ja/* against docs/*
 - `scripts/check-forbidden-expressions.sh` — detect deprecated terms from docs/product.md § Terms
 - `scripts/setup-labels.sh` — create GitHub labels for workflow

--- a/scripts/check-verify-dirty.sh
+++ b/scripts/check-verify-dirty.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# check-verify-dirty.sh - Classify dirty files for /verify Step 1
+# check-verify-dirty.sh - Session-aware dirty file classifier for /verify Step 1
 #
 # Usage: check-verify-dirty.sh <issue-number>
 #
 # Exit codes:
-#   0 — working directory is clean
-#   1 — dirty files include related or non-spec files (hard-error abort)
-#   2 — all dirty files are unrelated spec files (docs/spec/issue-N-*.md, N != issue-number)
+#   0 — working directory is clean, or all dirty files are self-worktree / other-worktree / other-session
+#   1 — dirty files include related or non-spec parent-main files (hard-error abort)
+#   2 — all remaining (parent-main) dirty files are unrelated spec files (docs/spec/issue-N-*.md, N != issue-number)
 #
+# Outputs classify=... lines to stderr for each dirty file (4-way classification:
+#   self-worktree, other-worktree, other-session, parent-main).
 # On exit 2, prints the unrelated spec file paths to stdout (one per line).
 
 set -euo pipefail
@@ -94,6 +96,29 @@ if [[ ${#ignored_files[@]} -gt 0 ]]; then
   if [[ ${#filtered[@]} -eq 0 ]]; then exit 0; fi
   dirty_files=("${filtered[@]}")
 fi
+
+# Session-aware classification: classify dirty files by origin before spec classification.
+# self-worktree: own session's worktree directory -> exit 0 (not a true dirty conflict)
+# other-worktree: another session's worktree directory -> stderr warning only (not blocking)
+# other-session: another session's docs/sessions dir -> stderr warning only (not blocking)
+# parent-main: everything else -> pass through to existing classification
+parent_main_files=()
+for f in "${dirty_files[@]}"; do
+  if [[ "$f" == .claude/worktrees/*+issue-${NUMBER}/* ]]; then
+    echo "[check-verify-dirty] classify=self-worktree path=$f" >&2
+  elif [[ "$f" == .claude/worktrees/* ]]; then
+    echo "[check-verify-dirty] classify=other-worktree path=$f" >&2
+  elif [[ "$f" == docs/sessions/*-*/* ]]; then
+    echo "[check-verify-dirty] classify=other-session path=$f" >&2
+  else
+    echo "[check-verify-dirty] classify=parent-main path=$f" >&2
+    parent_main_files+=("$f")
+  fi
+done
+if [[ ${#parent_main_files[@]} -eq 0 ]]; then
+  exit 0
+fi
+dirty_files=("${parent_main_files[@]}")
 
 # Classify each dirty file
 unrelated_spec_files=()

--- a/tests/verify-dirty-detection.bats
+++ b/tests/verify-dirty-detection.bats
@@ -169,3 +169,46 @@ EOF
     run bash "$REAL_SCRIPT" 123
     [ "$status" -eq 1 ]
 }
+
+@test "session-aware: self-worktree only dirty -> exit 0" {
+    cd "$REPO_DIR"
+    make_dirty ".claude/worktrees/code+issue-123/docs/spec/issue-123-foo.md"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"classify=self-worktree"* ]]
+}
+
+@test "session-aware: other-worktree only dirty -> exit 0 with warning" {
+    cd "$REPO_DIR"
+    make_dirty ".claude/worktrees/code+issue-999/scripts/foo.sh"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"classify=other-worktree"* ]]
+}
+
+@test "session-aware: other-session only dirty -> exit 0 with warning" {
+    cd "$REPO_DIR"
+    mkdir -p "docs/sessions/82534-1782700033"
+    make_dirty "docs/sessions/82534-1782700033/data-layer.md"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"classify=other-session"* ]]
+}
+
+@test "session-aware: parent-main only dirty -> exit 1" {
+    cd "$REPO_DIR"
+    make_dirty "scripts/some-script.sh"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"classify=parent-main"* ]]
+}
+
+@test "session-aware: self-worktree mixed with parent-main -> exit 1" {
+    cd "$REPO_DIR"
+    make_dirty ".claude/worktrees/code+issue-123/docs/spec/issue-123-foo.md"
+    make_dirty "scripts/foo.sh"
+    run bash "$REAL_SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"classify=self-worktree"* ]]
+    [[ "$output" == *"classify=parent-main"* ]]
+}

--- a/tests/verify-dirty-detection.bats
+++ b/tests/verify-dirty-detection.bats
@@ -18,6 +18,8 @@ setup() {
     git init -q
     git config user.email "test@example.com"
     git config user.name "Test"
+    # Disable global gitignore so .claude/worktrees/ paths appear in git status
+    git config core.excludesFile /dev/null
     # Track docs/spec so individual spec files appear in git status --short
     touch docs/spec/.gitkeep
     git add docs/spec/.gitkeep


### PR DESCRIPTION
Closes #859

## Summary

- `scripts/check-verify-dirty.sh` を session-aware に拡張: dirty file を `self-worktree` / `other-worktree` / `other-session` / `parent-main` の 4 分類で判別し、stderr に `classify=...` 形式で出力
- 全 dirty が `self-worktree` 配下の場合は exit 0 として扱う (新規挙動)
- 既存挙動 (引数なし呼び出し、verify-ignore-paths 適用、spec ファイルのみの exit 2) は維持
- `tests/verify-dirty-detection.bats` に session-aware 分類の test cases を追加
- `docs/structure.md` / `docs/ja/structure.md` を更新

## Test plan

- [x] `bats tests/verify-dirty-detection.bats` で全テスト pass
- [x] 既存テスト (引数なし呼び出し、verify-ignore-paths) も pass
- [x] `docs/structure.md` / `docs/ja/structure.md` の説明が新挙動を反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)
