### PR TITLE
Issue #853: Harden worktree-merge-push.sh rebase fallback for parallel session races

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -201,7 +201,7 @@ wholework/
 - `scripts/reconcile-phase-state.sh` — 全 phase の precondition チェックと completion チェックを行う汎用 state reconciler。`modules/phase-state.md` SSoT に基づく JSON v1 を出力（watchdog-reconcile.sh の後継）
 - `scripts/wait-ci-checks.sh` — claude 実行前に PR の全 CI チェック完了を待機
 - `scripts/pre-merge-check.sh` — ベースライン diff 分類器: 指定チェックをベースブランチと head ブランチで ephemeral worktree で実行し、結果を NEW_FAILURE (exit 2) / PRE_EXISTING / FIXED / CLEAN (exit 0) / env error (exit 1) に分類
-- `scripts/worktree-merge-push.sh` — 短命な patch lock を取得し、worktree ブランチを merge + push（rebase retry 付き）
+- `scripts/worktree-merge-push.sh` — 短命な patch lock を取得し、fetch-after-lock・is-ancestor による rebase skip・push retry loop (max 3) で並列 session race に対応した merge + push を実行
 - `scripts/detect-wrapper-anomaly.sh` — shell wrapper 出力の既知失敗パターンを検出し、Auto Retrospective の markdown 断片を生成
 - `scripts/test-failure-classify.sh` — テスト失敗出力を回復カテゴリに分類（snapshot/mock/fixture/logic/infra）。exit 0 = 修復可、exit 1 = 修復不可
 - `scripts/validate-recovery-plan.sh` — orchestration-recovery sub-agent が出力する recovery plan JSON を検証（schema チェック + forbidden ops ガード）

--- a/docs/spec/issue-853-worktree-merge-push-race-fix.md
+++ b/docs/spec/issue-853-worktree-merge-push-race-fix.md
@@ -111,23 +111,20 @@ conflict 発生時は `rebase --abort` + 明示エラーで停止する現行方
 - Nothing to note
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- fetch-after-lock は `if [[ -n "$FROM_BRANCH" ]]; then` の外側 (無条件実行) に置いた。lock-only push モードでも stale ref 排除が必要なため。
-- is-ancestor check は 2 回目の ff-only 失敗後のみ走らせる。1 回目の失敗後は `git pull --rebase` を先に試みる既存ロジックを維持。
-- push retry loop の `git rebase "origin/${BASE_BRANCH}"` は worktree 内ではなく現在の HEAD に対して実行する。retry 中は FROM_BRANCH は既に main に merge 済みのため、HEAD (= main) を rebase するのが正しい。
-- 既存テスト 2 件の `merge-base --is-ancestor` mock は `exit 1` (not ancestor) に固定し、既存のrebase 検証パスが is-ancestor check 追加後も機能することを確認した。
+- MUST 指摘なし。SHOULD 1 件 (docs 矛盾) はマージブロッカーなし、CONSIDER 1 件 (inner fetch logging) は best-effort パターンと整合。
+- 既存テスト維持の確認: `--from with base-diverged` 系 2 テストへの `merge-base --is-ancestor` mock 追加は正確で、Type=Task 重点項目 (テスト維持) をクリア。
+- Phase Handoff を code → review に更新。
 
 ### Deferred Items
-- `MAX_PUSH_RETRY` の `.wholework.yml` expose は初期実装では scope-out (ハードコード 3)。将来 Issue で対応可能。
-- push retry loop 内の sleep 1 はネットワーク安定化用だが、lock 保持中のため値の最適化は観察後に判断。
+- `modules/orchestration-fallbacks.md` の "retry up to 3 times" vs "On the 3rd failure, abort" の矛盾は SHOULD 指摘済み。機能上は問題なく、将来の改善候補として残す。
+- push retry loop 内の inner fetch エラーハンドリング (CONSIDER) は best-effort policy 踏襲のため defer。
 
 ### Notes for Next Phase
-- PR #873: 変更対象は `scripts/worktree-merge-push.sh`, `tests/worktree-merge-push.bats`, `modules/orchestration-fallbacks.md`, `docs/structure.md`, `docs/ja/structure.md`
-- 全 14 bats テスト PASS、全 AC の pre-merge verify コマンド PASS 済み。
-- `--strategy-option` は追加していないことを review 時に確認すること (AC4)。
-- Post-merge AC は観察系 (並列 session で race が発生しないこと) のため /verify では SKIP 扱いになる見込み。
+- AC 全 PASS、MUST 指摘なし → /merge 実行可。
+- Post-merge AC は観察系 (race が 3 回 retry 内で復旧) なので /verify では SKIP 扱いになる見込み (code phase 引き継ぎ通り)。
 
 ## Code Retrospective
 
@@ -141,3 +138,19 @@ conflict 発生時は `rebase --abort` + 明示エラーで停止する現行方
 
 ### Rework
 - 既存テスト 2 件 (`--from with base-diverged triggers worktree rebase fallback` / `--from with base-diverged and rebase conflict aborts and exits non-zero`) に `merge-base --is-ancestor` の mock (`exit 1`) を追加した。Spec には記載がなかったが、is-ancestor check 追加後の動作整合性確保のため必要な修正。
+
+## Review Retrospective
+
+### Aspect 1: Spec vs. Implementation Divergence Patterns
+
+- 指摘なし。PR diff は Spec の A/B/C 三点実装と完全に一致。Phase Handoff (code) の「A→C→B 順でスクリプト内に配置」という記述通り、fetch-after-lock → is-ancestor → push retry の順序が維持されている。
+- modules/orchestration-fallbacks.md の "retry up to 3 times" / "On the 3rd failure, abort" の内部矛盾は Spec に明示されておらず、review フェーズで初めて顕在化した。ドキュメント記述の精度に改善余地あり (SHOULD 指摘)。
+
+### Aspect 2: Recurring Issues
+
+- 今回の SHOULD 指摘 (docs 内部矛盾) は、実装カウント (3 push 失敗で abort) とリトライ数の表現 ("retry up to N times") がずれるパターン。push retry loop を持つスクリプト実装では再発しやすい。verify command に `rubric "error message says MAX_PUSH_RETRY retries but only MAX_PUSH_RETRY-1 fetch+rebase cycles occur"` を加えることで次回以降に機械検出可能。ただし今回の AC には verify command がなく、CI でも検出されていない。
+
+### Aspect 3: Acceptance Criteria Verification Difficulty
+
+- 全 AC に verify command (rubric or command) が付与されており UNCERTAIN なし (観察系 AC は verify-type: observation で適切に除外)。AC 設計は良好。
+- push race シナリオの rubric は "bats テストが追加されているか" を確認しているが、"fetch+rebase+push の retry サイクル数が正確か" は rubric テキストに含まれておらず、docs 矛盾の検出を UNCERTAIN ではなく review 観点に頼っている。rubric テキストに "error message が実際の retry 回数と一致すること" を追記する改善余地あり。

--- a/docs/spec/issue-853-worktree-merge-push-race-fix.md
+++ b/docs/spec/issue-853-worktree-merge-push-race-fix.md
@@ -109,3 +109,35 @@ conflict 発生時は `rebase --abort` + 明示エラーで停止する現行方
 ### Uncertainty resolution
 
 - Nothing to note
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- fetch-after-lock は `if [[ -n "$FROM_BRANCH" ]]; then` の外側 (無条件実行) に置いた。lock-only push モードでも stale ref 排除が必要なため。
+- is-ancestor check は 2 回目の ff-only 失敗後のみ走らせる。1 回目の失敗後は `git pull --rebase` を先に試みる既存ロジックを維持。
+- push retry loop の `git rebase "origin/${BASE_BRANCH}"` は worktree 内ではなく現在の HEAD に対して実行する。retry 中は FROM_BRANCH は既に main に merge 済みのため、HEAD (= main) を rebase するのが正しい。
+- 既存テスト 2 件の `merge-base --is-ancestor` mock は `exit 1` (not ancestor) に固定し、既存のrebase 検証パスが is-ancestor check 追加後も機能することを確認した。
+
+### Deferred Items
+- `MAX_PUSH_RETRY` の `.wholework.yml` expose は初期実装では scope-out (ハードコード 3)。将来 Issue で対応可能。
+- push retry loop 内の sleep 1 はネットワーク安定化用だが、lock 保持中のため値の最適化は観察後に判断。
+
+### Notes for Next Phase
+- PR #873: 変更対象は `scripts/worktree-merge-push.sh`, `tests/worktree-merge-push.bats`, `modules/orchestration-fallbacks.md`, `docs/structure.md`, `docs/ja/structure.md`
+- 全 14 bats テスト PASS、全 AC の pre-merge verify コマンド PASS 済み。
+- `--strategy-option` は追加していないことを review 時に確認すること (AC4)。
+- Post-merge AC は観察系 (並列 session で race が発生しないこと) のため /verify では SKIP 扱いになる見込み。
+
+## Code Retrospective
+
+### Deviations from Design
+- Spec の実装ステップ順は A→C→B だが、スクリプト内の変更位置の自然な順序 (fetch → is-ancestor → push retry) がそのまま A→C→B になっており設計と一致。順序上の逸脱なし。
+- docs/structure.md (および docs/ja/structure.md) のエントリ更新は Spec に明示されていなかったが、doc-checker の impact 判定で必要と判断して追加した。
+
+### Design Gaps/Ambiguities
+- 既存テストの `merge-base --is-ancestor` モック不足: Spec は新規 3 テストのみ言及していたが、既存の base-diverged テスト 2 件が `merge-base` を mock せず exit 0 (ancestor=true) になり rebase skip が発生してテスト意図と矛盾することが実装時に判明。既存テストの mock に `merge-base` ケースを追加した。
+- push retry loop の対象スコープ: retry loop 内の `git rebase "origin/${BASE_BRANCH}"` は FROM_BRANCH なしの lock-only push モードでも到達可能な配置だが、retry 中の rebase は `git push` 失敗後にのみ実行されるため問題なし。
+
+### Rework
+- 既存テスト 2 件 (`--from with base-diverged triggers worktree rebase fallback` / `--from with base-diverged and rebase conflict aborts and exits non-zero`) に `merge-base --is-ancestor` の mock (`exit 1`) を追加した。Spec には記載がなかったが、is-ancestor check 追加後の動作整合性確保のため必要な修正。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -209,7 +209,7 @@ Key modules:
 - `scripts/reconcile-phase-state.sh` — general-purpose state reconciler for precondition and completion checks across all phases; outputs JSON v1 per `modules/phase-state.md` SSoT (supersedes watchdog-reconcile.sh)
 - `scripts/wait-ci-checks.sh` — wait for all CI checks to complete on a PR before running claude
 - `scripts/pre-merge-check.sh` — baseline diff classifier: runs a specified check on both base and head branches in ephemeral worktrees; classifies result as NEW_FAILURE (exit 2) / PRE_EXISTING / FIXED / CLEAN (exit 0) / env error (exit 1)
-- `scripts/worktree-merge-push.sh` — acquire short-lived patch lock and merge worktree branch + push to main (with rebase retry)
+- `scripts/worktree-merge-push.sh` — acquire short-lived patch lock; fetch-after-lock, ff-only merge with is-ancestor rebase-skip, and push-retry loop (max 3) for parallel session race hardening
 - `scripts/detect-wrapper-anomaly.sh` — detect known failure patterns in shell wrapper output and generate Auto Retrospective markdown fragments
 - `scripts/test-failure-classify.sh` — classify test failure output into recovery categories (snapshot/mock/fixture/logic/infra); exit 0 = repairable, exit 1 = not repairable
 - `scripts/validate-recovery-plan.sh` — validate recovery plan JSON from orchestration-recovery sub-agent (schema check + forbidden ops guard)

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -43,27 +43,35 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 - merge
 
 ### Fallback Steps
+0. Immediately after `acquire_lock` (before the `--from` merge block): run `git fetch origin <base-branch>` as best-effort — failure emits a warning to stderr but does not abort. This ensures that subsequent ff-only merge and rebase steps reference an up-to-date `origin/<base-branch>` ref rather than a stale local snapshot.
 1. Log the FF failure to stderr: `echo "FF merge failed, attempting git pull --rebase origin <base>..." >&2`
 2. Run `git pull --rebase origin <base-branch>` to bring the local branch up to date with remote
 3. Re-attempt `git merge <worktree-branch> --ff-only`
 4. If the second attempt also fails (base advanced while worktree was running — local base is already in sync with origin but worktree branch has diverged):
    a. Log to stderr: `echo "FF merge still failed; base may have diverged. Rebasing ..." >&2`
+   4a. Run `git merge-base --is-ancestor "origin/<base-branch>" "<from-branch>"` to check whether the worktree branch already contains `origin/<base-branch>` as an ancestor:
+       - Exit 0 (ancestor): log "is-ancestor=true; skipping rebase" to stderr and skip to step 4e directly — the silent `git rebase` no-op path is eliminated
+       - Exit non-0 (not ancestor) or command error: fall through to step 4b
    b. Detect the worktree path for FROM_BRANCH via `git worktree list --porcelain | awk -v b="refs/heads/<from>" '/^worktree /{p=$2} $0 == "branch " b {print p; exit}'`
    c. If a worktree path is found: run `git -C <worktree-path> rebase origin/<base-branch>` (rebase from inside the checked-out worktree, which avoids the "already checked out" error); on conflict, run `git -C <worktree-path> rebase --abort 2>/dev/null || true` and exit 1
    d. If no worktree path is found (branch not checked out in any worktree): run `git rebase <base-branch> <from-branch>`; on conflict, run `git rebase --abort 2>/dev/null || true` and exit 1
-   e. On successful rebase: re-attempt `git merge <worktree-branch> --ff-only` (third attempt); failure propagates via `set -e`
+   e. On successful rebase (or is-ancestor skip): re-attempt `git merge <worktree-branch> --ff-only` (third attempt); failure propagates via `set -e`
 
 ### Escalation
 - If `git pull --rebase` itself fails (e.g., rebase conflict), abort with a non-zero exit and output an error message requesting manual conflict resolution
 - If the rebase in step 4 encounters conflicts, abort rebase and exit 1 — hand off to recovery sub-agent (#316) or request human intervention
 - Automatic rebase is attempted only once; no further looping after step 4e failure
+- Push retry loop (max 3): after all merge/rebase steps complete, `git push origin <base>` failures trigger a `git fetch + git rebase origin/<base> + git push` retry up to 3 times. On the 3rd failure, abort with exit 1 and "Manual push required." message. Rebase conflict during retry aborts with exit 1 (policy D maintained — no auto-resolve).
 
 ### Rationale
 - Inline logic in `scripts/worktree-merge-push.sh`
 - `git pull --rebase` is preferred over `git merge origin/<base>` to preserve a linear history
 - Step 4 (base-diverged rebase) added in #522: the existing `git pull --rebase` retry (steps 1–3) only handles the case where local base lags origin; when local base is already in sync with origin but the worktree branch was forked before a concurrent merge advanced base, a second ff-only failure occurs and worktree-branch rebase is required
 - `git -C <worktree-path> rebase` is preferred over `git rebase <base> <branch>` when the branch is checked out in a worktree, because git rejects rebase of a branch that is currently checked out elsewhere ("already checked out")
-- See also: #314 (phase state reconciler), #308 (orchestration improvement series), #517 (incident that triggered #522)
+- Step 0 (fetch-after-lock) added in #853: in parallel session environments, the `origin/<base>` ref may be stale at lock acquisition time; an explicit fetch immediately after the lock is acquired ensures all subsequent ref comparisons use current remote state
+- Step 4a (is-ancestor check) added in #853: when `git rebase` reports "Current branch is up to date" (is-ancestor=true) but the local main ref differs, the subsequent ff-only merge still fails silently; the explicit is-ancestor check detects this and skips directly to ff-only merge, eliminating the silent no-op path
+- Push retry loop added in #853: in parallel session environments a concurrent session may push between the worktree rebase and the local push, causing a non-fast-forward push failure; the retry loop (max 3, fetch+rebase+push each iteration) resolves this without requiring human intervention
+- See also: #314 (phase state reconciler), #308 (orchestration improvement series), #517 (incident that triggered #522), #853 (parallel session race hardening)
 
 ---
 

--- a/scripts/worktree-merge-push.sh
+++ b/scripts/worktree-merge-push.sh
@@ -77,6 +77,8 @@ acquire_lock() {
 
 acquire_lock
 
+git fetch origin "$BASE_BRANCH" 2>&1 || echo "Warning: git fetch origin ${BASE_BRANCH} failed; continuing with local refs" >&2
+
 if [[ -n "$FROM_BRANCH" ]]; then
   # See modules/orchestration-fallbacks.md#ff-only-merge-fallback
   if ! git merge "$FROM_BRANCH" --ff-only; then
@@ -84,18 +86,22 @@ if [[ -n "$FROM_BRANCH" ]]; then
     git pull --rebase origin "$BASE_BRANCH"
     if ! git merge "$FROM_BRANCH" --ff-only; then
       echo "FF merge still failed; base may have diverged. Rebasing ..." >&2
-      worktree_path=$(git worktree list --porcelain | awk -v b="refs/heads/${FROM_BRANCH}" '/^worktree /{p=$2} $0 == "branch " b {print p; exit}')
-      if [[ -n "$worktree_path" ]]; then
-        if ! git -C "$worktree_path" rebase "origin/${BASE_BRANCH}"; then
-          git -C "$worktree_path" rebase --abort 2>/dev/null || true
-          echo "Error: Rebase of ${FROM_BRANCH} onto origin/${BASE_BRANCH} failed with conflicts. Resolve manually." >&2
-          exit 1
-        fi
+      if git merge-base --is-ancestor "origin/${BASE_BRANCH}" "$FROM_BRANCH" 2>/dev/null; then
+        echo "Branch ${FROM_BRANCH} is already on origin/${BASE_BRANCH} (is-ancestor=true); skipping rebase" >&2
       else
-        if ! git rebase "$BASE_BRANCH" "$FROM_BRANCH"; then
-          git rebase --abort 2>/dev/null || true
-          echo "Error: Rebase of ${FROM_BRANCH} onto ${BASE_BRANCH} failed with conflicts. Resolve manually." >&2
-          exit 1
+        worktree_path=$(git worktree list --porcelain | awk -v b="refs/heads/${FROM_BRANCH}" '/^worktree /{p=$2} $0 == "branch " b {print p; exit}')
+        if [[ -n "$worktree_path" ]]; then
+          if ! git -C "$worktree_path" rebase "origin/${BASE_BRANCH}"; then
+            git -C "$worktree_path" rebase --abort 2>/dev/null || true
+            echo "Error: Rebase of ${FROM_BRANCH} onto origin/${BASE_BRANCH} failed with conflicts. Resolve manually." >&2
+            exit 1
+          fi
+        else
+          if ! git rebase "$BASE_BRANCH" "$FROM_BRANCH"; then
+            git rebase --abort 2>/dev/null || true
+            echo "Error: Rebase of ${FROM_BRANCH} onto ${BASE_BRANCH} failed with conflicts. Resolve manually." >&2
+            exit 1
+          fi
         fi
       fi
       git merge "$FROM_BRANCH" --ff-only
@@ -111,4 +117,23 @@ if [[ -n "$FROM_BRANCH" ]]; then
   fi
 fi
 
-git push origin "$BASE_BRANCH"
+MAX_PUSH_RETRY=3
+push_count=0
+while true; do
+  if git push origin "$BASE_BRANCH"; then
+    break
+  fi
+  push_count=$((push_count + 1))
+  if [[ $push_count -ge $MAX_PUSH_RETRY ]]; then
+    echo "Error: git push origin ${BASE_BRANCH} failed after ${MAX_PUSH_RETRY} retries. Manual push required." >&2
+    exit 1
+  fi
+  echo "Push rejected (non-fast-forward); retry ${push_count}/${MAX_PUSH_RETRY}: fetching and rebasing onto origin/${BASE_BRANCH}..." >&2
+  git fetch origin "$BASE_BRANCH"
+  if ! git rebase "origin/${BASE_BRANCH}"; then
+    git rebase --abort 2>/dev/null || true
+    echo "Error: Rebase during push retry failed with conflicts. Resolve manually." >&2
+    exit 1
+  fi
+  sleep 1
+done

--- a/tests/worktree-merge-push.bats
+++ b/tests/worktree-merge-push.bats
@@ -194,6 +194,10 @@ fi
 if [[ "\$1" == "-C" && "\$3" == "rebase" ]]; then
     exit 0
 fi
+# merge-base --is-ancestor: return 1 (not ancestor) so rebase runs
+if [[ "\$1" == "merge-base" && "\$2" == "--is-ancestor" ]]; then
+    exit 1
+fi
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/git"
@@ -231,6 +235,10 @@ fi
 if [[ "\$1" == "-C" && "\$3" == "rebase" && "\$4" != "--abort" ]]; then
     exit 1
 fi
+# merge-base --is-ancestor: return 1 (not ancestor) so rebase runs
+if [[ "\$1" == "merge-base" && "\$2" == "--is-ancestor" ]]; then
+    exit 1
+fi
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/git"
@@ -239,6 +247,89 @@ MOCK
     [ "$status" -ne 0 ]
     [[ "$output" == *"Rebase"*"failed with conflicts"* ]]
     ! grep -q "push" "$GIT_LOG"
+}
+
+@test "push race: push fails once then succeeds after fetch-rebase retry" {
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
+    echo "${BATS_TEST_TMPDIR}/test-repo"
+    exit 0
+fi
+if [[ "\$1" == "push" ]]; then
+    COUNT_FILE="${BATS_TEST_TMPDIR}/push_count"
+    count=0
+    [ -f "\$COUNT_FILE" ] && count=\$(cat "\$COUNT_FILE")
+    count=\$((count + 1))
+    echo "\$count" > "\$COUNT_FILE"
+    [ "\$count" -eq 1 ] && exit 1
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"retry 1/3"* ]]
+    grep -q "fetch origin main" "$GIT_LOG"
+    push_count=$(grep -c "push origin main" "$GIT_LOG")
+    [ "$push_count" -eq 2 ]
+}
+
+@test "is-ancestor true: rebase is skipped when branch already contains origin base" {
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
+    echo "${BATS_TEST_TMPDIR}/test-repo"
+    exit 0
+fi
+if [[ "\$1" == "merge" ]]; then
+    COUNT_FILE="${BATS_TEST_TMPDIR}/merge_count"
+    count=0
+    [ -f "\$COUNT_FILE" ] && count=\$(cat "\$COUNT_FILE")
+    count=\$((count + 1))
+    echo "\$count" > "\$COUNT_FILE"
+    [ "\$count" -le 2 ] && exit 1
+    exit 0
+fi
+# merge-base --is-ancestor: return 0 (ancestor=true) so rebase is skipped
+if [[ "\$1" == "merge-base" && "\$2" == "--is-ancestor" ]]; then
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"is-ancestor=true"* ]]
+    ! grep -q "rebase origin/main" "$GIT_LOG"
+    ! grep -qE "\-C .+ rebase" "$GIT_LOG"
+    grep -q "push origin main" "$GIT_LOG"
+}
+
+@test "max-retry exhaustion: push always fails and script exits with error" {
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
+    echo "${BATS_TEST_TMPDIR}/test-repo"
+    exit 0
+fi
+if [[ "\$1" == "push" ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Error"* ]]
+    [[ "$output" == *"3 retries"* ]]
 }
 
 @test "conflict markers cause abort with non-zero exit and no push" {


### PR DESCRIPTION
## Summary

`scripts/worktree-merge-push.sh` の merge-rebase-push サイクルを並列 session 環境で安定させるため、以下の 3 点を追加した。

- **A. fetch-after-lock** — `acquire_lock` 直後に `git fetch origin "$BASE_BRANCH"` を best-effort 実行し、stale な `origin/<base>` ref を排除
- **C. is-ancestor check** — 2 回目の ff-only merge 失敗後、`git merge-base --is-ancestor` で worktree branch が既に ancestor かを判定し、ancestor なら rebase を skip (silent no-op パスを排除)
- **B. push retry loop** — `git push` の non-fast-forward 失敗時に fetch + rebase + push を max 3 回 retry し、3 回失敗で abort + exit 1

conflict 発生時の abort + 明示エラー方針は変更なし (auto-resolve は追加しない)。

## Verification (pre-merge)

- `scripts/worktree-merge-push.sh` に `git fetch origin` が acquire_lock 直後に追加されている
- `scripts/worktree-merge-push.sh` に `MAX_PUSH_RETRY=3` push retry loop が追加されている
- `scripts/worktree-merge-push.sh` に `merge-base --is-ancestor` による rebase skip ロジックが追加されている
- `scripts/worktree-merge-push.sh` に `--strategy-option` 等の auto-resolve は追加されていない
- `bats tests/worktree-merge-push.bats` が全 14 テスト PASS

## Verification (post-merge)

- 次回並列 session 環境で worktree-merge-push.sh の race / silent fail が発生せず、3 回 retry 内で復旧することを観察

closes #853