### PR TITLE
Issue #964: Add matches_expected guard to Tier 3 recovery skip action

### DIFF
--- a/docs/spec/issue-964-recovery-skip-guard.md
+++ b/docs/spec/issue-964-recovery-skip-guard.md
@@ -80,3 +80,30 @@
 - **Steering Docs sync candidate 6件は変更不要の見込み**: `docs/product.md`/`docs/structure.md`/`docs/tech.md`/日本語ミラー3件は `spawn-recovery-subagent.sh` に言及するが、いずれも Tier 3 全体の役割 (サブエージェント起動・バリデーション・並行制御・recovery entry 記録) を抽象度高く説明しており、`skip` 分岐内部のガード有無という実装詳細には踏み込んでいない (grep 済み、既存記述はそのまま正確)。`doc-checker.md` の必須列挙ルールに従い候補として列挙したが、`/code` フェーズでの実読による最終確認を経ても変更不要と判断される可能性が高い。
 - **tests/run-auto-sub.bats・tests/auto-sub-observability.bats はソース変更不要**: 両ファイルとも `setup()` で `$MOCK_DIR/spawn-recovery-subagent.sh` 自体を丸ごとモックスクリプトに置き換えており (`run-auto-sub.sh` 側から見て `WHOLEWORK_SCRIPT_DIR` 経由で解決される)、実体である `scripts/spawn-recovery-subagent.sh` のロジック変更の影響を受けない。Issue 本文 AC3 が両ファイルを「cross-file test coupling」としてフルスイートに含めているのは安全網としての実行であり、ソース側の修正が必要という意味ではないことを確認済み。
 - **Issue body の背景記述との整合性確認**: Background に記載された行番号 (111行目の `RECONCILE_OUTPUT`、289-313行目の `skip)` 分岐) は実装コードの現況と一致しており、コンフリクトは検出しなかった。
+
+## Code Retrospective
+
+### Deviations from Design
+N/A — 実装は Implementation Steps 1-3 の記述通り。
+
+### Design Gaps/Ambiguities
+N/A
+
+### Rework
+N/A — Spec の設計 (fail-closed、abort と同じ exit code 契約、write_recovery_entry を呼ばない) をそのまま実装し、関連4ファイルのフルスイート (72件) がローカルで一発 pass した。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec Notes の fail-closed 判断をそのまま採用: `RECONCILE_OUTPUT` が空/パース不能な場合も `matches_expected != true` として拒否側に倒した (`python3 -c` の `except Exception: print('false')`)
+- 拒否時は `abort` 分岐と同じ契約 (`write_recovery_entry` を呼ばず非ゼロ exit) に揃え、retry/recover への自動フォールバックは行わない設計を維持
+
+### Deferred Items
+- AC3 (`github_check`) は PR #978 の CI 実行完了後にのみ確認可能なため、Issue のチェックボックスは AC1・AC2 のみ更新済み (AC3 は未チェックのまま `/review` フェーズ以降で確認)
+- Steering Docs sync candidate 6件 (`docs/product.md`/`docs/structure.md`/`docs/tech.md` と日本語ミラー) は grep で内容確認済みで変更不要と判断 (Spec Notes の見立て通り)
+
+### Notes for Next Phase
+- `/review` フェーズでは PR #978 の CI (`test.yml` ワークフローの "Run bats tests" ジョブ) が pass することを確認し、AC3 のチェックボックスを更新すること
+- ローカルでは `bats tests/spawn-recovery-subagent.bats tests/auto-recovery.bats tests/run-auto-sub.bats tests/auto-sub-observability.bats` の72件が全て pass 済み
+- 未解決の Uncertainties や設計上の懸念は残っていない

--- a/docs/spec/issue-964-recovery-skip-guard.md
+++ b/docs/spec/issue-964-recovery-skip-guard.md
@@ -93,17 +93,26 @@ N/A
 N/A — Spec の設計 (fail-closed、abort と同じ exit code 契約、write_recovery_entry を呼ばない) をそのまま実装し、関連4ファイルのフルスイート (72件) がローカルで一発 pass した。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec Notes の fail-closed 判断をそのまま採用: `RECONCILE_OUTPUT` が空/パース不能な場合も `matches_expected != true` として拒否側に倒した (`python3 -c` の `except Exception: print('false')`)
-- 拒否時は `abort` 分岐と同じ契約 (`write_recovery_entry` を呼ばず非ゼロ exit) に揃え、retry/recover への自動フォールバックは行わない設計を維持
+- Step 3 のレビュー深度判定で `--light` 指定 (ARGUMENTS) を優先し、Size 参照なしで `REVIEW_DEPTH=light` に確定。1エージェント (review-light) による4観点統合レビューを実施
+- AC3 (`github_check`) を PR #978 の CI 完了後に確認し PASS と判定、Issue チェックボックスを更新して完了
 
 ### Deferred Items
-- AC3 (`github_check`) は PR #978 の CI 実行完了後にのみ確認可能なため、Issue のチェックボックスは AC1・AC2 のみ更新済み (AC3 は未チェックのまま `/review` フェーズ以降で確認)
-- Steering Docs sync candidate 6件 (`docs/product.md`/`docs/structure.md`/`docs/tech.md` と日本語ミラー) は grep で内容確認済みで変更不要と判断 (Spec Notes の見立て通り)
+- None
 
 ### Notes for Next Phase
-- `/review` フェーズでは PR #978 の CI (`test.yml` ワークフローの "Run bats tests" ジョブ) が pass することを確認し、AC3 のチェックボックスを更新すること
-- ローカルでは `bats tests/spawn-recovery-subagent.bats tests/auto-recovery.bats tests/run-auto-sub.bats tests/auto-sub-observability.bats` の72件が全て pass 済み
-- 未解決の Uncertainties や設計上の懸念は残っていない
+- `/merge 978` を実行可能。MUST issue なし、CI 全ジョブ SUCCESS、AC3件すべて PASS 済み
+- ローカル regression (bats 4ファイル計72件、review-light 実行時の再確認では関連17件) は pass 済みだが、CI 側は "Run bats tests" ジョブの conclusion のみ参照 (フルログは未取得)
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+Nothing to note — diff は Spec の Implementation Steps の記述と一致しており、構造的な乖離は検出しなかった。
+
+### Recurring issues
+Nothing to note — `review-light` (4観点: spec deviation / edge cases・robustness / security・safety / documentation consistency) で issue 0件。同種の指摘の繰り返しも観測されなかった。
+
+### Acceptance criteria verification difficulty
+Nothing to note — AC1 (`grep`)・AC2 (`rubric`)・AC3 (`github_check`) の3件とも UNCERTAIN なく機械的に PASS 判定できた。AC3 は Phase Handoff (code) の "Notes for Next Phase" が指示した通り、PR #978 の CI ("Run bats tests" ジョブ) 完了後に確認しチェックボックスを更新した。

--- a/scripts/spawn-recovery-subagent.sh
+++ b/scripts/spawn-recovery-subagent.sh
@@ -307,6 +307,20 @@ case "$ACTION" in
     write_recovery_entry "retry" || true
     ;;
   skip)
+    SKIP_MATCHES_EXPECTED=$(python3 -c "
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+    print('true' if data.get('matches_expected') is True else 'false')
+except Exception:
+    print('false')
+" "$RECONCILE_OUTPUT")
+
+    if [[ "$SKIP_MATCHES_EXPECTED" != "true" ]]; then
+      echo "[spawn-recovery] action=skip rejected: matches_expected != true in RECONCILE_OUTPUT; stopping for human judgment" >&2
+      exit 1
+    fi
+
     echo "[spawn-recovery] action=skip: treating phase as complete"
     write_recovery_entry "skip" || true
     exit 0

--- a/tests/auto-recovery.bats
+++ b/tests/auto-recovery.bats
@@ -97,6 +97,12 @@ REPORT_FILE="$BATS_TEST_TMPDIR/docs/reports/orchestration-recoveries.md"
 
 @test "auto-recovery: action=skip writes recovery-sub-agent entry to report" {
     make_claude_mock '{"action":"skip","rationale":"phase already completed","steps":[]}'
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":true}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
     cd "$BATS_TEST_TMPDIR"
 
     run bash "$SCRIPT" code 42 --log "$LOG_FILE"
@@ -139,6 +145,12 @@ REPORT_FILE="$BATS_TEST_TMPDIR/docs/reports/orchestration-recoveries.md"
 
 @test "auto-recovery: missing report file skips write gracefully" {
     make_claude_mock '{"action":"skip","rationale":"already done","steps":[]}'
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":true}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
     cd "$BATS_TEST_TMPDIR"
     rm -f "$REPORT_FILE"
 

--- a/tests/spawn-recovery-subagent.bats
+++ b/tests/spawn-recovery-subagent.bats
@@ -108,8 +108,24 @@ MOCK
     grep -q "42" "$RUNNER_LOG"
 }
 
-@test "spawn-recovery: CLAUDE_BIN mock returns action=skip: exits 0 without runner invocation" {
+@test "spawn-recovery: CLAUDE_BIN mock returns action=skip with matches_expected:false: rejected" {
     make_claude_mock '{"action":"skip","rationale":"phase already completed","steps":[]}'
+    cd "$BATS_TEST_TMPDIR"
+
+    run bash "$SCRIPT" code 42 --log "$LOG_FILE"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"rejected"* ]]
+    [ ! -f "$RUNNER_LOG" ]
+}
+
+@test "spawn-recovery: CLAUDE_BIN mock returns action=skip with matches_expected:true: exits 0 without runner invocation" {
+    make_claude_mock '{"action":"skip","rationale":"phase already completed","steps":[]}'
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":true}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
     cd "$BATS_TEST_TMPDIR"
 
     run bash "$SCRIPT" code 42 --log "$LOG_FILE"
@@ -159,6 +175,12 @@ MOCK
 
 @test "spawn-recovery: stale slot lock (dead pid) is reclaimed and script proceeds" {
     make_claude_mock '{"action":"skip","rationale":"already done","steps":[]}'
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":true}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
     cd "$BATS_TEST_TMPDIR"
     mkdir -p ".tmp"
     mkdir ".tmp/recovery-subagent-slot-1"
@@ -176,6 +198,12 @@ MOCK
 printf 'Let me analyze this issue.\n\n{"action":"skip","rationale":"already resolved","steps":[]}\n\nHope that helps!'
 MOCK
     chmod +x "$MOCK_DIR/claude-mock"
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"matches_expected":true}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
     cd "$BATS_TEST_TMPDIR"
 
     run bash "$SCRIPT" code 42 --log "$LOG_FILE"


### PR DESCRIPTION
## Summary
- `scripts/spawn-recovery-subagent.sh` の Tier 3 リカバリ `skip)` 分岐に、`action=skip` を適用する前に既存の `RECONCILE_OUTPUT`（`reconcile-phase-state.sh <phase> --check-completion` の結果）から `matches_expected` を機械的に読み取るガードを追加
- `matches_expected` が `true` の場合のみ skip (exit 0) を許可し、`false`／空／パース不能な場合は `abort` と同じ exit code 契約（非ゼロ exit）で拒否し、human 判断のため停止する（retry/recover への自動フォールバックは行わない、fail-closed）
- `tests/spawn-recovery-subagent.bats` の既存テストを拒否側の regression テストに書き換え、`matches_expected:true` 時に skip が成功するテストを新規追加
- `tests/auto-recovery.bats` の skip 経路を検証する既存テストで、`reconcile-phase-state.sh` モックを `matches_expected:true` に上書きし、ガード追加後も skip 経路に到達できるよう調整

## Verification (pre-merge)
- `grep "matches_expected" scripts/spawn-recovery-subagent.sh` — ガードが実装されていることを確認済み
- rubric — skip 分岐が matches_expected=true でのみ許可され、false 時は abort 相当の契約で拒否することを確認済み
- `bats tests/spawn-recovery-subagent.bats tests/auto-recovery.bats tests/run-auto-sub.bats tests/auto-sub-observability.bats` をローカルで実行し、全72件 pass を確認済み（CI での再確認は github_check AC で実施）

## Verification (post-merge)
- なし

closes #964
