### PR TITLE
Issue #941: Fix Rationale for run-issue.sh/run-review.sh in model-effort-matrix

### DIFF
--- a/docs/ja/tech.md
+++ b/docs/ja/tech.md
@@ -86,10 +86,10 @@
 
 | コンポーネント | フェーズ | モデル | Effort | 根拠 |
 |-----------|-------|-------|--------|-----------|
-| run-issue.sh | issue | Sonnet | high | L/XL のスコープ分析とサブ issue 分割には徹底したオーケストレーションが必要 |
+| run-issue.sh | issue | Sonnet | high | Existing Issue Refinement は曖昧性解決・受入条件と verify command の作成などの実質的な判断作業を行い、パイプライン最上流の成果物を生成する。その誤りは下流の全フェーズに伝播し、C-series の中で最も波及範囲が広い |
 | run-spec.sh | spec | Sonnet（L では `--opus` で Opus；`--fable` で Fable 5） | Sonnet: max；Opus: xhigh（デフォルト）、max（`--max` 明示）；Fable 5: high（デフォルト）、max（`--max` 明示） | 設計品質が重要、spec のエラーは後続全フェーズに波及する。`/auto` は L サイズのみ `--opus` を渡す（XL は spec 前に分割済み） |
 | run-code.sh | code | Sonnet | high | 実装には徹底した推論が必要 |
-| run-review.sh | review | Sonnet | high | レビューのオーケストレーション、深い分析はサブエージェントが担う |
+| run-review.sh | review | Sonnet | high | orchestrator は dispatch 以外にも実質的な推論作業を行う — Step 7.2/7.4/7.6 は外部レビューのフィードバックを解釈して fix コミットを作成しており、run-code.sh 自身の実装推論と同種の作業である |
 | run-merge.sh | merge | Sonnet | low | 機械的なマージ操作、推論は最小限でよい |
 | issue-scope | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。スコープ特定精度はサブ issue 境界判断に直結 |
 | issue-risk | issue（L/XL のみ） | Opus | — | `/issue` Step 11a で L/XL 並列調査向けに呼び出される。リスク評価精度が受入条件品質を高める |

--- a/docs/spec/issue-941-model-effort-matrix-rationale.md
+++ b/docs/spec/issue-941-model-effort-matrix-rationale.md
@@ -53,15 +53,26 @@ No new comments since last phase.
 ### Rework
 - N/A
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — 実装は Spec の Implementation Steps 1-3 の推奨文言をそのまま採用しており、構造的な乖離はなかった。
+
+### Recurring issues
+- Nothing to note — 同種の指摘の繰り返しはなかった (rubric 3件とも一発 PASS)。
+
+### Acceptance criteria verification difficulty
+- Nothing to note — 3件すべて `rubric` 形式で明確に判定でき、UNCERTAIN は発生しなかった。verify command の過不足も見当たらない。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の Implementation Steps 1-3 で提示された推奨文言 (英語・日本語とも) をそのまま採用した。Rationale 列の記述精度のみが本 Issue のスコープであり、文言自体の独自解釈による変更はリスクを増やすだけで利益がないため。
-- `docs/tech.md`/`docs/ja/tech.md` の2行のみを変更し、Effort 列・run-*.sh 実効値・disposable Spec/report 等の除外ファイルには一切触れなかった (Spec Notes の除外方針に準拠)。
+- REVIEW_DEPTH=light (Size M / `--light` 明示指定) により review-light 1エージェントで4観点統合レビューを実施し、静的な2グループ並列レビューはスキップした。
+- 外部レビューツール (Copilot/Claude Code Review/CodeRabbit) はすべて `.wholework.yml` で無効のため Step 7 を全面スキップした。
 
 ### Deferred Items
-- None — 本 Issue は Rationale 列の記述精度修正のみを対象としており、後続フェーズへの繰越事項はない。
+- None — MUST/SHOULD/CONSIDER いずれの指摘もなく、Step 12 の修正作業は発生しなかった。
 
 ### Notes for Next Phase
-- 全 1107 bats テスト PASS、`validate-skill-syntax.py`・`check-forbidden-expressions.sh` とも問題なし。docs-only の軽微な変更であるため、review/merge フェーズでの追加確認は Rationale 文言の意味的正確性 (rubric 判定) に絞ってよい。
+- Acceptance Criteria 3件は Issue 側で既に `[x]` 済みだったが、`/review` の rubric 再検証でも独立して PASS を確認済み。`/merge 949` にそのまま進んでよい。

--- a/docs/spec/issue-941-model-effort-matrix-rationale.md
+++ b/docs/spec/issue-941-model-effort-matrix-rationale.md
@@ -41,3 +41,27 @@ No new comments since last phase.
 - **除外ファイル (履歴記録)**: 以下は現行 (修正前) の Rationale 文言をそれ自体の分析対象として引用している履歴記録であり、本 Issue の変更対象から除外する: `docs/spec/issue-923-run-issue-effort-recalib.md` / `docs/spec/issue-108-effort-matrix.md` (disposable Spec)、`docs/reports/sonnet-5-effort-recalibration-issue.md` (report)。`docs/tech.md`/`docs/ja/tech.md` 以外を変更しないという方針は、tech.md 自身の "Spec-first (disposable)" architecture decision と整合する。
 - `tests/*.bats` に Rationale 列の文言を検証するテストは存在しないことを grep で確認済み (変更不要)。
 - Issue body の Background 記述 (#923/#921 発見内容) を `docs/tech.md` の実ファイル内容 (89, 92, 121, 123行目) と突き合わせ、齟齬がないことを確認済み (conflict検出なし)。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Spec の Implementation Steps 1-3 の推奨文言をそのまま採用し、計画通りに実装した。
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の Implementation Steps 1-3 で提示された推奨文言 (英語・日本語とも) をそのまま採用した。Rationale 列の記述精度のみが本 Issue のスコープであり、文言自体の独自解釈による変更はリスクを増やすだけで利益がないため。
+- `docs/tech.md`/`docs/ja/tech.md` の2行のみを変更し、Effort 列・run-*.sh 実効値・disposable Spec/report 等の除外ファイルには一切触れなかった (Spec Notes の除外方針に準拠)。
+
+### Deferred Items
+- None — 本 Issue は Rationale 列の記述精度修正のみを対象としており、後続フェーズへの繰越事項はない。
+
+### Notes for Next Phase
+- 全 1107 bats テスト PASS、`validate-skill-syntax.py`・`check-forbidden-expressions.sh` とも問題なし。docs-only の軽微な変更であるため、review/merge フェーズでの追加確認は Rationale 文言の意味的正確性 (rubric 判定) に絞ってよい。

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -86,10 +86,10 @@ Entries are grouped by workflow order (triage → issue → spec → code → re
 
 | Component | Phase | Model | Effort | Rationale |
 |-----------|-------|-------|--------|-----------|
-| run-issue.sh | issue | Sonnet | high | L/XL scope analysis and sub-issue splitting require thorough orchestration |
+| run-issue.sh | issue | Sonnet | high | Existing Issue Refinement performs substantive judgment work (ambiguity resolution, AC/verify-command authoring) to produce the pipeline's most upstream artifact; errors propagate through every downstream phase — the longest blast radius in the C-series |
 | run-spec.sh | spec | Sonnet (Opus via `--opus` for L; Fable 5 via `--fable`) | Sonnet: max; Opus: xhigh (default), max (explicit `--max`); Fable 5: high (default), max (explicit `--max`) | Design quality is critical; spec errors propagate to all subsequent phases. `/auto` passes `--opus` for L-size only (XL is split before spec) |
 | run-code.sh | code | Sonnet | high | Implementation requires thorough reasoning |
-| run-review.sh | review | Sonnet | high | Review orchestration; sub-agents handle deep analysis |
+| run-review.sh | review | Sonnet | high | Orchestrator performs substantive reasoning beyond dispatch — Steps 7.2/7.4/7.6 interpret external review feedback and author fix commits, work comparable to run-code.sh's own implementation reasoning |
 | run-merge.sh | merge | Sonnet | low | Mechanical merge operation; minimal reasoning needed |
 | issue-scope | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Scope identification accuracy is critical for sub-issue boundary decisions |
 | issue-risk | issue (L/XL only) | Opus | — | Called by `/issue` Step 11a for L/XL parallel investigation. Risk assessment accuracy improves acceptance criteria quality |


### PR DESCRIPTION
## Summary
`docs/tech.md` § Phase-specific model and effort matrix の `run-issue.sh` 行・`run-review.sh` 行の Rationale 列を、#923 (C4) / #921 (C2) の Sonnet 5 effort 再校正で判明した正しい根拠に更新しました。従来の Rationale (`run-issue.sh`: 「L/XL scope analysis and sub-issue splitting require thorough orchestration」、`run-review.sh`: 「Review orchestration; sub-agents handle deep analysis」) は、実際には到達しないコードパスの記述、および「mechanical」という不正確な位置づけであることが各 Issue の recalibration note で判明していましたが、SSoT である表セル自体はスコープ外として据え置かれ、note との乖離が生じていました。本 PR はその乖離を解消します。Effort 列 (Sonnet: high) は変更していません。`docs/ja/tech.md` も対応する記述を同期更新しました。

## Verification (pre-merge)
- `docs/tech.md` の run-issue.sh / run-review.sh 行の Rationale が #923/#921 の recalibration note の根拠に更新されている
- Rationale 列の更新のみで Effort 列 (Sonnet: high) および run-*.sh の実効 effort 値は変更されていない
- `docs/ja/tech.md` の対応する Rationale 記述も同期更新されている

## Verification (post-merge)
- なし

closes #941
