### PR TITLE
Issue #897: Dispatch /verify from LLM-session observation emitters

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -188,7 +188,7 @@ wholework/
 - `scripts/get-verify-iteration.sh` — Issue コメントから `<!-- verify-iteration: N -->` マーカーの最大値を読み取る
 - `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: プロンプトが `/auto` パターンにマッチした場合にセッション名を自動リネーム
 - `scripts/log-permission.sh` — 権限イベントログ（JSON 出力）
-- `scripts/observation-trigger.sh` — イベント発火時に observation AC をディスパッチ: `opportunistic-search.sh --event` を呼び出し、マッチした各 Issue に `/verify` 再実行を促すコメントを投稿
+- `scripts/observation-trigger.sh` — イベント発火時に observation AC をディスパッチ: `opportunistic-search.sh --event` を呼び出し、マッチした各 Issue に `/verify` 再実行を促すコメントを投稿し、マッチした Issue 番号一覧を呼び出し元向けに stdout へ出力
 - `scripts/opportunistic-search.sh` — opportunistic スキル検索と observation イベントスキャン
 - `scripts/post_merge_check.sh` — 複数 Issue の post-merge 手動 AC（verify-type: manual）を 1 セッションでバンドル実行; AC ごとに P/F/S を対話入力; 全 PASS で phase/done 遷移、FAIL で reopen
 - `scripts/triage-backlog-filter.sh` — triage 向けバックログフィルタ

--- a/docs/spec/issue-897-observation-dispatch.md
+++ b/docs/spec/issue-897-observation-dispatch.md
@@ -77,17 +77,35 @@ No new comments since last phase (`phase/ready` 付与時刻 2026-07-04T20:21:51
 - 上記の forbidden expression 検出により、`modules/observation-trigger.md` の見出し・文言を1箇所リワードする追加コミットが発生した (実装ロジック自体の手戻りではなく、用語選択のみの修正)。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `AUTONOMY_TIER` gating (`L1`: advisory-only / `L2`・`L3`: dispatch) を `skills/triage/SKILL.md` の blocked-by backfill と同型パターンで実装した (Spec の設計判断通り)
-- dispatch 対象の除外は、単発ルートは現在処理中の `$NUMBER`、バッチルートは `BATCH_LIST` を用い、二重 dispatch を防いだ
-- `scripts/claude-watchdog.sh` は無変更 — stdout を捨てる既存呼び出しのため影響がないことをコード上で確認済み (137行目付近)
+- Pre-merge rubric AC 4件 (A〜D) はすべて実装内容から直接 PASS 判定し、UNCERTAIN・FAIL なし
+- review-light agent (light mode, 4 perspectives) で CONSIDER 1件 (Resume mode の dispatch 除外漏れ) を検出し、影響が低く既存パターンの踏襲であることから修正はスキップと判断した
+- CI 全ジョブ SUCCESS、MUST issue なしのため Step 12 修正作業・Step 12.3 再チェックは実施なし
 
 ### Deferred Items
-- dispatch 件数上限・コスト制御は Issue Notes の通り本 Issue のスコープ外のまま (`/spec` の Auto-Resolved Ambiguity Points で明記済み)
-- Post-merge AC (`次回 /auto --batch 実行での自動 dispatch 観察`, `verify-type: observation event=auto-run`) は `/verify` フェーズで観察待ち
+- CONSIDER issue (`skills/auto/SKILL.md:1135`, Resume mode の `BATCH_LIST`/`REMAINING` 再利用による dispatch 除外漏れ) は対応見送り。将来 batch checkpoint と合わせた「dispatch/processed 済み」セット永続化を検討する余地がある (review retrospective に記録済み)
+- Post-merge AC (`次回 /auto --batch 実行での自動 dispatch 観察`, `verify-type: observation event=auto-run`) は引き続き `/verify` フェーズで観察待ち
 
 ### Notes for Next Phase
-- `/review` フェーズでは `skills/review/SKILL.md` の `allowed-tools` に `Skill` を追加した点を含め、rubric 4件 (AC1〜4) の再確認を行うこと
-- Post-merge AC は次回 `/auto --batch` 実行時にバッチ対象外 Issue への `/verify` 自動 dispatch が観察されるまで保留のままでよい
+- `/merge` フェーズでは MUST issue なし・CI 全SUCCESSのため通常のマージ手順で進行可能
+- Post-merge AC の観察は次回 `/auto --batch` 実行時まで保留のままでよい
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — review-light agent (4 perspectives) は Spec の Implementation Steps 5件・rubric AC 4件すべてで実装と Spec の一致を確認した。乖離なし。
+
+### Recurring issues
+
+Nothing to note — 検出された issue は CONSIDER 1件のみで、複数箇所にまたがる同種の繰り返し issue ではない。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note — Pre-merge AC 4件はすべて rubric 形式で、UNCERTAIN 判定なく PASS 判定できた。verify command の記述・網羅性に問題は見られなかった。
+
+### Improvement proposals
+
+- **[CONSIDER] Resume mode (`--batch --resume`) の `BATCH_LIST`/`REMAINING` 再利用による dispatch 除外漏れ** — `skills/auto/SKILL.md:1135` の observation scan dispatch 除外判定が resume 後の `REMAINING` を参照するため、resume 前に処理済みの Issue が除外対象から漏れ、冗長な `/verify` dispatch が発生しうる。本 PR のスコープ外の既存パターン (line 1104 の Pending manual confirmation と同型) であり、影響も低い (概ね idempotent) ため今回は対応見送り。将来的に batch checkpoint と合わせた「dispatch/processed 済み」セット永続化を検討する余地がある。

--- a/docs/spec/issue-897-observation-dispatch.md
+++ b/docs/spec/issue-897-observation-dispatch.md
@@ -59,3 +59,35 @@
 ## Consumed Comments
 
 - saito / MEMBER / first-class / `/issue 897` の Issue Retrospective コメント (トリアージ結果: Type=Bug, Size=M, Value=3。Auto-Resolve Log 3点の詳細説明。内容は Issue 本文末尾の `## Auto-Resolved Ambiguity Points` セクションと重複しており、本 Spec の設計判断に新規情報の追加はなし) / https://github.com/saitoco/wholework/issues/897#issuecomment-4883649759
+
+No new comments since last phase (`phase/ready` 付与時刻 2026-07-04T20:21:51Z 以降のコメントなし).
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Implementation Steps 1〜5 は Spec 記載順序・内容通りに実装した (変数名 `OBSERVATION_MATCHES`、tier 分岐、`BATCH_LIST` 除外ロジック、`allowed-tools` への `Skill` 追加、`docs/structure.md`/`docs/ja/structure.md` 同期を含む)。
+
+### Design Gaps/Ambiguities
+
+- Spec の Implementation Steps には明記されていなかったが、`modules/observation-trigger.md` の新規セクション見出しに使った語が `scripts/check-forbidden-expressions.sh` が検出する旧称 (`/auto` の旧称) と一致していた。`docs/tech.md` § Forbidden Expressions は `check-forbidden-expressions.sh` 実行時のみ判明する制約であり、Spec 段階では見えにくい。同様に emitter 関連の Issue で prose を書く際は、この旧称の大文字始まり表記を避け "invoke" 等の言い換えを使う判断が必要になる。
+
+### Rework
+
+- 上記の forbidden expression 検出により、`modules/observation-trigger.md` の見出し・文言を1箇所リワードする追加コミットが発生した (実装ロジック自体の手戻りではなく、用語選択のみの修正)。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `AUTONOMY_TIER` gating (`L1`: advisory-only / `L2`・`L3`: dispatch) を `skills/triage/SKILL.md` の blocked-by backfill と同型パターンで実装した (Spec の設計判断通り)
+- dispatch 対象の除外は、単発ルートは現在処理中の `$NUMBER`、バッチルートは `BATCH_LIST` を用い、二重 dispatch を防いだ
+- `scripts/claude-watchdog.sh` は無変更 — stdout を捨てる既存呼び出しのため影響がないことをコード上で確認済み (137行目付近)
+
+### Deferred Items
+- dispatch 件数上限・コスト制御は Issue Notes の通り本 Issue のスコープ外のまま (`/spec` の Auto-Resolved Ambiguity Points で明記済み)
+- Post-merge AC (`次回 /auto --batch 実行での自動 dispatch 観察`, `verify-type: observation event=auto-run`) は `/verify` フェーズで観察待ち
+
+### Notes for Next Phase
+- `/review` フェーズでは `skills/review/SKILL.md` の `allowed-tools` に `Skill` を追加した点を含め、rubric 4件 (AC1〜4) の再確認を行うこと
+- Post-merge AC は次回 `/auto --batch` 実行時にバッチ対象外 Issue への `/verify` 自動 dispatch が観察されるまで保留のままでよい

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -196,7 +196,7 @@ Key modules:
 - `scripts/get-verify-iteration.sh` — read highest `<!-- verify-iteration: N -->` marker from Issue comments
 - `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: auto-rename session title when prompt matches `/auto` pattern
 - `scripts/log-permission.sh` — log permission events (JSON output)
-- `scripts/observation-trigger.sh` — dispatch observation-type ACs on event: calls `opportunistic-search.sh --event`, posts comment to each matched Issue recommending `/verify` re-run
+- `scripts/observation-trigger.sh` — dispatch observation-type ACs on event: calls `opportunistic-search.sh --event`, posts comment to each matched Issue recommending `/verify` re-run, and prints matched Issue numbers to stdout for caller dispatch
 - `scripts/opportunistic-search.sh` — opportunistic skill search and observation event scan
 - `scripts/post_merge_check.sh` — bundle and run post-merge manual (verify-type: manual) ACs for multiple Issues in one session; prompts P/F/S per AC; transitions to phase/done on all-PASS or reopens on FAIL
 - `scripts/triage-backlog-filter.sh` — filter backlog for triage

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -82,7 +82,7 @@ In shell contexts where `/verify` cannot be spawned (e.g., inside `claude-watchd
 - Post a comment to the Issue noting the event was observed
 - Recommend the user re-run `/verify <number>` to update the checkbox
 
-## `scripts/observation-trigger.sh` (実装済み #656)
+## `scripts/observation-trigger.sh` (実装済み #656; stdout output added in #897)
 
 A dedicated dispatch script (`scripts/observation-trigger.sh`) encapsulates the
 processing contract above, making emitter integration a one-liner:
@@ -92,8 +92,26 @@ processing contract above, making emitter integration a one-liner:
 ```
 
 The script calls `opportunistic-search.sh --event <name>`, and for each matched Issue
-posts a comment recommending the user re-run `/verify <N>` (comment-posting dispatch;
-no AI judgment in shell context). Implemented in #656.
+posts a comment recommending the user re-run `/verify <N>` (comment-posting side effect;
+unconditional regardless of caller context). It also prints the matched Issue numbers
+(newline-separated, one per line; empty output when no matches) to stdout, so that
+callers with a dispatch mechanism can act on the result directly instead of relying on
+the human reading the comment.
+
+**Dispatch responsibility split (since #897):** `observation-trigger.sh` itself never
+dispatches `/verify` — it only posts the comment and prints the matched numbers. Whether
+those numbers are turned into an actual `/verify` dispatch is the calling emitter's
+responsibility:
+
+- **LLM-session emitters** (`/auto`, `/review`) capture stdout and, when `AUTONOMY_TIER`
+  is `L2`/`L3` (via `modules/detect-config-markers.md`), dispatch
+  `Skill(skill="wholework:verify", args="$N")` for each matched number (excluding the
+  Issue the current phase just processed). At `L1`, dispatch is skipped and the posted
+  comment remains the only signal (advisory-only, matching the `L1` semantics in
+  `modules/autonomy-tier.md`).
+- **`scripts/claude-watchdog.sh`** (shell-only context, no `Skill` tool available) does
+  not capture or act on stdout — its existing comment-posting-only fallback is
+  unaffected by this change.
 
 ## Notes
 

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -98,9 +98,9 @@ unconditional regardless of caller context). It also prints the matched Issue nu
 callers with a dispatch mechanism can act on the result directly instead of relying on
 the human reading the comment.
 
-**Dispatch responsibility split (since #897):** `observation-trigger.sh` itself never
-dispatches `/verify` — it only posts the comment and prints the matched numbers. Whether
-those numbers are turned into an actual `/verify` dispatch is the calling emitter's
+**Who invokes `/verify` (since #897):** `observation-trigger.sh` itself never
+invokes `/verify` — it only posts the comment and prints the matched numbers. Whether
+those numbers are turned into an actual `/verify` call is the calling emitter's
 responsibility:
 
 - **LLM-session emitters** (`/auto`, `/review`) capture stdout and, when `AUTONOMY_TIER`

--- a/scripts/observation-trigger.sh
+++ b/scripts/observation-trigger.sh
@@ -61,3 +61,5 @@ fi
 for N in $NUMBERS; do
     gh issue comment "$N" --body "observation event \`${EVENT_NAME}\` detected. Run \`/verify ${N}\` to verify the condition and update the checkbox." 2>/dev/null || true
 done
+
+echo "$NUMBERS"

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -712,7 +712,11 @@ Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "P
 
 **Event-based observation scan (auto-run event, runs after Completion Report regardless of success/failure):**
 
-Run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event auto-run`
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event auto-run` and capture stdout as `OBSERVATION_MATCHES` (newline-separated Issue numbers; may be empty).
+
+If `OBSERVATION_MATCHES` is non-empty, read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section to load `AUTONOMY_TIER`, then apply tier-aware dispatch:
+- **L1**: skip dispatch (advisory-only — the comment already posted by `observation-trigger.sh` is the only action)
+- **L2 / L3**: for each number in `OBSERVATION_MATCHES` other than `$NUMBER` (the Issue this `/auto` run just processed), dispatch `Skill(skill="wholework:verify", args="$N")` sequentially
 
 **L3 auto-retrospective (batch/XL routes only, runs after observation scan regardless of success/failure):**
 
@@ -1124,7 +1128,11 @@ Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "P
 
 **Event-based observation scan (batch, best-effort):**
 
-Run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event auto-run`
+Run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event auto-run` and capture stdout as `OBSERVATION_MATCHES` (newline-separated Issue numbers; may be empty).
+
+If `OBSERVATION_MATCHES` is non-empty, read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section to load `AUTONOMY_TIER`, then apply tier-aware dispatch:
+- **L1**: skip dispatch (advisory-only — the comment already posted by `observation-trigger.sh` is the only action)
+- **L2 / L3**: for each number in `OBSERVATION_MATCHES` not already included in `BATCH_LIST` (Issues already processed by this batch), dispatch `Skill(skill="wholework:verify", args="$N")` sequentially
 
 **Next-cycle seed (batch, best-effort):**
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -2,7 +2,7 @@
 name: review
 description: PR review (`/review 88`). Automatically runs acceptance criteria verification, multi-perspective code review, issue resolution, and summary posting. Use after `/code` creates a PR and before `/merge` (`--light`/`--full` to adjust depth).
 context: fork
-allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, Workflow
+allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, Workflow, Skill
 ---
 
 # PR Review
@@ -800,6 +800,10 @@ After the opportunistic verification above (or in its place if `opportunistic-ve
 
 - If `REVIEW_DEPTH=full`: run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event pr-review-full`
 - If `REVIEW_DEPTH=light`: run `${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh --event pr-review-light`
+
+Capture the command's stdout as `OBSERVATION_MATCHES` (newline-separated Issue numbers; may be empty). If non-empty, read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section to load `AUTONOMY_TIER`, then apply tier-aware dispatch:
+- **L1**: skip dispatch (advisory-only — the comment already posted by `observation-trigger.sh` is the only action)
+- **L2 / L3**: for each number in `OBSERVATION_MATCHES` other than `$ISSUE_NUMBER` (the Issue this review just processed), dispatch `Skill(skill="wholework:verify", args="$N")` sequentially
 
 ## Completion Report
 

--- a/tests/observation-trigger.bats
+++ b/tests/observation-trigger.bats
@@ -72,6 +72,7 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -q "issue comment 42" "$BATS_TEST_TMPDIR/gh-calls.log"
     grep -q "watchdog-kill" "$BATS_TEST_TMPDIR/gh-calls.log"
+    [ "$output" = "42" ]
 }
 
 @test "success: multiple matches post one comment each" {
@@ -80,6 +81,8 @@ teardown() {
     [ "$status" -eq 0 ]
     grep -q "issue comment 10" "$BATS_TEST_TMPDIR/gh-calls.log"
     grep -q "issue comment 20" "$BATS_TEST_TMPDIR/gh-calls.log"
+    [[ "$output" == *"10"* ]]
+    [[ "$output" == *"20"* ]]
 }
 
 @test "resilience: opportunistic-search.sh error does not abort trigger" {


### PR DESCRIPTION
## Summary

`observation-trigger.sh` は observation event 発火時に matched Issue へコメントを投稿するだけで、`modules/observation-trigger.md` が定めた Output Processing Contract (「dispatch 可能な場合は `/verify` を dispatch」) を実装していなかった。本 PR は以下を実装する:

- `scripts/observation-trigger.sh`: 既存のコメント投稿ループの後に matched Issue 番号一覧を改行区切りで stdout に出力する処理を追加 (副作用のコメント投稿は変更なし)
- `skills/auto/SKILL.md`: 単発 Issue ルートとバッチルートの両方の Event-based observation scan ステップで、stdout を `OBSERVATION_MATCHES` としてキャプチャし、`AUTONOMY_TIER` が `L2`/`L3` の場合に `Skill(wholework:verify, args="$N")` を dispatch する処理を追加。`L1` は既存の advisory-only (コメントのみ) を維持
- `skills/review/SKILL.md`: 同型の dispatch 処理を追加し、`allowed-tools` に `Skill` を追加
- `modules/observation-trigger.md`: stdout 出力と dispatch 責務分担 (LLM セッション emitter vs `claude-watchdog.sh`) を明記
- `docs/structure.md` / `docs/ja/structure.md`: `observation-trigger.sh` の説明を新挙動に合わせて更新
- `tests/observation-trigger.bats`: stdout 出力内容 (Issue 番号) のアサーションを追加

`scripts/claude-watchdog.sh` (shell-only context) は無変更 — stdout をキャプチャしないため既存のコメント投稿のみのフォールバック挙動に影響はない。

## Verification (pre-merge)

- `bats tests/observation-trigger.bats` — 全8テストPASS (stdout アサーション含む)
- `bats tests/` フルスイート — 全1062テストPASS (behavioral change 検出により auto/review SKILL.md 変更の波及テストを含めて実行)
- `python3 scripts/validate-skill-syntax.py skills/` — 0 error
- `scripts/check-forbidden-expressions.sh` — 違反なし
- Acceptance Criteria の rubric 4件をセルフレビューし、実装が各条件を満たすことを確認 (Issue本文チェックボックス更新済み)

## Verification (post-merge)

- 次回 `/auto --batch` 実行で、バッチ対象外の Issue に observation 条件が発火した場合に `/verify` が自動 dispatch されることを観察

closes #897
