### PR TITLE
Issue #971: Extend hook-worktree-path-guard.sh to cover Read tool

### DIFF
--- a/docs/spec/issue-971-worktree-read-path-guard.md
+++ b/docs/spec/issue-971-worktree-read-path-guard.md
@@ -61,8 +61,30 @@ Codebase Investigation で、Issue 本文が言及していなかった追加の
 ### Rework
 - N/A — Implementation Steps 1-4 を計画通り実装し、bats テスト (9/9 PASS) と5件の pre-merge verify command が初回実行で全て PASS した。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — Implementation Steps 1-4 と PR diff は 1:1 対応しており、構造的な乖離は検出されなかった (review-light Perspective 1 で確認済み)。
+
+### Recurring issues
+- Nothing to note — MUST/SHOULD/CONSIDER いずれの指摘も発生しなかった。
+
+### Acceptance criteria verification difficulty
+- Nothing to note — 5件の verify command (file_contains ×2, grep, file_not_contains, rubric) はいずれも曖昧さなく機械的に判定でき、UNCERTAIN は発生しなかった。code フェーズで既に PASS 済みだった内容を review フェーズで独立に再検証し、同じ結果 (全PASS) を得た。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
+
+### Key Decisions
+- Light mode (`--light` 明示指定) で review-light エージェント1体による4観点統合レビューを実施。M サイズ相当の diff (117行、5ファイル) に対して妥当な深度と判断。
+- 外部レビューツール (copilot/claude-code-review/coderabbit) は `.wholework.yml` 未設定のため Step 7 を全体スキップ。
+
+### Deferred Items
+- Nothing to note — MUST/SHOULD/CONSIDER 指摘が発生しなかったため Step 12 の修正作業は不要だった。
+
+### Notes for Next Phase
+- 5件の pre-merge verify command は review フェーズでも独立に再検証し、全て PASS (code フェーズでの判定と一致)。
+- CI 全ジョブ SUCCESS (DCO, bats tests ×2, skill syntax ×2, forbidden expressions ×2, macOS shell compatibility ×2)。`/merge 985` に進んで問題なし。
 
 ### Key Decisions
 - Spec の Implementation Steps 1-4 をそのまま実装 (`hooks/hooks.json` matcher、`hook-worktree-path-guard.sh` case 文、bats テスト2件追加、`worktree-lifecycle.md` Scope limit 文言更新)。設計からの逸脱なし。

--- a/docs/spec/issue-971-worktree-read-path-guard.md
+++ b/docs/spec/issue-971-worktree-read-path-guard.md
@@ -49,3 +49,29 @@ Codebase Investigation で、Issue 本文が言及していなかった追加の
 - **`docs/structure.md` / `docs/ja/structure.md` 一行要約のリネームは見送り**: `hook-worktree-path-guard.sh` を grep した結果、両ファイルとも "blocks Edit/Write calls" という一行要約 (NotebookEdit 言及も元々省略された簡略表現) がヒットした。今回の変更に伴い "blocks Edit/Write/Read calls" 等へ更新することも検討したが、AC4 が要求するスコープは `modules/worktree-lifecycle.md` の Scope limit 文言の是正のみであり、`docs/structure.md` の一行要約は既存の簡略化された表現の範囲内 (NotebookEdit 追加時も更新されていない) と判断し、今回は Changed Files に Steering Docs sync candidate として残すに留めた。
 - **`modules/worktree-lifecycle.md` のセクション見出し ( `### Edit/Write path conventions in worktree sessions` ) のリネームも見送り**: 見出し名自体を "Edit/Write/Read path conventions" 等に変更すると、`docs/structure.md`・`docs/ja/structure.md`・`scripts/hook-worktree-path-guard.sh` の echo メッセージ内の cross-reference 文字列 (`§ Edit/Write path conventions in worktree sessions`) や過去の disposable Spec ( `docs/spec/issue-860-*.md` 等) への波及確認が必要になり、AC4 が要求するスコープ (Scope limit 文言の是正) を超える。AC4 の `file_not_contains` は見出し名ではなく Enforcement 段落内の特定フレーズのみを対象としているため、見出し名は変更せず据え置く。
 - **関連 Issue #888 (CLOSED / phase/done) の確認**: `hook: claude -p サブプロセスセッションでの hook-worktree-path-guard.sh 発火を検証` は解決済み。hook 自体の起動メカニズム (`--plugin-dir` 経由のプラグインロード) は実行環境で健全であることが既に確認されており、本 Issue の実装を妨げる要因はない。
+
+## Code Retrospective
+
+### Deviations from Design
+- Implementation Steps に明記されていなかった軽微な追加として、`scripts/hook-worktree-path-guard.sh` 冒頭のヘッダーコメント (`# PreToolUse hook: block Edit/Write/NotebookEdit calls ...`) も `Read` を含む記述に更新した。同じファイル・同じ行が対象とする `TOOL_NAME` case 文の直近にあり、更新しないと case 文の変更内容とヘッダーコメントの記述が食い違うため、ドキュメント整合性維持の一環として実施した。AC・Verification には影響しない。
+
+### Design Gaps/Ambiguities
+- N/A — Spec の Codebase Investigation (`hooks/hooks.json` matcher の発見) により、実装時に新たな設計ギャップは見つからなかった。
+
+### Rework
+- N/A — Implementation Steps 1-4 を計画通り実装し、bats テスト (9/9 PASS) と5件の pre-merge verify command が初回実行で全て PASS した。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の Implementation Steps 1-4 をそのまま実装 (`hooks/hooks.json` matcher、`hook-worktree-path-guard.sh` case 文、bats テスト2件追加、`worktree-lifecycle.md` Scope limit 文言更新)。設計からの逸脱なし。
+- `hook-worktree-path-guard.sh` 冒頭のヘッダーコメントも Read を含む記述に更新 (Spec には未記載の軽微な追加、AC・Verification には無影響)。
+
+### Deferred Items
+- `docs/structure.md` / `docs/ja/structure.md` の一行要約リネームは Spec Notes 通り見送り (AC4 のスコープ外と判断済み)。
+- `modules/worktree-lifecycle.md` のセクション見出しリネームも Spec Notes 通り見送り。
+
+### Notes for Next Phase
+- Pre-merge verify command 5件は本フェーズで実行済み・全て PASS (Issue 側チェックボックスも更新済み)。review フェーズでの再確認は不要だが、CI 側の bats 実行結果は別途確認すること。
+- 変更ファイルは `hooks/hooks.json`, `scripts/hook-worktree-path-guard.sh`, `tests/hook-worktree-path-guard.bats`, `modules/worktree-lifecycle.md` の4件のみ。`docs/structure.md` 系は意図的に未変更。

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|Write|NotebookEdit",
+        "matcher": "Edit|Write|NotebookEdit|Read",
         "hooks": [
           {
             "type": "command",

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -130,7 +130,7 @@ resulting dirty state of the parent repo file may fail unexpectedly.
 **How to verify CWD**: Run `pwd` to confirm you are inside the worktree, or confirm that
 the return value from `EnterWorktree` points to the worktree path before calling Edit.
 
-**Enforcement**: This convention is mechanically enforced by `scripts/hook-worktree-path-guard.sh` (registered as a PreToolUse hook in `hooks/hooks.json`), which blocks Edit/Write calls whose `file_path` is an absolute parent-repo path while the session is inside a worktree. **Scope limit**: the hook matches only the Edit/Write/NotebookEdit tools — Bash-based edits, including the `.claude/` file workaround above, are not covered, so the worktree-local-path discipline must still be applied manually there.
+**Enforcement**: This convention is mechanically enforced by `scripts/hook-worktree-path-guard.sh` (registered as a PreToolUse hook in `hooks/hooks.json`), which blocks Edit/Write/Read calls whose `file_path` is an absolute parent-repo path while the session is inside a worktree. **Scope limit**: the hook matches the Edit/Write/NotebookEdit/Read tools — Bash-based edits, including the `.claude/` file workaround above, are not covered, so the worktree-local-path discipline must still be applied manually there.
 
 ## Callers (auto-maintained)
 

--- a/scripts/hook-worktree-path-guard.sh
+++ b/scripts/hook-worktree-path-guard.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# PreToolUse hook: block Edit/Write/NotebookEdit calls that pass an absolute
+# PreToolUse hook: block Edit/Write/NotebookEdit/Read calls that pass an absolute
 # parent-repo path while the session is inside a worktree.
 # Exit 0 (allow) except when a worktree-session parent-repo absolute path is detected (exit 2, block).
 
@@ -8,7 +8,7 @@ INPUT=$(cat)
 TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')
 
 case "$TOOL_NAME" in
-  Edit|Write|NotebookEdit) ;;
+  Edit|Write|NotebookEdit|Read) ;;
   *) exit 0 ;;
 esac
 

--- a/tests/hook-worktree-path-guard.bats
+++ b/tests/hook-worktree-path-guard.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 # Tests for hook-worktree-path-guard.sh
-# Validates PreToolUse block/allow decisions for Edit/Write/NotebookEdit calls
-# depending on cwd (inside/outside a worktree) and file_path (relative,
+# Validates PreToolUse block/allow decisions for Edit/Write/NotebookEdit/Read
+# calls depending on cwd (inside/outside a worktree) and file_path (relative,
 # worktree-local absolute, or parent-repo absolute).
 
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/hook-worktree-path-guard.sh"
@@ -53,6 +53,21 @@ teardown() {
     run bash -c "echo '$INPUT' | \"$SCRIPT\""
     [ "$status" -eq 2 ]
     [[ "$output" == *"hook-worktree-path-guard"* ]]
+}
+
+@test "inside worktree + Read + parent-repo absolute path -> exit 2 (block)" {
+    cd "$FIXTURE_WORKTREE"
+    INPUT=$(printf '{"tool_name":"Read","tool_input":{"file_path":"%s/docs/foo.md"}}' "$FIXTURE_PARENT")
+    run bash -c "echo '$INPUT' | \"$SCRIPT\""
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"hook-worktree-path-guard"* ]]
+}
+
+@test "inside worktree + Read + worktree absolute path -> exit 0 (allow)" {
+    cd "$FIXTURE_WORKTREE"
+    INPUT=$(printf '{"tool_name":"Read","tool_input":{"file_path":"%s/docs/foo.md"}}' "$FIXTURE_WORKTREE")
+    run bash -c "echo '$INPUT' | \"$SCRIPT\""
+    [ "$status" -eq 0 ]
 }
 
 @test "inside worktree + parent-repo absolute path -> emits worktree-path-block event" {


### PR DESCRIPTION
## Summary
- Extend `scripts/hook-worktree-path-guard.sh` (PreToolUse hook) to cover the `Read` tool, applying the same exit-2 block behavior as `Edit`/`Write`/`NotebookEdit` when a parent-repo absolute path (missing the worktree segment) is referenced while inside a worktree session.
- Update `hooks/hooks.json` `PreToolUse` matcher from `Edit|Write|NotebookEdit` to `Edit|Write|NotebookEdit|Read` — without this, the hook script's own `TOOL_NAME` case extension alone would never receive `Read` tool calls, since the matcher is the tool-name filter Claude Code uses to decide whether to invoke the hook at all.
- Add two new bats test cases (`Read` + parent-repo absolute path → block; `Read` + worktree absolute path → allow) to `tests/hook-worktree-path-guard.bats`.
- Update `modules/worktree-lifecycle.md` § Notes Enforcement/Scope limit wording to reflect that the hook now also covers `Read`.

Fixes a recurring mistake pattern identified in Issue #961's retrospective, where absolute-path `Read` calls during a worktree session silently referenced the shared parent repository instead of the worktree copy.

## Verification (pre-merge)
- `hook-worktree-path-guard.sh` の TOOL_NAME case 文に `Read` を追加 — `file_contains "scripts/hook-worktree-path-guard.sh" "Read"`
- Read ツールでの絶対パス誤参照が Edit/Write と同様にブロックされる (rubric)
- `tests/hook-worktree-path-guard.bats` に Read 向けテストケースを追加 — `grep "Read" "tests/hook-worktree-path-guard.bats"`
- `modules/worktree-lifecycle.md` の Scope limit 記述を更新 — `file_not_contains "modules/worktree-lifecycle.md" "only the Edit/Write/NotebookEdit tools"`
- `hooks/hooks.json` の `PreToolUse` matcher に `Read` を追加 — `file_contains "hooks/hooks.json" "Read"`
- `bats tests/hook-worktree-path-guard.bats` — 9/9 PASS

## Verification (post-merge)
- なし

closes #971
