### PR TITLE
Issue #954: Add SendMessage/Write result delivery to issue investigation agents

### DIFF
--- a/agents/issue-precedent.md
+++ b/agents/issue-precedent.md
@@ -1,7 +1,7 @@
 ---
 name: issue-precedent
 description: Precedent Investigation: extract learnings from similar Issue/Spec retrospectives (for L/XL Issue parallel investigation)
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, SendMessage, Write
 model: opus
 ---
 
@@ -47,6 +47,11 @@ Analyze the collected retrospective information for:
 - **Failure patterns**: Common factors that caused rework or design changes
 - **Watch points**: Problems that repeatedly occurred across similar Issues
 - **Applicable insights**: Past decisions and solutions directly applicable to the current Issue
+
+### 4. Deliver Results
+
+- **Primary**: after generating the Output Format markdown, call `SendMessage({to: "main", message: <full Output Format markdown>, summary: "<5-10 words>"})` to deliver the results to the team-lead.
+- **Fallback**: if `SendMessage` is unavailable or errors, `Write` the same markdown to `.tmp/issue-$NUMBER-precedent.md` and state that path in your final response text.
 
 ## Output Format
 

--- a/agents/issue-risk.md
+++ b/agents/issue-risk.md
@@ -1,7 +1,7 @@
 ---
 name: issue-risk
 description: Risk Investigation: assess test impact, verify command effects, and breaking change potential (for L/XL Issue parallel investigation)
-tools: Read, Glob, Grep
+tools: Read, Glob, Grep, SendMessage, Write
 model: opus
 ---
 
@@ -53,6 +53,11 @@ Investigate test files under the `tests/` directory:
 ### 4. Risk Assessment
 
 For each risk item, evaluate impact level (High/Medium/Low) and probability (High/Medium/Low).
+
+### 5. Deliver Results
+
+- **Primary**: after generating the Output Format markdown, call `SendMessage({to: "main", message: <full Output Format markdown>, summary: "<5-10 words>"})` to deliver the results to the team-lead.
+- **Fallback**: if `SendMessage` is unavailable or errors, `Write` the same markdown to `.tmp/issue-$NUMBER-risk.md` and state that path in your final response text.
 
 ## Output Format
 

--- a/agents/issue-scope.md
+++ b/agents/issue-scope.md
@@ -1,7 +1,7 @@
 ---
 name: issue-scope
 description: Scope Investigation: identify change targets and impact scope (for L/XL Issue parallel investigation)
-tools: Read, Glob, Grep, Bash(git log:*, git diff:*)
+tools: Read, Glob, Grep, Bash(git log:*, git diff:*), SendMessage, Write
 model: opus
 ---
 
@@ -51,6 +51,11 @@ Use the extracted keywords to investigate with Glob/Grep/Read:
 ### 3. Dependency Mapping
 
 Organize the investigation results by structuring file dependencies in text format.
+
+### 4. Deliver Results
+
+- **Primary**: after generating the Output Format markdown, call `SendMessage({to: "main", message: <full Output Format markdown>, summary: "<5-10 words>"})` to deliver the results to the team-lead.
+- **Fallback**: if `SendMessage` is unavailable or errors, `Write` the same markdown to `.tmp/issue-$NUMBER-scope.md` and state that path in your final response text.
 
 ## Output Format
 

--- a/docs/spec/issue-954-agent-result-delivery.md
+++ b/docs/spec/issue-954-agent-result-delivery.md
@@ -89,16 +89,27 @@ No new comments since last phase.
 - N/A
 
 ## Phase Handoff
+<!-- phase: review -->
 
 ### Key Decisions
-- `SendMessage` を主経路、`Write` を到達性フォールバックとする配信方式を Spec 通りに実装 (Q&A で確定した方針、変更なし)
-- 3エージェントの verify command を `SendMessage` / `Write` の2本立てに分割した設計 (Purpose文言との整合性確保) をそのまま踏襲
+- レビューで検出された SHOULD 2件 (待機タイムアウト未定義・フォールバックファイル未クリーンアップ) はいずれも低リスクな改善のため、その場で修正してから merge 待ちとした (MUST ではないが既存の `.tmp/` 後始末慣習との不整合を残さない判断)
+- Pre-merge AC 8件 (file_contains×6 / section_contains×1 / rubric×1) は全て PASS。ポリシー変更に該当する修正はなかったため Issue 本文の受け入れ条件は更新していない
 
 ### Deferred Items
-- `agents/review-bug.md` 等、同種の tools 不足パターンを持つ他エージェントの横断監査 (Issue #954 Notes 欄に記載、別 Issue でのスコープ)
+- `agents/review-bug.md` 等、同種の tools 不足パターンを持つ他エージェントの横断監査 (Issue #954 Notes 欄に記載、別 Issue でのスコープ) — review フェーズでも変更なし
 - Post-merge AC: Size=XL の Issue で実際に `/issue` を実行し、SendMessage 経由 (または Write+Read フォールバック経由) で手動介入なしに結果回収できることの確認
 
 ### Notes for Next Phase
-- 3エージェントの `### N. Deliver Results` サブセクションは Primary/Fallback の文言パターンが統一されているか確認すること
-- `agents/*.md` 単体を対象とする bats テストは存在しない (フルスイート1115件は間接的なサニティチェックに留まる) — レビュー時はテスト結果ではなく差分の目視確認を優先すること
-- 同時期に進行した Issue #955 (`/issue` sub-issue split Step 3) も `skills/issue/SKILL.md` を変更しているが、three-dot diff (`main...`) で確認した通り編集箇所は重複しない (#954 は Step 12a、#955 は Step 3)
+- `/merge` 実行時、review フェーズの修正コミット (idle-cycle 閾値 + フォールバックファイル cleanup 追加) が最終差分に含まれていることを確認すること
+- Post-merge AC の実地確認 (Size=XL Issue での `/issue` 実行) は `/verify` フェーズで扱う
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- N/A — review-light の Perspective 1 (Spec Deviation) でも「Implementation Steps の記述と完全一致」と確認された。逸脱なし。
+
+### Recurring issues
+- review-light の Perspective 2 (Edge Cases/Robustness) で SHOULD 2件を検出: (1) team-lead 側の「メッセージ待ち」に idle_notification 回数などの閾値がなく無限ブロックの恐れ、(2) `.tmp/issue-$NUMBER-{scope,risk,precedent}.md` フォールバックファイルが Step 12b 後もクリーンアップされず残存する恐れ (同一 SKILL.md 内の他ステップは `rm -f` で後始末している慣習と不整合)。いずれも Spec の Implementation Steps には記載がなかった観点で、`SendMessage`/`Write` 併用型の配信パターンを新設する際は「待機タイムアウト」と「一時ファイル後始末」をセットで設計に含めるべき、という一般化可能な教訓。両方とも本 PR で修正済み。
+
+### Acceptance criteria verification difficulty
+- N/A — `file_contains`×6 / `section_contains`×1 / `rubric`×1 の Pre-merge AC はいずれも UNCERTAIN なく一発で PASS 判定できた。rubric 条件文が SendMessage 主経路と Write フォールバックの両方を明示的に言語化していたため、grader 判断に曖昧さはなかった。

--- a/docs/spec/issue-954-agent-result-delivery.md
+++ b/docs/spec/issue-954-agent-result-delivery.md
@@ -72,3 +72,33 @@
 - **外部仕様確認**: `SendMessage` は Claude Code ハーネス内蔵ツールであり公開 API ドキュメントは存在しないため、`modules/external-spec.md` の WebFetch/WebSearch 手順ではなく ToolSearch で実際の tool schema を取得して仕様を確認した (`to: "main"` — バックグラウンドサブエージェントが親セッションへ届ける唯一の経路。"Messages from teammates are delivered automatically" — team-lead 側のポーリングは不要かつ非対応)。
 - **Steering Docs sync candidate 調査**: `skills/issue/SKILL.md` を変更対象に含むため、キーワード `issue` で `docs/*.md` / `docs/ja/*.md` を grep したが、"issue" は汎用語のため全 steering doc (8 件) にヒットし信号にならなかった (scope: `docs/*.md`, `docs/ja/*.md` 全体、除外なし)。代わりにエージェント名 (`issue-scope` / `issue-risk` / `issue-precedent`) で `docs/workflow.md` と `README.md` を個別に grep したが 0 件だった (scope: `docs/workflow.md`, `README.md` の全文)。`docs/structure.md` の Agents 表は description のみを記載し tools 列を持たないため更新不要。以上より Steering Docs sync candidate なしと判断した。
 - **スコープ**: Issue #954 の Auto-Resolved Ambiguity Points により、本 Spec の対象は `issue-scope` / `issue-risk` / `issue-precedent` の 3 エージェントに限定する。`agents/review-bug.md` 等の同種パターンを持つ他エージェントの横断監査は対象外 (別 Issue で扱う)。
+
+## Consumed Comments
+
+No new comments since last phase.
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — 実装は Implementation Steps の記述通り (3エージェントへの `SendMessage, Write` 追加 + Deliver Results サブセクション、SKILL.md Step 12a への配信指示・Result collection 追記) に完了しており、設計からの逸脱はなかった。
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A
+
+## Phase Handoff
+
+### Key Decisions
+- `SendMessage` を主経路、`Write` を到達性フォールバックとする配信方式を Spec 通りに実装 (Q&A で確定した方針、変更なし)
+- 3エージェントの verify command を `SendMessage` / `Write` の2本立てに分割した設計 (Purpose文言との整合性確保) をそのまま踏襲
+
+### Deferred Items
+- `agents/review-bug.md` 等、同種の tools 不足パターンを持つ他エージェントの横断監査 (Issue #954 Notes 欄に記載、別 Issue でのスコープ)
+- Post-merge AC: Size=XL の Issue で実際に `/issue` を実行し、SendMessage 経由 (または Write+Read フォールバック経由) で手動介入なしに結果回収できることの確認
+
+### Notes for Next Phase
+- 3エージェントの `### N. Deliver Results` サブセクションは Primary/Fallback の文言パターンが統一されているか確認すること
+- `agents/*.md` 単体を対象とする bats テストは存在しない (フルスイート1115件は間接的なサニティチェックに留まる) — レビュー時はテスト結果ではなく差分の目視確認を優先すること
+- 同時期に進行した Issue #955 (`/issue` sub-issue split Step 3) も `skills/issue/SKILL.md` を変更しているが、three-dot diff (`main...`) で確認した通り編集箇所は重複しない (#954 は Step 12a、#955 は Step 3)

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -488,9 +488,11 @@ Task(subagent_type="issue-precedent", description="Precedent investigation",
   prompt="Issue=$NUMBER, Issue body=<full text>. Deliver your Output Format markdown via SendMessage(to=\"main\") on completion; if SendMessage is unavailable or fails, Write it to .tmp/issue-$NUMBER-precedent.md instead and state the path in your final response.")
 ```
 
-**Result collection**: `SendMessage` delivers each agent's Output Format markdown automatically — no team-lead polling required. Wait to receive messages from all 3 agents before proceeding to Step 12b. If a message from a given agent does not arrive (e.g., it errored out), read that agent's fallback file (`.tmp/issue-$NUMBER-scope.md` / `.tmp/issue-$NUMBER-risk.md` / `.tmp/issue-$NUMBER-precedent.md`) with `Read` to recover its results instead.
+**Result collection**: `SendMessage` delivers each agent's Output Format markdown automatically — no team-lead polling required. Wait to receive messages from all 3 agents before proceeding to Step 12b. If no message and no fallback file appear from a given agent within 3 `idle_notification` cycles, treat it as silently failed: read that agent's fallback file (`.tmp/issue-$NUMBER-scope.md` / `.tmp/issue-$NUMBER-risk.md` / `.tmp/issue-$NUMBER-precedent.md`) with `Read` to recover its results, applying the same handling as an explicit error if the file is also absent.
 
 On failure: fall back to standard scope assessment (when both `SendMessage` delivery and the `Write` fallback fail for an agent).
+
+After Step 12b integrates the results, delete any fallback files that were created: `rm -f .tmp/issue-$NUMBER-scope.md .tmp/issue-$NUMBER-risk.md .tmp/issue-$NUMBER-precedent.md` (best-effort; ignores files that were never created because `SendMessage` succeeded).
 
 #### Step 12b: Split Proposal (integrate results)
 

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -479,16 +479,18 @@ Get steering doc paths with Glob. Launch these 3 subagents in a single message t
 
 ```text
 Task(subagent_type="issue-scope", description="Scope investigation",
-  prompt="Issue=$NUMBER, Steering Documents=$STEERING_DOCS_FILES, Issue body=<full text>")
+  prompt="Issue=$NUMBER, Steering Documents=$STEERING_DOCS_FILES, Issue body=<full text>. Deliver your Output Format markdown via SendMessage(to=\"main\") on completion; if SendMessage is unavailable or fails, Write it to .tmp/issue-$NUMBER-scope.md instead and state the path in your final response.")
 
 Task(subagent_type="issue-risk", description="Risk investigation",
-  prompt="Issue=$NUMBER, Issue body=<full text>")
+  prompt="Issue=$NUMBER, Issue body=<full text>. Deliver your Output Format markdown via SendMessage(to=\"main\") on completion; if SendMessage is unavailable or fails, Write it to .tmp/issue-$NUMBER-risk.md instead and state the path in your final response.")
 
 Task(subagent_type="issue-precedent", description="Precedent investigation",
-  prompt="Issue=$NUMBER, Issue body=<full text>")
+  prompt="Issue=$NUMBER, Issue body=<full text>. Deliver your Output Format markdown via SendMessage(to=\"main\") on completion; if SendMessage is unavailable or fails, Write it to .tmp/issue-$NUMBER-precedent.md instead and state the path in your final response.")
 ```
 
-On failure: fall back to standard scope assessment.
+**Result collection**: `SendMessage` delivers each agent's Output Format markdown automatically — no team-lead polling required. Wait to receive messages from all 3 agents before proceeding to Step 12b. If a message from a given agent does not arrive (e.g., it errored out), read that agent's fallback file (`.tmp/issue-$NUMBER-scope.md` / `.tmp/issue-$NUMBER-risk.md` / `.tmp/issue-$NUMBER-precedent.md`) with `Read` to recover its results instead.
+
+On failure: fall back to standard scope assessment (when both `SendMessage` delivery and the `Write` fallback fail for an agent).
 
 #### Step 12b: Split Proposal (integrate results)
 


### PR DESCRIPTION
## Summary
- `issue-scope` / `issue-risk` / `issue-precedent` の3エージェントの `tools:` frontmatter に `SendMessage` (調査結果配信の主経路) と `Write` (フォールバック用ファイル出力) を追加
- 各エージェント定義に「Deliver Results」サブセクションを追加し、`SendMessage({to: "main", ...})` を主経路、`.tmp/issue-$NUMBER-{scope|risk|precedent}.md` への `Write` を到達性フォールバックとする配信手順を明記
- `skills/issue/SKILL.md` Step 12a の `Task(...)` プロンプトに配信指示を追記し、team-lead 側の受信待ち・フォールバック回収手順 (Result collection) を追加

## Verification (pre-merge)
- `issue-scope.md` / `issue-risk.md` / `issue-precedent.md` の `tools:` frontmatter に `SendMessage` と `Write` が追加されている
- `skills/issue/SKILL.md` Step 12a に SendMessage 優先・Write フォールバックの結果配信手順が明記されている
- `bats tests/` フルスイート (1115件) PASS

## Verification (post-merge)
- 実際に Size=XL の Issue で `/issue` を実行し、3エージェントの調査結果が手動介入なしに (SendMessage 経由、または未達時は Write+Read フォールバック経由で) 回収できることを確認する

closes #954
