### PR TITLE
Issue #916: detect-wrapper-anomaly merge phase の PR MERGED 状態で silent-no-op 誤検出を抑制

### DIFF
--- a/docs/spec/issue-916-merge-pr-merged-silent-noop.md
+++ b/docs/spec/issue-916-merge-pr-merged-silent-noop.md
@@ -70,3 +70,30 @@ Issue 本文 Option A が提案する通り、merge phase 専用に `gh pr view 
 - **`modules/orchestration-fallbacks.md` 更新は SHOULD レベル**: Issue 本文の Acceptance Criteria (Pre-merge 3件) はいずれも `scripts/detect-wrapper-anomaly.sh` とそのテストのみを対象としており、`modules/orchestration-fallbacks.md` の更新には専用の verify command が設定されていない。本 Spec でも Issue 本文の3件と件数・内容を完全一致させるため、`## Verification > Pre-merge` には追加の verify item を設けない (ドキュメント同期は Implementation Step 3 で対応する SHOULD 項目として扱う)。
 - **Verify command sync 確認**: 本 Spec の `## Verification > Pre-merge` は Issue 本文 `## Acceptance Criteria > Pre-merge` の3項目と verify コマンドを含め完全に一致 (件数一致: Issue側3件 / Spec側3件)。Post-merge も Issue本文の1件と一致。
 - **Issue body vs 実装の整合性確認**: Issue Background に記載の「既存の origin/main フォールバック fetch は `code-patch`/`code` phase 限定」という記述は `scripts/detect-wrapper-anomaly.sh` 現行実装 (line 103: `if [[ "$PHASE" == "code-patch" || "$PHASE" == "code" ]]`) と一致していることを確認済み。コンフリクトなし。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜3 は Spec の記述通りに実装した。
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Placed the merge-phase `gh pr view` MERGED check as the first branch inside the `elif [[ "$EXIT_CODE" == "0" ]]` block, ahead of the existing `matches_expected:true` and success-phrase checks, so it short-circuits before any log-based logic runs.
+- Kept the fail-safe default exactly as specified: only an explicit `MERGED` state (exit 0 from `gh pr view`) suppresses the anomaly; any other state or command failure falls through unchanged to existing logic.
+- Named the new local variables (`_merge_pr_confirmed_merged`, `_merge_pr_state`) distinctly from existing ones (`_found_on_origin`) to avoid any accidental variable reuse across branches.
+
+### Deferred Items
+- Option B (origin/main fallback fetch extended to merge phase) was explicitly not implemented, per the Spec's decision to treat Option A as sufficient.
+- `modules/orchestration-fallbacks.md` update was treated as a SHOULD-level doc sync (no dedicated verify command), completed alongside the code change but not gated by an AC.
+
+### Notes for Next Phase
+- Post-merge AC is `verify-type: opportunistic` — the next `/auto` pr route merge phase completion is the natural observation point; no dedicated action needed at review/merge time.
+- All 3 pre-merge ACs verified PASS in this phase; Issue checkboxes already updated to `[x]`.

--- a/docs/spec/issue-916-merge-pr-merged-silent-noop.md
+++ b/docs/spec/issue-916-merge-pr-merged-silent-noop.md
@@ -82,18 +82,27 @@ Issue 本文 Option A が提案する通り、merge phase 専用に `gh pr view 
 ### Rework
 - N/A
 
+## review retrospective
+
+### Spec vs implementation divergence patterns
+特になし。Implementation Steps 1〜3 は Spec の記述通りに実装されており、乖離は検出されなかった。
+
+### Recurring issues
+特になし。review-light の4観点 (Spec乖離 / Bug・ロジックエラー / セキュリティ / ドキュメント整合性) いずれも issue 0件。`_merge_pr_state=$(...); [[ $? -eq 0 ]]` のイディオムはコマンド置換直後の終了ステータスを正しく捕捉することを確認済み。
+
+### Acceptance criteria verification difficulty
+特になし。Pre-merge 3件の verify command (rubric×2, file_contains×1) はいずれも明確に PASS 判定可能で、UNCERTAIN は発生しなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Placed the merge-phase `gh pr view` MERGED check as the first branch inside the `elif [[ "$EXIT_CODE" == "0" ]]` block, ahead of the existing `matches_expected:true` and success-phrase checks, so it short-circuits before any log-based logic runs.
-- Kept the fail-safe default exactly as specified: only an explicit `MERGED` state (exit 0 from `gh pr view`) suppresses the anomaly; any other state or command failure falls through unchanged to existing logic.
-- Named the new local variables (`_merge_pr_confirmed_merged`, `_merge_pr_state`) distinctly from existing ones (`_found_on_origin`) to avoid any accidental variable reuse across branches.
+- review-light (軽量統合レビュー) を4観点 (Spec乖離/Bug/セキュリティ/ドキュメント整合性) で実行し、issue 0件を確認した上でそのまま `/merge` を推奨する結論とした。
+- `--issue` 引数が merge phase では実際には PR 番号を保持するという Spec Notes の既存挙動を、`run-auto-sub.sh` の呼び出し規約から独立して再確認し、バグではないことを検証した。
 
 ### Deferred Items
-- Option B (origin/main fallback fetch extended to merge phase) was explicitly not implemented, per the Spec's decision to treat Option A as sufficient.
-- `modules/orchestration-fallbacks.md` update was treated as a SHOULD-level doc sync (no dedicated verify command), completed alongside the code change but not gated by an AC.
+- None
 
 ### Notes for Next Phase
-- Post-merge AC is `verify-type: opportunistic` — the next `/auto` pr route merge phase completion is the natural observation point; no dedicated action needed at review/merge time.
-- All 3 pre-merge ACs verified PASS in this phase; Issue checkboxes already updated to `[x]`.
+- 全 Pre-merge AC は PASS 済み、CI も全ジョブ SUCCESS。`/merge 924` にそのまま進んで問題ない。
+- Post-merge AC (`verify-type: opportunistic`) は次回 `/auto` pr route の merge phase 完了時に観察する。

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -478,6 +478,8 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 
 When `reconcile-phase-state.sh --check-completion` returns `"matches_expected":true`, `detect-wrapper-anomaly.sh` skips the silent-no-op entry entirely, regardless of `commits_found`. This covers the async external commit recognition pattern: a skill detects that the target Issue was already implemented in a prior PR and transitions directly to `phase/verify` without creating a new commit. The reconciler's phase-label and state checks confirm completion (`matches_expected:true`), so no anomaly entry is warranted.
 
+For the `merge` phase specifically, `detect-wrapper-anomaly.sh` additionally runs an independent live check (`gh pr view <PR> --json state -q '.state'`) before falling through to the log/git-log-based checks above. If the PR state is confirmed `MERGED`, the silent-no-op entry is skipped regardless of wrapper log content or local git history. This is necessary because a squash merge lands on `origin/main` via the GitHub API and the local working tree is not automatically fetched, making the log-based and git-log-based checks unreliable for this phase (Issue #916). If the `gh pr view` call fails (API error, rate limit) or the state is not `MERGED`, detection falls through to the existing logic (fail-safe, not fail-open).
+
 See also: `#async-external-commit` (reconcile-first authority — `matches_expected:true` takes precedence over `commits_found` in anomaly detection).
 
 ### Rationale

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -95,7 +95,16 @@ elif grep -qiE "APIConnectionError|Request timed out|overloaded_error|529.*[Oo]v
   ANOMALY_DESC="API connection error in phase \`$PHASE\` (exit code $EXIT_CODE): API connection/overload pattern detected in wrapper output. The forked session terminated mid-run before phase completion."
   IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#mid-run-api-error\`: run reconcile-phase-state.sh to check actual completion, restore the phase label if needed, then retry the phase once with the corresponding run-*.sh script."
 elif [[ "$EXIT_CODE" == "0" ]]; then
-  if grep -q '"matches_expected":true' "$LOG_FILE"; then
+  _merge_pr_confirmed_merged=false
+  if [[ "$PHASE" == "merge" ]]; then
+    _merge_pr_state=$(gh pr view "$ISSUE_NUMBER" --json state -q '.state' 2>/dev/null)
+    if [[ $? -eq 0 && "$_merge_pr_state" == "MERGED" ]]; then
+      _merge_pr_confirmed_merged=true
+    fi
+  fi
+  if [[ "$_merge_pr_confirmed_merged" == "true" ]]; then
+    : # merge phase live check: gh pr view confirms PR MERGED, skip silent-no-op detection entirely (fail-safe: gh failure or non-MERGED state falls through to existing logic below)
+  elif grep -q '"matches_expected":true' "$LOG_FILE"; then
     : # reconcile-first authority: matches_expected:true skips silent-no-op (covers async external commit recognition)
   elif grep -qiE "完了しました|commit and push|successfully committed|pushed to|changes have been committed" "$LOG_FILE"; then
     if ! git log --oneline -20 2>/dev/null | grep -q "#${ISSUE_NUMBER}"; then

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -112,6 +112,67 @@ MOCK
     [ -z "$output" ]
 }
 
+@test "silent no-op: suppressed for merge phase when gh pr view confirms MERGED" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/git" <<'MOCK'
+#!/bin/bash
+# mock git: returns empty output for all subcommands
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/git"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+echo "MERGED"
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    echo "実装が完了しました。commit and push も完了しています。" > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 0 --issue 905 --phase merge
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "silent no-op: still detected for merge phase when gh pr view returns non-MERGED state" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/git" <<'MOCK'
+#!/bin/bash
+# mock git: returns empty output for all subcommands
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/git"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+echo "OPEN"
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    echo "実装が完了しました。commit and push も完了しています。" > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 0 --issue 905 --phase merge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"silent-no-op"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+}
+
+@test "silent no-op: falls through to existing logic when gh pr view fails" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/git" <<'MOCK'
+#!/bin/bash
+# mock git: returns empty output for all subcommands
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/git"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    echo "実装が完了しました。commit and push も完了しています。" > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 0 --issue 905 --phase merge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"silent-no-op"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+}
+
 @test "dirty working tree: detects VERIFY_FAILED with uncommitted changes" {
     printf "VERIFY_FAILED\nCannot run verify because there are uncommitted changes in the working tree.\n" > "$LOG_FILE"
     run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 393 --phase verify


### PR DESCRIPTION
## Summary
- `scripts/detect-wrapper-anomaly.sh` の merge phase silent-no-op 判定に、`gh pr view <PR> --json state -q '.state'` による live PR MERGED 状態チェックを追加。PR が確認済み MERGED の場合は既存のログ/git-log ベースの判定より前に silent-no-op 検出全体をスキップする。
- `gh pr view` が失敗するか状態が MERGED 以外の場合は既存ロジックへフォールスルーする fail-safe デフォルトを採用 (fail-open にはしない)。
- `tests/detect-wrapper-anomaly.bats` に merge phase + PR 状態の3ケース (MERGED で抑止 / 非MERGEDで検出継続 / gh 失敗時にフォールスルー) を追加。
- `modules/orchestration-fallbacks.md` の `code-patch-silent-no-op` Exception Condition に merge phase の live チェックに関する説明を追記。

## Verification (pre-merge)
- `detect-wrapper-anomaly.sh` の merge phase silent-no-op 検出が、PR MERGED 状態では anomaly を出力しないよう修正されている
- MERGED 状態チェックが `scripts/detect-wrapper-anomaly.sh` 内に実装されている (`file_contains "MERGED"`)
- bats test で、merge phase + PR MERGED 状態のケースで silent-no-op anomaly が抑止されることを検証 (`bats tests/detect-wrapper-anomaly.bats` 36 tests 全PASS)

## Verification (post-merge)
- 次回 `/auto` の pr route merge phase 完了時、false-positive silent-no-op が発生しないことを観察 (opportunistic)

closes #916