### PR TITLE
Issue #906: Gate code-patch-silent-no-op Tier 2 recovered on completion check

### DIFF
--- a/docs/spec/issue-906-tier2-silent-no-op-recovered.md
+++ b/docs/spec/issue-906-tier2-silent-no-op-recovered.md
@@ -70,3 +70,33 @@
 ## Consumed Comments
 
 - saito (MEMBER, first-class) — `/issue 906 --non-interactive` の Issue Retrospective。実装対象ファイルの訂正 (`apply-fallback.sh`) と AC1〜3 の確定内容を記録したコメント。内容は既に Issue 本文に反映済みのため、Spec 側での追加対応は不要と判断した。
+- `/code 906 --pr --non-interactive` (code フェーズ): No new comments since last phase.
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps の Option A どおりに実装した。
+
+### Design Gaps/Ambiguities
+- `apply_code_patch_silent_no_op_retry()` の completion check は「関数末尾」に置く設計だったため、既存の `AUTO_RETRY_ENABLED=true` 分岐の早期 `return 0` を `if/else` に書き換えて両分岐が同じ completion check に合流するようにした。Spec の Implementation Steps には明記されていなかった小さな構造変更だが、「retry (または skip) 後に完了を確認する」という Purpose の要求を両分岐に一律適用するために必要だった。
+- `/code` skill 自身の Step 11 (pr route) に `gh pr create` 実行前の `git push origin HEAD` の明記がなく、未 push のブランチで `gh pr create` が失敗する事象を実際に踏んだ。本 Issue のスコープ外 (`/code` skill 自体の改善) のため、フォローアップ Issue #908 (`retro/code`) を起票した。
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `apply_code_patch_silent_no_op_retry()` の completion check は、retry を実行した分岐と `AUTO_RETRY_ENABLED=true` によりスキップした分岐の両方が合流する関数末尾に置いた (`if/else` + 共通の completion check)。理由: skip 分岐だけ検証を免除すると、built-in retry が既に使い果たされているケースでの silent no-op を見逃す可能性が残るため。
+- `case "code-patch-silent-no-op)"` は `apply_code_patch_silent_no_op_retry` の戻り値で分岐させ、失敗時は `printf` をスキップして `exit 1` とした。新しい abort 経路は追加せず、既存の Tier 2→Tier 3 (`run-auto-sub.sh` の exit-code ベース) エスカレーションをそのまま再利用する Issue 本文の方針に従った。
+- `tests/apply-fallback.bats` の `setup()` に `reconcile-phase-state.sh` のデフォルトモック (`matches_expected:true`) を追加し、既存の 2 件の `code-patch-silent-no-op` テストが回帰なく PASS することを確認した。
+
+### Deferred Items
+- Option B (他の Tier 2 ハンドラへの同型ガード全走査) は Issue 本文で明示的にスコープ外とされているため未着手。
+- `/code` skill 自身の pr route Step 11 に `git push origin HEAD` の明記がない gap はフォローアップ Issue #908 (`retro/code`) に切り出し、本 Issue のスコープ外とした。
+
+### Notes for Next Phase
+- `bats tests/` フルスイート (1064 tests) を実行し全件 PASS を確認済み (behavioral change detection により `tests/apply-fallback.bats` 単体ではなくフルスイートを実行)。
+- Issue AC3 (`github_check "gh pr checks" "Run bats tests"`) は PR 作成前のため pre-merge 時点では UNCERTAIN。PR #907 の CI green を review/merge フェーズで確認すること。
+- PR #907 は `closes #906` を含む。

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -466,11 +466,11 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 - code (patch route)
 
 ### Fallback Steps
-1. Retry `run-code.sh <issue> --patch` once
-2. If the second run also exits 1 (still no commit detected by reconcile) → escalate to Tier 3
+1. Retry `run-code.sh <issue> --patch` once (skipped when `run-code.sh`'s built-in `auto-retry-on-fail` has already exhausted its retries, to avoid double-retry)
+2. After the retry (or skip), check `matches_expected` via `reconcile-phase-state.sh code-patch <issue> --check-completion`. If `false` → escalate to Tier 3
 
 ### Escalation
-- If the retry itself exits non-zero and reconcile still reports `commits_found:false`, escalate to Tier 3 (recovery sub-agent)
+- If the retry (or skip) is followed by `matches_expected:false` from the completion check, escalate to Tier 3 (recovery sub-agent) — this also covers the case where the retry itself exits 0 but is itself a silent no-op (Issues #895, #904)
 - Do not retry more than once automatically; a second silent no-op may indicate a structural issue requiring human investigation
 
 ### Exception Condition

--- a/scripts/apply-fallback.sh
+++ b/scripts/apply-fallback.sh
@@ -91,6 +91,9 @@ apply_dco_signoff_autofix() {
 # Safe because reconcile confirms commits_found:false (clean state, no partial commit).
 # Guard: skips Tier 2 retry when run-code.sh built-in auto-retry is configured to prevent
 # double-retry (run-code.sh exhausts its retries before returning, so Tier 2 would be redundant).
+# After the retry (or skip), the completion signature is re-checked via
+# reconcile-phase-state.sh --check-completion so a retry that itself returns a silent no-op
+# is not mistakenly reported as recovered (Issues #895, #904).
 apply_code_patch_silent_no_op_retry() {
   local _ww_yml
   _ww_yml="$(dirname "$SCRIPT_DIR")/.wholework.yml"
@@ -102,11 +105,17 @@ apply_code_patch_silent_no_op_retry() {
   fi
   if [[ "$_auto_retry_enabled" == "true" ]]; then
     echo "[apply-fallback] code-patch-silent-no-op: AUTO_RETRY_ENABLED=true, built-in retry in run-code.sh already exhausted; skipping Tier 2 retry" >&2
+  else
+    echo "[apply-fallback] code-patch-silent-no-op: retrying run-code.sh --patch for issue $ISSUE" >&2
+    "$SCRIPT_DIR/run-code.sh" "$ISSUE" --patch >> "$LOG_FILE" 2>&1
+    echo "[apply-fallback] code-patch-silent-no-op: done" >&2
+  fi
+
+  if "$SCRIPT_DIR/reconcile-phase-state.sh" "$PHASE" "$ISSUE" --check-completion 2>/dev/null | grep -q '"matches_expected":true'; then
     return 0
   fi
-  echo "[apply-fallback] code-patch-silent-no-op: retrying run-code.sh --patch for issue $ISSUE" >&2
-  "$SCRIPT_DIR/run-code.sh" "$ISSUE" --patch >> "$LOG_FILE" 2>&1
-  echo "[apply-fallback] code-patch-silent-no-op: done" >&2
+  echo "[apply-fallback] code-patch-silent-no-op: completion check still reports matches_expected:false after retry/skip; escalating to Tier 3" >&2
+  return 1
 }
 
 # Handler: json-mode-silent-hang
@@ -131,13 +140,16 @@ case "$symptom_anchor" in
       "- N/A (resolved by Tier 2 fallback catalog)"
     ;;
   code-patch-silent-no-op)
-    apply_code_patch_silent_no_op_retry
-    printf '%s\n' \
-      "### Orchestration Anomalies" \
-      "- **[code-patch-silent-no-op]** Tier 2 fallback applied: phase=\`$PHASE\`, action=run-code.sh-patch-retry, result=recovered." \
-      "" \
-      "### Improvement Proposals" \
-      "- N/A (resolved by Tier 2 fallback catalog)"
+    if apply_code_patch_silent_no_op_retry; then
+      printf '%s\n' \
+        "### Orchestration Anomalies" \
+        "- **[code-patch-silent-no-op]** Tier 2 fallback applied: phase=\`$PHASE\`, action=run-code.sh-patch-retry, result=recovered." \
+        "" \
+        "### Improvement Proposals" \
+        "- N/A (resolved by Tier 2 fallback catalog)"
+    else
+      exit 1
+    fi
     ;;
   json-mode-silent-hang)
     apply_json_mode_silent_hang_retry

--- a/tests/apply-fallback.bats
+++ b/tests/apply-fallback.bats
@@ -32,6 +32,15 @@ fi
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/git"
+
+    # Default mock: reconcile-phase-state.sh reports completion succeeded.
+    # Individual tests override this to simulate matches_expected:false.
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":true}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
 }
 
 teardown() {
@@ -153,6 +162,36 @@ MOCK
     [[ "$output" == *"Orchestration Anomalies"* ]]
     [[ "$output" == *"dco-signoff-missing-autofix"* ]]
     [[ "$output" == *"result=recovered"* ]]
+}
+
+@test "code-patch-silent-no-op: retry itself returns silent no-op → not reported as recovered, escalates to Tier 3" {
+    LOG_FILE="$BATS_TEST_TMPDIR/test.log"
+    echo "Warning: claude exited 0 but code-patch phase did not complete (silent no-op)." > "$LOG_FILE"
+
+    RUN_CODE_LOG="$BATS_TEST_TMPDIR/run-code.log"
+    cat > "$MOCK_DIR/run-code.sh" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$RUN_CODE_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+
+    # Override the default mock: retry completed (exit 0) but produced no commit,
+    # so the post-retry completion check still reports matches_expected:false.
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":false}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
+    run bash "$SCRIPT" code-patch 42 --log "$LOG_FILE"
+    [ "$status" -ne 0 ]
+    [[ "$output" != *"result=recovered"* ]]
+
+    # The retry was still attempted before the completion check failed
+    grep -q "42" "$RUN_CODE_LOG"
+    grep -q -- "--patch" "$RUN_CODE_LOG"
 }
 
 @test "apply-fallback: code-patch-silent-no-op: stdout contains Orchestration Anomalies metadata" {


### PR DESCRIPTION
## Summary
- `apply_code_patch_silent_no_op_retry()` in `scripts/apply-fallback.sh` now checks `reconcile-phase-state.sh code-patch <issue> --check-completion` after the retry (or skip, when `run-code.sh`'s built-in `auto-retry-on-fail` has already exhausted its retries), returning failure when `matches_expected:false` instead of unconditionally succeeding.
- The `code-patch-silent-no-op)` case branch in `scripts/apply-fallback.sh` now only prints `result=recovered` when the handler returns success; otherwise it exits non-zero, falling through to the existing Tier 2→Tier 3 escalation path in `run-auto-sub.sh`.
- Updated `modules/orchestration-fallbacks.md`'s `code-patch-silent-no-op` entry (Fallback Steps / Escalation) to describe the new completion-check gate.
- Added a bats test to `tests/apply-fallback.bats` covering the case where the retry itself returns another silent no-op (no commit) — asserting non-zero exit and no `result=recovered` in output. Also added a default `reconcile-phase-state.sh` mock (`matches_expected:true`) to `setup()` so the two pre-existing `code-patch-silent-no-op` tests continue to pass.

## Verification (pre-merge)
- `scripts/apply-fallback.sh` の `apply_code_patch_silent_no_op_retry()` に `check-completion` 確認処理が実装されている (grep 確認済み)
- `tests/apply-fallback.bats` に silent no-op retry → Tier 3 エスカレーションを検証する新規テストを追加 (bats 実行で PASS 確認済み)
- `bats tests/` フルスイート (1064 tests) が全て PASS

## Verification (post-merge)
- 次回 `/auto --batch` 実行時、Tier 2 fallback が発火した Issue の `## Auto Retrospective` セクションで `result=recovered` エントリの reconcile 結果と実 commit の一致を観察

closes #906