### PR TITLE
Issue #882: review: capabilities.workflow 有効時のカスタム agentType 未登録を修正

### DIFF
--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -31,7 +31,7 @@
   | issue | 条件付き | headless（run-issue.sh）/ in-session（直接呼び出し） | 直接呼び出し時は shared、run-issue.sh 経由時は fork（L/XL 並列調査ではサブエージェントが分離コンテキストで実行） |
   | spec | 条件付き | headless（run-spec.sh）/ in-session（直接呼び出し） | 直接呼び出し時は shared、run-spec.sh 経由時は fork |
   | code | 必要 | headless（run-code.sh）/ in-session（直接呼び出し） | Spec を読み独立して実行する、実装前のコンテキストの影響を受けない |
-  | review | 必要 | In-session（Workflow opt-in: capabilities.workflow: true）/ headless フォールバック | 実装フェーズのバイアスを継がず、クリーンな視点でコードをレビューする |
+  | review | 必要 | headless（run-review.sh）/ in-session（直接呼び出し） | 実装フェーズのバイアスを継がず、クリーンな視点でコードをレビューする |
   | merge | 必要 | headless（run-merge.sh） | 判断は Spec + PR メタデータで完結、レビューコンテキストを持ち越さない |
   | verify | 不要 | In-session | 大部分が機械的処理（verify command 実行 + checkbox 更新）、manual AC 確認には fork コンテキストで実行できない AskUserQuestion が必要、FAIL → /code（fork）で再実行するため bias 伝播リスクは低い |
   | auto | 不要 | In-session | 親オーケストレーターはユーザーの Claude Code セッションで実行される、各子フェーズは `run-*.sh` 経由で独立した `claude -p` プロセスとして実行 |

--- a/docs/spec/issue-882-review-agent-not-registered.md
+++ b/docs/spec/issue-882-review-agent-not-registered.md
@@ -86,18 +86,31 @@
 ### Post-merge follow-up (not blocking, recorded per Spec Notes)
 - Spec Notes の「agentType namespace 化の残留不確実性」に記載の通り、`run-review.sh` を実際に headless 実行して `review-spec` agentType が意図通り解決されるかの経験的確認は本 PR ではスコープ外とし、PR body の Verification (post-merge) に記録した。namespace 化されていた場合は追加修正が必要になる可能性があるが、Implementation Step 3 の Pre-flight 検出・フォールバックが defense-in-depth として機能するため AC2 は本 PR の変更のみで満たされる。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — review-spec の Perspective 1 (Spec Deviation) で乖離ゼロと判定された。変更ファイル一覧・`--plugin-dir` 挿入位置ともに Spec 記載通りで、スコープ外の変更もなかった。
+
+### Recurring issues
+
+本 Issue #882 自体が、issue #875 の review retrospective (Workflow パスの `review-spec`/`review-bug` agentType 未解決 fallback) から起票された改善提案である。今回 `--plugin-dir` 修正と Pre-flight 検出の両方が実装されたことで、同種の fallback イベントが再発しても headless 実行の根本原因側は解消され、Pre-flight 側で警告付きの安全なフォールバックが機能する二重の備えができた。実際、本 review フェーズ自身のセッションでも `review-spec`/`review-bug` が agentType 一覧に含まれておらず Pre-flight フォールバックが発火しており (PR コメント参照)、このセッションの起動経路 (`--plugin-dir` 未使用) が今回の修正でカバーされる範囲か否かは post-merge で `run-review.sh` を実地実行して確認する必要がある (Spec Notes for Next Phase に記載済み、未解消のまま残る)。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note — AC1/AC2 とも rubric 型検証で、アドバーサリアルグレーダー (独立した general-purpose エージェント2体) による検証で両方 PASS と明確に判定できた。UNCERTAIN は発生せず、rubric の文言自体も曖昧さは検出されなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `--plugin-dir "$(dirname "$SCRIPT_DIR")"` を全 5 run-*.sh・計 8 箇所に追加。`run-merge.sh` の `MAIN_REPO_ROOT` フォールバック分岐でも `SCRIPT_DIR` は常に scripts/ ディレクトリを指すため、`dirname` で一貫してプラグインルートに解決できることを確認済み。
-- Pre-flight 検出は `skills/review/workflow-guidance.md` 側 (Workflow パス直前) に置いた。呼び出し元の `skills/review/SKILL.md` ではなく Domain file 側に置いたのは、Workflow パスの実行判断そのものがこのファイルの責務だからで、静的 Task fan-out 側には変更を加えていない。
-- bats mock の更新は、arg-parsing `case` 文を持つブロックのみに `--plugin-dir` ケースを追加した (catch-all `echo "$@"` ブロックや counter/exit-code 専用ブロックは元々全引数をログするか case 文自体を持たないため変更不要と判断)。
+- review-spec の SHOULD 指摘 (Pre-flight チェックが `skills/review/SKILL.md:300` の「follow the Processing Steps」という文言から見て素通りされうる導線問題) を修正: `skills/review/SKILL.md:300` に Pre-flight を先に実行する旨を明記した。Pre-flight セクション自体を Processing Steps 内に統合する代替案もあったが、Domain file 側の構造 (Pre-flight → Processing Steps の順で独立した見出し) を変えずに呼び出し元の文言だけで導線を明確化する方が影響範囲が小さいと判断した。
+- Workflow パス (`capabilities.workflow: true`) が有効だったため、本 PR で追加された Pre-flight チェックを review フェーズ自身に適用し、静的 Task fan-out にフォールバックして実行した。これにより Spec の Notes for Next Phase が求めていた経験的検証を部分的に実施できた。
 
 ### Deferred Items
-- `review-spec` / `review-bug` agentType が `--plugin-dir` ロード後に namespace 化されずに解決されるか (bare 名 vs `wholework:review-spec` 形式) の経験的確認は post-merge 作業として PR body に記録し、本 PR ではスコープ外とした。
-- `docs/product.md` / `docs/guide/index.md` / `docs/guide/troubleshooting.md` / `docs/ja/guide/autonomy.md` の翻訳同期ギャップ (`check-translation-sync.sh` で検出) は本 Issue と無関係の既存差分のため未着手。
+- `review-spec` / `review-bug` agentType が `--plugin-dir` 修正後に `run-review.sh` 経由の headless 実行で実際に解決されるかの経験的確認は、本 review セッション自体が `--plugin-dir` 未使用の別経路で起動されていたため確認できず、post-merge フォローアップとして残る。
+- `docs/product.md` 等の翻訳同期ギャップは本 Issue と無関係のため未着手のまま。
 
 ### Notes for Next Phase
-- `/review` フェーズで実際に `capabilities.workflow: true` 環境の Workflow パスを通す機会があれば、Pre-flight ログ (agentType 一覧に review-spec/review-bug が含まれるか) を確認し、`--plugin-dir` 修正が意図通り機能しているか経験的に検証してほしい。
-- AC1/AC2 とも rubric 型検証であり、`/code` フェーズで自己判定して Issue チェックボックスを更新済み。`/verify` フェーズで改めて rubric grader によるフル評価が行われる。
+- `/merge 889` を実行する前提が整っている (MUST 指摘なし、CI 全 SUCCESS、AC1/AC2 とも PASS)。
+- post-merge で `run-review.sh` を実際に headless 実行し、`review-spec`/`review-bug` agentType が Pre-flight ログ上で利用可能と判定されるかを確認することを推奨する (Spec Notes 記載の検証項目、review フェーズでは代替できなかった)。

--- a/docs/spec/issue-882-review-agent-not-registered.md
+++ b/docs/spec/issue-882-review-agent-not-registered.md
@@ -71,3 +71,33 @@
 - **agentType namespace 化の残留不確実性**: Root Cause 参照。`/code` フェーズは実装後、可能であれば実際に `run-review.sh` (または同等の headless 呼び出し) を一度実行し、`review-spec` が意図通り解決されるか経験的に確認することが望ましい。namespace 化されていることが判明した場合は `agentType:` / `subagent_type=` 参照値への追加修正が必要になる可能性があるが、Implementation Step 3 の検出・フォールバックが defense-in-depth として機能するため、その場合でも AC2 は満たされる。
 - **スコープについて**: `capabilities.workflow` を実際に消費するのは現状 `/review` のみだが、`--plugin-dir` の欠落は `run-*.sh` 全 5 ファイルに共通する構造的な問題であり (`/issue` の L/XL サブエージェント分割 `issue-scope` / `issue-risk` / `issue-precedent` も同じ agentType 未解決リスクを抱える)、5 ファイル全てへの適用が妥当と判断した。
 - **issue #888 との関係**: Root Cause 参照。issue #888 は `hook-worktree-path-guard.sh` が `claude -p` サブプロセスで発火するかどうかを別スコープで調査中であり、本 Issue の根本原因 (`--plugin-dir` 欠落) が同じ現象の原因である可能性が高い。本 Issue のスコープには含めないが、issue #888 側の調査で参照される可能性がある。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — 4 つの Implementation Step をすべて設計通りに実装した (順序も Spec 記載どおり)。
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- worktree セッション中、最初の Edit 呼び出しで `file_path` にメインリポジトリの絶対パス (`/Users/saito/src/wholework/scripts/...`) を誤って指定し、worktree ではなくメインリポジトリ側のファイルが変更されてしまった (`modules/worktree-lifecycle.md` の「Edit/Write path conventions in worktree sessions」に明記された既知の失敗パターン)。`git status`/`grep` の不一致で即座に検知し、`git checkout --` でメインリポジトリ側を復元してから worktree 絶対パス (`.claude/worktrees/code+issue-882/...`) で全編集をやり直した。実害 (誤コミット) は発生していない。
+
+### Post-merge follow-up (not blocking, recorded per Spec Notes)
+- Spec Notes の「agentType namespace 化の残留不確実性」に記載の通り、`run-review.sh` を実際に headless 実行して `review-spec` agentType が意図通り解決されるかの経験的確認は本 PR ではスコープ外とし、PR body の Verification (post-merge) に記録した。namespace 化されていた場合は追加修正が必要になる可能性があるが、Implementation Step 3 の Pre-flight 検出・フォールバックが defense-in-depth として機能するため AC2 は本 PR の変更のみで満たされる。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `--plugin-dir "$(dirname "$SCRIPT_DIR")"` を全 5 run-*.sh・計 8 箇所に追加。`run-merge.sh` の `MAIN_REPO_ROOT` フォールバック分岐でも `SCRIPT_DIR` は常に scripts/ ディレクトリを指すため、`dirname` で一貫してプラグインルートに解決できることを確認済み。
+- Pre-flight 検出は `skills/review/workflow-guidance.md` 側 (Workflow パス直前) に置いた。呼び出し元の `skills/review/SKILL.md` ではなく Domain file 側に置いたのは、Workflow パスの実行判断そのものがこのファイルの責務だからで、静的 Task fan-out 側には変更を加えていない。
+- bats mock の更新は、arg-parsing `case` 文を持つブロックのみに `--plugin-dir` ケースを追加した (catch-all `echo "$@"` ブロックや counter/exit-code 専用ブロックは元々全引数をログするか case 文自体を持たないため変更不要と判断)。
+
+### Deferred Items
+- `review-spec` / `review-bug` agentType が `--plugin-dir` ロード後に namespace 化されずに解決されるか (bare 名 vs `wholework:review-spec` 形式) の経験的確認は post-merge 作業として PR body に記録し、本 PR ではスコープ外とした。
+- `docs/product.md` / `docs/guide/index.md` / `docs/guide/troubleshooting.md` / `docs/ja/guide/autonomy.md` の翻訳同期ギャップ (`check-translation-sync.sh` で検出) は本 Issue と無関係の既存差分のため未着手。
+
+### Notes for Next Phase
+- `/review` フェーズで実際に `capabilities.workflow: true` 環境の Workflow パスを通す機会があれば、Pre-flight ログ (agentType 一覧に review-spec/review-bug が含まれるか) を確認し、`--plugin-dir` 修正が意図通り機能しているか経験的に検証してほしい。
+- AC1/AC2 とも rubric 型検証であり、`/code` フェーズで自己判定して Issue チェックボックスを更新済み。`/verify` フェーズで改めて rubric grader によるフル評価が行われる。

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -40,7 +40,7 @@ English | [日本語](ja/tech.md)
   | issue | Conditional | headless (run-issue.sh) / in-session (direct) | Shared when invoked directly; fork when via run-issue.sh (sub-agents run in isolated context for L/XL parallel investigation) |
   | spec | Conditional | headless (run-spec.sh) / in-session (direct) | Shared when invoked directly; fork when via run-spec.sh |
   | code | Yes | headless (run-code.sh) / in-session (direct) | Reads Spec and executes independently; not influenced by pre-implementation context |
-  | review | Yes | In-session (Workflow opt-in via capabilities.workflow: true) / headless fallback | Reviews code from a clean perspective without inheriting implementation phase bias |
+  | review | Yes | headless (run-review.sh) / in-session (direct) | Reviews code from a clean perspective without inheriting implementation phase bias |
   | merge | Yes | headless (run-merge.sh) | Decision completes with Spec + PR metadata; does not carry over review context |
   | verify | No | In-session | Mostly mechanical (verify command execution + checkbox update); manual AC confirmation requires AskUserQuestion which cannot run in fork context; FAIL → /code (fork) re-runs so bias propagation risk is low |
   | auto | No | In-session | Parent orchestrator runs in the user's Claude Code session; each child phase runs as an independent `claude -p` process via `run-*.sh` |

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -253,6 +253,7 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
       --model sonnet \
       --effort high \
       --output-format json \
+      --plugin-dir "$(dirname "$SCRIPT_DIR")" \
       $PERMISSION_FLAG \
       > "$TOKEN_USAGE_FILE"
   EXIT_CODE=$?
@@ -264,6 +265,7 @@ else
     "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
       --model sonnet \
       --effort high \
+      --plugin-dir "$(dirname "$SCRIPT_DIR")" \
       $PERMISSION_FLAG
   EXIT_CODE=$?
 fi

--- a/scripts/run-issue.sh
+++ b/scripts/run-issue.sh
@@ -116,6 +116,7 @@ run_with_retry_on_kill env -u CLAUDECODE ANTHROPIC_MODEL=sonnet \
   "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
     --model sonnet \
     --effort high \
+    --plugin-dir "$(dirname "$SCRIPT_DIR")" \
     $PERMISSION_FLAG
 EXIT_CODE=$?
 set -e

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -145,6 +145,7 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
       --model sonnet \
       --effort low \
       --output-format json \
+      --plugin-dir "$(dirname "$SCRIPT_DIR")" \
       $PERMISSION_FLAG \
       > "$TOKEN_USAGE_FILE"
   EXIT_CODE=$?
@@ -155,6 +156,7 @@ else
     env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
       --model sonnet \
       --effort low \
+      --plugin-dir "$(dirname "$SCRIPT_DIR")" \
       $PERMISSION_FLAG
   EXIT_CODE=$?
 fi

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -135,6 +135,7 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
       --model sonnet \
       --effort high \
       --output-format json \
+      --plugin-dir "$(dirname "$SCRIPT_DIR")" \
       $PERMISSION_FLAG \
       > "$TOKEN_USAGE_FILE"
   EXIT_CODE=$?
@@ -145,6 +146,7 @@ else
     env -u CLAUDECODE "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
       --model sonnet \
       --effort high \
+      --plugin-dir "$(dirname "$SCRIPT_DIR")" \
       $PERMISSION_FLAG
   EXIT_CODE=$?
 fi

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -164,6 +164,7 @@ run_with_retry_on_kill env -u CLAUDECODE ANTHROPIC_MODEL="${MODEL}" \
   "$SCRIPT_DIR/claude-watchdog.sh" claude -p "$PROMPT" \
     --model "${MODEL}" \
     --effort "${EFFORT}" \
+    --plugin-dir "$(dirname "$SCRIPT_DIR")" \
     $PERMISSION_FLAG
 EXIT_CODE=$?
 set -e

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -346,8 +346,8 @@ Split into 2 groups and run in parallel using Task tool (`REVIEW_DEPTH=full` or 
 
 | Group | Aspects | Model | Agent file |
 |-------|---------|-------|-----------|
-| **Spec: spec/documentation** | Spec divergence, documentation consistency, steering document alignment | **opus** | `~/.claude/agents/review-spec.md` |
-| **Bug: bug/logic error detection** | HIGH SIGNAL bugs, logic errors, security issues | **opus** | `~/.claude/agents/review-bug.md` (×2 parallel) |
+| **Spec: spec/documentation** | Spec divergence, documentation consistency, steering document alignment | **opus** | `agents/review-spec.md` |
+| **Bug: bug/logic error detection** | HIGH SIGNAL bugs, logic errors, security issues | **opus** | `agents/review-bug.md` (×2 parallel) |
 
 ### 10.2. Parallel Execution Steps
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -297,7 +297,7 @@ gh pr view "$NUMBER" --json statusCheckRollup
 
 ## Step 10: Multi-perspective Code Review (parallel execution)
 
-**Workflow path (opt-in)**: When `HAS_WORKFLOW_CAPABILITY=true` and `REVIEW_DEPTH=full`, follow the Processing Steps in `skills/review/workflow-guidance.md` (loaded in Step 3) to run a finder → adversarial verify pipeline using the Workflow tool. When `HAS_WORKFLOW_CAPABILITY=false` or unset (the default), run the static Task fan-out below (Steps 10.0–10.3) unchanged.
+**Workflow path (opt-in)**: When `HAS_WORKFLOW_CAPABILITY=true` and `REVIEW_DEPTH=full`, first run the "Pre-flight: agentType Availability Check" in `skills/review/workflow-guidance.md` (loaded in Step 3), then follow that file's Processing Steps to run a finder → adversarial verify pipeline using the Workflow tool. When `HAS_WORKFLOW_CAPABILITY=false` or unset (the default), run the static Task fan-out below (Steps 10.0–10.3) unchanged.
 
 **In light mode**: if `REVIEW_DEPTH=light` and Issue number was extracted (Step 7 ran), run 1-agent lightweight integrated review instead of 2-agent parallel (see 10.0). If Issue number was not extracted and Step 7 was skipped, run full mode (10.1–10.3) regardless of `REVIEW_DEPTH`.
 

--- a/skills/review/workflow-guidance.md
+++ b/skills/review/workflow-guidance.md
@@ -33,6 +33,15 @@ The Workflow execution path preserves the same find/filter separation contract a
 - **Adversarial verification** plays the **filter role**: each finding is independently challenged by a refutation agent. Findings that survive adversarial refutation (`refuted: false`) become confirmed issues
 - **Fallback path**: when `HAS_WORKFLOW_CAPABILITY=false` or unset (the default), Steps 10.1–10.3 static Task fan-out run unchanged
 
+## Pre-flight: agentType Availability Check
+
+Before running the Workflow pipeline (Processing Steps below), confirm that `review-spec` and `review-bug` are both present in the session's Agent tool available agentType list (the list surfaced in the system context at session start).
+
+- **Both present**: proceed with the Processing Steps (Workflow Path) unchanged.
+- **Either missing**: output a warning that names the missing agentType(s) and references issue #882 for background (headless `claude -p` sessions launched without `--plugin-dir` do not load this plugin's `agents/*.md` custom agentTypes), then fall back to the static Task fan-out in `skills/review/SKILL.md` Steps 10.1–10.3 for this run instead of the Workflow path.
+
+This check exists because `capabilities.workflow: true` alone does not guarantee the custom agentTypes are resolvable — see issue #882 Root Cause for the headless `--plugin-dir` failure mode this guards against.
+
 ## Processing Steps (Workflow Path)
 
 When `HAS_WORKFLOW_CAPABILITY=true` and `REVIEW_DEPTH=full`, replace Steps 10.1–10.3 with the following:

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -40,6 +40,7 @@ for arg in "$@"; do
         --model) echo "FLAG_MODEL=1" >> "$CLAUDE_CALL_LOG" ;;
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 echo "ANTHROPIC_MODEL=$ANTHROPIC_MODEL" >> "$CLAUDE_CALL_LOG"
@@ -164,6 +165,7 @@ teardown() {
     grep -q "FLAG_P=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_MODEL=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
+    grep -q "FLAG_PLUGIN_DIR=1" "$CLAUDE_CALL_LOG"
 
     grep -q "ARGUMENTS: 123 --non-interactive" "$CLAUDE_CALL_LOG"
 
@@ -382,6 +384,7 @@ for arg in "$@"; do
     case "$arg" in
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 exit 0

--- a/tests/run-issue.bats
+++ b/tests/run-issue.bats
@@ -41,6 +41,7 @@ for arg in "$@"; do
         --model) echo "FLAG_MODEL=1" >> "$CLAUDE_CALL_LOG" ;;
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 echo "ANTHROPIC_MODEL=$ANTHROPIC_MODEL" >> "$CLAUDE_CALL_LOG"
@@ -157,6 +158,7 @@ teardown() {
     grep -q "FLAG_P=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_MODEL=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
+    grep -q "FLAG_PLUGIN_DIR=1" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: ARGUMENTS contains issue number and --non-interactive" {
@@ -222,6 +224,7 @@ for arg in "$@"; do
     case "$arg" in
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 exit 0

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -46,6 +46,7 @@ for arg in "$@"; do
         --model) echo "FLAG_MODEL=1" >> "$CLAUDE_CALL_LOG" ;;
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 FOUND_P=0
@@ -193,6 +194,7 @@ teardown() {
     grep -q "FLAG_P=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_MODEL=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
+    grep -q "FLAG_PLUGIN_DIR=1" "$CLAUDE_CALL_LOG"
 
     grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
@@ -260,6 +262,7 @@ for arg in "$@"; do
     case "$arg" in
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 exit 0

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -42,6 +42,7 @@ for arg in "$@"; do
         --model) echo "FLAG_MODEL=1" >> "$CLAUDE_CALL_LOG" ;;
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 FOUND_P=0
@@ -172,6 +173,7 @@ teardown() {
     grep -q "FLAG_P=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_MODEL=1" "$CLAUDE_CALL_LOG"
     grep -q "FLAG_SKIP_PERMS=1" "$CLAUDE_CALL_LOG"
+    grep -q "FLAG_PLUGIN_DIR=1" "$CLAUDE_CALL_LOG"
 
     grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
 }
@@ -267,6 +269,7 @@ for arg in "$@"; do
     case "$arg" in
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 exit 0

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -41,6 +41,7 @@ for arg in "$@"; do
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
         --effort) echo "FLAG_EFFORT=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 echo "ANTHROPIC_MODEL=$ANTHROPIC_MODEL" >> "$CLAUDE_CALL_LOG"
@@ -189,6 +190,7 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -q "MODEL_VALUE=sonnet" "$CLAUDE_CALL_LOG"
     grep -q "ANTHROPIC_MODEL=sonnet" "$CLAUDE_CALL_LOG"
+    grep -q "FLAG_PLUGIN_DIR=1" "$CLAUDE_CALL_LOG"
 }
 
 @test "success: default effort is max" {
@@ -269,6 +271,7 @@ for arg in "$@"; do
     case "$arg" in
         --dangerously-skip-permissions) echo "FLAG_SKIP_PERMS=1" >> "$CLAUDE_CALL_LOG" ;;
         --permission-mode) echo "FLAG_PERM_MODE=1" >> "$CLAUDE_CALL_LOG" ;;
+        --plugin-dir) echo "FLAG_PLUGIN_DIR=1" >> "$CLAUDE_CALL_LOG" ;;
     esac
 done
 exit 0


### PR DESCRIPTION
## Summary

`.wholework.yml` に `capabilities.workflow: true` を設定した環境で `/review --full` を実行すると、`skills/review/workflow-guidance.md` の Workflow パスが `review-spec` / `review-bug` カスタム agentType を Agent tool registry から解決できず即座に失敗する問題 (#875 由来) の根本原因を修正する。

- 根本原因: `scripts/run-spec.sh` / `run-code.sh` / `run-review.sh` / `run-merge.sh` / `run-issue.sh` の `claude -p` 呼び出しに `--plugin-dir` が指定されておらず、headless セッションで wholework プラグイン自体 (と `agents/*.md` のカスタム agentType) がロードされていなかった。全 5 ファイル・計 8 箇所の呼び出しに `--plugin-dir "$(dirname "$SCRIPT_DIR")"` を追加。
- Defense-in-depth: `skills/review/workflow-guidance.md` に `## Pre-flight: agentType Availability Check` を新設。`review-spec` / `review-bug` が利用可能 agentType 一覧に無い場合は警告を出し、`skills/review/SKILL.md` Steps 10.1–10.3 の静的 Task fan-out にフォールバックする。
- 陳腐化したドキュメント参照の是正: `skills/review/SKILL.md` の Group Definitions テーブルが指していた `~/.claude/agents/review-spec.md` (旧シンボリックリンク方式の名残) を `agents/review-spec.md` に修正。`docs/tech.md` / `docs/ja/tech.md` の Architecture Decisions テーブル review 行を実装 (headless run-review.sh / in-session direct) と一致するよう修正。
- `tests/run-*.bats` (5 ファイル) に `--plugin-dir` フラグ検出のアサーションを追加。

## Verification (pre-merge)

- `agents/*.md` のカスタム agentType が Agent tool registry に登録されない原因 (`--plugin-dir` 未使用時の `CLAUDE_PLUGIN_ROOT` 未設定を含む) が Spec の Root Cause セクションおよび Issue コメントに記録されている
- 根本原因の修正 (`--plugin-dir` 追加) と、`capabilities.workflow: true` 設定時の agentType 不在検出・警告ロジックの両方が実装されている
- `bats tests/` (1045 tests) が全て PASS

## Verification (post-merge)

- 可能であれば `run-review.sh` (または同等の headless 呼び出し) を実際に一度実行し、`review-spec` agentType が意図通り解決されるか経験的に確認する (Spec Notes 参照。namespace 化されている場合は追加修正が必要になる可能性があるが、Pre-flight フォールバックにより AC2 は維持される)

closes #882
