### PR TITLE
Issue #860: PreToolUse hook で worktree Edit/Write path 誤用を構造的に block

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -162,6 +162,7 @@ wholework/
 - `scripts/phase-banner.sh` — run-*.sh スクリプトで `print_start_banner` / `print_end_banner` 関数を提供する source 可能なヘルパー
 - `scripts/emit-event.sh` — `.tmp/auto-events.jsonl` への構造化 JSONL イベント emission を提供する source 可能なヘルパー; run-*.sh、claude-watchdog.sh、wait-ci-checks.sh が使用
 - `scripts/append-consumed-comments-section.sh` — post-processor フォールバック: LLM が Step 5 を silent skip した際に Spec へ `## Consumed Comments` を追記; run-spec.sh / run-code.sh (pre/post カウント比較) と verify SKILL.md (明示 bash call) が使用
+- `scripts/hook-worktree-path-guard.sh` — PreToolUse hook: worktree session 中に parent-repo absolute path を file_path とする Edit/Write 呼び出しを block する (`modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions` の structural enforcement)
 
 **GitHub API ユーティリティ:**
 - `scripts/gh-graphql.sh` — キャッシュ付き GraphQL クエリ実行

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -169,6 +169,7 @@ Key modules:
 - `scripts/phase-banner.sh` — sourceable helper providing `print_start_banner` / `print_end_banner` functions for run-*.sh scripts
 - `scripts/emit-event.sh` — sourceable helper providing `emit_event()` for structured JSONL event emission to `.tmp/auto-events.jsonl`; used by run-*.sh, claude-watchdog.sh, and wait-ci-checks.sh
 - `scripts/append-consumed-comments-section.sh` — post-processor fallback: appends `## Consumed Comments` to Spec when LLM silently skips Step 5; used by run-spec.sh / run-code.sh (pre/post count comparison) and verify SKILL.md (explicit bash call)
+- `scripts/hook-worktree-path-guard.sh` — PreToolUse hook: blocks Edit/Write calls with parent-repo absolute file_path while inside a worktree session (structural enforcement of `modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions`)
 
 **GitHub API utilities:**
 - `scripts/gh-graphql.sh` — GraphQL query executor with caching

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-worktree-path-guard.sh",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -122,7 +122,7 @@ resulting dirty state of the parent repo file may fail unexpectedly.
 **How to verify CWD**: Run `pwd` to confirm you are inside the worktree, or confirm that
 the return value from `EnterWorktree` points to the worktree path before calling Edit.
 
-**Enforcement**: This convention is mechanically enforced by `scripts/hook-worktree-path-guard.sh` (registered as a PreToolUse hook in `hooks/hooks.json`), which blocks Edit/Write calls whose `file_path` is an absolute parent-repo path while the session is inside a worktree.
+**Enforcement**: This convention is mechanically enforced by `scripts/hook-worktree-path-guard.sh` (registered as a PreToolUse hook in `hooks/hooks.json`), which blocks Edit/Write calls whose `file_path` is an absolute parent-repo path while the session is inside a worktree. **Scope limit**: the hook matches only the Edit/Write/NotebookEdit tools — Bash-based edits, including the `.claude/` file workaround above, are not covered, so the worktree-local-path discipline must still be applied manually there.
 
 ## Callers (auto-maintained)
 

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -122,6 +122,8 @@ resulting dirty state of the parent repo file may fail unexpectedly.
 **How to verify CWD**: Run `pwd` to confirm you are inside the worktree, or confirm that
 the return value from `EnterWorktree` points to the worktree path before calling Edit.
 
+**Enforcement**: This convention is mechanically enforced by `scripts/hook-worktree-path-guard.sh` (registered as a PreToolUse hook in `hooks/hooks.json`), which blocks Edit/Write calls whose `file_path` is an absolute parent-repo path while the session is inside a worktree.
+
 ## Callers (auto-maintained)
 
 All callers that read this module. Update this table when a new Skill starts reading `modules/worktree-lifecycle.md`.

--- a/scripts/hook-worktree-path-guard.sh
+++ b/scripts/hook-worktree-path-guard.sh
@@ -12,7 +12,7 @@ case "$TOOL_NAME" in
   *) exit 0 ;;
 esac
 
-FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty')
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
 
 [ -z "$FILE_PATH" ] && exit 0
 

--- a/scripts/hook-worktree-path-guard.sh
+++ b/scripts/hook-worktree-path-guard.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# PreToolUse hook: block Edit/Write/NotebookEdit calls that pass an absolute
+# parent-repo path while the session is inside a worktree.
+# Exit 0 (allow) except when a worktree-session parent-repo absolute path is detected (exit 2, block).
+
+INPUT=$(cat)
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
+
+case "$TOOL_NAME" in
+  Edit|Write|NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+[ -z "$FILE_PATH" ] && exit 0
+
+CWD=$(pwd)
+
+case "$CWD" in
+  *".claude/worktrees/"*) ;;
+  *) exit 0 ;;
+esac
+
+WORKTREE_ROOT=$(printf '%s' "$CWD" | sed -E 's|(\.claude/worktrees/[^/]+).*|\1|')
+PARENT_REPO=$(printf '%s' "$WORKTREE_ROOT" | sed -E 's|/\.claude/worktrees/[^/]+$||')
+
+case "$FILE_PATH" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+
+case "$FILE_PATH" in
+  "$WORKTREE_ROOT"/*|"$WORKTREE_ROOT") exit 0 ;;
+esac
+
+case "$FILE_PATH" in
+  "$PARENT_REPO"/*)
+    echo "hook-worktree-path-guard: blocked $TOOL_NAME on parent-repo absolute path '$FILE_PATH' while inside worktree session at '$CWD'. Use the worktree-local path instead (see modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions)." >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/tests/hook-worktree-path-guard.bats
+++ b/tests/hook-worktree-path-guard.bats
@@ -46,3 +46,11 @@ teardown() {
     run bash -c "echo '$INPUT' | \"$SCRIPT\""
     [ "$status" -eq 0 ]
 }
+
+@test "inside worktree + NotebookEdit + parent-repo absolute notebook_path -> exit 2 (block)" {
+    cd "$FIXTURE_WORKTREE"
+    INPUT=$(printf '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"%s/docs/foo.ipynb"}}' "$FIXTURE_PARENT")
+    run bash -c "echo '$INPUT' | \"$SCRIPT\""
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"hook-worktree-path-guard"* ]]
+}

--- a/tests/hook-worktree-path-guard.bats
+++ b/tests/hook-worktree-path-guard.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+# Tests for hook-worktree-path-guard.sh
+# Validates PreToolUse block/allow decisions for Edit/Write/NotebookEdit calls
+# depending on cwd (inside/outside a worktree) and file_path (relative,
+# worktree-local absolute, or parent-repo absolute).
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/hook-worktree-path-guard.sh"
+
+setup() {
+    FIXTURE_PARENT="$BATS_TEST_TMPDIR/parentrepo"
+    FIXTURE_WORKTREE="$FIXTURE_PARENT/.claude/worktrees/test-issue"
+    mkdir -p "$FIXTURE_WORKTREE/docs"
+    mkdir -p "$FIXTURE_PARENT/docs"
+}
+
+teardown() {
+    rm -rf "$FIXTURE_PARENT"
+}
+
+@test "inside worktree + parent-repo absolute path -> exit 2 (block)" {
+    cd "$FIXTURE_WORKTREE"
+    INPUT=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s/docs/foo.md"}}' "$FIXTURE_PARENT")
+    run bash -c "echo '$INPUT' | \"$SCRIPT\""
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"hook-worktree-path-guard"* ]]
+}
+
+@test "inside worktree + worktree absolute path -> exit 0 (allow)" {
+    cd "$FIXTURE_WORKTREE"
+    INPUT=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s/docs/foo.md"}}' "$FIXTURE_WORKTREE")
+    run bash -c "echo '$INPUT' | \"$SCRIPT\""
+    [ "$status" -eq 0 ]
+}
+
+@test "inside worktree + relative path -> exit 0 (allow)" {
+    cd "$FIXTURE_WORKTREE"
+    INPUT='{"tool_name":"Edit","tool_input":{"file_path":"docs/foo.md"}}'
+    run bash -c "echo '$INPUT' | \"$SCRIPT\""
+    [ "$status" -eq 0 ]
+}
+
+@test "outside worktree + any path -> exit 0 (allow)" {
+    cd "$FIXTURE_PARENT"
+    INPUT=$(printf '{"tool_name":"Edit","tool_input":{"file_path":"%s/docs/foo.md"}}' "$FIXTURE_PARENT")
+    run bash -c "echo '$INPUT' | \"$SCRIPT\""
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Structural fix for #860 verify FAIL: adds a PreToolUse hook that blocks Edit/Write/NotebookEdit calls whose `file_path` is a parent-repo absolute path while the session is inside a worktree.

- `scripts/hook-worktree-path-guard.sh` (new) — bash 3.2+ compatible, jq-based parse, cwd × file_path matching
- `hooks/hooks.json` — adds `PreToolUse` entry for `Edit|Write|NotebookEdit`
- `tests/hook-worktree-path-guard.bats` (new) — 4 scenarios (inside/outside worktree × parent/worktree/relative path)
- `modules/worktree-lifecycle.md` — reference to hook enforcement appended to existing prose
- `docs/structure.md` and `docs/ja/structure.md` — add hook to scripts list

Existing prose documentation is preserved (defense-in-depth); hook adds structural enforcement.

## Recovery note

The code phase wrapper reported silent no-op (branch committed but not pushed / PR not created) and its auto-retry failed due to a parent-main stray file (`docs/ja/reports/claude-sonnet-5-impact-strategy.md`, out of scope per Spec, created during silent no-op period — stashed as `stash@{0}` for retention) . Manually recovered by push + PR create. This event will be recorded in the Spec's `## Auto Retrospective` section.

## Test plan

- [ ] `bats tests/hook-worktree-path-guard.bats` all pass (4 scenarios)
- [ ] Full bats suite still passes
- [ ] Manual observation: run a `/spec` or `/code` session, EnterWorktree, then attempt Edit with parent-repo absolute path → hook should block with exit 2 + stderr message

Closes #860
