### PR TITLE
Issue #961: worktree-merge-push.sh を checkout レスの ref-fetch マージに書き換え

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -201,7 +201,7 @@ wholework/
 - `scripts/reconcile-phase-state.sh` — 全 phase の precondition チェックと completion チェックを行う汎用 state reconciler。`modules/phase-state.md` SSoT に基づく JSON v1 を出力（watchdog-reconcile.sh の後継）
 - `scripts/wait-ci-checks.sh` — claude 実行前に PR の全 CI チェック完了を待機
 - `scripts/pre-merge-check.sh` — ベースライン diff 分類器: 指定チェックをベースブランチと head ブランチで ephemeral worktree で実行し、結果を NEW_FAILURE (exit 2) / PRE_EXISTING / FIXED / CLEAN (exit 0) / env error (exit 1) に分類
-- `scripts/worktree-merge-push.sh` — 短命な patch lock を取得し、fetch-after-lock・is-ancestor による rebase skip・push retry loop (max 3) で並列 session race に対応した merge + push を実行
+- `scripts/worktree-merge-push.sh` — 短命な patch lock を取得し、fetch-after-lock・checkout レスの ref-fetch マージ (`git fetch . <from>:<base>`)・is-ancestor による rebase skip・push retry loop (max 3) で並列 session race に対応した merge + push を実行
 - `scripts/detect-foreign-worktree.sh` — CWD が foreign（呼び出し元と異なる owner の）git worktree 内かどうかを判定する。`modules/worktree-lifecycle.md` の Entry section から使用される
 - `scripts/detect-wrapper-anomaly.sh` — shell wrapper 出力の既知失敗パターンを検出し、Auto Retrospective の markdown 断片を生成
 - `scripts/test-failure-classify.sh` — テスト失敗出力を回復カテゴリに分類（snapshot/mock/fixture/logic/infra）。exit 0 = 修復可、exit 1 = 修復不可

--- a/docs/spec/issue-961-worktree-merge-push-checkout.md
+++ b/docs/spec/issue-961-worktree-merge-push-checkout.md
@@ -72,19 +72,30 @@
 ### Rework
 - worktree に `EnterWorktree` を経由せずセッションを再開したため、`modules/orchestration-fallbacks.md` と `tests/worktree-merge-push.bats` への最初の Edit 呼び出しが誤って共有メインリポジトリ (`/Users/saito/src/wholework/...`) の絶対パスに対して行われ、worktree 側 (`.claude/worktrees/code+issue-961/`) には反映されなかった。`bats tests/worktree-merge-push.bats` をworktree側で実行した際に旧テスト名のまま (`--from triggers git merge --ff-only` 等) 出力されたことで発覚。差分を worktree 側にコピーし、`git checkout --` でメインリポジトリ側を元の状態に復元して解消した。再開セッションでは、Edit/Write の対象パスが実際に worktree 内を指しているか (`pwd` 確認) を先に行うべきだった。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- なし。Primary FF-merge path・rebase fallback は Spec の Implementation Steps (tier1/tier2 フォールバック分岐) と実装が完全に一致しており、構造的な乖離は見られなかった。
+
+### Recurring issues
+- **worktree-local path の取り違えが code フェーズと review フェーズで連続して発生**: 本 review フェーズでも、`Read` ツールで最初に `scripts/worktree-merge-push.sh` を絶対パス指定した際、誤って共有メインリポジトリ側 (`/Users/saito/src/wholework/scripts/...`、worktree セグメント欠落) を読み込み、旧ロジック (`git pull --rebase` あり) を見てしまうという事象があった。`git show HEAD:...` で worktree 側の実コミット内容を確認して復旧した。code フェーズの Rework 記録 (同じ取り違えを Edit で経験) と合わせて、worktree セッションで絶対パスを扱う際は `pwd` 確認または worktree セグメントを含む絶対パスの使用を徹底する運用上の弱点が2フェーズ連続で顕在化した。
+- **push-retry ループの checkout 依存が本 Issue のスコープ境界をまたいで見落とされていた**: Issue #961 の Changed Files 節は primary merge path (行83-109) のみを修正対象と明示的にスコープしていたが、同一スクリプト内の push-retry ループ (行129-148、#853 由来、本 PR 未変更) には本 Issue の Root Cause と同一クラスの checkout 依存 (`git rebase` が HEAD に対して無条件に動作) が残存していた。スコープ境界の外側にある「同じ根本原因を共有するコード片」を横断的に検知する仕組みがなく、review-light エージェントへの追加コンテキスト注入 (プロンプトで明示的に当該箇所を指示) によって初めて発見できた。
+
+### Acceptance criteria verification difficulty
+- なし。Pre-merge AC 3件はいずれも rubric / file_not_contains ベースで機械的に PASS 判定でき、UNCERTAIN は発生しなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `scripts/worktree-merge-push.sh` の primary path 実装 (前セッションでコミット済みの `git fetch . <from>:<base>` ロジック) はそのまま採用し、追加変更なしと判断した — Spec の tier 1/tier 2 フォールバック分岐と実装が一致していることを確認済み。
-- `modules/orchestration-fallbacks.md` の `#ff-only-merge-fallback` エントリは Symptom/Fallback Steps/Escalation/Rationale の全セクションを新ロジックに合わせて全面書き換えし、旧 `git pull --rebase` ベースの記述を残さなかった。
-- `tests/worktree-merge-push.bats` に、foreign checkout かつ worktree 未検出時に bare な rebase/merge が一切発行されないことを検証する新規テストを追加し、AC1/AC2 の safety 特性をテストレベルでも担保した。
+- Code Review (review-light) で検出した push-retry ループの checkout 依存 (SHOULD) と関連ドキュメント整合性 (CONSIDER) は、Issue #961 の Changed Files 節が明示的にスコープ外としていること、および本 PR の主目的 (primary merge path の checkout レス化) が達成されていることを踏まえ、本 PR では修正せずレビューコメントとして記録するに留めた。
+- MUST issue が0件のため、gh-pr-review.sh は `COMMENT` イベントで投稿された (`REQUEST_CHANGES` は発生していない)。
 
 ### Deferred Items
+- push-retry ループ (`scripts/worktree-merge-push.sh` 行129-148) の bare `git rebase "origin/${BASE_BRANCH}"` が HEAD (共有ディレクトリの現在のチェックアウト) に対して動作するため、foreign checkout + push race が重なると本 Issue と同種の欠陥 (無関係セッションのブランチを誤って書き換える) を再現しうる。follow-up Issue 化を検討 (`/verify` フェーズでの Improvement Proposal 集約に委ねる)。
 - Post-merge AC (複数セッション環境での実地確認) は manual verify-type のため、`/verify` フェーズでの人手確認待ち。
-- なし (その他のフォローアップ Issue は本実装スコープでは発生していない)。
 
 ### Notes for Next Phase
-- Pre-merge AC 3件はいずれも rubric / file_not_contains ベースで PASS 判定済み、Issue 本文のチェックボックスは更新済み。
-- `bats tests/` フルスイート (1118 tests, 0 failures) を実行済み — `modules/orchestration-fallbacks.md` を参照する `tests/orchestration-fallbacks.bats` (schema validation) も含めて確認済み。
-- Post-merge の manual AC 確認時は、共有メインディレクトリが他ブランチを checkout した状態で `worktree-merge-push.sh --from <branch>` を実行し、ref-fetch が拒否されつつ bare な rebase/merge が一切発行されないことを実地で確認すること。
+- Pre-merge AC 3件はいずれも rubric / file_not_contains ベースで PASS 判定済み、Issue 本文のチェックボックスは既に `[x]` 済み (code フェーズ側で更新済みのものを維持)。
+- CI (`bats tests`, `Validate skill syntax`, `Forbidden Expressions check`, `macOS shell compatibility`, `DCO`) は全ジョブ SUCCESS。
+- Post-merge の manual AC 確認時は、共有メインディレクトリが他ブランチを checkout した状態で `worktree-merge-push.sh --from <branch>` を実行し、ref-fetch が拒否されつつ bare な rebase/merge が一切発行されないことに加え、push-retry ループに到達するケース (non-fast-forward push race) がある場合は push-retry の checkout 依存リスクも併せて観察すること。

--- a/docs/spec/issue-961-worktree-merge-push-checkout.md
+++ b/docs/spec/issue-961-worktree-merge-push-checkout.md
@@ -60,3 +60,31 @@
 - **Auto-Resolve Log は本フェーズでは追加なし**: Issue 側の Auto-Resolve Log (Issue Retrospective コメントに記録済み) で AC2 の verify command が既に `file_not_contains "git pull --rebase"` に差し替えられており、Spec フェーズで新たに解決すべき曖昧点はなかった。
 - **非 `-C` フォールバックの削除は挙動変更を伴わない見込み**: 現行スクリプトで `git rebase "$BASE_BRANCH" "$FROM_BRANCH"` (worktree パスが見つからない場合の最終手段) に到達するのは `$FROM_BRANCH` の worktree が既に存在しない場合のみだが、Wholework の呼び出しパターンでは常に `ExitWorktree(action: "keep")` を経てから本スクリプトを呼ぶため、この分岐は実運用ではそもそも到達しない。削除は観測可能な挙動を変えるものではなく、潜在的な欠陥経路を閉じるものである。
 - `docs/spec/issue-961-recovery.md` は `/issue` フェーズでの silent-hang に対する手動リカバリ記録であり、本 Issue の技術設計とは無関係のため本 Spec には引き継いでいない (プロセス上の記録として別ファイルのまま残す)。
+
+## Code Retrospective
+
+### Deviations from Design
+- なし。Implementation Steps 1〜4 を計画通りに実装した。Step 1 (`scripts/worktree-merge-push.sh` の primary path 書き換え) は本セッション開始前に既に別セッションでコミット済み (34a59d1c) だったため、本セッションでは Spec の設計 (primary path / フォールバック tier 1・2 の分岐条件) と実装内容が一致していることを確認したのみで、追加変更は行っていない。
+
+### Design Gaps/Ambiguities
+- なし。Spec の Notes に技術的前提の実証結果が記録済みで、実装時に新たに確認すべき曖昧点はなかった。
+
+### Rework
+- worktree に `EnterWorktree` を経由せずセッションを再開したため、`modules/orchestration-fallbacks.md` と `tests/worktree-merge-push.bats` への最初の Edit 呼び出しが誤って共有メインリポジトリ (`/Users/saito/src/wholework/...`) の絶対パスに対して行われ、worktree 側 (`.claude/worktrees/code+issue-961/`) には反映されなかった。`bats tests/worktree-merge-push.bats` をworktree側で実行した際に旧テスト名のまま (`--from triggers git merge --ff-only` 等) 出力されたことで発覚。差分を worktree 側にコピーし、`git checkout --` でメインリポジトリ側を元の状態に復元して解消した。再開セッションでは、Edit/Write の対象パスが実際に worktree 内を指しているか (`pwd` 確認) を先に行うべきだった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `scripts/worktree-merge-push.sh` の primary path 実装 (前セッションでコミット済みの `git fetch . <from>:<base>` ロジック) はそのまま採用し、追加変更なしと判断した — Spec の tier 1/tier 2 フォールバック分岐と実装が一致していることを確認済み。
+- `modules/orchestration-fallbacks.md` の `#ff-only-merge-fallback` エントリは Symptom/Fallback Steps/Escalation/Rationale の全セクションを新ロジックに合わせて全面書き換えし、旧 `git pull --rebase` ベースの記述を残さなかった。
+- `tests/worktree-merge-push.bats` に、foreign checkout かつ worktree 未検出時に bare な rebase/merge が一切発行されないことを検証する新規テストを追加し、AC1/AC2 の safety 特性をテストレベルでも担保した。
+
+### Deferred Items
+- Post-merge AC (複数セッション環境での実地確認) は manual verify-type のため、`/verify` フェーズでの人手確認待ち。
+- なし (その他のフォローアップ Issue は本実装スコープでは発生していない)。
+
+### Notes for Next Phase
+- Pre-merge AC 3件はいずれも rubric / file_not_contains ベースで PASS 判定済み、Issue 本文のチェックボックスは更新済み。
+- `bats tests/` フルスイート (1118 tests, 0 failures) を実行済み — `modules/orchestration-fallbacks.md` を参照する `tests/orchestration-fallbacks.bats` (schema validation) も含めて確認済み。
+- Post-merge の manual AC 確認時は、共有メインディレクトリが他ブランチを checkout した状態で `worktree-merge-push.sh --from <branch>` を実行し、ref-fetch が拒否されつつ bare な rebase/merge が一切発行されないことを実地で確認すること。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -209,7 +209,7 @@ Key modules:
 - `scripts/reconcile-phase-state.sh` — general-purpose state reconciler for precondition and completion checks across all phases; outputs JSON v1 per `modules/phase-state.md` SSoT (supersedes watchdog-reconcile.sh)
 - `scripts/wait-ci-checks.sh` — wait for all CI checks to complete on a PR before running claude
 - `scripts/pre-merge-check.sh` — baseline diff classifier: runs a specified check on both base and head branches in ephemeral worktrees; classifies result as NEW_FAILURE (exit 2) / PRE_EXISTING / FIXED / CLEAN (exit 0) / env error (exit 1)
-- `scripts/worktree-merge-push.sh` — acquire short-lived patch lock; fetch-after-lock, ff-only merge with is-ancestor rebase-skip, and push-retry loop (max 3) for parallel session race hardening
+- `scripts/worktree-merge-push.sh` — acquire short-lived patch lock; fetch-after-lock, checkout-less ref-fetch merge (`git fetch . <from>:<base>`) with is-ancestor rebase-skip, and push-retry loop (max 3) for parallel session race hardening
 - `scripts/detect-foreign-worktree.sh` — detect whether CWD is inside a foreign (different-owner) git worktree; used by `modules/worktree-lifecycle.md` Entry section
 - `scripts/detect-wrapper-anomaly.sh` — detect known failure patterns in shell wrapper output and generate Auto Retrospective markdown fragments
 - `scripts/test-failure-classify.sh` — classify test failure output into recovery categories (snapshot/mock/fixture/logic/infra); exit 0 = repairable, exit 1 = not repairable

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -35,43 +35,41 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 ## ff-only-merge-fallback
 
 ### Symptom
-- `git merge <branch> --ff-only` exits non-zero
-- Typical message: `fatal: Not possible to fast-forward, aborting.`
+- `git fetch . <from-branch>:<base-branch>` exits non-zero
+- Typical messages: `fatal: refusing to fetch into branch 'refs/heads/<base>' checked out at ...` (exit 128, base is checked out somewhere) or `! [rejected] ... (non-fast-forward)` (exit 1, not a fast-forward)
 
 ### Applicable Phases
 - code (patch route — `scripts/worktree-merge-push.sh`)
 - merge
 
 ### Fallback Steps
-0. Immediately after `acquire_lock` (before the `--from` merge block): run `git fetch origin <base-branch>` as best-effort — failure emits a warning to stderr but does not abort. This ensures that subsequent ff-only merge and rebase steps reference an up-to-date `origin/<base-branch>` ref rather than a stale local snapshot.
-1. Log the FF failure to stderr: `echo "FF merge failed, attempting git pull --rebase origin <base>..." >&2`
-2. Run `git pull --rebase origin <base-branch>` to bring the local branch up to date with remote
-3. Re-attempt `git merge <worktree-branch> --ff-only`
-4. If the second attempt also fails (base advanced while worktree was running — local base is already in sync with origin but worktree branch has diverged):
-   a. Log to stderr: `echo "FF merge still failed; base may have diverged. Rebasing ..." >&2`
-   4a. Run `git merge-base --is-ancestor "origin/<base-branch>" "<from-branch>"` to check whether the worktree branch already contains `origin/<base-branch>` as an ancestor:
-       - Exit 0 (ancestor): log "is-ancestor=true; skipping rebase" to stderr and skip to step 4e directly — the silent `git rebase` no-op path is eliminated
-       - Exit non-0 (not ancestor) or command error: fall through to step 4b
-   b. Detect the worktree path for FROM_BRANCH via `git worktree list --porcelain | awk -v b="refs/heads/<from>" '/^worktree /{p=$2} $0 == "branch " b {print p; exit}'`
-   c. If a worktree path is found: run `git -C <worktree-path> rebase origin/<base-branch>` (rebase from inside the checked-out worktree, which avoids the "already checked out" error); on conflict, run `git -C <worktree-path> rebase --abort 2>/dev/null || true` and exit 1
-   d. If no worktree path is found (branch not checked out in any worktree): run `git rebase <base-branch> <from-branch>`; on conflict, run `git rebase --abort 2>/dev/null || true` and exit 1
-   e. On successful rebase (or is-ancestor skip): re-attempt `git merge <worktree-branch> --ff-only` (third attempt); failure propagates via `set -e`
+0. Immediately after `acquire_lock` (before the `--from` merge block): run `git fetch origin <base-branch>` as best-effort — failure emits a warning to stderr but does not abort. This ensures that subsequent ref-fetch and rebase steps reference an up-to-date `origin/<base-branch>` ref rather than a stale local snapshot.
+1. **Primary path**: run `git fetch . "<from-branch>:<base-branch>"` — a checkout-less ref-to-ref fetch within the same repository. Git itself refuses this when `<base-branch>` is checked out in any worktree (exit 128) or when it would not be a fast-forward (exit 1), so success means `<base-branch>` was fast-forwarded without touching the shared directory's working tree or HEAD.
+2. If the ref-fetch fails, check whether the shared directory itself has `<base-branch>` checked out (`git rev-parse --abbrev-ref HEAD`):
+   - If it matches `<base-branch>`: this is the one case ref-fetch is expected to reject on its own target. Run `git merge <from-branch> --ff-only` in place (safe, since the shared directory genuinely is `<base-branch>`). Failure here aborts with exit 1 and an explicit "resolve manually" message.
+   - If it does not match `<base-branch>` (a true divergence, or another session's foreign checkout): continue to step 3. Do **not** fall back to a bare `git rebase`/`git merge` against the shared directory's current HEAD — that would reintroduce the checkout-dependent defect this fallback exists to close.
+3. Run `git merge-base --is-ancestor "origin/<base-branch>" "<from-branch>"` to check whether the worktree branch already contains `origin/<base-branch>` as an ancestor:
+   - Exit 0 (ancestor): log "is-ancestor=true; skipping rebase" to stderr and skip to step 6 directly — the silent `git rebase` no-op path is eliminated
+   - Exit non-0 (not ancestor) or command error: fall through to step 4
+4. Detect the worktree path for FROM_BRANCH via `git worktree list --porcelain | awk -v b="refs/heads/<from>" '/^worktree /{p=$2} $0 == "branch " b {print p; exit}'`
+5. If a worktree path is found: run `git -C <worktree-path> rebase origin/<base-branch>` (rebase from inside the checked-out worktree, which avoids touching the shared directory and avoids the "already checked out" error); on conflict, run `git -C <worktree-path> rebase --abort 2>/dev/null || true` and exit 1. If no worktree path is found (branch not checked out in any worktree), exit 1 with an explicit "resolve manually" message — a bare `git rebase <base> <from>` is not used, since it would implicitly check out `<from-branch>` in the shared directory, the same defect class this fallback closes.
+6. On successful rebase (or is-ancestor skip): re-attempt `git fetch . "<from-branch>:<base-branch>"` (not a third bare `git merge --ff-only` — the ref-fetch keeps this retry checkout-less too); failure propagates via `set -e`
 
 ### Escalation
-- If `git pull --rebase` itself fails (e.g., rebase conflict), abort with a non-zero exit and output an error message requesting manual conflict resolution
-- If the rebase in step 4 encounters conflicts, abort rebase and exit 1 — hand off to recovery sub-agent (#316) or request human intervention
-- Automatic rebase is attempted only once; no further looping after step 4e failure
+- If the ref-fetch in step 1 fails for a reason other than the shared directory holding `<base-branch>` checked out (step 2's non-matching branch), and no worktree is found for `<from-branch>` in step 5, abort with a non-zero exit and output an error message requesting manual resolution
+- If the rebase in step 5 encounters conflicts, abort rebase and exit 1 — hand off to recovery sub-agent (#316) or request human intervention
+- Automatic rebase is attempted only once; no further looping after step 6 failure
 - Push retry loop (max 3): after all merge/rebase steps complete, `git push origin <base>` failures trigger a `git fetch + git rebase origin/<base> + git push` retry up to 3 times. On the 3rd failure, abort with exit 1 and "Manual push required." message. Rebase conflict during retry aborts with exit 1 (policy D maintained — no auto-resolve).
 
 ### Rationale
 - Inline logic in `scripts/worktree-merge-push.sh`
-- `git pull --rebase` is preferred over `git merge origin/<base>` to preserve a linear history
-- Step 4 (base-diverged rebase) added in #522: the existing `git pull --rebase` retry (steps 1–3) only handles the case where local base lags origin; when local base is already in sync with origin but the worktree branch was forked before a concurrent merge advanced base, a second ff-only failure occurs and worktree-branch rebase is required
-- `git -C <worktree-path> rebase` is preferred over `git rebase <base> <branch>` when the branch is checked out in a worktree, because git rejects rebase of a branch that is currently checked out elsewhere ("already checked out")
+- `git fetch . <from>:<base>` is preferred over `git pull --rebase origin <base>` as the primary path because it never depends on, or mutates, the shared directory's current checkout — git's own ref-fetch safety checks (checked-out-branch refusal, non-fast-forward refusal) reproduce `--ff-only` safety guarantees without ever touching working tree state. This closes the defect reported in #961, where the old `git pull --rebase origin <base>` fallback ran unconditionally against whatever branch the shared directory happened to have checked out, silently rebasing an unrelated session's in-progress branch
+- Step 3 (base-diverged rebase) added in #522: when local base is already in sync with origin but the worktree branch was forked before a concurrent merge advanced base, the ref-fetch is rejected as non-fast-forward and a worktree-branch rebase is required
+- `git -C <worktree-path> rebase` is preferred over a bare `git rebase <base> <branch>` when the branch is checked out in a worktree, because a bare rebase implicitly checks out `<branch>` in the shared directory — the same checkout-dependent defect class this fallback closes; the non-worktree bare-rebase fallback was removed in #961 for the same reason
 - Step 0 (fetch-after-lock) added in #853: in parallel session environments, the `origin/<base>` ref may be stale at lock acquisition time; an explicit fetch immediately after the lock is acquired ensures all subsequent ref comparisons use current remote state
-- Step 4a (is-ancestor check) added in #853: when `git rebase` reports "Current branch is up to date" (is-ancestor=true) but the local main ref differs, the subsequent ff-only merge still fails silently; the explicit is-ancestor check detects this and skips directly to ff-only merge, eliminating the silent no-op path
+- Step 3 (is-ancestor check) added in #853: when `git rebase` reports "Current branch is up to date" (is-ancestor=true) but the local main ref differs, the subsequent ref-fetch still fails silently; the explicit is-ancestor check detects this and skips directly to the ref-fetch retry, eliminating the silent no-op path
 - Push retry loop added in #853: in parallel session environments a concurrent session may push between the worktree rebase and the local push, causing a non-fast-forward push failure; the retry loop (max 3, fetch+rebase+push each iteration) resolves this without requiring human intervention
-- See also: #314 (phase state reconciler), #308 (orchestration improvement series), #517 (incident that triggered #522), #853 (parallel session race hardening)
+- See also: #314 (phase state reconciler), #308 (orchestration improvement series), #517 (incident that triggered #522), #853 (parallel session race hardening), #961 (checkout-less ref-fetch replacement for the `git pull --rebase` fallback, and removal of the non-worktree bare-rebase branch)
 
 ---
 

--- a/scripts/worktree-merge-push.sh
+++ b/scripts/worktree-merge-push.sh
@@ -81,11 +81,20 @@ git fetch origin "$BASE_BRANCH" 2>&1 || echo "Warning: git fetch origin ${BASE_B
 
 if [[ -n "$FROM_BRANCH" ]]; then
   # See modules/orchestration-fallbacks.md#ff-only-merge-fallback
-  if ! git merge "$FROM_BRANCH" --ff-only; then
-    echo "FF merge failed, attempting git pull --rebase origin ${BASE_BRANCH}..." >&2
-    git pull --rebase origin "$BASE_BRANCH"
-    if ! git merge "$FROM_BRANCH" --ff-only; then
-      echo "FF merge still failed; base may have diverged. Rebasing ..." >&2
+  # Primary path: a checkout-less ref-to-ref fetch. git itself refuses this when
+  # BASE_BRANCH is checked out in any worktree (exit 128) or when it would not be a
+  # fast-forward (exit 1) -- giving --ff-only-equivalent safety without touching the
+  # shared directory's working tree or HEAD.
+  if ! git fetch . "${FROM_BRANCH}:${BASE_BRANCH}"; then
+    current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ "$current_branch" == "$BASE_BRANCH" ]]; then
+      echo "ref-fetch rejected because ${BASE_BRANCH} is checked out here; merging in place instead..." >&2
+      if ! git merge "$FROM_BRANCH" --ff-only; then
+        echo "Error: FF merge failed even though ${BASE_BRANCH} is checked out locally. Resolve manually." >&2
+        exit 1
+      fi
+    else
+      echo "ref-fetch rejected; base may have diverged. Checking ancestry..." >&2
       if git merge-base --is-ancestor "origin/${BASE_BRANCH}" "$FROM_BRANCH" 2>/dev/null; then
         echo "Branch ${FROM_BRANCH} is already on origin/${BASE_BRANCH} (is-ancestor=true); skipping rebase" >&2
       else
@@ -97,14 +106,14 @@ if [[ -n "$FROM_BRANCH" ]]; then
             exit 1
           fi
         else
-          if ! git rebase "$BASE_BRANCH" "$FROM_BRANCH"; then
-            git rebase --abort 2>/dev/null || true
-            echo "Error: Rebase of ${FROM_BRANCH} onto ${BASE_BRANCH} failed with conflicts. Resolve manually." >&2
-            exit 1
-          fi
+          echo "Error: Cannot locate a worktree for ${FROM_BRANCH} to rebase without touching the shared directory's checkout. Resolve manually." >&2
+          exit 1
         fi
       fi
-      git merge "$FROM_BRANCH" --ff-only
+      if ! git fetch . "${FROM_BRANCH}:${BASE_BRANCH}"; then
+        echo "Error: ref-fetch of ${FROM_BRANCH} into ${BASE_BRANCH} still failed after rebase. Resolve manually." >&2
+        exit 1
+      fi
     fi
   fi
 

--- a/tests/worktree-merge-push.bats
+++ b/tests/worktree-merge-push.bats
@@ -124,14 +124,15 @@ MOCK
     grep -q -- ':-300}' "$SCRIPT"
 }
 
-@test "--from triggers git merge --ff-only" {
+@test "--from triggers checkout-less ref-fetch (primary path)" {
     run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
     [ "$status" -eq 0 ]
-    grep -q "merge test-branch --ff-only" "$GIT_LOG"
+    grep -q "fetch . test-branch:main" "$GIT_LOG"
     grep -q "push origin main" "$GIT_LOG"
+    ! grep -q "merge test-branch --ff-only" "$GIT_LOG"
 }
 
-@test "--from with FF failure triggers git pull --rebase and retry" {
+@test "--from with ref-fetch rejected while base is checked out locally merges in place" {
     cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
 echo "\$@" >> "$GIT_LOG"
@@ -139,13 +140,14 @@ if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
     echo "${BATS_TEST_TMPDIR}/test-repo"
     exit 0
 fi
+if [[ "\$1" == "fetch" && "\$2" == "." ]]; then
+    exit 1
+fi
+if [[ "\$1" == "rev-parse" && "\$2" == "--abbrev-ref" ]]; then
+    echo "main"
+    exit 0
+fi
 if [[ "\$1" == "merge" ]]; then
-    COUNT_FILE="${BATS_TEST_TMPDIR}/merge_count"
-    count=0
-    [ -f "\$COUNT_FILE" ] && count=\$(cat "\$COUNT_FILE")
-    count=\$((count + 1))
-    echo "\$count" > "\$COUNT_FILE"
-    [ "\$count" -eq 1 ] && exit 1
     exit 0
 fi
 exit 0
@@ -154,9 +156,10 @@ MOCK
 
     run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"FF merge failed"* ]]
-    grep -q "pull --rebase origin main" "$GIT_LOG"
+    [[ "$output" == *"checked out here; merging in place"* ]]
+    grep -q "merge test-branch --ff-only" "$GIT_LOG"
     grep -q "push origin main" "$GIT_LOG"
+    ! grep -q "pull --rebase" "$GIT_LOG"
 }
 
 @test "--base targets non-main branch" {
@@ -176,14 +179,17 @@ if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
     echo "${BATS_TEST_TMPDIR}/test-repo"
     exit 0
 fi
-if [[ "\$1" == "merge" ]]; then
-    COUNT_FILE="${BATS_TEST_TMPDIR}/merge_count"
+if [[ "\$1" == "rev-parse" && "\$2" == "--abbrev-ref" ]]; then
+    echo "other-branch"
+    exit 0
+fi
+if [[ "\$1" == "fetch" && "\$2" == "." ]]; then
+    COUNT_FILE="${BATS_TEST_TMPDIR}/fetch_count"
     count=0
     [ -f "\$COUNT_FILE" ] && count=\$(cat "\$COUNT_FILE")
     count=\$((count + 1))
     echo "\$count" > "\$COUNT_FILE"
-    # First two merge attempts fail; third succeeds
-    [ "\$count" -le 2 ] && exit 1
+    [ "\$count" -eq 1 ] && exit 1
     exit 0
 fi
 if [[ "\$1" == "worktree" && "\$2" == "list" ]]; then
@@ -206,8 +212,11 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" == *"base may have diverged"* ]]
     grep -q "worktree list --porcelain" "$GIT_LOG"
-    grep -q "rebase origin/main" "$GIT_LOG"
+    grep -q -- "-C ${WORKTREE_PATH} rebase origin/main" "$GIT_LOG"
     grep -q "push origin main" "$GIT_LOG"
+    ! grep -q "merge test-branch --ff-only" "$GIT_LOG"
+    fetch_count=$(grep -c "fetch . test-branch:main" "$GIT_LOG")
+    [ "$fetch_count" -eq 2 ]
 }
 
 @test "--from with base-diverged and rebase conflict aborts and exits non-zero" {
@@ -221,11 +230,12 @@ if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
     echo "${BATS_TEST_TMPDIR}/test-repo"
     exit 0
 fi
-if [[ "\$1" == "merge" ]]; then
-    exit 1
-fi
-if [[ "\$1" == "pull" ]]; then
+if [[ "\$1" == "rev-parse" && "\$2" == "--abbrev-ref" ]]; then
+    echo "other-branch"
     exit 0
+fi
+if [[ "\$1" == "fetch" && "\$2" == "." ]]; then
+    exit 1
 fi
 if [[ "\$1" == "worktree" && "\$2" == "list" ]]; then
     printf "worktree ${WORKTREE_PATH}\nbranch refs/heads/test-branch\n\n"
@@ -246,6 +256,40 @@ MOCK
     run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Rebase"*"failed with conflicts"* ]]
+    ! grep -q "push" "$GIT_LOG"
+}
+
+@test "--from with foreign checkout and no worktree found aborts without touching shared directory" {
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
+    echo "${BATS_TEST_TMPDIR}/test-repo"
+    exit 0
+fi
+if [[ "\$1" == "rev-parse" && "\$2" == "--abbrev-ref" ]]; then
+    echo "some-other-session-branch"
+    exit 0
+fi
+if [[ "\$1" == "fetch" && "\$2" == "." ]]; then
+    exit 1
+fi
+if [[ "\$1" == "worktree" && "\$2" == "list" ]]; then
+    printf ""
+    exit 0
+fi
+if [[ "\$1" == "merge-base" && "\$2" == "--is-ancestor" ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Cannot locate a worktree"* ]]
+    ! grep -q "merge test-branch --ff-only" "$GIT_LOG"
+    ! grep -qE "^rebase " "$GIT_LOG"
     ! grep -q "push" "$GIT_LOG"
 }
 
@@ -286,13 +330,17 @@ if [[ "\$1" == "rev-parse" && "\$2" == "--show-toplevel" ]]; then
     echo "${BATS_TEST_TMPDIR}/test-repo"
     exit 0
 fi
-if [[ "\$1" == "merge" ]]; then
-    COUNT_FILE="${BATS_TEST_TMPDIR}/merge_count"
+if [[ "\$1" == "rev-parse" && "\$2" == "--abbrev-ref" ]]; then
+    echo "other-branch"
+    exit 0
+fi
+if [[ "\$1" == "fetch" && "\$2" == "." ]]; then
+    COUNT_FILE="${BATS_TEST_TMPDIR}/fetch_count"
     count=0
     [ -f "\$COUNT_FILE" ] && count=\$(cat "\$COUNT_FILE")
     count=\$((count + 1))
     echo "\$count" > "\$COUNT_FILE"
-    [ "\$count" -le 2 ] && exit 1
+    [ "\$count" -eq 1 ] && exit 1
     exit 0
 fi
 # merge-base --is-ancestor: return 0 (ancestor=true) so rebase is skipped
@@ -309,6 +357,8 @@ MOCK
     ! grep -q "rebase origin/main" "$GIT_LOG"
     ! grep -qE "\-C .+ rebase" "$GIT_LOG"
     grep -q "push origin main" "$GIT_LOG"
+    fetch_count=$(grep -c "fetch . test-branch:main" "$GIT_LOG")
+    [ "$fetch_count" -eq 2 ]
 }
 
 @test "max-retry exhaustion: push always fails and script exits with error" {


### PR DESCRIPTION
## Summary
- `scripts/worktree-merge-push.sh` の FF マージ処理を、working directory の checkout に一切依存しない `git fetch . <from>:<base>` (ref-to-ref fetch) を primary path とするロジックに書き換え。git 自身の safety チェック (checked-out-branch 拒否 / non-fast-forward 拒否) により `--ff-only` と同等の安全性を checkout レスで実現する。
- 共有ディレクトリの現在の checkout 状態に暗黙に依存していた `git pull --rebase origin <base>` フォールバックを完全に削除。base が共有ディレクトリで checkout されている唯一のケースのみ、その場での `git merge --ff-only` にフォールバックする。
- 非 worktree (bare) な `git rebase <base> <from>` フォールバックも削除。worktree が見つからない場合は "resolve manually" の明示エラーで exit 1 とする (これも共有ディレクトリの checkout を暗黙に変更してしまうため)。
- `modules/orchestration-fallbacks.md` の `#ff-only-merge-fallback` エントリを新ロジックに合わせて更新。
- `tests/worktree-merge-push.bats` の該当テストの git モック呼び出し順序を新 primary path に合わせて更新し、foreign checkout かつ worktree 未検出時に bare な rebase/merge が一切発行されないことを検証する新規テストを追加。
- `docs/structure.md` / `docs/ja/structure.md` の一行説明を checkout レス設計に合わせて更新。

## Verification (pre-merge)
- scripts/worktree-merge-push.sh が checkout レスのマージ処理 (`git fetch . <from>:<base>`) に書き換えられている
- スクリプト内に `git pull --rebase` フォールバックが残っていないことを確認
- modules/orchestration-fallbacks.md の `#ff-only-merge-fallback` が checkout 非依存の手順に更新されている
- `bats tests/` フルスイート (1118 tests) が全て PASS

## Verification (post-merge)
- 複数セッションが同一リポジトリで同時に worktree 作業と直接作業 (checkout) を行う環境で、`/verify`・`/spec`・`/code --patch` の merge-to-main が他セッションのブランチに影響しないことを実地確認する (manual)

closes #961
