### PR TITLE
feat: add verify session instrumentation events (#902)

### DIFF
--- a/docs/spec/issue-902-verify-session-instrumentation.md
+++ b/docs/spec/issue-902-verify-session-instrumentation.md
@@ -71,3 +71,33 @@
 - **Issue #900 との整合性確認**: `scripts/get-auto-session-report.sh` の Verify Phase Residuals 検出は Issue #900 でライブラベル参照方式 (`gh issue list --label phase/verify`) に切り替え済みであり、本 Issue が追加する `phase_start`/`phase_complete` (phase=verify) イベントには依存しない。したがって本実装は既存の集計ロジックに影響しない、純粋な追加のみの変更である。
 - **フォローアップ候補 (本 Spec のスコープ外)**: `scripts/get-auto-session-report.sh` 内の Metrics 出力キャベア (「The verify phase does not emit phase_start/phase_complete events...」という一文) は、本 Issue 実装後は事実と異なる記述になる。同ファイルの `PHASE_ACTIVITY_TABLE`/`_phase_breakdown` 集計ロジック自体は `.phase` 値ベースの汎用実装のため、コード変更なしで `verify` フェーズも自動的に集計対象に含まれる。ただし当該キャベア文言の削除・更新は本 Issue の Acceptance Criteria に含まれないスコープ外の変更のため、別 Issue での対応を推奨する。
 - **重複 Issue のクローズ状況**: #898・#899 は `/issue` フェーズで本 Issue (#902) を正 (canonical) として重複クローズ済み。#898 は実装未了で「#902 を正として実装を進める」と明記されている。本 Spec の設計に影響する重複実装は存在しない。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+実装は Implementation Steps 1〜5 の内容と厳密に一致していた (発火箇所・イベント名・フィールド名・Step 11 の5終端分岐カバレッジすべて)。ただし Step 3 のコードスニペットに含まれていた `${N}`/`${RESPONSE}` という bash 変数代入前提の記法は、本 Spec 自身がそのまま実装へ転記した結果であり、コード化フェーズで新たに生じた乖離ではない。`skills/verify/SKILL.md` の既存慣例 (`{N}` のようなプレースホルダーは `$` なしで書く。実際の bash 変数を指す場合のみ `${NEXT_ITERATION}` のように `$` を使う) との不整合が Spec 作成時点から埋め込まれていたことになる。次回同種の Spec 作成時は、SKILL.md 内の既存コードスニペット記法 (代入済み変数か prose プレースホルダーか) を踏襲するよう明記するとよい。
+
+### Recurring issues
+
+なし。今回の2件の SHOULD 指摘 (記法不整合、`docs/structure.md` の記述漏れ) はいずれも単発の軽微な指摘であり、過去レビューで繰り返し出ているパターンとは異なる。
+
+### Acceptance criteria verification difficulty
+
+3件すべて rubric ベースで、うち1件は `file_contains` による補助検証も付与されていたため、判定に迷う UNCERTAIN は発生しなかった。Post-merge の1件は `verify-type: opportunistic` であり `/merge` 後の次回 `/verify` 実行で観測されるため、本レビューでの判定対象外として扱った。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- Pre-merge AC 3件はすべて PASS。`file_contains` 補助検証済みの2件を含め UNCERTAIN なし
+- SHOULD指摘2件 (`${N}`/`${RESPONSE}` 記法不整合、`docs/structure.md` の記述漏れ) はレビュー中に修正 (追加コミット `78fafc29`)
+- `docs/structure.md` への指摘は本PRの diff 外ファイルのため line comment ではなく Review body の General Comments に記載 (GitHub API は diff 外パスへの line comment を 422 で拒否する)
+
+### Deferred Items
+- `scripts/get-auto-session-report.sh` の Metrics 出力キャベア文言 (「The verify phase does not emit phase_start/phase_complete events...」) は本実装後は事実と異なる記述になるが、Spec の Notes 記載通りスコープ外として別 Issue 送りとする
+- Post-merge AC (opportunistic): 次回 `/merge` 後の `/verify` 実行で `phase_start`/`phase_complete`/`verify_user_confirm` の実記録を観測する必要あり
+
+### Notes for Next Phase
+- `/merge` 実行時、追加コミット `78fafc29` (レビュー指摘対応) を含めてマージすること
+- マージ後の次回 `/verify` 実行時、Post-merge AC の opportunistic 観測を忘れずに行うこと

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -167,7 +167,7 @@ Key modules:
 
 **Phase banner:**
 - `scripts/phase-banner.sh` — sourceable helper providing `print_start_banner` / `print_end_banner` functions for run-*.sh scripts
-- `scripts/emit-event.sh` — sourceable helper providing `emit_event()` for structured JSONL event emission to `.tmp/auto-events.jsonl`; used by run-*.sh, claude-watchdog.sh, and wait-ci-checks.sh
+- `scripts/emit-event.sh` — sourceable helper providing `emit_event()` for structured JSONL event emission to `.tmp/auto-events.jsonl`; used by run-*.sh, claude-watchdog.sh, wait-ci-checks.sh, and `skills/verify/SKILL.md` (explicit bash call, no wrapper)
 - `scripts/append-consumed-comments-section.sh` — post-processor fallback: appends `## Consumed Comments` to Spec when LLM silently skips Step 5; used by run-spec.sh / run-code.sh (pre/post count comparison) and verify SKILL.md (explicit bash call)
 - `scripts/hook-worktree-path-guard.sh` — PreToolUse hook: blocks Edit/Write calls with parent-repo absolute file_path while inside a worktree session (structural enforcement of `modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions`)
 

--- a/modules/event-emission.md
+++ b/modules/event-emission.md
@@ -122,6 +122,10 @@ stays empty and `phase_start` / `phase_complete` are not emitted — preventing 
 | `run-merge.sh` | `merge` | |
 | `run-auto-sub.sh` | Sets `EMIT_PHASE_NAME` before delegating | Orchestrator; delegates to above |
 
+## Non-Wrapper Emitters
+
+`skills/verify/SKILL.md` emits `phase_start`/`phase_complete` (phase=`verify`) inline — directly from the skill body, gated only on `AUTO_EVENTS_LOG` being set — rather than through a `run-*.sh` wrapper. This is intentional: `/verify` has no `run-verify.sh` wrapper (removed in #485 when `/verify` moved to in-session execution), so the `_EMIT_PHASE_OWNED` pattern above, which lives in wrapper scripts, does not apply. `phase_complete` fires at every terminal branch of Step 11 (PASS/SKIPPED, FAIL retry, FAIL max-iterations, PENDING, UNCERTAIN) — not only on full PASS — because reaching an AC verdict, not the verdict itself, is the phase's completion signal. The skill also emits `verify_user_confirm` (phase-specific event, not a lifecycle event) at Step 8b whenever the interactive-mode manual-AC `AskUserQuestion` receives a response.
+
 ## Backfill
 
 `_maybe_emit_phase_complete()` is registered as an EXIT trap in each wrapper. On exit, it checks

--- a/scripts/emit-event.sh
+++ b/scripts/emit-event.sh
@@ -52,6 +52,10 @@
 #   iteration=<n>                 verify iteration counter (NEXT_ITERATION)
 #   failed_ac_count=<n>           number of FAIL conditions in auto-verification targets
 #
+# verify_user_confirm: /verify interactive mode で manual AC の AskUserQuestion に回答した
+#   ac_index=<n>                  acceptance condition index (1-based) the question was asked for
+#   response=<response>           Claude Execute | Manual Verification (Show Guide) | SKIP
+#
 # worktree-path-block: hook-worktree-path-guard.sh blocked an Edit/Write/NotebookEdit call
 #   that passed a parent-repo absolute path while the session was inside a worktree
 #   tool=<name>                   Edit | Write | NotebookEdit

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -39,6 +39,14 @@ Handle by exit code:
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="issue", ENTITY_NUMBER=$NUMBER, SKILL_NAME="verify".
 
+Emit `phase_start` (phase=verify) immediately after the banner (only when `AUTO_EVENTS_LOG` is set):
+```bash
+if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
+  source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+  EMIT_ISSUE_NUMBER=$NUMBER emit_event "phase_start" "phase=verify"
+fi
+```
+
 **pre-check: all-checked, no-implementation pattern**
 
 After the banner, detect the false-ready state: all acceptance conditions are pre-checked (`[x]`) but no implementation commit or merged PR exists for this issue. If detected, output a warning and continue (do not abort).
@@ -315,6 +323,16 @@ For each executable condition, ask:
   - "Manual Verification (Show Guide)" — display verification guide; leave checkbox unchecked
   - "SKIP" — skip for now; leave checkbox unchecked
 
+Immediately after receiving the user's response, emit `verify_user_confirm` (only when `AUTO_EVENTS_LOG` is set):
+```bash
+if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
+  source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+  EMIT_ISSUE_NUMBER=$NUMBER emit_event "verify_user_confirm" \
+    "ac_index=${N}" \
+    "response=${RESPONSE}"
+fi
+```
+
 If "Claude Execute" is selected: run the command/approach → judge PASS or FAIL → record result for checkbox flip.
 
 **2b. If not executable: display verification guide only**
@@ -419,6 +437,14 @@ Apply the following judgment based on the verification results (exhaustive):
 
 **(a) All auto-verification target conditions are PASS or SKIPPED (0 FAIL/UNCERTAIN among auto-verification targets; SKIPPED is ignored as environment conditions were unmet):**
 
+Emit `phase_complete` (phase=verify; only when `AUTO_EVENTS_LOG` is set):
+```bash
+if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
+  source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+  EMIT_ISSUE_NUMBER=$NUMBER emit_event "phase_complete" "phase=verify"
+fi
+```
+
 - Check if any unchecked (`- [ ]`) `<!-- verify-type: opportunistic -->`, `<!-- verify-type: observation ... -->`, or `<!-- verify-type: manual -->` conditions remain in the post-merge section of the Issue body (manual conditions SKIPped in Step 8 remain unchecked; observation conditions remain unchecked until their event fires)
 - **If unchecked opportunistic, observation, or manual conditions remain**: assign `phase/verify` (Issue state unchanged):
     ```bash
@@ -503,6 +529,13 @@ NEXT_ITERATION=$((CURRENT_ITERATION + 1))
           "failed_ac_count=${FAIL_COUNT}"
       fi
       ```
+    - Emit `phase_complete` (phase=verify; only when `AUTO_EVENTS_LOG` is set):
+      ```bash
+      if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
+        source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+        EMIT_ISSUE_NUMBER=$NUMBER emit_event "phase_complete" "phase=verify"
+      fi
+      ```
     - Output guidance for the user:
       ```
       Issue #N を再オープンしました。以下のいずれかで修正してください:
@@ -585,6 +618,13 @@ NEXT_ITERATION=$((CURRENT_ITERATION + 1))
           "failed_ac_count=${FAIL_COUNT}"
       fi
       ```
+    - Emit `phase_complete` (phase=verify; only when `AUTO_EVENTS_LOG` is set):
+      ```bash
+      if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
+        source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+        EMIT_ISSUE_NUMBER=$NUMBER emit_event "phase_complete" "phase=verify"
+      fi
+      ```
     - Assign `phase/verify` label (Issue state unchanged):
       ```bash
       ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" verify
@@ -597,6 +637,14 @@ NEXT_ITERATION=$((CURRENT_ITERATION + 1))
 
 **(c) PENDING only (no FAIL, PENDING ≥1):**
 
+Emit `phase_complete` (phase=verify; only when `AUTO_EVENTS_LOG` is set):
+```bash
+if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
+  source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+  EMIT_ISSUE_NUMBER=$NUMBER emit_event "phase_complete" "phase=verify"
+fi
+```
+
 - Assign `phase/verify` label (Issue state unchanged):
     ```bash
     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" verify
@@ -604,6 +652,14 @@ NEXT_ITERATION=$((CURRENT_ITERATION + 1))
 - Notify user: "CI が実行中のため一部の条件が PENDING です。CI 完了後に `/verify $NUMBER` を再実行してください。"
 
 **(d) UNCERTAIN only (no FAIL, UNCERTAIN ≥1):**
+
+Emit `phase_complete` (phase=verify; only when `AUTO_EVENTS_LOG` is set):
+```bash
+if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
+  source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
+  EMIT_ISSUE_NUMBER=$NUMBER emit_event "phase_complete" "phase=verify"
+fi
+```
 
 - Assign `phase/verify` label (Issue state unchanged):
     ```bash

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -328,8 +328,8 @@ Immediately after receiving the user's response, emit `verify_user_confirm` (onl
 if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
   source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
   EMIT_ISSUE_NUMBER=$NUMBER emit_event "verify_user_confirm" \
-    "ac_index=${N}" \
-    "response=${RESPONSE}"
+    "ac_index={N}" \
+    "response={the selected option text}"
 fi
 ```
 

--- a/tests/emit-event.bats
+++ b/tests/emit-event.bats
@@ -126,6 +126,40 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "emit_event writes phase=verify phase_start with correct JSON shape" {
+    bash -c "source \"$SCRIPT\" && emit_event \"phase_start\" \"phase=verify\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    local line
+    line=$(cat "$AUTO_EVENTS_LOG")
+    [[ "$line" == *'"event":"phase_start"'* ]]
+    [[ "$line" == *'"phase":"verify"'* ]]
+    [[ "$line" == *'"issue":42'* ]]
+}
+
+@test "emit_event writes phase=verify phase_complete with correct JSON shape" {
+    bash -c "source \"$SCRIPT\" && emit_event \"phase_complete\" \"phase=verify\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    local line
+    line=$(cat "$AUTO_EVENTS_LOG")
+    [[ "$line" == *'"event":"phase_complete"'* ]]
+    [[ "$line" == *'"phase":"verify"'* ]]
+    [[ "$line" == *'"issue":42'* ]]
+}
+
+@test "emit_event writes verify_user_confirm with ac_index and response fields" {
+    bash -c "source \"$SCRIPT\" && emit_event \"verify_user_confirm\" \"ac_index=2\" \"response=Claude Execute\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    run jq -r '.ac_index' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "2" ]]
+    run jq -r '.response' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "Claude Execute" ]]
+}
+
 @test "emit_event sourced under zsh parses without error (regression #891)" {
     command -v zsh >/dev/null 2>&1 || skip "zsh not installed"
     run zsh -c "source \"$SCRIPT\" && emit_event \"zsh_compat\" \"phase=code\""


### PR DESCRIPTION
## 概要

`/verify` セッションに event log 計装を追加し、#877 再測定で判明した「代理指標しか取れない」ギャップを解消する (closes #902)。

`/verify` は #485 で `run-verify.sh` が削除され in-session (parent context) 実行に移行したため、`spec`/`code`/`review`/`merge` のような wrapper 経由の `phase_start`/`phase_complete` 計装が無かった。本 PR は skill 本体からインラインで計装を発火する。

## 変更内容

- `skills/verify/SKILL.md`: `phase_start` (開始時) / `phase_complete` (Step 11 の全終端分岐) / `verify_user_confirm` (Step 8b の interactive manual AC 回答時) を `AUTO_EVENTS_LOG` ゲート付きで発火
- `scripts/emit-event.sh`: `verify_user_confirm` イベントの spec をコメントに追記
- `modules/event-emission.md`: `/verify` の non-wrapper emitter パターンを文書化
- `tests/emit-event.bats`: 新規イベント発火の bats テストを追加

## 検証

- Pre-merge AC (rubric × 3): phase event 発火ロジック / AskUserQuestion 計装 / bats テスト追加
- Post-merge AC (observation): 次回 `/verify` 実行時に実イベントが `.tmp/auto-events.jsonl` へ記録されることを観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDyt8heWtuuv8a36VxJXBh
