### PR TITLE
Issue #857: Add check-allowed-tools.sh for pre-commit allowed-tools mismatch detection

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（62 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（63 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -35,7 +35,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（93 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（94 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents
@@ -218,6 +218,7 @@ wholework/
 - `scripts/run-spec.sh` — spec スキル実行
 
 **ツーリング:**
+- `scripts/check-allowed-tools.sh` — SKILL.md body の ${CLAUDE_PLUGIN_ROOT}/scripts/* 参照と allowed-tools フロントマターの差分を中間 commit 前に検出する；`skills/code/SKILL.md` Step 8 から呼び出される
 - `scripts/check-eager-load-capability.sh` — eager-load 共通モジュール（verify-patterns.md、verify-executor.md）への capability guidance 混入検出スクリプト；/audit drift Step 2 から呼び出される
 - `scripts/validate-permissions.sh` — skill ディレクトリと name: フィールドの一貫性を検証
 - `scripts/validate-skill-syntax.py` — SKILL.md frontmatter と構文を検証

--- a/docs/spec/issue-857-allowed-tools-precheck.md
+++ b/docs/spec/issue-857-allowed-tools-precheck.md
@@ -78,6 +78,38 @@
 - `/spec` 時点での既存チェック (`skills/spec/SKILL.md` Step 10 allowed-tools impact chain check) は**新規** `scripts/*.sh` ファイル追加のみを対象とし、既存スクリプトの新規参照は対象外。本実装はこのギャップを `/code` Step 8 で補完する
 - 実装行数スコープ (測定時点: `scripts/` ディレクトリ, `ls` コマンド出力): 現在 60 ファイル + `git-hooks/` ディレクトリ = 61 エントリ → 新規 1 ファイル追加で 61 ファイル + `git-hooks/` = 62 エントリ; `docs/structure.md` の "60 files" 表記は ディレクトリを除いたファイル数 (git-hooks/ サブディレクトリ 1 個を除く)
 
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A (Spec の実装ステップに従い、差分なし)
+
+### Design Gaps/Ambiguities
+
+- `$stderr` キャプチャの bats 構文: bats 1.13.0 では `run --separate-stderr` が必要。Spec ではこの点が未記載だったが、既存テスト (`tests/check-file-overlap.bats`) を参照して `bats_require_minimum_version 1.5.0` と `--separate-stderr` を追加した
+- `docs/ja/structure.md` のファイルカウントが英語版よりも +2 先行していた (62 ファイル vs 60 ファイル) が、既存の drift であり本 PR では delta (+1) を適用するに留めた
+
+### Rework
+
+- 初回の bats テストで `$stderr` が空になる問題が発生。`run` を `run --separate-stderr` に変更することで解決。1ステップ修正のみで完了
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `check-allowed-tools.sh` を独立スクリプトとして作成し、`validate-skill-syntax.py` のラッパーとして実装 (ロジック重複なし)
+- `bats_require_minimum_version 1.5.0` と `run --separate-stderr` を使用して stderr を正確にキャプチャ
+- `skills/code/SKILL.md` の `allowed-tools` フロントマターに `check-allowed-tools.sh:*` を追加
+
+### Deferred Items
+- `/spec` 時点での allowed-tools チェック (Proposal A) は本 PR の対象外。Spec Notes の既存チェックは新規スクリプト追加のみ対象
+- `docs/ja/structure.md` と英語版のファイルカウント差分 (+2) は pre-existing drift として本 PR では修正せず
+
+### Notes for Next Phase
+- PR #874 は CI テスト通過を確認してからマージすること
+- `bats tests/` は全 1041 テスト通過 (exit 0) を確認済み
+- `validate-skill-syntax.py` warnings: `loop-paths-fallback` (既存、本 PR 無関係)
+
 ## spec retrospective
 
 ### Minor observations

--- a/docs/spec/issue-857-allowed-tools-precheck.md
+++ b/docs/spec/issue-857-allowed-tools-precheck.md
@@ -94,20 +94,20 @@
 - 初回の bats テストで `$stderr` が空になる問題が発生。`run` を `run --separate-stderr` に変更することで解決。1ステップ修正のみで完了
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `check-allowed-tools.sh` を独立スクリプトとして作成し、`validate-skill-syntax.py` のラッパーとして実装 (ロジック重複なし)
-- `bats_require_minimum_version 1.5.0` と `run --separate-stderr` を使用して stderr を正確にキャプチャ
-- `skills/code/SKILL.md` の `allowed-tools` フロントマターに `check-allowed-tools.sh:*` を追加
+- MUST issues なし; 全 4 受け入れ条件 PASS
+- `review-light` エージェントが実行環境で未登録のため、エージェント定義 (`agents/review-light.md`) を直接読み込み手動レビューとして実施
+- CI 全ジョブ SUCCESS を確認済み
 
 ### Deferred Items
-- `/spec` 時点での allowed-tools チェック (Proposal A) は本 PR の対象外。Spec Notes の既存チェックは新規スクリプト追加のみ対象
-- `docs/ja/structure.md` と英語版のファイルカウント差分 (+2) は pre-existing drift として本 PR では修正せず
+- Post-merge 観察 AC (observation event `auto-run`) は merge 後の次回 SKILL.md 改修 Issue で観察
+- `docs/ja/structure.md` と英語版のファイルカウント差分 (+2) は pre-existing drift として未修正
 
 ### Notes for Next Phase
-- PR #874 は CI テスト通過を確認してからマージすること
-- `bats tests/` は全 1041 テスト通過 (exit 0) を確認済み
+- MUST issues なし; `/merge 874` 実行可能
+- `bats tests/` 全 1041 テスト通過 (CI 確認済み)
 - `validate-skill-syntax.py` warnings: `loop-paths-fallback` (既存、本 PR 無関係)
 
 ## spec retrospective
@@ -125,3 +125,18 @@
 ### Uncertainty resolution
 
 - `validate-skill-syntax.py` の出力フォーマット確認: "が allowed-tools の Bash" という文字列が `validate_body_scripts_in_allowed_tools` エラーメッセージに含まれることを line 718-722 で確認済み (`script_path_pattern not in allowed_tools` → `f"... が allowed-tools の Bash(...) パターンに含まれていません"`)
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Nothing to note. 実装は Spec の 4 ステップと完全に一致。Spec 記載の変更ファイルがすべて PR に含まれていた。
+
+### Recurring issues
+
+- Nothing to note. 今回の PR は単機能追加 (check-allowed-tools.sh) のみ; 繰り返しパターンなし。
+
+### Acceptance criteria verification difficulty
+
+- `rubric` 条件は `validate-skill-syntax.py` の内部実装 (line 695 `validate_body_scripts_in_allowed_tools`) を参照しており、ソースコードを読まないと検証困難。次回 rubric 記述時は実装の参照可能な部分 (ファイルパス、関数名) を明示することで AI 検証の精度が上がる。
+- `command "bats tests/"` は safe mode では CI 参照フォールバックが必要; CI が SUCCESS であることが前提。CI 未完了の場合は PENDING になる点を注意 (今回は問題なし)。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (60 files)
+├── scripts/             # Utility scripts used by skills and agents (61 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -42,7 +42,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (91 files)
+├── tests/               # Bats test files for scripts (92 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -226,6 +226,7 @@ Key modules:
 - `scripts/run-spec.sh` — run spec skill
 
 **Tooling:**
+- `scripts/check-allowed-tools.sh` — detect SKILL.md body-to-allowed-tools mismatches before intermediate commits; called from `skills/code/SKILL.md` Step 8
 - `scripts/check-eager-load-capability.sh` — detect capability guidance mixed into eager-load shared modules (verify-patterns.md, verify-executor.md); called from /audit drift Step 2
 - `scripts/validate-permissions.sh` — validate skill directory ↔ name: field consistency
 - `scripts/validate-skill-syntax.py` — validate SKILL.md frontmatter and syntax

--- a/scripts/check-allowed-tools.sh
+++ b/scripts/check-allowed-tools.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Check for SKILL.md body-to-allowed-tools mismatches before intermediate commits.
+# Calls validate-skill-syntax.py and filters for allowed-tools mismatch errors.
+# Usage: check-allowed-tools.sh [skill-dir]
+#   skill-dir: directory to scan (default: skills/)
+# Exit codes: 0 = no mismatches (or validator absent), 1 = mismatches detected
+
+set -euo pipefail
+
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+VALIDATOR="$SCRIPT_DIR/validate-skill-syntax.py"
+SKILL_DIR="${1:-skills/}"
+
+if [ ! -f "$VALIDATOR" ]; then
+    exit 0
+fi
+
+output=$(python3 "$VALIDATOR" "$SKILL_DIR" 2>&1) || true
+
+mismatches=$(printf '%s\n' "$output" | grep "allowed-tools の Bash" || true)
+
+if [ -n "$mismatches" ]; then
+    echo "Warning: allowed-tools mismatch detected in SKILL.md:" >&2
+    printf '%s\n' "$mismatches" >&2
+    echo "Fix the allowed-tools frontmatter before committing." >&2
+    exit 1
+fi
+
+exit 0

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -2,7 +2,7 @@
 name: code
 description: Local implementation (`/code 123`). Size auto-detection routes XS/S→patch (direct commit to main), M/L→branch+PR. Override with `--patch`/`--pr`. Does not update CLAUDE.md, run session retrospectives, or manage memory.
 context: fork
-allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
+allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-allowed-tools.sh:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
 # Local Implementation
@@ -247,6 +247,16 @@ Implement every step listed in the Spec's "Implementation Steps" regardless of t
 - Use TaskCreate/TaskUpdate to manage tasks while working
 - **DCO: always use `git commit -s` (--signoff)** — applies to all commits throughout this skill: Step 8 intermediate commits, Step 11 final commit, and Step 12 retrospective commit
 - Commit after each step completes
+
+#### Allowed-tools Pre-commit Check
+
+If `scripts/validate-skill-syntax.py` exists and the current step modifies a SKILL.md file, before making the intermediate commit run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/check-allowed-tools.sh skills/
+```
+
+If the script exits non-zero, fix the allowed-tools mismatch before committing.
 
 #### Stale Test Assertion Check
 

--- a/tests/check-allowed-tools.bats
+++ b/tests/check-allowed-tools.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$PROJECT_ROOT/scripts/check-allowed-tools.sh"
+
+setup() {
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR/mocks"
+}
+
+@test "check-allowed-tools: exits 1 with stderr warning when allowed-tools mismatch detected" {
+    cat > "$MOCK_DIR/validate-skill-syntax.py" <<'EOF'
+#!/usr/bin/env python3
+import sys
+print("error: 本文中に参照されたスクリプト 'my-script.sh' が allowed-tools の Bash(...) パターンに含まれていません")
+print("1 error(s) found")
+sys.exit(1)
+EOF
+    chmod +x "$MOCK_DIR/validate-skill-syntax.py"
+
+    run --separate-stderr "$SCRIPT" skills/
+    [ "$status" -eq 1 ]
+    [[ "$stderr" == *"Warning: allowed-tools mismatch"* ]]
+}
+
+@test "check-allowed-tools: exits 0 when no mismatches detected" {
+    cat > "$MOCK_DIR/validate-skill-syntax.py" <<'EOF'
+#!/usr/bin/env python3
+print("0 error(s) found")
+EOF
+    chmod +x "$MOCK_DIR/validate-skill-syntax.py"
+
+    run "$SCRIPT" skills/
+    [ "$status" -eq 0 ]
+}
+
+@test "check-allowed-tools: exits 0 when validator is absent" {
+    run "$SCRIPT" skills/
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- `scripts/check-allowed-tools.sh` を新規作成: SKILL.md body の `${CLAUDE_PLUGIN_ROOT}/scripts/*` 参照と `allowed-tools` フロントマターの差分を中間 commit 前に検出する
- `skills/code/SKILL.md` Step 8 に `#### Allowed-tools Pre-commit Check` サブセクションを追加し、SKILL.md を変更する中間 commit 前に `check-allowed-tools.sh` を実行するよう指示
- `skills/code/SKILL.md` の `allowed-tools` フロントマターに `check-allowed-tools.sh:*` を追加
- `tests/check-allowed-tools.bats` を新規作成: 新しい呼び出しパスを3ケースで検証
- `docs/structure.md` / `docs/ja/structure.md` を更新: ファイルカウント更新、Tooling セクションに `check-allowed-tools.sh` エントリを追加

## Verification (pre-merge)

- `scripts/check-allowed-tools.sh` が `validate-skill-syntax.py` を呼び出し、`allowed-tools` の Bash エントリ漏れを検出する実装
- 差分検出時に stderr 出力 + exit 1 で通知される
- `tests/check-allowed-tools.bats` に新しい呼び出しパスを検証するテストが追加されている (既存の `tests/validate-skill-syntax.bats` lines 310-340 の関数レベルテストとは別)
- `bats tests/` 全テスト通過済み

## Verification (post-merge)

- 次回 SKILL.md 改修を伴う Issue (`/code` 実装で新規 script 呼び出しを追加) で、検査が中間 commit 前に発火し `validate-skill-syntax.py` での rework が発生しないことを観察

closes #857