### PR TITLE
Issue #918: Update commit template Co-Authored-By to Sonnet 5

### DIFF
--- a/agents/orchestration-recovery.md
+++ b/agents/orchestration-recovery.md
@@ -110,7 +110,7 @@ When the log shows a watchdog kill after implementation was complete but before 
   "action": "recover",
   "rationale": "Watchdog killed run-code.sh after implementation but before commit or PR creation. Recovering by committing uncommitted changes, pushing the feature branch, and creating the PR.",
   "steps": [
-    { "op": "run_command", "cmd": "git add -A && git commit -s -m 'feat: implement issue #N (closes #N)\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>'" },
+    { "op": "run_command", "cmd": "git add -A && git commit -s -m 'feat: implement issue #N (closes #N)\n\nCo-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>'" },
     { "op": "run_command", "cmd": "git push origin worktree-code+issue-N" },
     { "op": "run_command", "cmd": "gh pr create --base main --head worktree-code+issue-N --title 'Issue #N: summary' --body 'closes #N'" }
   ]

--- a/docs/spec/issue-918-commit-template-sonnet-5.md
+++ b/docs/spec/issue-918-commit-template-sonnet-5.md
@@ -63,19 +63,19 @@ Issue 本文は「計約17箇所」と記載しているが、grep 実測では1
 
 ## Phase Handoff
 
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- 対象10ファイル内の `Claude Sonnet 4.6` (計18箇所) を `Claude Sonnet 5` に単純文字列置換した。置換前後で grep 実測件数が Spec の想定 (10ファイル18箇所) と完全一致することを確認済み
-- 除外対象の歴史的記録ファイル5件 (`docs/reports/sonnet-5-tokenizer-impact.md` および disposable Spec 4件) が変更されていないことを確認済み
-- Behavioral Change Detection の basename grep (`SKILL.md` 等が広範囲のテストファイルに一致) により、対象を絞らずフルスイート (`bats tests/`、1088件) を実行し全件 PASS を確認した
+- 全11条件を `file_contains`/`file_not_contains` の機械的チェックで検証し、全件 PASS を確認した (UNCERTAIN なし)
+- REVIEW_DEPTH=light (Size=M、`--light` 明示指定) のため review-light による4観点統合レビューを実施し、issue 検出なしを確認した
+- 外部レビューツール (Copilot/Claude Code Review/CodeRabbit) は `.wholework.yml` 未設定のため Step 7 は全体スキップした
 
 ### Deferred Items
 - None
 
 ### Notes for Next Phase
-- 各 AC の verify command は `file_not_contains`/`file_contains` の機械的チェックのみで、post-merge (`/verify`) でも同一結果が再現されるはず
 - Post-merge AC は「なし」のため `/verify` での追加確認事項はない
+- MUST issue が無かったため Step 12 (修正サイクル) は未実行。`/merge 929` にそのまま進行可能
 
 ## Code Retrospective
 
@@ -87,3 +87,14 @@ Issue 本文は「計約17箇所」と記載しているが、grep 実測では1
 
 ### Rework
 - N/A
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — 実装は Spec の Implementation Steps 通りで、Spec と PR diff の間に構造的な乖離はなかった
+
+### Recurring issues
+- Nothing to note — review-light の4観点すべてで issue 検出なし。単純文字列置換タスクとして issue の再発パターンは見られなかった
+
+### Acceptance criteria verification difficulty
+- Nothing to note — 全11条件が `file_contains`/`file_not_contains` の機械的チェックのみで PASS/FAIL を判定でき、UNCERTAIN は発生しなかった。verify command の過不足も見られなかった

--- a/docs/spec/issue-918-commit-template-sonnet-5.md
+++ b/docs/spec/issue-918-commit-template-sonnet-5.md
@@ -60,3 +60,30 @@
 ### 実測件数
 
 Issue 本文は「計約17箇所」と記載しているが、grep 実測では10ファイル合計18箇所 (内訳は `## Changed Files` 参照)。近似表記の範囲内であり、対象ファイル一覧・各ファイルの検証方式には影響ない。
+
+## Phase Handoff
+
+<!-- phase: code -->
+
+### Key Decisions
+- 対象10ファイル内の `Claude Sonnet 4.6` (計18箇所) を `Claude Sonnet 5` に単純文字列置換した。置換前後で grep 実測件数が Spec の想定 (10ファイル18箇所) と完全一致することを確認済み
+- 除外対象の歴史的記録ファイル5件 (`docs/reports/sonnet-5-tokenizer-impact.md` および disposable Spec 4件) が変更されていないことを確認済み
+- Behavioral Change Detection の basename grep (`SKILL.md` 等が広範囲のテストファイルに一致) により、対象を絞らずフルスイート (`bats tests/`、1088件) を実行し全件 PASS を確認した
+
+### Deferred Items
+- None
+
+### Notes for Next Phase
+- 各 AC の verify command は `file_not_contains`/`file_contains` の機械的チェックのみで、post-merge (`/verify`) でも同一結果が再現されるはず
+- Post-merge AC は「なし」のため `/verify` での追加確認事項はない
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps の記載通りに実施し、逸脱なし
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A

--- a/modules/doc-commit-push.md
+++ b/modules/doc-commit-push.md
@@ -25,7 +25,7 @@ Runs `git status --porcelain` first; if there are no changes, exits silently wit
    git add -A
    git commit -s -m "docs: ${SUMMARY}
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
    ```
    ```bash
    git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -106,7 +106,7 @@ if ! git -C "$_repo_root" diff --quiet "$SPEC_REL" 2>/dev/null; then
     && git -C "$_repo_root" commit -s \
          -m "Add consumed comments fallback for issue #${ISSUE_NUMBER} (${PHASE_NAME} phase)
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" 2>/dev/null \
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" 2>/dev/null \
     && git -C "$_repo_root" push origin HEAD 2>/dev/null \
     || echo "append-consumed-comments-section.sh: WARNING — commit/push failed (best-effort)" >&2
 fi

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -100,7 +100,7 @@ _write_manual_recovery_to_spec() {
     if git -C "$_repo_root" add "$spec_rel_path" \
        && git -C "$_repo_root" commit -s -m "Record manual recovery in auto retrospective for issue #${issue}
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
        && git -C "$_repo_root" push origin HEAD; then
       echo "[#${issue}] [recovery] spec auto retrospective updated for issue #${issue} (manual recovery)"
     else
@@ -230,7 +230,7 @@ _write_tier2_recovery_to_spec() {
     if git -C "$_repo_root" add "$spec_rel_path" \
        && git -C "$_repo_root" commit -s -m "Record Tier 2 recovery in auto retrospective for issue #${issue}
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
        && git -C "$_repo_root" push origin HEAD; then
       echo "${LOG_PREFIX} [recovery] spec auto retrospective updated for issue #${issue}"
     else
@@ -278,7 +278,7 @@ _write_tier3_recovery_to_spec() {
     if git -C "$_repo_root" add "$spec_rel_path" \
        && git -C "$_repo_root" commit -s -m "Record Tier 3 recovery in auto retrospective for issue #${issue}
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
        && git -C "$_repo_root" push origin HEAD; then
       echo "${LOG_PREFIX} [recovery] spec auto retrospective updated for issue #${issue} (tier3)"
     else
@@ -333,7 +333,7 @@ PYEOF
     if git -C "$_repo_root" add "docs/reports/orchestration-recoveries.md" \
        && git -C "$_repo_root" commit -s -m "Record wrapper-retry-on-kill recovery for issue #${issue} ${phase}
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>" \
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
        && git -C "$_repo_root" push origin HEAD; then
       echo "${LOG_PREFIX} [recovery] wrapper-retry-on-kill recovery log committed and pushed"
     else

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -454,7 +454,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Pr
    git add $SPEC_PATH/issue-$NUMBER-*.md
    git commit -s -m "Add issue retrospective for issue #$NUMBER
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
    git push origin main
    ```
 
@@ -573,7 +573,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Pr
    git add $SPEC_PATH/issue-$NUMBER-*.md docs/reports/orchestration-recoveries.md
    git commit -s -m "Add auto retrospective for issue #$NUMBER
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
    git push origin main
    ```
 
@@ -764,7 +764,7 @@ If `OBSERVATION_MATCHES` is non-empty, read `${CLAUDE_PLUGIN_ROOT}/modules/detec
      git add "$SESSION_DIR"
      git commit -s -m "Add L3 session data for session ${AUTO_SESSION_ID}
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
      git push origin main
      ```
      Output "L3 session events committed (not notable — session.md skipped)." and skip the remaining L3 steps.
@@ -874,7 +874,7 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
     git add "$SESSION_DIR"
     git commit -s -m "Add L3 session retrospective for session ${AUTO_SESSION_ID}
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
     git push origin main
     ```
 

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -481,7 +481,7 @@ git add <changed files>
 # If BASE_BRANCH is not main: "{prefix} <summary>"
 git commit -s -m "{prefix} <summary>
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
 ```
 
 ```bash
@@ -611,7 +611,7 @@ If there are items under "Deviations from Design" (reordering of implementation 
    git add $SPEC_PATH/issue-$NUMBER-*.md
    git commit -s -m "Add code retrospective for issue #$NUMBER
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
    ```
    ```bash
    git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }

--- a/skills/doc/translate-phase.md
+++ b/skills/doc/translate-phase.md
@@ -158,7 +158,7 @@ git status
 git add README.md README.{lang}.md docs/ 
 git commit -s -m "docs: regenerate {lang} translations
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
 ```
 
 ```bash

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -225,7 +225,7 @@ merge is an intermediate phase — write the Phase Handoff so verify can read it
    ```bash
    git commit -s -m "Add merge phase handoff for issue #$ISSUE_NUMBER
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
    ```
    ```bash
    git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -591,7 +591,7 @@ Fix all MUST issues. Claude decides whether to fix SHOULD/CONSIDER issues.
 
 Refs: $PR_COMMENT_URL
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
    ```
 6. **Push with git push**
 
@@ -774,7 +774,7 @@ Reflect on the review phase; record improvement proposals in the Spec only. Issu
      git add $SPEC_PATH/issue-$ISSUE_NUMBER-*.md
      git commit -s -m "Add review retrospective for issue #$ISSUE_NUMBER
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
      ```
      ```bash
      git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -758,7 +758,7 @@ As the final step of the workflow, verify conducts a retrospective of the entire
      git add $SPEC_PATH/issue-"$NUMBER"-*.md
      git commit -s -m "Add verify retrospective for issue #$NUMBER
 
-Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
      ```
      ```bash
      git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }


### PR DESCRIPTION
## Summary
コミットメッセージテンプレート内にハードコードされていた `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` を `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>` に一括更新した (10ファイル、計18箇所)。#914 で `docs/tech.md` の default parent が Sonnet 5 に更新済みであり、`run-*.sh` の bare `sonnet` エイリアスが実行時点で Sonnet 5 を解決するため、テンプレートの co-author 表記を実態に整合させるもの。

対象10ファイル:
- `agents/orchestration-recovery.md`
- `modules/doc-commit-push.md`
- `scripts/append-consumed-comments-section.sh`
- `scripts/run-auto-sub.sh` (4箇所)
- `skills/auto/SKILL.md` (4箇所)
- `skills/code/SKILL.md` (2箇所)
- `skills/merge/SKILL.md`
- `skills/review/SKILL.md` (2箇所)
- `skills/verify/SKILL.md`
- `skills/doc/translate-phase.md`

歴史的記録ファイル (`docs/reports/sonnet-5-tokenizer-impact.md`、disposable Spec 4件) は意図的にスコープ外。

## Verification (pre-merge)
- 対象10ファイルすべてで `Claude Sonnet 4.6` の残存がゼロであることを grep で確認済み
- `skills/code/SKILL.md` に `Claude Sonnet 5` が含まれることを確認済み
- 除外対象の歴史的記録ファイルが変更されていないことを確認済み
- bats フルスイート 1088件 PASS (behavioral change detection によりフルスイート実行)
- `check-allowed-tools.sh` / `validate-skill-syntax.py` / `check-forbidden-expressions.sh` すべて成功

## Verification (post-merge)
- なし (Issue 本文の Post-merge AC は「なし」)

closes #918