### PR TITLE
Issue #861: Add session isolation check to run-*.sh

### DIFF
--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -131,6 +131,21 @@ if ! [[ "$SUB_NUMBER" =~ ^[0-9]+$ ]]; then
 fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+# Session isolation check: detect other-session dirty files (best-effort)
+if [[ -x "${SCRIPT_DIR}/check-verify-dirty.sh" ]]; then
+  _dirty_exit=0
+  bash "${SCRIPT_DIR}/check-verify-dirty.sh" "${SUB_NUMBER}" || _dirty_exit=$?
+  case "${_dirty_exit}" in
+    0) ;;
+    1)
+      echo "Error: parent main has uncommitted changes. Resolve before proceeding." >&2
+      exit 1
+      ;;
+    2)
+      echo "Warning: detected other-session dirty files. Proceeding (best-effort)." >&2
+      ;;
+  esac
+fi
 LOG_PREFIX="[#${SUB_NUMBER}]"
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -47,6 +47,21 @@ if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
 fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+# Session isolation check: detect other-session dirty files (best-effort)
+if [[ -x "${SCRIPT_DIR}/check-verify-dirty.sh" ]]; then
+  _dirty_exit=0
+  bash "${SCRIPT_DIR}/check-verify-dirty.sh" "${ISSUE_NUMBER}" || _dirty_exit=$?
+  case "${_dirty_exit}" in
+    0) ;;
+    1)
+      echo "Error: parent main has uncommitted changes. Resolve before proceeding." >&2
+      exit 1
+      ;;
+    2)
+      echo "Warning: detected other-session dirty files. Proceeding (best-effort)." >&2
+      ;;
+  esac
+fi
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
 PGID=$(ps -o pgid= -p $$ | tr -d ' ')

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -12,6 +12,21 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
 fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+# Session isolation check: detect other-session dirty files (best-effort)
+if [[ -x "${SCRIPT_DIR}/check-verify-dirty.sh" ]]; then
+  _dirty_exit=0
+  bash "${SCRIPT_DIR}/check-verify-dirty.sh" "${PR_NUMBER}" || _dirty_exit=$?
+  case "${_dirty_exit}" in
+    0) ;;
+    1)
+      echo "Error: parent main has uncommitted changes. Resolve before proceeding." >&2
+      exit 1
+      ;;
+    2)
+      echo "Warning: detected other-session dirty files. Proceeding (best-effort)." >&2
+      ;;
+  esac
+fi
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
 PGID=$(ps -o pgid= -p $$ | tr -d ' ')

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -14,6 +14,21 @@ if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
 fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+# Session isolation check: detect other-session dirty files (best-effort)
+if [[ -x "${SCRIPT_DIR}/check-verify-dirty.sh" ]]; then
+  _dirty_exit=0
+  bash "${SCRIPT_DIR}/check-verify-dirty.sh" "${PR_NUMBER}" || _dirty_exit=$?
+  case "${_dirty_exit}" in
+    0) ;;
+    1)
+      echo "Error: parent main has uncommitted changes. Resolve before proceeding." >&2
+      exit 1
+      ;;
+    2)
+      echo "Warning: detected other-session dirty files. Proceeding (best-effort)." >&2
+      ;;
+  esac
+fi
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
 PGID=$(ps -o pgid= -p $$ | tr -d ' ')

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -42,6 +42,22 @@ fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 
+# Session isolation check: detect other-session dirty files (best-effort)
+if [[ -x "${SCRIPT_DIR}/check-verify-dirty.sh" ]]; then
+  _dirty_exit=0
+  bash "${SCRIPT_DIR}/check-verify-dirty.sh" "${ISSUE_NUMBER}" || _dirty_exit=$?
+  case "${_dirty_exit}" in
+    0) ;;
+    1)
+      echo "Error: parent main has uncommitted changes. Resolve before proceeding." >&2
+      exit 1
+      ;;
+    2)
+      echo "Warning: detected other-session dirty files. Proceeding (best-effort)." >&2
+      ;;
+  esac
+fi
+
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 export AUTO_EVENTS_LOG
 PGID=$(ps -o pgid= -p $$ | tr -d ' ')

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -36,6 +36,12 @@ emit_event() { :; }
 _emit_comments_consumed() { :; }
 MOCK
 
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+
     # Mock phase-banner.sh (sourced by run-auto-sub.sh)
     cat > "$MOCK_DIR/phase-banner.sh" <<'MOCK'
 print_start_banner() { echo "Starting /$3 for issue #$2"; }
@@ -1056,4 +1062,26 @@ MOCK
     run bash "$SCRIPT" 42
     [ "$status" -eq 0 ]
     [ "$(cat "$COUNTER_FILE")" -eq 2 ]
+}
+
+@test "session-isolation: exit 1 causes abort with error" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"parent main has uncommitted changes"* ]]
+}
+
+@test "session-isolation: exit 2 shows warning and continues" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 2
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"other-session dirty files"* ]]
 }

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -90,6 +90,12 @@ _emit_comments_consumed() { :; }
 _append_consumed_comments_section() { :; }
 MOCK
 
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+
     # Real guard-prefix.sh and retry-on-kill.sh (sourced via WHOLEWORK_SCRIPT_DIR)
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
@@ -778,4 +784,26 @@ MOCK
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
     [ "$(cat "$COUNTER_FILE")" -eq 2 ]
+}
+
+@test "session-isolation: exit 1 causes abort with error" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"parent main has uncommitted changes"* ]]
+}
+
+@test "session-isolation: exit 2 shows warning and continues" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 2
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"other-session dirty files"* ]]
 }

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -93,6 +93,12 @@ emit_event() { return 0; }
 _emit_comments_consumed() { :; }
 MOCK
 
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+
     # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
 
@@ -562,4 +568,26 @@ MOCK
     run bash "$SCRIPT" 88
     [ "$status" -eq 1 ]
     [[ "$output" == *"new FAILURE"* || "$output" == *"NEW_FAILURE"* || "$output" == *"Error: pre-merge-check"* ]]
+}
+
+@test "session-isolation: exit 1 causes abort with error" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"parent main has uncommitted changes"* ]]
+}
+
+@test "session-isolation: exit 2 shows warning and continues" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 2
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"other-session dirty files"* ]]
 }

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -89,6 +89,12 @@ emit_event() { return 0; }
 _emit_comments_consumed() { :; }
 MOCK
 
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+
     # Real guard-prefix.sh (sourced via WHOLEWORK_SCRIPT_DIR)
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
 
@@ -372,3 +378,25 @@ MOCK
     grep -q "phase_complete" "$EMIT_LOG"
 }
 
+
+@test "session-isolation: exit 1 causes abort with error" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"parent main has uncommitted changes"* ]]
+}
+
+@test "session-isolation: exit 2 shows warning and continues" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 2
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"other-session dirty files"* ]]
+}

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -114,6 +114,12 @@ emit_event() { return 0; }
 _append_consumed_comments_section() { :; }
 MOCK
 
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+
     # Real guard-prefix.sh and retry-on-kill.sh (sourced via WHOLEWORK_SCRIPT_DIR)
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
@@ -459,4 +465,26 @@ MOCK
     run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
     [ "$(cat "$COUNTER_FILE")" -eq 2 ]
+}
+
+@test "session-isolation: exit 1 causes abort with error" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"parent main has uncommitted changes"* ]]
+}
+
+@test "session-isolation: exit 2 shows warning and continues" {
+    cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
+#!/bin/bash
+exit 2
+MOCK
+    chmod +x "$MOCK_DIR/check-verify-dirty.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"other-session dirty files"* ]]
 }


### PR DESCRIPTION
Closes #861

## Summary

各 `run-*.sh` (run-spec / run-code / run-review / run-merge / run-auto-sub) の冒頭に `check-verify-dirty.sh` を呼ぶ session isolation check を追加。並列セッション環境で他セッションの作業ファイル衝突を早期検出する。

- `[[ -x ... ]]` guard により script 不存在時は block しない (best-effort)
- parent main の重大 dirty (exit 1) → abort
- 他セッション由来 dirty (exit 2) → warning + 続行
- run-review.sh / run-merge.sh は PR number を best-effort proxy として使用
- bats テストに exit 1 / exit 2 の両ケースを追加 (全 5 ファイル)

## Test plan

- [x] `bats tests/` 全 pass
- [x] 各 run-*.sh が check-verify-dirty.sh を呼ぶことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
