### PR TITLE
Issue #987: Resolve PR->Issue number for review/merge phase events

### DIFF
--- a/docs/spec/issue-987-auto-review-merge-pr-issue.md
+++ b/docs/spec/issue-987-auto-review-merge-pr-issue.md
@@ -71,19 +71,31 @@
 ### Rework
 - なし。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- なし。review-spec 相当の観点 (review-light Perspective 1) で Spec Implementation Steps 1〜5 と PR diff の一致を確認した。
+
+### Recurring issues
+- **「開発環境の偶発的な env var 汚染がテストのバグを隠蔽する」パターンを検出**: 本 Issue が修正しようとしていた対象そのもの (`run_phase_with_recovery()` が `EMIT_ISSUE_NUMBER`/`EMIT_PHASE_NAME`/`_EXTRA_SELF_ISSUE` を `export` する仕組み) により、`/auto` 経由で起動された worktree セッション (今回の `/code`/`/review` 実行環境を含む) には、これらの変数がアンビエントに存在する。今回追加された regression テスト (tests/run-auto-sub.bats:998) のモックは `$EMIT_PHASE_NAME` を `set -u` 下でデフォルト値なしに参照しており、`emit_event "sub_start"` (EMIT_PHASE_NAME 設定前) 呼び出し時にクラッシュするバグを含んでいた。PR 作成者のローカル実行では偶然これらの変数が既にエクスポートされていたため「フルスイート 1130 件すべて PASS」と誤って報告され、クリーンな GitHub Actions ランナーでのみ実際に FAIL した。`/review` Step 9 (CI Status Check) が FAILURE を検出し、`env -i` によるクリーン環境再現で根本原因を特定できた。
+  - **改善提案**: `EMIT_*`/`_EXTRA_SELF_ISSUE` のような env var を介した状態伝搬パターンをテストするコードは、bats テスト実行前に `env -i HOME="$HOME" PATH="$PATH" bash -c 'bats ...'` のようなクリーン環境での実行を Local 開発ガイドラインに明記する、または CI 設定自体がクリーン環境である前提に依存せず bats のテストヘルパー内で明示的に `unset EMIT_ISSUE_NUMBER EMIT_PHASE_NAME EMIT_PR_NUMBER _EXTRA_SELF_ISSUE AUTO_SESSION_ID` する setup() の防御的初期化を追加する、のいずれかを検討する価値がある (`/verify` での Improvement Proposal 集約時に起票判断)。
+
+### Acceptance criteria verification difficulty
+- なし。Pre-merge AC 2件は rubric verify command により UNCERTAIN なく PASS 判定できた。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `run_phase_with_recovery()` の `EMIT_ISSUE_NUMBER`/`EMIT_PR_NUMBER` 解決を `_EXTRA_SELF_ISSUE` の有無・差分で分岐させ、review/merge phase 以外 (code-patch/code-pr) では `EMIT_PR_NUMBER` を明示的に unset して次呼び出しへの値漏れを防いだ (Spec Implementation Steps 2 の指示通り)。
-- `_maybe_emit_phase_complete()` の backfill JSON にも `pr` フィールドを追加し、EXIT trap 経由の printf 直書きパスでも `emit_event()` と一貫した形状にした。
-- PR ルート (Size M) を採用し、実装ファイル (scripts 2 件、モジュール 1 件、テスト 2 件) を 1 コミットにまとめて main への直接コミットを避けた。
+- CI (`Run bats tests`) が FAILURE だったため、`gh run view --log` でジョブログを取得し `not ok 718` の失敗テストを特定、`env -i` によるクリーン環境ローカル再現で根本原因 (`tests/run-auto-sub.bats:998` のモックが `set -u` 下で `$EMIT_PHASE_NAME` を無防備参照) を確定してから修正した。
+- MUST 修正 (bats モックのデフォルト値展開) と CONSIDER 修正 (`modules/event-emission.md` の相互参照訂正) を実施。SHOULD 指摘 (`_maybe_emit_phase_complete()` backfill パスの regression テスト欠如) は EXIT trap 発火の安全な再現に追加の足場が必要でリスク・工数が見合わないため見送った。
+- 修正後、`env -i` クリーン環境でフルスイート (1130件) を実行し 0 failures を確認 (並列実行 (`--jobs`) 時に見られた 2 件の flaky failure は逐次実行で再現せず、本 PR の変更とは無関係と判断)。
 
 ### Deferred Items
-- `run-review.sh`/`run-merge.sh` 自身の backfill trap への `pr` フィールド追加は、Spec Notes に記載の通り本 Issue のスコープ外として見送った (SIGTERM/watchdog kill 時の稀な backfill レコードのみに影響する軽微な一貫性向上)。
-- Post-merge observation AC (「次回 `/auto --batch` の L3 session report で Issues processed が実 Issue 数と一致する」) は次回の pr route を含む batch 実行時に `/verify` が rubric で再評価する。
+- `_maybe_emit_phase_complete()` backfill パスへの `pr` フィールド regression テスト追加 (SHOULD) — レビューコメントとして記録済み、次回関連改修時に着手余地あり。
+- `run-review.sh`/`run-merge.sh` 自身の backfill trap への `pr` フィールド追加は Spec Notes 記載の通りスコープ外 (変更なし)。
+- Post-merge observation AC は次回の pr route を含む batch 実行時に `/verify` が rubric で再評価する (変更なし)。
 
 ### Notes for Next Phase
-- Pre-merge AC 2件は rubric 判定で PASS 済み (Issue 本文チェックボックスも更新済み)。Post-merge AC 1件は残っており、`/review`/`/merge` は変更しない。
-- `bats tests/` フルスイート (1130件) 実行済み、0 failures。behavioral change 判定によりフルスイートを実行した (emit-event.sh/run-auto-sub.sh が直接カウンターパート以外の複数テストファイルから参照されているため)。
-- Issue #987 の `phase/ready` ラベルが実行開始時点で既に `phase/code` に遷移済みだった (前回 `/code` 実行が中断した形跡)。Spec は既存だったため、そのまま利用して続行した。詳細は Code Retrospective の Design Gaps/Ambiguities を参照。
+- `/merge` はそのまま実行可能。MUST issue は修正済み、CI は再実行後に確認が必要 (プッシュ済みの修正コミットで再トリガー済み)。
+- review retrospective に「開発環境の env var 汚染がテストのバグを隠蔽するパターン」を Recurring issues として記録した。`/verify` での Improvement Proposal 集約時に起票判断すること。

--- a/docs/spec/issue-987-auto-review-merge-pr-issue.md
+++ b/docs/spec/issue-987-auto-review-merge-pr-issue.md
@@ -59,3 +59,31 @@
 - **`run-review.sh` / `run-merge.sh` 自身の backfill trap は対象外とする判断**: 両スクリプトはそれぞれ独自の `_maybe_emit_phase_complete()` (printf 直書き、`emit_event()` 非経由) を持つが、`EMIT_ISSUE_NUMBER`/`EMIT_PR_NUMBER` は `run-auto-sub.sh` からの `export` を子プロセスとして継承するため、`issue` フィールド自体は本 Spec の Implementation Steps 2 の修正のみで正しくなる (`EMIT_PHASE_NAME` が既に設定されているため、両スクリプト自身の `_EMIT_PHASE_OWNED` ブロック — `export EMIT_ISSUE_NUMBER="$PR_NUMBER"` を含む — は実行されない)。両スクリプト自身の backfill JSON に `pr` フィールドを追加する対応 (SIGTERM/watchdog kill 時の稀な backfill レコードのみに影響する軽微な一貫性向上) は、AC の必須要件ではなく light spec のスコープ外として見送った。
 - **`get-auto-session-report.sh` は変更不要と判断**: 同スクリプトの `unique | length` によるユニーク Issue 集計 (line 175, 272 付近) は `issue` フィールドをそのまま使う既存ロジックであり、emit 時点で `issue` フィールドが正しくなれば追加の集計側修正なしに "Issues processed" の水増しは解消される。同スクリプトが既に持つ `_pr_num=$(gh pr list --search "closes #${_num}" ...)` (line 312 付近、表の PR 列表示用) は本 Issue が明示的に不採用とした「集計時解決」とは別目的の既存機能であり、本 Spec では変更しない。
 - **docs/workflow.md, docs/tech.md, docs/structure.md, docs/migration-notes.md は変更不要と判断**: いずれも `run-auto-sub.sh`/`emit-event.sh` に言及があるが (grep 済み)、ワークフロー全体像やアーキテクチャ概要レベルの記述に留まり、イベント JSON スキーマの詳細 (今回変更対象) には踏み込んでいない。`docs/migration-notes.md` の言及は private→public 移行時点の履歴記録であり対象外。SSoT である `modules/event-emission.md` のみを更新する。
+
+## Code Retrospective
+
+### Deviations from Design
+- なし。Implementation Steps 1〜5 を設計通りの順序・内容で実装した。
+
+### Design Gaps/Ambiguities
+- **`/code` Step 3 の `phase/ready` チェック前提と実際の label 履歴の不一致**: 実行開始時点で Issue #987 のラベルは `phase/ready` ではなく既に `phase/code` だった。GitHub timeline を確認したところ、本セッション開始前に別の `/code` 実行が `phase/ready→phase/code` 遷移まで完了させた後、実装コミットを残さず中断していたことが判明した (Spec は既存、コミット履歴には spec コミットのみ)。`/code` Step 3 の分岐は「`phase/ready` 不在 = Spec 未生成」を暗黙の前提としているが、今回のように「前回実行が既に `phase/code` へ進めた後に中断した」ケースでは Spec が既存のまま `phase/ready` が不在になる。既存 Spec を読み込んで続行することで正しく処理できたが、この中断→再開パターンを Step 3 のチェックロジックが明示的に区別していない点は改善余地として残る (直接のスコープ外、独立した改善提案として起票は見送り — 発生頻度が低く、既存 Spec の有無で安全にフォールバックできているため)。
+
+### Rework
+- なし。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `run_phase_with_recovery()` の `EMIT_ISSUE_NUMBER`/`EMIT_PR_NUMBER` 解決を `_EXTRA_SELF_ISSUE` の有無・差分で分岐させ、review/merge phase 以外 (code-patch/code-pr) では `EMIT_PR_NUMBER` を明示的に unset して次呼び出しへの値漏れを防いだ (Spec Implementation Steps 2 の指示通り)。
+- `_maybe_emit_phase_complete()` の backfill JSON にも `pr` フィールドを追加し、EXIT trap 経由の printf 直書きパスでも `emit_event()` と一貫した形状にした。
+- PR ルート (Size M) を採用し、実装ファイル (scripts 2 件、モジュール 1 件、テスト 2 件) を 1 コミットにまとめて main への直接コミットを避けた。
+
+### Deferred Items
+- `run-review.sh`/`run-merge.sh` 自身の backfill trap への `pr` フィールド追加は、Spec Notes に記載の通り本 Issue のスコープ外として見送った (SIGTERM/watchdog kill 時の稀な backfill レコードのみに影響する軽微な一貫性向上)。
+- Post-merge observation AC (「次回 `/auto --batch` の L3 session report で Issues processed が実 Issue 数と一致する」) は次回の pr route を含む batch 実行時に `/verify` が rubric で再評価する。
+
+### Notes for Next Phase
+- Pre-merge AC 2件は rubric 判定で PASS 済み (Issue 本文チェックボックスも更新済み)。Post-merge AC 1件は残っており、`/review`/`/merge` は変更しない。
+- `bats tests/` フルスイート (1130件) 実行済み、0 failures。behavioral change 判定によりフルスイートを実行した (emit-event.sh/run-auto-sub.sh が直接カウンターパート以外の複数テストファイルから参照されているため)。
+- Issue #987 の `phase/ready` ラベルが実行開始時点で既に `phase/code` に遷移済みだった (前回 `/code` 実行が中断した形跡)。Spec は既存だったため、そのまま利用して続行した。詳細は Code Retrospective の Design Gaps/Ambiguities を参照。

--- a/modules/event-emission.md
+++ b/modules/event-emission.md
@@ -61,7 +61,7 @@ is written with `"backfilled": true`. This covers exit code 0 (clean exit) and e
 
 For review/merge phase events dispatched via `run-auto-sub.sh`'s `run_phase_with_recovery()`,
 the `issue` field always holds the real Issue number (not the PR number the phase was invoked
-with) — resolved from `_EXTRA_SELF_ISSUE` (see `_EMIT_PHASE_OWNED` pattern below). The PR number
+with) — resolved from `_EXTRA_SELF_ISSUE` (see `run-auto-sub.sh` row in Wrapper Coverage Table below). The PR number
 is recorded separately in a `pr` field so both remain traceable without the PR being double-counted
 as an independent Issue by `get-auto-session-report.sh` (#987):
 

--- a/modules/event-emission.md
+++ b/modules/event-emission.md
@@ -57,6 +57,28 @@ is written with `"backfilled": true`. This covers exit code 0 (clean exit) and e
 }
 ```
 
+### pr field (review/merge phase events)
+
+For review/merge phase events dispatched via `run-auto-sub.sh`'s `run_phase_with_recovery()`,
+the `issue` field always holds the real Issue number (not the PR number the phase was invoked
+with) — resolved from `_EXTRA_SELF_ISSUE` (see `_EMIT_PHASE_OWNED` pattern below). The PR number
+is recorded separately in a `pr` field so both remain traceable without the PR being double-counted
+as an independent Issue by `get-auto-session-report.sh` (#987):
+
+```json
+{
+  "ts": "2026-07-11T00:00:00Z",
+  "issue": 987,
+  "event": "phase_start",
+  "session_id": "abc123",
+  "pr": 1001,
+  "phase": "review"
+}
+```
+
+The `pr` field is added only when `EMIT_PR_NUMBER` is set (code phase events, which are called
+with the real Issue number directly, never carry a `pr` field).
+
 ### wrapper_exit
 
 Emitted by `claude-watchdog.sh` on abnormal wrapper exit. Field: `exit_code`.
@@ -76,6 +98,12 @@ Emitted after a successful `--output-format json` run. Fields: `input_tokens`, `
 | `AUTO_SESSION_ID` | wrapper (from `.tmp/auto-session-{PGID}`) | Identifies the `/auto` session |
 | `EMIT_ISSUE_NUMBER` | wrapper | Issue number for the current phase |
 | `EMIT_PHASE_NAME` | wrapper | Phase name (see Wrapper Coverage Table below) |
+
+### Optional environment variables
+
+| Variable | Set by | Description |
+|----------|--------|-------------|
+| `EMIT_PR_NUMBER` | `run-auto-sub.sh` (review/merge phase calls only) | PR number, recorded in a separate `pr` field alongside the real Issue number in `EMIT_ISSUE_NUMBER` (see "pr field" above) |
 
 ### _EMIT_PHASE_OWNED pattern
 
@@ -120,7 +148,7 @@ stays empty and `phase_start` / `phase_complete` are not emitted — preventing 
 | `run-code.sh` | `code-pr` \| `code-patch` \| `code` | Selects based on route flag |
 | `run-review.sh` | `review` | |
 | `run-merge.sh` | `merge` | |
-| `run-auto-sub.sh` | Sets `EMIT_PHASE_NAME` before delegating | Orchestrator; delegates to above |
+| `run-auto-sub.sh` | Sets `EMIT_PHASE_NAME` before delegating | Orchestrator; delegates to above. For review/merge phase calls, resolves `EMIT_ISSUE_NUMBER`/`EMIT_PR_NUMBER` from `_EXTRA_SELF_ISSUE` so the real Issue number (not the PR number) lands in the `issue` field (#987) |
 
 ## Non-Wrapper Emitters
 

--- a/scripts/emit-event.sh
+++ b/scripts/emit-event.sh
@@ -10,6 +10,8 @@
 #
 # Optional env vars:
 #   EMIT_PHASE_NAME    - Phase name for the current execution context
+#   EMIT_PR_NUMBER     - PR number when the current phase is called with a PR number
+#                        (e.g. review/merge); adds a "pr" field distinct from "issue"
 
 # Documented event schemas:
 #
@@ -70,6 +72,9 @@ emit_event() {
   local _issue="${EMIT_ISSUE_NUMBER:-0}"
   local _sid="${AUTO_SESSION_ID:-}"
   local json="{\"ts\":\"${ts}\",\"issue\":${_issue},\"event\":\"${event_type}\",\"session_id\":\"${_sid}\""
+  if [[ -n "${EMIT_PR_NUMBER:-}" ]]; then
+    json="${json},\"pr\":${EMIT_PR_NUMBER}"
+  fi
   while [[ $# -gt 0 ]]; do
     local kv="$1"; local k="${kv%%=*}"; local v="${kv#*=}"
     # sanitize value: strip newlines, replace tabs, escape backslash and double-quote

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -194,8 +194,10 @@ _maybe_emit_phase_complete() {
         '[.[] | select(.issue == $n)] | last // empty | .event // ""' 2>/dev/null || true)
   if [[ "${_last_event}" == "phase_start" ]]; then
     local _ts; _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    local _pr_field=""
+    [[ -n "${EMIT_PR_NUMBER:-}" ]] && _pr_field=",\"pr\":${EMIT_PR_NUMBER}"
     printf '%s\n' \
-      "{\"ts\":\"${_ts}\",\"issue\":${EMIT_ISSUE_NUMBER},\"event\":\"phase_complete\",\"session_id\":\"${AUTO_SESSION_ID}\",\"phase\":\"${EMIT_PHASE_NAME}\",\"backfilled\":true}" \
+      "{\"ts\":\"${_ts}\",\"issue\":${EMIT_ISSUE_NUMBER},\"event\":\"phase_complete\",\"session_id\":\"${AUTO_SESSION_ID}\"${_pr_field},\"phase\":\"${EMIT_PHASE_NAME}\",\"backfilled\":true}" \
       >> "${AUTO_EVENTS_LOG}" 2>/dev/null || true
   fi
 }
@@ -396,7 +398,13 @@ run_phase_with_recovery() {
   mkdir -p .tmp
   log_file=".tmp/wrapper-out-${issue}-${phase}.log"
 
-  export EMIT_ISSUE_NUMBER="$issue"
+  if [[ -n "${_EXTRA_SELF_ISSUE:-}" ]] && [[ "${_EXTRA_SELF_ISSUE}" != "${issue}" ]]; then
+    export EMIT_ISSUE_NUMBER="$_EXTRA_SELF_ISSUE"
+    export EMIT_PR_NUMBER="$issue"
+  else
+    export EMIT_ISSUE_NUMBER="$issue"
+    unset EMIT_PR_NUMBER
+  fi
   export EMIT_PHASE_NAME="$phase"
 
   # Bash-side comments_consumed emit for code phases (issue-level comment consumption).

--- a/tests/emit-event.bats
+++ b/tests/emit-event.bats
@@ -171,6 +171,29 @@ teardown() {
     [[ "$line" == *'"phase":"code"'* ]]
 }
 
+@test "emit_event includes pr field when EMIT_PR_NUMBER is set (Issue #987)" {
+    export EMIT_PR_NUMBER="1001"
+    bash -c "source \"$SCRIPT\" && emit_event \"phase_start\" \"phase=review\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    run jq -r '.pr' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "1001" ]]
+    run jq -r '.issue' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "42" ]]
+}
+
+@test "emit_event omits pr field when EMIT_PR_NUMBER is unset (Issue #987)" {
+    unset EMIT_PR_NUMBER
+    bash -c "source \"$SCRIPT\" && emit_event \"phase_start\" \"phase=code-pr\""
+    run jq . "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    run jq -r 'has("pr")' "$AUTO_EVENTS_LOG"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "false" ]]
+}
+
 @test "restore_auto_session_pointer restores AUTO_SESSION_ID/AUTO_EVENTS_LOG from auto-session-current (Issue #902)" {
     mkdir -p "$BATS_TEST_TMPDIR/work1/.tmp"
     echo "test-session-123" > "$BATS_TEST_TMPDIR/work1/.tmp/auto-session-current"

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -995,7 +995,7 @@ MOCK
 
     cat > "$MOCK_DIR/emit-event.sh" <<MOCK
 emit_event() {
-  echo "phase=\$EMIT_PHASE_NAME issue=\$EMIT_ISSUE_NUMBER pr=\${EMIT_PR_NUMBER:-<unset>} event=\$1" >> "$BATS_TEST_TMPDIR/emit.log"
+  echo "phase=\${EMIT_PHASE_NAME:-} issue=\${EMIT_ISSUE_NUMBER:-} pr=\${EMIT_PR_NUMBER:-<unset>} event=\$1" >> "$BATS_TEST_TMPDIR/emit.log"
 }
 _emit_comments_consumed() { :; }
 MOCK

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -989,6 +989,31 @@ MOCK
     grep -q "concurrent_commit_detected.*commit_sha=ccc3333" "$BATS_TEST_TMPDIR/emit.log"
 }
 
+@test "review/merge phase events emit issue=<real Issue number> and pr=<PR number> (issue #987)" {
+    export AUTO_EVENTS_LOG="$BATS_TEST_TMPDIR/auto-events.jsonl"
+    export EMIT_ISSUE_NUMBER="42"
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() {
+  echo "phase=\$EMIT_PHASE_NAME issue=\$EMIT_ISSUE_NUMBER pr=\${EMIT_PR_NUMBER:-<unset>} event=\$1" >> "$BATS_TEST_TMPDIR/emit.log"
+}
+_emit_comments_consumed() { :; }
+MOCK
+
+    # Default fixture (see setup): SUB_NUMBER=42, PR_NUMBER=99, Size M.
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+
+    # code-pr phase is called with the real Issue number and no PR context.
+    grep -q "phase=code-pr issue=42 pr=<unset>" "$BATS_TEST_TMPDIR/emit.log"
+
+    # review/merge phases are called with issue=$PR_NUMBER=99, but _EXTRA_SELF_ISSUE=42
+    # resolves EMIT_ISSUE_NUMBER back to the real Issue number, with the PR number
+    # preserved separately in EMIT_PR_NUMBER.
+    grep -q "phase=review issue=42 pr=99" "$BATS_TEST_TMPDIR/emit.log"
+    grep -q "phase=merge issue=42 pr=99" "$BATS_TEST_TMPDIR/emit.log"
+}
+
 @test "run-auto-sub: tier2 recovery: writes Auto Retrospective to spec file" {
     export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
 


### PR DESCRIPTION
## Summary

`run-auto-sub.sh` の review/merge phase 呼び出し (`run_phase_with_recovery "review" "$PR_NUMBER" ...` / `"merge" "$PR_NUMBER" ...`) は、`emit_event()` の `issue` フィールドに実 Issue 番号ではなく PR 番号を記録してしまっていた。これにより `get-auto-session-report.sh` の集計で PR 番号が独立した "Issue" として二重集計され、"Issues processed" 等のメトリクスが歪む問題があった (実例: batch session `18964-1783692542` で "Issues processed: 10" と誤集計)。

方式は **emit 時解決**: `run_phase_with_recovery()` が既に受け取っている `_EXTRA_SELF_ISSUE` (実 Issue 番号、#974 で導入済みの伝搬パターンを再利用) を使って `EMIT_ISSUE_NUMBER` を実 Issue 番号に解決し、PR 番号は新設の `EMIT_PR_NUMBER`/`pr` フィールドに別途記録してトレーサビリティを維持する。

- `scripts/emit-event.sh`: `emit_event()` に `EMIT_PR_NUMBER` が設定されている場合のみ `pr` フィールドを JSON に追加
- `scripts/run-auto-sub.sh`: `run_phase_with_recovery()` の `EMIT_ISSUE_NUMBER` 解決ロジックを `_EXTRA_SELF_ISSUE` 分岐に変更。`_maybe_emit_phase_complete()` の backfill JSON にも `pr` フィールドを追加
- `modules/event-emission.md`: `pr` フィールドと `EMIT_PR_NUMBER` の仕様を追記 (SSoT)
- `tests/emit-event.bats` / `tests/run-auto-sub.bats`: regression テストを追加

## Verification (pre-merge)
- review/merge phase のイベントが emit 時点で実 Issue 番号を issue フィールドに記録する仕組みが実装されていることを rubric で確認
- PR 番号の独立 Issue 混入を防ぐ regression テストが追加されていることを rubric で確認
- `bats tests/` フルスイート 1130 件すべて PASS (behavioral change 判定によりフルスイート実行)

## Verification (post-merge)
- 次回 pr route を含む `/auto --batch` の L3 session report で、Issues processed が実 Issue 数と一致することを観察

closes #987
