### PR TITLE
Issue #915: Add fallback Review Response Summary poster for silent no-op

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（63 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（64 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -35,7 +35,7 @@ wholework/
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（94 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（95 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents
@@ -207,6 +207,7 @@ wholework/
 - `scripts/validate-recovery-plan.sh` — orchestration-recovery sub-agent が出力する recovery plan JSON を検証（schema チェック + forbidden ops ガード）
 - `scripts/apply-fallback.sh` — `modules/orchestration-fallbacks.md` の Tier 2 bash projection。wrapper ログから既知の symptom anchor を検出し recovery handler を dispatch する（ハンドラ: dco-signoff-missing-autofix、code-patch-silent-no-op）
 - `scripts/spawn-recovery-subagent.sh` — `run-auto-sub.sh` が呼び出す Tier 3 recovery オーケストレーター。`claude -p` で `agents/orchestration-recovery` を spawn し、`validate-recovery-plan.sh` で plan を検証し、`WHOLEWORK_MAX_RECOVERY_SUBAGENTS` による mkdir-based スロットロックで並列性を制御し、成功時に `write_recovery_entry()` で `docs/reports/orchestration-recoveries.md` にエントリを記録する
+- `scripts/post-fallback-review-summary.sh` — `run-review.sh` が exit 0 + `matches_expected:false`（silent no-op）を検出した際に呼び出す。PR に "Acceptance Criteria Verification Results" を含む既存レビューが見つかった場合のみ `<!-- review-summary -->` マーカー付きのフォールバック Review Response Summary を投稿し、見つからない場合は投稿せず exit 1 を返す
 
 **Skill runners:**
 - `scripts/guard-prefix.sh` — 全 run-*.sh がソースする共有 GUARD_PREFIX 定義。自律実行向けのアーリーストップ防止とバウンダリリマインダーを含む

--- a/docs/spec/issue-915-review-summary-silent-noop.md
+++ b/docs/spec/issue-915-review-summary-silent-noop.md
@@ -87,20 +87,20 @@ No new comments since last phase.
 - **Verify command sync 確認**: 本 Spec の `## Verification > Pre-merge` は Issue 本文 `## Acceptance Criteria > Pre-merge` の2項目と verify コマンドを含め完全に一致 (件数一致: Issue側2件 / Spec側2件)。Post-merge も Issue本文の1件と一致。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の Implementation Steps 1〜5 をそのままの順序・内容で実装した (deviation なし)
-- `post-fallback-review-summary.sh` のガード条件は Spec 記載どおり "Acceptance Criteria Verification Results" を含む既存 Review の有無とし、修正コミットの有無はガードに使わなかった (#907 が修正コミットなしのケースだったため)
-- `tests/run-review.bats` の再チェック用 `reconcile-phase-state.sh` mock は呼び出し回数に応じて出力を切り替えるステートフルな実装 (1回目 false、2回目以降 true) にして、フォールバック投稿前後の状態遷移を検証した
+- `/review 920 --light --non-interactive` で軽量統合レビュー (review-light エージェント 1 体) を実行。Spec deviation / Edge cases・robustness / Security / Documentation consistency の 4 観点すべてで指摘なしと判定
+- 2 件の rubric 形式 AC ("修正コミット push 後の Response Summary 投稿を保証する仕組み" / "silent no-op ケースをカバーする bats test") は、実装ファイル (`scripts/post-fallback-review-summary.sh`, `scripts/run-review.sh` の該当分岐) を直接読み、`tests/post-fallback-review-summary.bats` + `tests/run-review.bats` をローカル実行 (全 30 テスト PASS) して両方 PASS と判定した
+- 修正コミットが発生しなかったため Step 12 (Issue 対応)・Step 13 (受け入れ条件整合性チェック) は共にスキップ
 
 ### Deferred Items
-- `scripts/detect-wrapper-anomaly.sh` の `reconciler-header-mismatch` パターンの誤帰属修正 (Spec Notes に記載、別 Issue 推奨。本 Issue のスコープ外)
-- フォールバック投稿と本来の Step 14 投稿が両方成功した場合の重複コメント dedup ロジック (Spec Notes に記載、cosmetic tradeoff として許容)
+- `scripts/detect-wrapper-anomaly.sh` の `reconciler-header-mismatch` パターンの誤帰属修正 (Spec Notes に記載、別 Issue 推奨。本 Issue のスコープ外、review phase でも変更なし)
+- フォールバック投稿と本来の Step 14 投稿が両方成功した場合の重複コメント dedup ロジック (Spec Notes に記載、cosmetic tradeoff として許容のまま)
 
 ### Notes for Next Phase
-- Review phase (`/review` on PR #920) で本 PR 自体をレビューする際、`scripts/run-review.sh` の変更が review skill 自身の completion 検出ロジックに影響するため、review 実行時に silent no-op が発生した場合は今回追加したフォールバックが作動することを期待した挙動として扱う
-- Behavioral Change Detection (Step 9) により `scripts/run-review.sh` の変更が `tests/run-auto-sub.bats` からも参照されていることを検出し、`bats tests/` フルスイート (1084 tests) を実行して回帰なしを確認済み
+- Merge phase (`/merge 920`) では MUST issue が存在しないため通常の merge フローで進行可能
+- 本 PR がレビューしている `scripts/run-review.sh` の変更 (silent no-op フォールバック) 自体は、今回の `/review` 実行中には発火しなかった (通常どおり Step 14 で Response Summary が投稿された) — dogfooding の観察事項として記録
 
 ## Code Retrospective
 
@@ -112,3 +112,14 @@ No new comments since last phase.
 
 ### Rework
 - N/A
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+Nothing to note (review-light の 4 観点すべてで Spec と実装の乖離なしと判定)。
+
+### Recurring issues
+Nothing to note (Copilot/Claude 双方の外部レビューは未設定 `.wholework.yml` により Step 7 は全てスキップ、Step 10 light mode の単一 review-light エージェント実行のみで完結)。
+
+### Acceptance criteria verification difficulty
+2 件とも `rubric` 形式の AC だったが、実装コード (該当関数・分岐) と bats テストを直接読んで判定するのに十分な情報量があり UNCERTAIN は発生しなかった。強いて言えば、rubric テキスト自体は「仕組みが実装されている」という抽象度の高い記述で、対象ファイル名を明示していなかったため、対象範囲の特定は PR diff のファイルリストから逆算する必要があった。今後同種の rubric を書く際は `docs/tech.md` の記載 (rubric ガイドライン) に倣い、対象スクリプト名を明示すると verify 実行がより機械的になる。

--- a/docs/spec/issue-915-review-summary-silent-noop.md
+++ b/docs/spec/issue-915-review-summary-silent-noop.md
@@ -85,3 +85,30 @@ No new comments since last phase.
 - **allowed-tools への影響なし**: `post-fallback-review-summary.sh` は `run-review.sh` (bash サブプロセス) から呼び出されるため、`skills/review/SKILL.md` の `allowed-tools` frontmatter への追加は不要 (既存の `apply-fallback.sh` 等、wrapper script 間の内部呼び出しと同じパターン)。
 - **Issue body vs 実装の整合性確認**: Issue Background に記載の「reconcile: matches_expected:false ... → wrapper exit 1」は `scripts/run-review.sh` の現行実装 (L178-181) と一致していることを確認済み。コンフリクトなし。
 - **Verify command sync 確認**: 本 Spec の `## Verification > Pre-merge` は Issue 本文 `## Acceptance Criteria > Pre-merge` の2項目と verify コマンドを含め完全に一致 (件数一致: Issue側2件 / Spec側2件)。Post-merge も Issue本文の1件と一致。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の Implementation Steps 1〜5 をそのままの順序・内容で実装した (deviation なし)
+- `post-fallback-review-summary.sh` のガード条件は Spec 記載どおり "Acceptance Criteria Verification Results" を含む既存 Review の有無とし、修正コミットの有無はガードに使わなかった (#907 が修正コミットなしのケースだったため)
+- `tests/run-review.bats` の再チェック用 `reconcile-phase-state.sh` mock は呼び出し回数に応じて出力を切り替えるステートフルな実装 (1回目 false、2回目以降 true) にして、フォールバック投稿前後の状態遷移を検証した
+
+### Deferred Items
+- `scripts/detect-wrapper-anomaly.sh` の `reconciler-header-mismatch` パターンの誤帰属修正 (Spec Notes に記載、別 Issue 推奨。本 Issue のスコープ外)
+- フォールバック投稿と本来の Step 14 投稿が両方成功した場合の重複コメント dedup ロジック (Spec Notes に記載、cosmetic tradeoff として許容)
+
+### Notes for Next Phase
+- Review phase (`/review` on PR #920) で本 PR 自体をレビューする際、`scripts/run-review.sh` の変更が review skill 自身の completion 検出ロジックに影響するため、review 実行時に silent no-op が発生した場合は今回追加したフォールバックが作動することを期待した挙動として扱う
+- Behavioral Change Detection (Step 9) により `scripts/run-review.sh` の変更が `tests/run-auto-sub.bats` からも参照されていることを検出し、`bats tests/` フルスイート (1084 tests) を実行して回帰なしを確認済み
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A (Spec の Implementation Steps 1〜5 をそのまま実装)
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (63 files)
+├── scripts/             # Utility scripts used by skills and agents (64 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -42,7 +42,7 @@ wholework/
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (94 files)
+├── tests/               # Bats test files for scripts (95 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -215,6 +215,7 @@ Key modules:
 - `scripts/validate-recovery-plan.sh` — validate recovery plan JSON from orchestration-recovery sub-agent (schema check + forbidden ops guard)
 - `scripts/apply-fallback.sh` — Tier 2 bash projection of `modules/orchestration-fallbacks.md`; detects known symptom anchors from wrapper logs and dispatches recovery handlers (handlers: dco-signoff-missing-autofix, code-patch-silent-no-op)
 - `scripts/spawn-recovery-subagent.sh` — Tier 3 recovery orchestrator invoked by `run-auto-sub.sh`; spawns `agents/orchestration-recovery` via `claude -p`, validates the returned plan with `validate-recovery-plan.sh`, enforces concurrency via `WHOLEWORK_MAX_RECOVERY_SUBAGENTS` mkdir-based slot locks, and records successful recoveries to `docs/reports/orchestration-recoveries.md` via `write_recovery_entry()`
+- `scripts/post-fallback-review-summary.sh` — called by `run-review.sh` on exit 0 + `matches_expected:false` (silent no-op); posts a `<!-- review-summary -->`-marked fallback Review Response Summary only when a prior review containing "Acceptance Criteria Verification Results" is found for the PR, otherwise exits 1 without posting
 
 **Skill runners:**
 - `scripts/guard-prefix.sh` — shared GUARD_PREFIX definition sourced by all run-*.sh; includes anti-early-stop and boundary reminders for autonomous execution

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -251,6 +251,7 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 - review
 
 ### Fallback Steps
+0. `run-review.sh` already attempts an automated fallback post before this catalog entry is reached: on exit 0 + `matches_expected:false`, it calls `scripts/post-fallback-review-summary.sh <PR>`, which posts a `<!-- review-summary -->`-marked Response Summary only when a prior review containing "Acceptance Criteria Verification Results" is found for the PR, then re-checks completion. The manual steps below are needed only when that automated fallback also failed (guard evidence not found, or `gh pr comment` itself failed).
 1. Re-run `reconcile-phase-state.sh review --pr <N>` to check whether a cache-related false negative caused the mismatch; if the result flips to `matches_expected:true`, continue normally
 2. Run `gh pr view <N> --comments` to inspect PR comments directly; check whether a summary-style comment exists (any heading containing "review", "summary", "サマリ", "レビュー", etc.)
 3. If a summary comment exists but `<!-- review-summary -->` marker is absent: edit the comment via `gh api repos/{owner}/{repo}/issues/comments/<comment-id> -f body="<!-- review-summary -->\n<original-body>"` to prepend the marker, then re-run `reconcile-phase-state.sh review --pr <N>` to confirm `matches_expected:true`. If the heading is a localized variant not covered by existing fallback signatures, open a follow-up Issue to add the regex to `scripts/reconcile-phase-state.sh`

--- a/scripts/post-fallback-review-summary.sh
+++ b/scripts/post-fallback-review-summary.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# post-fallback-review-summary.sh
+# Fallback poster for the Review Response Summary comment.
+#
+# Called by run-review.sh when claude exits 0 but reconcile-phase-state.sh
+# reports matches_expected:false (silent no-op: Step 11 review posted, but
+# Step 14 Response Summary never got posted before exit). Only posts a
+# fallback comment when evidence of a completed Step 11 review exists
+# ("Acceptance Criteria Verification Results" in an existing PR review) —
+# this guard prevents a false "recovered" report when review never
+# actually progressed.
+#
+# Usage:
+#   scripts/post-fallback-review-summary.sh <pr-number>
+
+set -euo pipefail
+
+PR_NUMBER="${1:?Usage: post-fallback-review-summary.sh <pr-number>}"
+
+if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+    echo "Error: PR number must be numeric: $PR_NUMBER" >&2
+    exit 1
+fi
+
+REVIEW_BODIES=$(gh pr view "$PR_NUMBER" --json reviews --jq '.reviews[].body' 2>/dev/null) || true
+
+if ! echo "$REVIEW_BODIES" | grep -q "Acceptance Criteria Verification Results"; then
+    echo "post-fallback-review-summary: no prior Review with Acceptance Criteria Verification Results found for PR #${PR_NUMBER}; skipping fallback post" >&2
+    exit 1
+fi
+
+FALLBACK_BODY="<!-- review-summary -->
+## Review Response Summary
+
+This is an auto-generated fallback summary, posted by \`post-fallback-review-summary.sh\` after the review session exited without posting its own Response Summary (silent no-op). A prior review with Acceptance Criteria Verification Results was found for this PR.
+
+Before merging, manually confirm CI status and the content of any fix commits pushed during this review."
+
+if ! gh pr comment "$PR_NUMBER" --body "$FALLBACK_BODY"; then
+    echo "Error: failed to post fallback Review Response Summary to PR #${PR_NUMBER}" >&2
+    exit 1
+fi

--- a/scripts/run-review.sh
+++ b/scripts/run-review.sh
@@ -177,7 +177,18 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
       fi
     elif echo "$_reconcile_out" | grep -q '"matches_expected":false'; then
       echo "Warning: claude exited 0 but review phase did not complete (silent no-op). reconcile: $_reconcile_out" >&2
-      EXIT_CODE=1
+      if "$SCRIPT_DIR/post-fallback-review-summary.sh" "$PR_NUMBER"; then
+        _recheck_out=$("$SCRIPT_DIR/reconcile-phase-state.sh" review "$_REVIEW_ISSUE" --pr "$PR_NUMBER" --check-completion 2>/dev/null) || true
+        if echo "$_recheck_out" | grep -q '"matches_expected":true'; then
+          echo "post-fallback-review-summary: fallback Response Summary posted, review phase recovered. recheck: $_recheck_out"
+          EXIT_CODE=0
+        else
+          echo "post-fallback-review-summary: fallback post succeeded but recheck still does not match expected. recheck: $_recheck_out" >&2
+          EXIT_CODE=1
+        fi
+      else
+        EXIT_CODE=1
+      fi
     fi
   else
     echo "reconcile-phase-state: could not extract issue number from PR #${PR_NUMBER}, skipping reconcile" >&2

--- a/tests/post-fallback-review-summary.bats
+++ b/tests/post-fallback-review-summary.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+
+# Tests for post-fallback-review-summary.sh
+# Mocks: gh (pr view --json reviews, pr comment)
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/post-fallback-review-summary.sh"
+
+setup() {
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    GH_CALL_LOG="$BATS_TEST_TMPDIR/gh_calls.log"
+    export GH_CALL_LOG
+    GH_COMMENT_BODY_FILE="$BATS_TEST_TMPDIR/gh_comment_body.txt"
+    export GH_COMMENT_BODY_FILE
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "no AC Verification Results review: exits 1 without posting" {
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GH_CALL_LOG"
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+    echo '["Looks good to me, no concerns."]' | tr -d '[]"'
+    exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "comment" ]]; then
+    echo "ERROR: comment should not have been posted" >&2
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"skipping fallback post"* ]]
+    ! grep -q "pr comment" "$GH_CALL_LOG"
+}
+
+@test "AC Verification Results review exists: posts marker comment" {
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GH_CALL_LOG"
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+    echo "## Acceptance Criteria Verification Results"
+    exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "comment" ]]; then
+    for arg in "\$@"; do
+        if [[ "\$prev" == "--body" ]]; then
+            echo "\$arg" > "$GH_COMMENT_BODY_FILE"
+        fi
+        prev="\$arg"
+    done
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    grep -q "pr comment" "$GH_CALL_LOG"
+    [[ "$(cat "$GH_COMMENT_BODY_FILE")" == "<!-- review-summary -->"* ]]
+    grep -q "## Review Response Summary" "$GH_COMMENT_BODY_FILE"
+}
+
+@test "gh pr comment failure propagates as exit 1" {
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GH_CALL_LOG"
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+    echo "## Acceptance Criteria Verification Results"
+    exit 0
+fi
+if [[ "\$1" == "pr" && "\$2" == "comment" ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed to post fallback Review Response Summary"* ]]
+}

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -139,6 +139,13 @@ exit 0
 MOCK
     chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
 
+    # Mock post-fallback-review-summary.sh: default exit 1 (no recovery)
+    cat > "$MOCK_DIR/post-fallback-review-summary.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/post-fallback-review-summary.sh"
+
     # Create SKILL.md fixture
     mkdir -p "$BATS_TEST_TMPDIR/skills/review"
     cat > "$BATS_TEST_TMPDIR/skills/review/SKILL.md" <<'SKILL'
@@ -300,6 +307,53 @@ echo '{"matches_expected":false,"phase":"review"}'
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Warning:"*"silent no-op"* ]]
+}
+
+@test "reconcile: fallback post succeeds and recheck confirms matches_expected:true results in exit 0" {
+    RECONCILE_CALL_COUNT_FILE="$BATS_TEST_TMPDIR/reconcile_call_count"
+    echo 0 > "$RECONCILE_CALL_COUNT_FILE"
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<MOCK
+#!/bin/bash
+COUNT=\$(cat "$RECONCILE_CALL_COUNT_FILE")
+COUNT=\$((COUNT + 1))
+echo "\$COUNT" > "$RECONCILE_CALL_COUNT_FILE"
+if [[ "\$COUNT" -eq 1 ]]; then
+    echo '{"matches_expected":false,"phase":"review"}'
+else
+    echo '{"matches_expected":true,"phase":"review"}'
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
+    cat > "$MOCK_DIR/post-fallback-review-summary.sh" <<'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/post-fallback-review-summary.sh"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"fallback Response Summary posted"* ]]
+}
+
+@test "reconcile: fallback post itself fails keeps exit 1" {
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":false,"phase":"review"}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
+    cat > "$MOCK_DIR/post-fallback-review-summary.sh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/post-fallback-review-summary.sh"
+
     run bash "$SCRIPT" 123
     [ "$status" -eq 1 ]
     [[ "$output" == *"Warning:"*"silent no-op"* ]]


### PR DESCRIPTION
## Summary

`run-review.sh` が `claude -p` 終了後に `reconcile-phase-state.sh` で `matches_expected:false` (Review Response Summary 未投稿の silent no-op) を検出した際、新規スクリプト `scripts/post-fallback-review-summary.sh` を呼び出して決定論的なフォールバック投稿を試みるようにした。フォールバックは、PR に "Acceptance Criteria Verification Results" を含む既存 Review が見つかった場合のみ `<!-- review-summary -->` マーカー付きの簡易 Response Summary を投稿する (証跡なしの誤った "recovered" 報告を防ぐガード)。フォールバック投稿成功後は completion を再チェックし、`matches_expected:true` に復帰すれば `EXIT_CODE=0` に戻す。

- `scripts/post-fallback-review-summary.sh` を新規作成 (証跡ガード付きフォールバック投稿)
- `scripts/run-review.sh` の exit 0 + `matches_expected:false` 分岐でフォールバックを呼び出し、成功時は completion 再チェックで `EXIT_CODE` を復帰
- `modules/orchestration-fallbacks.md` の `review-completion-false-negative` エントリに、自動フォールバックが既に試行済みである旨を追記
- `docs/structure.md` / `docs/ja/structure.md` を同期 (新規スクリプトのエントリ追加、ファイル数更新)

## Verification (pre-merge)

- `scripts/post-fallback-review-summary.sh` に、Step 11 完了の証跡 (Acceptance Criteria Verification Results を含む既存 Review) がある場合のみ投稿するガードが実装されている
- `tests/post-fallback-review-summary.bats` (新規 3 ケース) と `tests/run-review.bats` (新規 2 ケース + 既存回帰確認) が全て PASS

## Verification (post-merge)

- 次回 `/auto` セッション実行時、修正コミットのある PR で Response Summary の欠落が発生しない (または wrapper が確実に補完する) ことを観察

closes #915
