### PR TITLE
Issue #962: scripts: 自身の格納先リポジトリを誤操作する repo-root 算出パターンを複数スクリプトで修正

### DIFF
--- a/docs/spec/issue-962-fix-repo-root-computation.md
+++ b/docs/spec/issue-962-fix-repo-root-computation.md
@@ -88,3 +88,31 @@ fi
 
 ### Size 再評価の見込み
 本 Issue は triage 時点で Size=S (patch route) だが、実際の Changed Files は本番スクリプト5件 + テスト3件の計8件となり、`modules/size-workflow-table.md` の Axis 1 (6-10件 → L) に該当する。Axis 2 の「root cause の明確なバグ修正 (-1 step)」を適用しても M 相当となる可能性が高い。Step 18 (Size-to-Workflow Determination) で正式に再評価し、必要であれば pr route (M) に昇格する。参考: Issue #966 (対象1ファイル + テスト1ファイルの計2件、同種の修正) は Size=S/patch route のまま完了しているが、本 Issue は対象ファイル数が5倍のため異なる判断になる可能性がある。
+
+## Code Retrospective
+
+### Deviations from Design
+- Spec の Size 再評価見込み (Notes 末尾) を待たず、`--pr --non-interactive` フラグが明示指定されていたため pr route (branch+PR) で実行した。明示フラグは Size 自動判定より優先される既定の挙動であり、逸脱ではなく設計通りの優先順位適用。
+
+### Design Gaps/Ambiguities
+- Spec の Changed Files は `tests/append-consumed-comments-section.bats`・`tests/run-code.bats`・`tests/apply-fallback.bats` の3ファイルのみを変更対象として列挙していたが、実装後の `bats tests/` フルスイート実行で `tests/run-verify.bats` (同じく `append-consumed-comments-section.sh` を対象とする別系統のテストスイート) が4件 FAIL した。原因は同ファイルの `setup()` デフォルト `$MOCK_DIR/git` モックと2箇所の個別テスト内モックがいずれも `rev-parse --show-toplevel` 未対応で、`_repo_root` が空文字列に解決されたため。Spec の「横断確認」は `scripts/*.sh` 側のみを対象としており、`tests/` 側で同一スクリプトを参照する別スイートの網羅までは対象にしていなかった。同様の齟齬を避けるため、今後 repo-root 算出パターンを変更する Issue では `git grep -l "<変更対象スクリプト名>" tests/` で影響テストファイルを事前に洗い出すことを推奨する。
+- Spec は `tests/run-code.bats` の git モック上書き4箇所 (stale-branch/signoff×2/stash) を「対象外で問題ない」と分類していたが、実際には stash テスト (`auto-retry: preflight stashes parent-main stray untracked file before retry re-invocation`) のみ `_REPO_ROOT` (→ `.wholework.yml` の `auto-retry-on-fail` 判定) に依存しており、ハンドラ追加が必要だった。他の3箇所 (stale-branch/signoff×2) は該当コードパスが `_REPO_ROOT` を経由しないため無害という判定は正しかった。「4箇所とも対象外」という一括判定ではなく、各上書きモックが `_REPO_ROOT`/`_WW_YML` 依存パスに到達するかを個別に確認する必要があった。
+
+### Rework
+- なし (実装は Spec Implementation Steps 1-5 の順に一度で完了。上記2件のテストギャップはフルスイート実行時に発見・その場で追加修正し、そのまま最終コミットに含めた)
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Size=S だが `--pr --non-interactive` の明示フラグに従い pr route (branch+PR) で実行した (Size 自動判定より明示フラグを優先する既定ルール通り)。
+- 対象5ファイルすべてで `git rev-parse --show-toplevel 2>/dev/null || pwd` パターンに統一し、`#966` (`run-auto-sub.sh`) で確立済みのパターンを踏襲した。
+- `bats tests/` フルスイートで behavioral change を検出したため (`grep -rl` で対象スクリプト名が Spec 未記載のテストファイルにもヒット)、narrow scope ではなくフルスイートを実行し、Spec 未記載だった `tests/run-verify.bats` のテストギャップを実装段階で発見・修正した。
+
+### Deferred Items
+- `scripts/check-file-overlap.sh:36` の同型パターンは Spec Notes の通り本 Issue のスコープ外とし、follow-up Issue での対応を推奨する (dead code かつ既存テストとの分離設計に緊張関係があるため単純な置換では済まない)。
+- Post-merge AC (別プロジェクト実地確認) は manual verify-type のため `/verify` フェーズでの人手確認待ち。
+
+### Notes for Next Phase
+- `/review` では Spec Notes の「Size 再評価の見込み」記述 (実際の Changed Files 8件は Axis 1 で L 相当) を踏まえつつ、明示 `--pr` 指定により pr route が既に適用済みである点を前提に進めてよい。
+- Code Retrospective の Design Gaps 2件 (テストスイート網羅漏れ、git モック上書き箇所の個別依存判定) は、今後同種の repo-root 修正 Issue のレビュー観点として活用できる。

--- a/docs/spec/issue-962-fix-repo-root-computation.md
+++ b/docs/spec/issue-962-fix-repo-root-computation.md
@@ -101,18 +101,28 @@ fi
 ### Rework
 - なし (実装は Spec Implementation Steps 1-5 の順に一度で完了。上記2件のテストギャップはフルスイート実行時に発見・その場で追加修正し、そのまま最終コミットに含めた)
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+Code Retrospective で報告済みの2件 (`tests/run-verify.bats` の Spec 未記載、`tests/run-code.bats` stash テストの個別依存判定漏れ) 以外に、review-light によるフルスコープ再確認でも新規の乖離は検出されなかった。5スクリプトの修正内容は Spec Implementation Steps と行単位で一致していた。
+
+### Recurring issues
+`dirname "$SCRIPT_DIR"` による repo-root 誤算出パターンは #966 (`worktree-merge-push.sh`) → 本 Issue (5ファイル) → `check-file-overlap.sh:36` (follow-up 対象として特定済み、未着手) と複数 Issue にまたがって出現している。同種パターンが `scripts/` 配下に散発する背景には、プラグインとして他プロジェクトから呼び出される wholework の実行モデル (`SCRIPT_DIR` がプラグインインストール場所を指し、CWD ベースの repo root と乖離する) があり、根本的な再発防止には「新規スクリプト追加時に repo-root 算出を `git rev-parse --show-toplevel` ベースの共通ヘルパーに強制する」仕組み (lint ルールや共有関数化) が有効な可能性がある。現状は Issue 単位のスポット修正が続いている。
+
+### Acceptance criteria verification difficulty
+UNCERTAIN なし。5件の `grep "git rev-parse --show-toplevel"` AC は機械的に一意に判定でき、横断確認 rubric も `dirname "$SCRIPT_DIR"` の再 grep で客観的に検証できた。Issue Notes に記載の通り「rubric → 機械検証への差し替え」が事前に行われていたことが、今回の検証容易性に直接寄与している。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Size=S だが `--pr --non-interactive` の明示フラグに従い pr route (branch+PR) で実行した (Size 自動判定より明示フラグを優先する既定ルール通り)。
-- 対象5ファイルすべてで `git rev-parse --show-toplevel 2>/dev/null || pwd` パターンに統一し、`#966` (`run-auto-sub.sh`) で確立済みのパターンを踏襲した。
-- `bats tests/` フルスイートで behavioral change を検出したため (`grep -rl` で対象スクリプト名が Spec 未記載のテストファイルにもヒット)、narrow scope ではなくフルスイートを実行し、Spec 未記載だった `tests/run-verify.bats` のテストギャップを実装段階で発見・修正した。
+- Size M (`get-issue-size.sh` 値) だが `--light --non-interactive` の明示フラグに従い light mode (review-light 1 エージェント統合レビュー) で実行した。
+- 5件の grep AC・横断確認 rubric AC をすべて自ら独立に再検証 (grep 実行) してから PASS 判定した。既に Issue 側で `[x]` 済みだった状態と一致することを確認し、チェックボックスの再更新は no-op とした。
 
 ### Deferred Items
-- `scripts/check-file-overlap.sh:36` の同型パターンは Spec Notes の通り本 Issue のスコープ外とし、follow-up Issue での対応を推奨する (dead code かつ既存テストとの分離設計に緊張関係があるため単純な置換では済まない)。
+- `scripts/check-file-overlap.sh:36` の同型パターン修正は本 Issue のスコープ外のまま (follow-up Issue 未起票)。
 - Post-merge AC (別プロジェクト実地確認) は manual verify-type のため `/verify` フェーズでの人手確認待ち。
 
 ### Notes for Next Phase
-- `/review` では Spec Notes の「Size 再評価の見込み」記述 (実際の Changed Files 8件は Axis 1 で L 相当) を踏まえつつ、明示 `--pr` 指定により pr route が既に適用済みである点を前提に進めてよい。
-- Code Retrospective の Design Gaps 2件 (テストスイート網羅漏れ、git モック上書き箇所の個別依存判定) は、今後同種の repo-root 修正 Issue のレビュー観点として活用できる。
+- `/merge` は MUST issue なし・CI 全 SUCCESS のため通常フローで進めてよい。
+- `/verify` では Post-merge AC (tofas 等別プロジェクトでの実地確認) が唯一の残タスク。

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -18,7 +18,7 @@ if [[ -z "$ISSUE_NUMBER" || -z "$PHASE_NAME" ]]; then
 fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
-_repo_root="$(dirname "$SCRIPT_DIR")"
+_repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Get spec directory (pass config path explicitly to avoid CWD sensitivity)
 SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="$_repo_root/.wholework.yml" \

--- a/scripts/apply-fallback.sh
+++ b/scripts/apply-fallback.sh
@@ -9,6 +9,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 PHASE="${1:?Usage: apply-fallback.sh <phase> <issue> --log <log-file>}"
 ISSUE="${2:?Usage: apply-fallback.sh <phase> <issue> --log <log-file>}"
@@ -96,7 +97,7 @@ apply_dco_signoff_autofix() {
 # is not mistakenly reported as recovered (Issues #895, #904).
 apply_code_patch_silent_no_op_retry() {
   local _ww_yml
-  _ww_yml="$(dirname "$SCRIPT_DIR")/.wholework.yml"
+  _ww_yml="${REPO_ROOT}/.wholework.yml"
   local _auto_retry_enabled="false"
   if [[ -f "$_ww_yml" ]]; then
     local _raw

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -128,7 +128,7 @@ else
 fi
 
 AUTONOMY_TIER=$("$SCRIPT_DIR/get-config-value.sh" autonomy L1 2>/dev/null || echo L1)
-_REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 _WW_YML="${_REPO_ROOT}/.wholework.yml"
 AUTO_RETRY_ENABLED="false"
 AUTO_RETRY_MAX_ITERATIONS=3
@@ -237,9 +237,9 @@ fi
 
 # Pre-count: capture ## Consumed Comments section count before claude runs.
 # Used by post-processor fallback to detect when LLM silently skipped writeback.
-_SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="$(dirname "$SCRIPT_DIR")/.wholework.yml" \
+_SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="${_REPO_ROOT}/.wholework.yml" \
   "$SCRIPT_DIR/get-config-value.sh" spec-path docs/spec 2>/dev/null || echo "docs/spec")
-_SPEC_FILE_PRE=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+_SPEC_FILE_PRE=$(ls "${_REPO_ROOT}/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
 _PRE_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_PRE:-/dev/null}" 2>/dev/null || true)
 _PRE_COUNT="${_PRE_COUNT:-0}"
 
@@ -364,7 +364,7 @@ fi
 # Post-processor fallback: if LLM did not append ## Consumed Comments, do it now.
 # Compare post-count with pre-count; trigger fallback when count did not increase.
 if [[ $EXIT_CODE -eq 0 ]]; then
-  _SPEC_FILE_POST=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+  _SPEC_FILE_POST=$(ls "${_REPO_ROOT}/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
   _POST_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_POST:-/dev/null}" 2>/dev/null || true)
   _POST_COUNT="${_POST_COUNT:-0}"
   if [[ "$_POST_COUNT" -le "$_PRE_COUNT" ]]; then

--- a/scripts/run-spec.sh
+++ b/scripts/run-spec.sh
@@ -41,6 +41,7 @@ if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
 fi
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
 # Session isolation check: detect other-session dirty files (best-effort)
 if [[ -x "${SCRIPT_DIR}/check-verify-dirty.sh" ]]; then
@@ -145,9 +146,9 @@ ARGUMENTS: ${ISSUE_NUMBER} --non-interactive"
 
 # Pre-count: capture ## Consumed Comments section count before claude runs.
 # Used by post-processor fallback to detect when LLM silently skipped writeback.
-_SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="$(dirname "$SCRIPT_DIR")/.wholework.yml" \
+_SPEC_DIR=$(WHOLEWORK_CONFIG_PATH="${REPO_ROOT}/.wholework.yml" \
   "$SCRIPT_DIR/get-config-value.sh" spec-path docs/spec 2>/dev/null || echo "docs/spec")
-_SPEC_FILE_PRE=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+_SPEC_FILE_PRE=$(ls "${REPO_ROOT}/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
 _PRE_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_PRE:-/dev/null}" 2>/dev/null || true)
 _PRE_COUNT="${_PRE_COUNT:-0}"
 
@@ -188,7 +189,7 @@ fi
 # Post-processor fallback: if LLM did not append ## Consumed Comments, do it now.
 # Compare post-count with pre-count; trigger fallback when count did not increase.
 if [[ $EXIT_CODE -eq 0 ]]; then
-  _SPEC_FILE_POST=$(ls "$(dirname "$SCRIPT_DIR")/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
+  _SPEC_FILE_POST=$(ls "${REPO_ROOT}/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
   _POST_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_POST:-/dev/null}" 2>/dev/null || true)
   _POST_COUNT="${_POST_COUNT:-0}"
   if [[ "$_POST_COUNT" -le "$_PRE_COUNT" ]]; then

--- a/scripts/spawn-recovery-subagent.sh
+++ b/scripts/spawn-recovery-subagent.sh
@@ -10,6 +10,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
 
 PHASE="${1:?Usage: spawn-recovery-subagent.sh <phase> <issue> --log <log-file>}"
@@ -205,7 +206,7 @@ fi
 write_recovery_entry() {
   local action="$1"
   local report_file
-  report_file="$(dirname "$SCRIPT_DIR")/docs/reports/orchestration-recoveries.md"
+  report_file="${REPO_ROOT}/docs/reports/orchestration-recoveries.md"
   if [[ ! -f "$report_file" ]]; then
     echo "[spawn-recovery] orchestration-recoveries.md not found; skipping record" >&2
     return 0

--- a/tests/append-consumed-comments-section.bats
+++ b/tests/append-consumed-comments-section.bats
@@ -36,10 +36,14 @@ exit 0
 MOCK
     chmod +x "$MOCK_DIR/gh"
 
-    cat > "$MOCK_DIR/git" <<'MOCK'
+    cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
-if [[ " $* " == *" diff "* ]] && [[ " $* " == *" --quiet "* ]]; then
+if [[ " \$* " == *" diff "* ]] && [[ " \$* " == *" --quiet "* ]]; then
     exit 1
+fi
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$REPO_ROOT"
+    exit 0
 fi
 exit 0
 MOCK

--- a/tests/apply-fallback.bats
+++ b/tests/apply-fallback.bats
@@ -15,18 +15,22 @@ setup() {
     export GIT_PUSH_LOG="$BATS_TEST_TMPDIR/git-push.log"
 
     # Mock git: capture amend and push invocations
-    cat > "$MOCK_DIR/git" <<'MOCK'
+    cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
-if [[ "$1" == "rev-parse" && "$2" == "--abbrev-ref" ]]; then
+if [[ "\$1" == "rev-parse" && "\$2" == "--abbrev-ref" ]]; then
     echo "worktree-code+issue-42"
     exit 0
 fi
-if [[ "$1" == "commit" && "$*" == *"--amend"* ]]; then
-    echo "$@" >> "$GIT_AMEND_LOG"
+if [[ "\$1" == "commit" && "\$*" == *"--amend"* ]]; then
+    echo "\$@" >> "$GIT_AMEND_LOG"
     exit 0
 fi
-if [[ "$1" == "push" && "$*" == *"--force-with-lease"* ]]; then
-    echo "$@" >> "$GIT_PUSH_LOG"
+if [[ "\$1" == "push" && "\$*" == *"--force-with-lease"* ]]; then
+    echo "\$@" >> "$GIT_PUSH_LOG"
+    exit 0
+fi
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
     exit 0
 fi
 exit 0

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -101,8 +101,12 @@ MOCK
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/guard-prefix.sh" "$MOCK_DIR/guard-prefix.sh"
     cp "$(dirname "$BATS_TEST_FILENAME")/../scripts/retry-on-kill.sh" "$MOCK_DIR/retry-on-kill.sh"
 
-    cat > "$MOCK_DIR/git" <<'MOCK'
+    cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
+    exit 0
+fi
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/git"
@@ -846,6 +850,10 @@ if [[ "\$1" == "ls-files" ]]; then
 fi
 if [[ "\$1" == "stash" && "\$2" == "push" ]]; then
   rm -f "$STRAY_FILE"
+  exit 0
+fi
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+  echo "$BATS_TEST_TMPDIR"
   exit 0
 fi
 exit 0

--- a/tests/run-verify.bats
+++ b/tests/run-verify.bats
@@ -48,8 +48,12 @@ MOCK
     chmod +x "$MOCK_DIR/gh"
 
     # Default git mock: no changes (diff --quiet exits 0 = no diff)
-    cat > "$MOCK_DIR/git" <<'MOCK'
+    cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
+    exit 0
+fi
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/git"
@@ -98,6 +102,10 @@ teardown() {
     export GIT_LOG
     cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
+    exit 0
+fi
 echo "GIT_CALLED: \$*" >> "${GIT_LOG}"
 exit 0
 MOCK
@@ -155,6 +163,10 @@ MOCK
     # Note: script calls "git -C /repo/root diff --quiet", so $3 == "diff"
     cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
+    exit 0
+fi
 if [[ "\$3" == "diff" && "\$*" == *"--quiet"* ]]; then
     exit 1
 fi


### PR DESCRIPTION
## Summary
- tofas #12 の `/verify` 実行中 (2026-07-09) に発生した誤 push インシデントの再発防止として、`_repo_root`/`_REPO_ROOT` 系変数の算出を「スクリプト自身の格納パス起点」から「呼び出し元 CWD 起点の `git rev-parse --show-toplevel`」へ統一
- 対象は Issue Cross-scan Findings で確認された5ファイル: `append-consumed-comments-section.sh` / `spawn-recovery-subagent.sh` / `run-spec.sh` / `run-code.sh` / `apply-fallback.sh`
- `--plugin-dir` 用途の既存 `dirname "$SCRIPT_DIR")"` (プラグイン自身のインストール場所を渡す正当な用途) は変更対象外
- `tests/append-consumed-comments-section.bats` / `tests/run-code.bats` / `tests/apply-fallback.bats` / `tests/run-verify.bats` の `$MOCK_DIR/git` モックに `rev-parse --show-toplevel` ハンドラを追加 (Spec には未記載だった `tests/run-verify.bats` も、実装後のフルスイート実行で追加のテスト依存が判明したため対応)
- `scripts/*.sh` 全体を横断確認し、上記5ファイル以外に同種パターンが残っていないことを確認 (除外対象・follow-up 対象は Spec Notes に記載済み)

## Verification (pre-merge)
- `grep "git rev-parse --show-toplevel"` で5ファイルそれぞれの修正を確認 (PASS)
- 横断確認 rubric: `scripts/*.sh` 全体を再 grep し、対象5ファイル以外に同種パターンが残っていないことを確認 (PASS)
- `bats tests/` フルスイート 1118 件 PASS

## Verification (post-merge)
- 別プロジェクト (tofas 等) の worktree 内から `/verify` および `/spec`/`/code` (comment-consumption フォールバックが発火するケース) を実行し、Consumed Comments セクション・orchestration-recoveries.md への追記・auto-retry-on-fail 設定判定のいずれもが呼び出し元プロジェクトの正しいリポジトリ/設定に対して行われることを実地確認する (manual)

closes #962
