### PR TITLE
Issue #986: Add push retry to run-auto-sub.sh recovery record writes

### DIFF
--- a/docs/spec/issue-986-auto-sub-recovery-push-retry.md
+++ b/docs/spec/issue-986-auto-sub-recovery-push-retry.md
@@ -86,19 +86,28 @@
 ### Rework
 - N/A — 手戻りは発生しなかった。
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+- Nothing to note — Implementation Steps どおり、5 箇所すべてが `_push_with_retry()` を経由する形で実装されており、diff レベルで Spec と実装の乖離は見られなかった。
+
+### Recurring Issues
+- リトライループを持つ bats テストで、最終カウント (`push_count`) のみを assert し、リトライ間に挟まる中間ステップ (今回は `fetch`/`rebase`) の呼び出し回数を assert しない、という抜けが見られた (`tests/run-auto-sub.bats` の exhausted-retry テスト)。`worktree-merge-push.bats` 等、同種の push retry loop を検証する既存テストでも同じ抜けがないか、次回の関連改修時に確認する価値がある。
+
+### Acceptance Criteria Verification Difficulty
+- 2 件とも `rubric` で PASS に解決。5 箇所の置換箇所が diff で機械的に確認でき、テストシナリオも Issue の記述 (成功/上限到達) と1対1で対応していたため、grader 判断に曖昧さはなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `_push_with_retry()` は `worktree-merge-push.sh` の lock+push-only mode (`<from-branch>` 未指定) の既存リトライアルゴリズムをそのまま踏襲し、新規パターンを発明しなかった (Spec Notes の既存方針どおり)。
-- リトライ回数は "計 3 回の push 試行" (初回 + 2 回の fetch+rebase リトライ) というカウント方式を `worktree-merge-push.sh` の `MAX_PUSH_RETRY=3` に合わせて統一した。
-- 失敗時は `exit` せず `return 1` のみとし、5 箇所の呼び出し元が持つ既存の best-effort `if/else WARNING` 構造をそのまま維持した (記録より phase 継続を優先する既存方針を壊さない)。
+- review-light (light mode) を実行し、4 観点 (Spec 逸脱 / Edge Case / セキュリティ / ドキュメント整合性) を1エージェントで統合的にチェックした。CONSIDER 1件 (テストの fetch/rebase 回数未検証) を検出し、修正コストが低く価値があると判断してその場で修正した。
+- ローカル `bats tests/run-auto-sub.bats` 実行で無関係な既存失敗 (test 36, Issue #987 関連) を検出したが、この PR の変更を stash して再実行しても同じ失敗が再現したため pre-existing と確認し、CI (Run bats tests SUCCESS ×2) を正としてこの PR のブロッカーとしなかった。
 
 ### Deferred Items
-- Post-merge AC (次回 batch 実行中の実地観察) は `/verify` フェーズでの observation イベント待ちのまま。
-- Notes に記載の `_write_wrapper_retry_recovery` コミットメッセージ形式差異の記述不一致 (Code Retrospective 参照) は本 Issue のスコープ外として未着手。
-- 関連 Issue #984 (recovery 記録の PR番号/Issue番号混同) は本 Issue と独立した別欠陥として未対応のまま。
+- Post-merge AC (次回 batch 実行中の実地観察) は引き続き `/verify` フェーズでの observation イベント待ち。
+- test 36 (Issue #987 関連、ローカル環境依存の可能性がある既存失敗) はこの PR のスコープ外として未調査のまま。
 
 ### Notes for Next Phase
-- `/review` では 5 箇所すべてが `_push_with_retry` を呼び出していること、および `add`/`commit` 部分やメッセージ文言が変更されていないことを diff で確認すると効率的。
-- `bats tests/` フルスイート (1132 件) が green であることを確認済み — `run-auto-sub.sh` を参照する `tests/auto-sub-observability.bats` / `tests/run-code.bats` への影響もないことを確認済み。
+- `/merge` 前に CI が全て green であることを確認済み (DCO / Run bats tests ×2 / Validate skill syntax ×2 / Forbidden Expressions check ×2 / macOS shell compatibility ×2)。
+- MUST 指摘なし、CONSIDER 1件は修正済み。追加の re-review は不要。

--- a/docs/spec/issue-986-auto-sub-recovery-push-retry.md
+++ b/docs/spec/issue-986-auto-sub-recovery-push-retry.md
@@ -74,3 +74,31 @@
 - **`_write_wrapper_retry_recovery` のコミットメッセージ形式差異は本 Issue のスコープ外**: 同関数のコミットメッセージは他 4 箇所と異なり `Co-Authored-By:` トレーラーを含まないが、push リトライとは無関係な既存の差異であり本 Issue では触れない。
 - **Steering Docs sync candidate 確認結果**: `docs/structure.md` (L207, L218, L223) / `docs/tech.md` (L55) / `docs/workflow.md` (L111, L113) / `docs/migration-notes.md` (L48-52, L554-558) はいずれも grep 済みで、`run-auto-sub.sh` の一行要約または高レベルな動作説明に留まり、recovery 記録 push のリトライ機構という粒度までは踏み込んでいないため、本 Issue での変更は不要と判断した。`/code` での再確認を妨げないよう Changed Files に候補として残す。
 - **関連 Issue #984 はスコープ外**: Related Issues に挙げられている #984 (recovery 記録の PR番号/Issue番号混同) は同じ 5 つの recovery-write 経路に関わる別欠陥だが、push リトライとは独立した問題であり本 Issue では対応しない。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜5 をそのままの順序・位置で実装した。
+
+### Design Gaps/Ambiguities
+- Notes の「`_write_wrapper_retry_recovery` のコミットメッセージ形式差異」記述 (同関数のコミットメッセージは他 4 箇所と異なり `Co-Authored-By:` トレーラーを含まない、という記載) は、実装時点のソースでは実際には含まれていることを確認した。差異が既に解消済みか、Spec 起草時の調査に誤りがあった可能性があるが、いずれにせよ push リトライとは無関係かつ本 Issue のスコープ外のため、修正は行わなかった。
+
+### Rework
+- N/A — 手戻りは発生しなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `_push_with_retry()` は `worktree-merge-push.sh` の lock+push-only mode (`<from-branch>` 未指定) の既存リトライアルゴリズムをそのまま踏襲し、新規パターンを発明しなかった (Spec Notes の既存方針どおり)。
+- リトライ回数は "計 3 回の push 試行" (初回 + 2 回の fetch+rebase リトライ) というカウント方式を `worktree-merge-push.sh` の `MAX_PUSH_RETRY=3` に合わせて統一した。
+- 失敗時は `exit` せず `return 1` のみとし、5 箇所の呼び出し元が持つ既存の best-effort `if/else WARNING` 構造をそのまま維持した (記録より phase 継続を優先する既存方針を壊さない)。
+
+### Deferred Items
+- Post-merge AC (次回 batch 実行中の実地観察) は `/verify` フェーズでの observation イベント待ちのまま。
+- Notes に記載の `_write_wrapper_retry_recovery` コミットメッセージ形式差異の記述不一致 (Code Retrospective 参照) は本 Issue のスコープ外として未着手。
+- 関連 Issue #984 (recovery 記録の PR番号/Issue番号混同) は本 Issue と独立した別欠陥として未対応のまま。
+
+### Notes for Next Phase
+- `/review` では 5 箇所すべてが `_push_with_retry` を呼び出していること、および `add`/`commit` 部分やメッセージ文言が変更されていないことを diff で確認すると効率的。
+- `bats tests/` フルスイート (1132 件) が green であることを確認済み — `run-auto-sub.sh` を参照する `tests/auto-sub-observability.bats` / `tests/run-code.bats` への影響もないことを確認済み。

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -41,6 +41,7 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 ### Applicable Phases
 - code (patch route — `scripts/worktree-merge-push.sh`)
 - merge
+- auto (`run-auto-sub.sh`'s recovery-record push, 5 sites — lock+push-only mode variant, no `--from` branch)
 
 ### Fallback Steps
 0. Immediately after `acquire_lock` (before the `--from` merge block): run `git fetch origin <base-branch>` as best-effort — failure emits a warning to stderr but does not abort. This ensures that subsequent ref-fetch and rebase steps reference an up-to-date `origin/<base-branch>` ref rather than a stale local snapshot.
@@ -70,7 +71,7 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 - Step 3 (is-ancestor check) added in #853: when `git rebase` reports "Current branch is up to date" (is-ancestor=true) but the local main ref differs, the subsequent ref-fetch still fails silently; the explicit is-ancestor check detects this and skips directly to the ref-fetch retry, eliminating the silent no-op path
 - Push retry loop added in #853: in parallel session environments a concurrent session may push between the worktree rebase and the local push, causing a non-fast-forward push failure; the retry loop (max 3, fetch+rebase+push each iteration) resolves this without requiring human intervention
 - Push retry loop aligned with the checkout-less design in #970: the retry-scoped rebase reused a bare `git rebase origin/<base>` against the shared directory's current HEAD, which is the same checkout-dependent defect class #961 closed for the primary merge path — it just went unnoticed because #961's Changed Files scoped out this loop. #970 brings the retry rebase in line with step 5's worktree-scoped rebase whenever `<from-branch>` is available, leaving the bare rebase only for the `<from-branch>`-unset lock+push-only mode where no other branch exists to rebase
-- See also: #314 (phase state reconciler), #308 (orchestration improvement series), #517 (incident that triggered #522), #853 (parallel session race hardening), #961 (checkout-less ref-fetch replacement for the `git pull --rebase` fallback, and removal of the non-worktree bare-rebase branch), #970 (checkout-less rewrite of the push-retry loop's rebase, closing the gap #961 left out of scope)
+- See also: #314 (phase state reconciler), #308 (orchestration improvement series), #517 (incident that triggered #522), #853 (parallel session race hardening), #961 (checkout-less ref-fetch replacement for the `git pull --rebase` fallback, and removal of the non-worktree bare-rebase branch), #970 (checkout-less rewrite of the push-retry loop's rebase, closing the gap #961 left out of scope), #986 (applied this push retry pattern to `run-auto-sub.sh`'s 5 recovery-record write paths via the shared `_push_with_retry()` helper, the lock+push-only mode variant of this fallback)
 
 ---
 

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -20,6 +20,35 @@ _spec_has_changes() {
   git -C "$repo_root" status --porcelain "$spec_rel_path" 2>/dev/null | grep -q .
 }
 
+# Pushes HEAD to origin, retrying with fetch+rebase on non-fast-forward rejection.
+# Lock+push-only mode variant (no --from branch to rebase separately) of the push
+# retry loop in scripts/worktree-merge-push.sh.
+# See modules/orchestration-fallbacks.md#ff-only-merge-fallback
+# Usage: _push_with_retry REPO_ROOT
+# Returns 0 on success, 1 if all retries are exhausted or a step fails. Never exits
+# the script -- callers keep their existing best-effort if/else WARNING handling.
+_push_with_retry() {
+  local repo_root="$1"
+  local attempt=0
+  local branch
+
+  while true; do
+    if git -C "$repo_root" push origin HEAD; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    if [[ $attempt -ge 3 ]]; then
+      return 1
+    fi
+    branch=$(git -C "$repo_root" rev-parse --abbrev-ref HEAD) || return 1
+    git -C "$repo_root" fetch origin "$branch" || return 1
+    if ! git -C "$repo_root" rebase "origin/${branch}"; then
+      git -C "$repo_root" rebase --abort 2>/dev/null || true
+      return 1
+    fi
+  done
+}
+
 # Validates recovery function arguments to prevent path traversal via glob patterns.
 # Usage: _validate_recovery_args ISSUE [PHASE] [RECOVERY_TYPE]
 # Returns 1 and prints to stderr if any argument fails validation.
@@ -105,7 +134,7 @@ _write_manual_recovery_to_spec() {
        && git -C "$_repo_root" commit -s -m "Record manual recovery in auto retrospective for issue #${issue}
 
 Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
-       && git -C "$_repo_root" push origin HEAD; then
+       && _push_with_retry "$_repo_root"; then
       echo "[#${issue}] [recovery] spec auto retrospective updated for issue #${issue} (manual recovery)"
     else
       echo "[#${issue}] WARNING: could not commit/push manual recovery to spec; continuing" >&2
@@ -236,7 +265,7 @@ _write_tier2_recovery_to_spec() {
        && git -C "$_repo_root" commit -s -m "Record Tier 2 recovery in auto retrospective for issue #${issue}
 
 Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
-       && git -C "$_repo_root" push origin HEAD; then
+       && _push_with_retry "$_repo_root"; then
       echo "${LOG_PREFIX} [recovery] spec auto retrospective updated for issue #${issue}"
     else
       echo "${LOG_PREFIX} WARNING: could not commit/push Tier 2 recovery to spec; continuing" >&2
@@ -283,7 +312,7 @@ _write_tier3_recovery_to_spec() {
        && git -C "$_repo_root" commit -s -m "Record Tier 3 recovery in auto retrospective for issue #${issue}
 
 Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
-       && git -C "$_repo_root" push origin HEAD; then
+       && _push_with_retry "$_repo_root"; then
       echo "${LOG_PREFIX} [recovery] spec auto retrospective updated for issue #${issue} (tier3)"
     else
       echo "${LOG_PREFIX} WARNING: could not commit/push Tier 3 recovery to spec; continuing" >&2
@@ -337,7 +366,7 @@ PYEOF
        && git -C "$_repo_root" commit -s -m "Record wrapper-retry-on-kill recovery for issue #${issue} ${phase}
 
 Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
-       && git -C "$_repo_root" push origin HEAD; then
+       && _push_with_retry "$_repo_root"; then
       echo "${LOG_PREFIX} [recovery] wrapper-retry-on-kill recovery log committed and pushed"
     else
       echo "${LOG_PREFIX} WARNING: could not commit/push wrapper-retry-on-kill recovery log" >&2
@@ -537,7 +566,7 @@ run_phase_with_recovery() {
     if ! git -C "$_repo_root" diff --quiet "docs/reports/orchestration-recoveries.md" 2>/dev/null; then
       if git -C "$_repo_root" add "docs/reports/orchestration-recoveries.md" \
          && git -C "$_repo_root" commit -s -m "Record Tier 3 recovery event for issue #${issue} ${phase} phase" \
-         && git -C "$_repo_root" push origin HEAD; then
+         && _push_with_retry "$_repo_root"; then
         echo "${LOG_PREFIX} [recovery] recovery log committed and pushed"
       else
         echo "${LOG_PREFIX} WARNING: could not commit/push recovery log; /verify may detect dirty file" >&2

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -1164,6 +1164,105 @@ MOCK
     grep -qE "commit.*manual recovery" "$GIT_LOG"
 }
 
+@test "run-auto-sub: push retry: non-fast-forward push succeeds after one fetch+rebase retry" {
+    export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    echo "# Issue #42: test spec" > "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GIT_LOG"
+if [[ "$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
+    exit 0
+fi
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo " M docs/spec/issue-42-test.md"
+    exit 0
+fi
+if [[ "$*" == *"rev-parse --abbrev-ref HEAD"* ]]; then
+    echo "main"
+    exit 0
+fi
+if [[ "$*" == *"push origin HEAD"* ]]; then
+    COUNT_FILE="$BATS_TEST_TMPDIR/push_count"
+    count=0
+    [ -f "$COUNT_FILE" ] && count=$(cat "$COUNT_FILE")
+    count=$((count + 1))
+    echo "$count" > "$COUNT_FILE"
+    [ "$count" -eq 1 ] && exit 1
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    # No open PR for this issue: override the global gh mock's pr list default.
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo "[]"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" --write-manual-recovery 42 code push-only
+    [ "$status" -eq 0 ]
+    push_count=$(grep -c "push origin HEAD" "$GIT_LOG")
+    [ "$push_count" -eq 2 ]
+    grep -q "fetch origin main" "$GIT_LOG"
+    grep -q "rebase origin/main" "$GIT_LOG"
+}
+
+@test "run-auto-sub: push retry: gives up after 3 attempts and warns but continues" {
+    export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    echo "# Issue #42: test spec" > "$BATS_TEST_TMPDIR/docs/spec/issue-42-test.md"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GIT_LOG"
+if [[ "$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
+    exit 0
+fi
+if [[ "$*" == *"status"* && "$*" == *"--porcelain"* && "$*" == *"issue-42"* ]]; then
+    echo " M docs/spec/issue-42-test.md"
+    exit 0
+fi
+if [[ "$*" == *"rev-parse --abbrev-ref HEAD"* ]]; then
+    echo "main"
+    exit 0
+fi
+if [[ "$*" == *"push origin HEAD"* ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    # No open PR for this issue: override the global gh mock's pr list default.
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo "[]"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" --write-manual-recovery 42 code push-only
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"WARNING: could not commit/push manual recovery to spec; continuing"* ]]
+    push_count=$(grep -c "push origin HEAD" "$GIT_LOG")
+    [ "$push_count" -eq 3 ]
+}
+
 @test "run-auto-sub: manual recovery: skips commit when an open PR exists for the issue" {
     export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
     export GH_LOG="$BATS_TEST_TMPDIR/gh.log"

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -1261,6 +1261,10 @@ MOCK
     [[ "$output" == *"WARNING: could not commit/push manual recovery to spec; continuing"* ]]
     push_count=$(grep -c "push origin HEAD" "$GIT_LOG")
     [ "$push_count" -eq 3 ]
+    fetch_count=$(grep -c "fetch origin main" "$GIT_LOG")
+    [ "$fetch_count" -eq 2 ]
+    rebase_count=$(grep -c "rebase origin/main" "$GIT_LOG")
+    [ "$rebase_count" -eq 2 ]
 }
 
 @test "run-auto-sub: manual recovery: skips commit when an open PR exists for the issue" {


### PR DESCRIPTION
## Summary

`run-auto-sub.sh` の recovery 記録書き込み経路 5 箇所 (`_write_manual_recovery_to_spec` / `_write_tier2_recovery_to_spec` / `_write_tier3_recovery_to_spec` / `_write_wrapper_retry_recovery` / `run_phase_with_recovery` 内 Tier3 recoveries log push) に、`git push origin HEAD` の non-fast-forward 失敗時のリトライ処理を追加した。

- 新規ヘルパー `_push_with_retry()` を追加 (`_spec_has_changes()` の直後、`_validate_recovery_args()` の手前)。`modules/orchestration-fallbacks.md#ff-only-merge-fallback` の push retry loop (lock+push-only mode variant) と同じアルゴリズムで、`git fetch origin <branch>` → `git rebase origin/<branch>` を挟んで最大 3 回 push を試行する
- 5 箇所すべての `&& git -C "$_repo_root" push origin HEAD` を `&& _push_with_retry "$_repo_root"` に置き換え。`add`/`commit` 部分や成功時/WARNING 時のメッセージ文言は変更していない (ベストエフォート契約を維持)
- `modules/orchestration-fallbacks.md` の `#ff-only-merge-fallback` エントリの Applicable Phases / Rationale に本 Issue (#986) の適用を追記
- `tests/run-auto-sub.bats` に、push 失敗 → fetch+rebase → 再push成功のシナリオと、3回リトライしても失敗し WARNING を出して続行するシナリオの計 2 件のテストを追加

## Verification (pre-merge)
- run-auto-sub.sh の recovery 記録書き込み経路 5 箇所すべてが `_push_with_retry` 共通ヘルパーを使用し、non-fast-forward 失敗時に fetch+rebase を挟んで最大 3 回リトライする
- `tests/run-auto-sub.bats` にリトライ成功/上限到達 (3回) の両ケースを検証するテストが追加され、`bats tests/` (フルスイート 1132 件) が green

## Verification (post-merge)
- 次回 `/auto --batch` 実行中に recovery 記録の push が remote 先行と競合した際、リトライで記録が保全されることを観察

closes #986
