### PR TITLE
Issue #945: Fix gh-pr-review.sh 422 error for diff-range-outside line comments

### DIFF
--- a/docs/spec/issue-945-gh-pr-review-diff-range-422.md
+++ b/docs/spec/issue-945-gh-pr-review-diff-range-422.md
@@ -54,3 +54,32 @@
 - **外部仕様依存チェック**: GitHub REST API 公式ドキュメント (`docs.github.com/en/rest/pulls/reviews`) では `line`/`side`/`start_line`/`start_side` フィールドの詳細な制約は明記されていない。422 発生条件 ("Pull request review thread line must be part of the diff") は公式ドキュメントに明文化されたエラーメッセージではなく、実運用時の community reports (GitHub Discussions) および Issue #934 での実際の発生事例から確認した。この点は `gh-pr-review.sh` の実装が「未文書化だが実運用で確認された API 制約」に依拠することを意味し、将来 GitHub 側の挙動が変わった場合は本ロジックの見直しが必要になりうる
 - **diff の取得方法**: `skills/review/SKILL.md` は `gh pr diff "$NUMBER"` (オプションなし、素の unified diff 形式) を既に Step 10 で使用しており (`.tmp/pr-diff-$NUMBER.txt` に保存)、本 Issue の `gh-pr-review.sh` 内実装もこの既存呼び出し規約と同一のコマンド形式 (`gh pr diff "$PR_NUMBER"`) を用いる
 - **doc-checker Impact Assessment**: Change Type 表 (workflow phase changes / project structure changes) にはいずれも該当しない (スクリプト内部ロジックの堅牢化であり、ワークフローフェーズやディレクトリ構成の変更を伴わない)。Steering Docs sync candidate として列挙した4ファイルは、いずれも `gh-pr-review.sh` の一行説明・Interface changes 記載のみを含み、本 Issue の変更 (内部フォールバック機構の追加) では記載内容の実質的な変更は不要と判断したが、最終確認は `/code` に委ねる
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜4 の順序・範囲通りに実装した (再構成・省略なし)
+
+### Design Gaps/Ambiguities
+- Spec Notes は新設する `gh pr diff` モック分岐のフィクスチャ diff について、範囲外テストケースの line 番号選定にのみ言及していたが、実装時に判明した点として、`gh-pr-review.sh` は line comments が存在する限り無条件で `gh pr diff` を呼ぶようになるため、既存5テストケース (`scripts/example.sh:10/42`、`scripts/other.sh:10/20`、`scripts/valid.sh:5`) を壊さないよう、フィクスチャの各ファイルのハンク範囲を `1-50` まで広げる必要があった。既存テストとの整合性確保は Spec に明記されておらず、実装時の判断で対応した
+
+### Rework
+- N/A —手戻りは発生しなかった
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- 実装箇所は Issue Retrospective で自動解決済みの方針通り `scripts/gh-pr-review.sh` に一本化した
+- diff ハンク範囲のパースは python3 heredoc 内で正規表現 (`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`) により実装し、bash 側は `mktemp` + `trap EXIT` での一時ファイル管理のみに留めた (既存コードスタイルと統一)
+- General Comments へのマージは、本文中に `### General Comments` 見出しが既にあればその直後に追記、なければ `### General Comments (auto-added: line outside PR diff range)` を新設するロジックとした (`skills/review/SKILL.md` Step 11 の既存パターンを再利用)
+- `HAS_MUST` (REQUEST_CHANGES 判定) は変更せず、`$LINE_COMMENTS_FILE` 全件を対象にした既存ロジックのまま維持し、範囲外へ振り分けられた MUST コメントも判定に引き続き寄与させた
+
+### Deferred Items
+- Post-merge の "422 エラーによる手戻りが発生しないことを観察" は `/verify` フェーズに委ねる (opportunistic verify-type)
+- `side: LEFT` のケースは Spec Notes 記載の通りスコープ外のまま (現行コードベースに使用箇所なし)
+
+### Notes for Next Phase
+- `tests/gh-pr-review.bats` は新規3ケース (範囲外フォールバック単体・範囲内範囲外混在・既存 General Comments 見出しへの追記) と回帰用の `gh pr diff` 失敗ケース1件を追加し、既存5ケースを含む全17ケースが PASS
+- Issue #945 の Pre-merge AC 2件は `rubric` 判定で PASS 済みでチェック済み、Issue body 更新済み
+- PR #950 (base: main) 作成済み。ドキュメント同期は不要と判断済み (`docs/structure.md` / `docs/migration-notes.md` および ja ミラーの記載は変更なしで正確)

--- a/docs/spec/issue-945-gh-pr-review-diff-range-422.md
+++ b/docs/spec/issue-945-gh-pr-review-diff-range-422.md
@@ -67,19 +67,32 @@
 - N/A —手戻りは発生しなかった
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- 実装箇所は Issue Retrospective で自動解決済みの方針通り `scripts/gh-pr-review.sh` に一本化した
-- diff ハンク範囲のパースは python3 heredoc 内で正規表現 (`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`) により実装し、bash 側は `mktemp` + `trap EXIT` での一時ファイル管理のみに留めた (既存コードスタイルと統一)
-- General Comments へのマージは、本文中に `### General Comments` 見出しが既にあればその直後に追記、なければ `### General Comments (auto-added: line outside PR diff range)` を新設するロジックとした (`skills/review/SKILL.md` Step 11 の既存パターンを再利用)
-- `HAS_MUST` (REQUEST_CHANGES 判定) は変更せず、`$LINE_COMMENTS_FILE` 全件を対象にした既存ロジックのまま維持し、範囲外へ振り分けられた MUST コメントも判定に引き続き寄与させた
+- review-light (軽量統合レビュー、REVIEW_DEPTH=light) を実行し、SHOULD 1件・CONSIDER 1件を検出。MUST はなし
+- SHOULD 指摘 (`side` 省略時に diff range チェックをすり抜ける) は修正: `c.get('side') == 'RIGHT'` を `c.get('side', 'RIGHT') == 'RIGHT'` に変更し、GitHub API 自体の `side` デフォルト値と挙動を揃えた。bats テストを1件追加 (18/18 PASS)
+- CONSIDER 指摘 (`line` の型未検証による TypeError リスク) は見送り: 唯一の呼び出し元 (`skills/review/SKILL.md` Step 10) が常に整数の `line` を渡す契約であり、現時点では顕在化しない入力依存のエッジケースと判断
+- Issue #945 の Pre-merge AC 2件は rubric 判定で PASS (実装・bats テストの両方を確認済み)
 
 ### Deferred Items
 - Post-merge の "422 エラーによる手戻りが発生しないことを観察" は `/verify` フェーズに委ねる (opportunistic verify-type)
 - `side: LEFT` のケースは Spec Notes 記載の通りスコープ外のまま (現行コードベースに使用箇所なし)
+- CONSIDER 指摘 (`line` 型検証) は対応見送り。将来 `gh-pr-review.sh` を独立 CLI として非 SKILL.md 経由で呼ぶ利用者が現れた場合に再評価
 
 ### Notes for Next Phase
-- `tests/gh-pr-review.bats` は新規3ケース (範囲外フォールバック単体・範囲内範囲外混在・既存 General Comments 見出しへの追記) と回帰用の `gh pr diff` 失敗ケース1件を追加し、既存5ケースを含む全17ケースが PASS
-- Issue #945 の Pre-merge AC 2件は `rubric` 判定で PASS 済みでチェック済み、Issue body 更新済み
-- PR #950 (base: main) 作成済み。ドキュメント同期は不要と判断済み (`docs/structure.md` / `docs/migration-notes.md` および ja ミラーの記載は変更なしで正確)
+- `tests/gh-pr-review.bats` は本 review フェーズで追加した1件を含め全18ケースが PASS (元の17ケース + `side` 省略時のフォールバック検証1件)
+- CI (DCO / bats / validate-skill-syntax / Forbidden Expressions / macOS shell compatibility) は全て SUCCESS
+- ポリシー変更は検出されなかったため Issue の受け入れ条件は未更新
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- N/A — Implementation Steps 1〜4 と PR diff の間に構造的な乖離はなかった。`side` 省略時の扱いは Spec Notes (53行目) に「`side: RIGHT` のみを対象とする」と明記されていたが、「省略された場合の扱い」は明示されておらず、review-light が指摘するまで気づかれなかった暗黙のギャップだった
+
+### Recurring issues
+- N/A — 同種の指摘が複数出るパターンは見られなかった (SHOULD 1件・CONSIDER 1件はいずれも異なる観点)
+
+### Acceptance criteria verification difficulty
+- 2件とも `rubric` 判定で UNCERTAIN にならず明確に PASS 判定できた。Spec Notes に実装箇所・振り分けロジック・bats フィクスチャ形式まで詳細に記述されていたため、rubric grader が参照すべき実装差分の範囲が曖昧にならなかったことが要因と考えられる
+- 今回のように「スコープ外」と明記した項目 (`side: LEFT`) がある場合、"未言及の暗黙のデフォルト値" (今回は `side` 省略時のデフォルト) についても Spec Notes で明示しておくと、review フェーズでの SHOULD 指摘を未然に防げた可能性がある。今後 rubric 対象の Spec を書く際の一般的な改善点として記録するが、Issue化するほどの汎用性は現時点では確認できていない

--- a/scripts/gh-pr-review.sh
+++ b/scripts/gh-pr-review.sh
@@ -20,6 +20,13 @@
 #     "severity": "MUST"
 #   }
 #   Note: severity field is used to determine the event type and is excluded from the API request
+#
+# Diff-range fallback:
+#   Each line comment's path/line is checked against the PR diff's hunk ranges
+#   (via `gh pr diff`). Comments whose line falls outside the diff range (side: RIGHT
+#   only) are excluded from the API `comments[]` payload and merged into the review
+#   body as a "### General Comments" Markdown list instead, since the GitHub Pull
+#   Request Review API rejects lines that are not part of the diff.
 
 set -euo pipefail
 
@@ -73,6 +80,14 @@ if [ -n "$LINE_COMMENTS_FILE" ]; then
         exit 1
     fi
 
+    # Fetch PR diff to build the hunk range map used for diff-range fallback classification
+    DIFF_FILE=$(mktemp)
+    trap 'rm -f "$DIFF_FILE"' EXIT
+    if ! gh pr diff "$PR_NUMBER" > "$DIFF_FILE" 2>/dev/null; then
+        echo "Error: failed to fetch PR diff for #$PR_NUMBER" >&2
+        exit 1
+    fi
+
     # Check for MUST severity to determine event type
     HAS_MUST=$(python3 - "$LINE_COMMENTS_FILE" <<'PYEOF'
 import sys, json
@@ -87,12 +102,16 @@ PYEOF
         EVENT="REQUEST_CHANGES"
     fi
 
-    # Build payload: exclude severity field, filter invalid entries, then POST
-    REVIEW_PAYLOAD=$(python3 - "$REVIEW_BODY_FILE" "$LINE_COMMENTS_FILE" "$EVENT" <<'PYEOF'
-import sys, json
+    # Build payload: exclude severity field, filter invalid entries, classify by
+    # PR diff hunk range (in-range stays as a line comment; out-of-range is merged
+    # into the review body as General Comments), then POST
+    REVIEW_PAYLOAD=$(python3 - "$REVIEW_BODY_FILE" "$LINE_COMMENTS_FILE" "$EVENT" "$DIFF_FILE" <<'PYEOF'
+import sys, json, re
+
 review_body_file = sys.argv[1]
 line_comments_file = sys.argv[2]
 event = sys.argv[3]
+diff_file = sys.argv[4]
 
 with open(review_body_file) as f:
     body = f.read()
@@ -109,10 +128,56 @@ for c in comments:
         continue
     clean_comments.append({k: v for k, v in c.items() if k != 'severity'})
 
+# Parse the PR diff into a path -> [(new_start, new_end), ...] hunk range map
+with open(diff_file) as f:
+    diff_text = f.read()
+
+range_map = {}
+current_path = None
+hunk_re = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@')
+for line in diff_text.splitlines():
+    if line.startswith('+++ '):
+        target = line[4:].strip()
+        if target == '/dev/null':
+            current_path = None
+        elif target.startswith('b/'):
+            current_path = target[2:]
+        else:
+            current_path = target
+        continue
+    m = hunk_re.match(line)
+    if m and current_path is not None:
+        new_start = int(m.group(1))
+        new_count = int(m.group(2)) if m.group(2) is not None else 1
+        if new_count > 0:
+            range_map.setdefault(current_path, []).append((new_start, new_start + new_count - 1))
+
+def in_diff_range(path, line_no):
+    return any(start <= line_no <= end for start, end in range_map.get(path, []))
+
+in_range_comments = []
+out_of_range_comments = []
+for c in clean_comments:
+    if c.get('side') == 'RIGHT' and not in_diff_range(c['path'], c['line']):
+        out_of_range_comments.append(c)
+    else:
+        in_range_comments.append(c)
+
+if out_of_range_comments:
+    bullets = '\n'.join(
+        f"- **{c['path']}:{c['line']}**: {c['body']}" for c in out_of_range_comments
+    )
+    heading_re = re.compile(r'^### General Comments.*$', re.MULTILINE)
+    m = heading_re.search(body)
+    if m:
+        body = body[:m.end()] + '\n' + bullets + body[m.end():]
+    else:
+        body = body.rstrip('\n') + '\n\n### General Comments (auto-added: line outside PR diff range)\n' + bullets + '\n'
+
 # Omit comments field if no valid comments remain
 payload = {'body': body, 'event': event}
-if clean_comments:
-    payload['comments'] = clean_comments
+if in_range_comments:
+    payload['comments'] = in_range_comments
 print(json.dumps(payload))
 PYEOF
     )

--- a/scripts/gh-pr-review.sh
+++ b/scripts/gh-pr-review.sh
@@ -158,7 +158,7 @@ def in_diff_range(path, line_no):
 in_range_comments = []
 out_of_range_comments = []
 for c in clean_comments:
-    if c.get('side') == 'RIGHT' and not in_diff_range(c['path'], c['line']):
+    if c.get('side', 'RIGHT') == 'RIGHT' and not in_diff_range(c['path'], c['line']):
         out_of_range_comments.append(c)
     else:
         in_range_comments.append(c)

--- a/tests/gh-pr-review.bats
+++ b/tests/gh-pr-review.bats
@@ -26,6 +26,27 @@ if [ "\$1" = "repo" ] && [ "\$2" = "view" ]; then
     echo "owner/repo"
     exit 0
 fi
+# pr diff: fixture unified diff with wide hunk ranges covering the paths/lines used in tests
+if [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then
+    cat <<'DIFF'
+diff --git a/scripts/example.sh b/scripts/example.sh
+index 1111111..2222222 100644
+--- a/scripts/example.sh
++++ b/scripts/example.sh
+@@ -1,50 +1,50 @@
+diff --git a/scripts/other.sh b/scripts/other.sh
+index 3333333..4444444 100644
+--- a/scripts/other.sh
++++ b/scripts/other.sh
+@@ -1,50 +1,50 @@
+diff --git a/scripts/valid.sh b/scripts/valid.sh
+index 5555555..6666666 100644
+--- a/scripts/valid.sh
++++ b/scripts/valid.sh
+@@ -1,50 +1,50 @@
+DIFF
+    exit 0
+fi
 # api: capture stdin when --input - is used
 if [ "\$1" = "api" ]; then
     if echo "\$@" | grep -q -- "--input"; then
@@ -142,6 +163,69 @@ for c in comments:
 "
 }
 
+# --- Diff-range fallback cases ---
+
+@test "success: line comment outside PR diff range falls back to General Comments" {
+    echo "review body text" > "$BATS_TEST_TMPDIR/review.md"
+    cat > "$BATS_TEST_TMPDIR/comments.json" <<'JSON'
+[
+  {"path": "scripts/example.sh", "line": 999, "body": "MUST update this pre-existing line", "side": "RIGHT", "severity": "MUST"}
+]
+JSON
+    run bash "$SCRIPT" 159 "$BATS_TEST_TMPDIR/review.md" "$BATS_TEST_TMPDIR/comments.json"
+    [ "$status" -eq 0 ]
+    grep -q "ARGS: pr diff 159" "$GH_CALL_LOG"
+    python3 -c "
+import json
+payload = json.load(open('$GH_API_STDIN'))
+# out-of-range MUST comment still drives REQUEST_CHANGES
+assert payload['event'] == 'REQUEST_CHANGES', f'Expected REQUEST_CHANGES, got {payload[\"event\"]}'
+assert 'comments' not in payload, 'out-of-range comment should not remain in comments[]'
+assert '### General Comments' in payload['body']
+assert 'scripts/example.sh:999' in payload['body']
+assert 'MUST update this pre-existing line' in payload['body']
+"
+}
+
+@test "success: mix of in-range and out-of-range comments splits correctly" {
+    echo "review body text" > "$BATS_TEST_TMPDIR/review.md"
+    cat > "$BATS_TEST_TMPDIR/comments.json" <<'JSON'
+[
+  {"path": "scripts/example.sh", "line": 10, "body": "SHOULD fix this in-range", "side": "RIGHT", "severity": "SHOULD"},
+  {"path": "scripts/other.sh", "line": 999, "body": "SHOULD fix this out-of-range", "side": "RIGHT", "severity": "SHOULD"}
+]
+JSON
+    run bash "$SCRIPT" 159 "$BATS_TEST_TMPDIR/review.md" "$BATS_TEST_TMPDIR/comments.json"
+    [ "$status" -eq 0 ]
+    python3 -c "
+import json
+payload = json.load(open('$GH_API_STDIN'))
+assert len(payload['comments']) == 1, 'only the in-range comment should remain'
+assert payload['comments'][0]['path'] == 'scripts/example.sh'
+assert 'scripts/other.sh:999' in payload['body']
+assert 'SHOULD fix this out-of-range' in payload['body']
+"
+}
+
+@test "success: out-of-range comment merges after an existing General Comments heading" {
+    printf 'review body text\n\n### General Comments\n- existing note\n' > "$BATS_TEST_TMPDIR/review.md"
+    cat > "$BATS_TEST_TMPDIR/comments.json" <<'JSON'
+[
+  {"path": "scripts/other.sh", "line": 999, "body": "SHOULD fix this out-of-range", "side": "RIGHT", "severity": "SHOULD"}
+]
+JSON
+    run bash "$SCRIPT" 159 "$BATS_TEST_TMPDIR/review.md" "$BATS_TEST_TMPDIR/comments.json"
+    [ "$status" -eq 0 ]
+    python3 -c "
+import json
+payload = json.load(open('$GH_API_STDIN'))
+body = payload['body']
+assert body.count('### General Comments') == 1, 'should reuse the existing heading, not add a new one'
+assert '- existing note' in body
+assert 'scripts/other.sh:999' in body
+"
+}
+
 # --- Error cases ---
 
 @test "error: no arguments" {
@@ -187,6 +271,33 @@ for c in comments:
     run bash "$SCRIPT" 159 "$BATS_TEST_TMPDIR/review.md" "$BATS_TEST_TMPDIR/bad.json"
     [ "$status" -eq 1 ]
     [[ "$output" == *"invalid line comments JSON"* ]]
+}
+
+@test "error: gh pr diff failure exits with code 1 and Error message" {
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+echo "ARGS: \$@" >> "$GH_CALL_LOG"
+if [ "\$1" = "repo" ] && [ "\$2" = "view" ]; then
+    echo "owner/repo"
+    exit 0
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then
+    echo "error: pull request not found" >&2
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    echo "review body text" > "$BATS_TEST_TMPDIR/review.md"
+    cat > "$BATS_TEST_TMPDIR/comments.json" <<'JSON'
+[
+  {"path": "scripts/example.sh", "line": 10, "body": "SHOULD fix this", "side": "RIGHT", "severity": "SHOULD"}
+]
+JSON
+    run bash "$SCRIPT" 159 "$BATS_TEST_TMPDIR/review.md" "$BATS_TEST_TMPDIR/comments.json"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed to fetch PR diff"* ]]
 }
 
 @test "error: gh api POST failure exits with code 1 and Error message" {

--- a/tests/gh-pr-review.bats
+++ b/tests/gh-pr-review.bats
@@ -226,6 +226,23 @@ assert 'scripts/other.sh:999' in body
 "
 }
 
+@test "success: out-of-range comment with omitted side defaults to RIGHT and falls back" {
+    echo "review body text" > "$BATS_TEST_TMPDIR/review.md"
+    cat > "$BATS_TEST_TMPDIR/comments.json" <<'JSON'
+[
+  {"path": "scripts/example.sh", "line": 999, "body": "SHOULD fix this out-of-range", "severity": "SHOULD"}
+]
+JSON
+    run bash "$SCRIPT" 159 "$BATS_TEST_TMPDIR/review.md" "$BATS_TEST_TMPDIR/comments.json"
+    [ "$status" -eq 0 ]
+    python3 -c "
+import json
+payload = json.load(open('$GH_API_STDIN'))
+assert 'comments' not in payload, 'comment with omitted side should be treated as RIGHT and fall back'
+assert 'scripts/example.sh:999' in payload['body']
+"
+}
+
 # --- Error cases ---
 
 @test "error: no arguments" {


### PR DESCRIPTION
## Summary
- `gh-pr-review.sh` に、line comments の各エントリが PR diff のハンク範囲内かを事前チェックする仕組みを追加した (`gh pr diff` の unified diff からハンクヘッダーをパースし、`path → [(new_start, new_end), ...]` の範囲マップを構築)
- 範囲外 (`side: RIGHT` の `line` が範囲マップ外) と判定されたコメントは API 送信用の `comments[]` から除外し、レビュー本文の `### General Comments` セクションに Markdown 箇条書きとして統合するフォールバックを実装した (既存の General Comments 見出しがあればその直後に追記、なければ新設)
- `HAS_MUST` (REQUEST_CHANGES 判定) は従来通り line comments 全件を対象にしたロジックのままとし、範囲外へ振り分けられた MUST コメントも判定に寄与し続ける

## Verification (pre-merge)
- `gh-pr-review.sh` に diff hunk 範囲外行の自動フォールバック (comments 配列からの除外 + レビュー本文への General Comments 統合) が実装されている
- `tests/gh-pr-review.bats` に diff 範囲外行指定時の General Comments フォールバック動作を検証するテストが追加されている (新規3ケース + 回帰確認用の `gh pr diff` エラーケース1件、既存5ケースは変更なしで PASS 継続)

## Verification (post-merge)
- 次回 review エージェントが既存箇所の未更新を指摘した際、422 エラーによる手戻りが発生しないことを観察

closes #945
