### PR TITLE
Issue #932: detect-wrapper-anomaly review-completion-false-negativeの誤検出を修正

### DIFF
--- a/docs/spec/issue-932-review-completion-recheck.md
+++ b/docs/spec/issue-932-review-completion-recheck.md
@@ -74,16 +74,31 @@ No new comments since last phase.
 - N/A
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の指示通り、`review-completion-false-negative` の `elif` 条件に `&& ! grep -q '"matches_expected":true' "$LOG_FILE"` を追加し、既存の `EXIT_CODE=0` 分岐の reconcile-first authority ロジックと同型の抑止条件とした
-- 新規 bats テストは Spec 指定通り既存の "no detection for unrelated log" テストの直後に追加し、`post-fallback-review-summary.sh` の recovery 成功ログメッセージを模した内容とした
+- REVIEW_DEPTH=light (`--light` 明示指定) で review-light agent による軽量統合レビュー (4 観点) を実施し、elif チェーンの実行時挙動 (reconciler-header-mismatch 分岐や EXIT_CODE=0 分岐との相互作用) まで踏み込んで検証した
+- MUST/SHOULD/CONSIDER のいずれも検出されず、Issue 12 (Issue Resolution) はスキップして Step 13 (Acceptance Criteria Consistency Check) に進んだ
 
 ### Deferred Items
-- `docs/structure.md` / `docs/ja/structure.md` の sync candidate 確認: 両ファイルの `detect-wrapper-anomaly.sh` 説明文 ("detect known failure patterns...") は本修正後も妥当なため更新不要と判断 (更新自体は見送りではなく、確認の結果不要と判明したもの)
-- Post-merge の opportunistic observation (次回 `/auto` review phase での実地確認) は次フェーズ以降で発生
+- `docs/structure.md` / `docs/ja/structure.md` の sync candidate 確認は code phase で完了済み (更新不要と判断)。review phase で再確認し同結論を維持
+- Post-merge の opportunistic observation (次回 `/auto` review phase での実地確認) は merge 後に発生
+
+### Notes for Next Phase
+- MUST issue なし、CI 全 SUCCESS のため `/merge 937` にそのまま進める
+- Acceptance Criteria の Pre-merge 2件は Issue 側で既に `[x]` 済み (review 側で再検証し PASS を確認、追加更新は不要)
 
 ### Notes for Next Phase
 - Pre-merge verify command 2件 (rubric) は `bats tests/detect-wrapper-anomaly.bats` 40/40 PASS の実行結果を根拠に PASS と判断し、Issue チェックボックスを更新済み
 - `modules/orchestration-fallbacks.md` の Rationale 追記は Spec Notes 記載の通り SHOULD レベル (専用 verify command なし) のため、review phase で追加の verify command 要求は不要
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — PR diff は Spec の Implementation Steps 1〜3 と verbatim 一致していた (review-light agent が `scripts/detect-wrapper-anomaly.sh` の elif 条件追加・bats テスト追加位置・`modules/orchestration-fallbacks.md` の Rationale 追記文の3点を個別に確認済み)
+
+### Recurring issues
+- Nothing to note (review workflow 上の問題ではない) — ただし本 Issue 自体が #916 (merge phase live check) / #927 (review phase live check) に続く同系統3件目の false positive 修正であり、`detect-wrapper-anomaly.sh` の `elif` チェーンに新しい recovery/fallback 機構を追加するたびに既存の静的パターン判定が古くなるという構造的な傾向が見える。review-light agent は今回、後続の `mid-run-api-error`・`EXIT_CODE=0` 分岐への影響 (elif チェーン順序・ログ内容の重複) まで踏み込んで実行時挙動を検証しており、この種の「静的ログマッチ + 新規リカバリ機構」の組み合わせでは、レビュー側が elif チェーン全体の実行時トレースを行うのが有効というパターンが確認できた
+
+### Acceptance criteria verification difficulty
+- Nothing to note — Pre-merge 2件はいずれも rubric 形式の verify command で、`bats tests/detect-wrapper-anomaly.bats` の実行結果 (40/40 PASS、新規テスト含む) を根拠に機械的に PASS 判定できた。UNCERTAIN は発生しなかった

--- a/docs/spec/issue-932-review-completion-recheck.md
+++ b/docs/spec/issue-932-review-completion-recheck.md
@@ -61,3 +61,29 @@ No new comments since last phase.
 - **`docs/reports/orchestration-recoveries.md` は対象外**: 同ファイルは自動生成の追記専用レポートであり、本 Issue のスコープは将来の誤記録の発生を防ぐことにあるため、既存の誤記録レコードを遡って訂正する対象にはしない。
 - **`modules/orchestration-fallbacks.md` 更新は SHOULD レベル**: Issue 本文の Acceptance Criteria (Pre-merge 2件) はいずれも `scripts/detect-wrapper-anomaly.sh` とそのテストのみを対象としており、専用の verify command は設定しない (#927 の同種判断を踏襲)。
 - **Verify command sync 確認**: 本 Spec の `## Verification > Pre-merge` は Issue 本文 `## Acceptance Criteria > Pre-merge` の2項目と verify コマンドを含め完全一致 (件数一致: Issue 側2件 / Spec 側2件)。Post-merge も Issue 本文の1件と一致 (`verify-type: opportunistic` を含め verbatim コピー)。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜3 をそのまま実施した
+
+### Design Gaps/Ambiguities
+- N/A — Uncertainties セクションはなく、Notes に記載済みの判断 (recheck 判定方式・Bug-type conflict check・SHOULD レベル判断) で実装完了まで到達できた
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の指示通り、`review-completion-false-negative` の `elif` 条件に `&& ! grep -q '"matches_expected":true' "$LOG_FILE"` を追加し、既存の `EXIT_CODE=0` 分岐の reconcile-first authority ロジックと同型の抑止条件とした
+- 新規 bats テストは Spec 指定通り既存の "no detection for unrelated log" テストの直後に追加し、`post-fallback-review-summary.sh` の recovery 成功ログメッセージを模した内容とした
+
+### Deferred Items
+- `docs/structure.md` / `docs/ja/structure.md` の sync candidate 確認: 両ファイルの `detect-wrapper-anomaly.sh` 説明文 ("detect known failure patterns...") は本修正後も妥当なため更新不要と判断 (更新自体は見送りではなく、確認の結果不要と判明したもの)
+- Post-merge の opportunistic observation (次回 `/auto` review phase での実地確認) は次フェーズ以降で発生
+
+### Notes for Next Phase
+- Pre-merge verify command 2件 (rubric) は `bats tests/detect-wrapper-anomaly.bats` 40/40 PASS の実行結果を根拠に PASS と判断し、Issue チェックボックスを更新済み
+- `modules/orchestration-fallbacks.md` の Rationale 追記は Spec Notes 記載の通り SHOULD レベル (専用 verify command なし) のため、review phase で追加の verify command 要求は不要

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -264,6 +264,7 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 - First observed during Issue #528 implementation: PR #544 had a review summary comment with heading `## レビューレスポンスサマリー` (not covered by existing fallback signatures) and the `<!-- review-summary -->` marker was absent; `reconcile-phase-state.sh` returned `matches_expected:false` and `run-review.sh` exited non-zero; Tier 2 `detect-wrapper-anomaly.sh` returned empty output (pattern not cataloged)
 - Issue #528 introduced `<!-- review-summary -->` as the primary signature in `modules/phase-state.md`, resolving the root cause; this catalog entry serves as the safety net when LLM omits the marker and uses a non-standard heading simultaneously
 - Exclusivity with `reconciler-header-mismatch`: the `elif` chain in `scripts/detect-wrapper-anomaly.sh` ensures that logs containing `Review Summary` are caught by `reconciler-header-mismatch` first; `review-completion-false-negative` fires only when that pattern does not match
+- Suppression on recovery (#932): if the same log later contains a `"matches_expected":true` line (e.g. after `post-fallback-review-summary.sh` recovers the phase), the `review-completion-false-negative` condition is skipped entirely — the same reconcile-first-authority principle used by the `EXIT_CODE=0` silent-no-op branch, applied here to avoid reporting an anomaly for a phase that has already recovered
 
 ---
 

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -86,7 +86,8 @@ elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q "Review Summary" 
   PATTERN_NAME="reconciler-header-mismatch"
   ANOMALY_DESC="Reconciler detected header mismatch in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`Review Summary\` pattern detected in wrapper output. The reconciler could not find \`## Review Response Summary\` in the PR comment, indicating a mismatch between the skill output header and the reconciler's expected pattern. Reference: #394."
   IMPROVEMENT_HINT="Check whether \`run-review.sh\` or the review skill changed the header format of the PR comment. The reconciler expects \`## Review Response Summary\` as defined in \`modules/phase-state.md\`. See \`modules/orchestration-fallbacks.md#reconciler-header-mismatch\` for the full recovery procedure."
-elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q '"phase":"review"' "$LOG_FILE"; then
+elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q '"phase":"review"' "$LOG_FILE" && ! grep -q '"matches_expected":true' "$LOG_FILE"; then
+  # reconcile-first authority: a later matches_expected:true in the same log (post-fallback-review-summary.sh recovery) suppresses this anomaly
   PATTERN_NAME="review-completion-false-negative"
   ANOMALY_DESC="Review phase completion false-negative in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`phase:review\` detected in reconciler output, but no existing fallback header (## Review Response Summary / ## レビュー回答サマリ) was found in wrapper log. Likely caused by LLM omitting the \`<!-- review-summary -->\` marker and using a non-standard heading. Reference: #547."
   IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#review-completion-false-negative\`: re-run reconcile, check PR comments for summary, add \`<!-- review-summary -->\` marker if present, or re-run /review if absent."

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -434,3 +434,11 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" != *"review-completion-false-negative"* ]]
 }
+
+@test "review-completion-false-negative: suppressed when recheck recovers to matches_expected true" {
+    printf '"matches_expected":false\n"phase":"review"\npost-fallback-review-summary: fallback Response Summary posted, review phase recovered. recheck: "matches_expected":true\n' > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"review-completion-false-negative"* ]]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Summary
- `scripts/detect-wrapper-anomaly.sh` の `review-completion-false-negative` (#547) 分岐に、後続の recheck 成功 (`"matches_expected":true` が同一ログ内に出現) を検出したら anomaly を抑止する条件を追加 (`EXIT_CODE=0` 分岐の reconcile-first authority ロジックと同型)
- `tests/detect-wrapper-anomaly.bats` に、recheck で matches_expected:true に復帰するケースで anomaly が抑止されることを検証する bats テストを追加
- `modules/orchestration-fallbacks.md` の `review-completion-false-negative` エントリの Rationale に、今回の抑止条件を追記

## Verification (pre-merge)
- `detect-wrapper-anomaly.sh` の `review-completion-false-negative` 判定が、recheck で `matches_expected:true` に復帰している場合には anomaly を報告しないよう修正されている
- bats test で、review-completion-false-negative 検出後に recheck で matches_expected:true に復帰するケースに対して anomaly が発生しないことが検証されている (`bats tests/detect-wrapper-anomaly.bats` 40/40 PASS)

## Verification (post-merge)
- 次回 `/auto` の review phase で post-fallback recovery が成功した際、false-positive anomaly が発生しないことを観察

closes #932
