### PR TITLE
Issue #989: bats setup() に EMIT_* / AUTO_SESSION_ID の防御的 unset を追加

### DIFF
--- a/docs/spec/issue-989-bats-setup-defensive-unset.md
+++ b/docs/spec/issue-989-bats-setup-defensive-unset.md
@@ -50,3 +50,27 @@ Issue #987 の review フェーズで、`run-auto-sub.sh` の `run_phase_with_re
 - **SPEC_DEPTH=light (Size M) のため Step 7 (Ambiguity Resolution) / Step 8 (Uncertainty Identification) はスキップ。** ただし Issue 本文に `/issue` フェーズの non-interactive 自動解決結果が既に記載されている: setup() には「unset → 明示 export」の順で5変数を追加する方針を採用 (`tests/run-spec.bats` / `tests/run-merge.bats` / `tests/run-code.bats` の既存パターン (`unset EMIT_PHASE_NAME EMIT_ISSUE_NUMBER AUTO_SESSION_ID` を setup() 後半に配置) と整合)。不採用案 (emit-event.bats の明示 export を削除し各テスト個別に export させる) は影響範囲が広いため見送り。
 - **Verify command 補強について**: rubric の grader 記述が `EMIT_ISSUE_NUMBER` / `EMIT_PHASE_NAME` / `EMIT_PR_NUMBER` / `_EXTRA_SELF_ISSUE` / `AUTO_SESSION_ID` という具体的な変数名 (定数名) を列挙しているため (`modules/verify-patterns.md` §9 の rubric+定数名補強ルールに該当)、決定的な補強として `file_contains "AUTO_SESSION_ID"` を両ファイルに追加した。この2件は Issue 本文の Pre-merge AC (2件) には存在しないため、Spec の Pre-merge Verification 件数 (4件) と Issue 本文の Pre-merge AC 件数 (2件) は意図的な差分 (Count alignment check の警告は許容する)。他4変数は実装前から両ファイル中に (異なる文脈で) 既に出現するため before/after のデルタシグナルとして機能しない一方、`AUTO_SESSION_ID` は両ファイルとも実装前0件のため補強対象として選定した。
 - **ドキュメント同期は対象外と判断**: この防御的 unset パターンは `docs/tech.md` § BATS Mocking Convention (`WHOLEWORK_SCRIPT_DIR`) とは別の関心事であり、Issue 本文も変更対象を2ファイルに明示的に限定している (不採用案の理由と同じく影響範囲拡大を回避する方針)。パターンをテスト規約として `docs/tech.md` に文書化する提案は将来のフォローアップ候補として残すが、本 Issue の Acceptance Criteria には含めない。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A (Implementation Steps 1-2 をそのまま適用。`tests/run-auto-sub.bats` は既存 unset 行への追記、`tests/emit-event.bats` は明示 export 直前への unset 追加という Spec の指定通り)
+
+### Design Gaps/Ambiguities
+- N/A (setup() 変更の落とし所は Issue 本文の Auto-Resolve Log で既に確定済みで、実装時に新たな曖昧点は発生しなかった)
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec Implementation Steps 1-2 の記述通り、`unset → 明示 export` の順序を維持したまま両ファイルの setup() を修正した
+- Pre-merge verify command は Spec の4件 (Issue AC 2件 + file_contains 補強2件) を全て実行し、rubric/command/file_contains×2 いずれも PASS
+
+### Deferred Items
+- `docs/tech.md` へのパターン文書化 (Spec Notes に記載の将来フォローアップ候補) は本 Issue のスコープ外のまま据え置き
+
+### Notes for Next Phase
+- Post-merge AC は CI 上の bats フルスイート green 確認のみ。対象2ファイル以外への副作用は Pre-merge 時点のローカル実行 (83/83 green) で観測されていない

--- a/docs/spec/issue-989-bats-setup-defensive-unset.md
+++ b/docs/spec/issue-989-bats-setup-defensive-unset.md
@@ -62,15 +62,27 @@ Issue #987 の review フェーズで、`run-auto-sub.sh` の `run_phase_with_re
 ### Rework
 - N/A
 
+## review retrospective
+
+### Spec vs. Implementation Divergence Patterns
+- Nothing to note (PR diff は Spec Implementation Steps 1-2 と完全一致。乖離なし)
+
+### Recurring Issues
+- Nothing to note (review-light の4観点いずれも issue 検出なし)
+
+### Acceptance Criteria Verification Difficulty
+- Nothing to note (rubric / command とも UNCERTAIN なく決定的に PASS 判定できた。Spec の Pre-merge Verification 件数 (4件: Issue AC 2件 + file_contains 補強2件) と Issue 本文の Pre-merge AC 件数 (2件) の差は Spec Notes で意図的な差分として既に説明済みで、review 時に混乱は発生しなかった)
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec Implementation Steps 1-2 の記述通り、`unset → 明示 export` の順序を維持したまま両ファイルの setup() を修正した
-- Pre-merge verify command は Spec の4件 (Issue AC 2件 + file_contains 補強2件) を全て実行し、rubric/command/file_contains×2 いずれも PASS
+- Issue Size = M (REVIEW_DEPTH=light) のため review-light エージェント1体による4観点統合レビューを実施し、Step 10.1-10.3 の並列 review-spec/review-bug 構成は使用しなかった
+- 外部レビューツール (Copilot/Claude Code Review/CodeRabbit) はすべて `.wholework.yml` 未設定のため Step 7 を全スキップし、Step 8 (静的 AC 検証) から開始した
 
 ### Deferred Items
-- `docs/tech.md` へのパターン文書化 (Spec Notes に記載の将来フォローアップ候補) は本 Issue のスコープ外のまま据え置き
+- None (issue なしのため Step 12 の fix 作業も AC 更新も発生しなかった)
 
 ### Notes for Next Phase
-- Post-merge AC は CI 上の bats フルスイート green 確認のみ。対象2ファイル以外への副作用は Pre-merge 時点のローカル実行 (83/83 green) で観測されていない
+- `/merge 997` 実行可。MUST issue なし、CI 全ジョブ green、Issue AC 2件とも PASS 済み
+- Post-merge AC (CI 上の bats フルスイート green 確認) は `/verify` で確認予定

--- a/tests/emit-event.bats
+++ b/tests/emit-event.bats
@@ -9,6 +9,7 @@ setup() {
     mkdir -p "$MOCK_DIR"
     export PATH="$MOCK_DIR:$PATH"
     export AUTO_EVENTS_LOG="$BATS_TEST_TMPDIR/auto-events.jsonl"
+    unset EMIT_ISSUE_NUMBER EMIT_PR_NUMBER EMIT_PHASE_NAME _EXTRA_SELF_ISSUE AUTO_SESSION_ID
     export EMIT_ISSUE_NUMBER="42"
     export EMIT_PHASE_NAME="code"
 

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -10,7 +10,7 @@ setup() {
     # outer run-auto-sub.sh process (e.g. this suite invoked from inside a
     # live /review or /merge phase session) — tests below assert issue-42
     # targeting under the assumption these start unset, per issue #984 fix.
-    unset EMIT_ISSUE_NUMBER EMIT_PR_NUMBER EMIT_PHASE_NAME _EXTRA_SELF_ISSUE
+    unset EMIT_ISSUE_NUMBER EMIT_PR_NUMBER EMIT_PHASE_NAME _EXTRA_SELF_ISSUE AUTO_SESSION_ID
 
     # Isolate test from repo .wholework.yml
     echo "permission-mode: bypass" > "$BATS_TEST_TMPDIR/.wholework.yml"


### PR DESCRIPTION
## Summary
Issue #987 の review フェーズで実例が発生した「開発環境の env var 汚染がテストのバグを隠蔽して false PASS を生む」問題への対策として、`tests/run-auto-sub.bats` と `tests/emit-event.bats` の setup() に防御的な `unset` を追加した。

- `tests/run-auto-sub.bats`: setup() 冒頭の既存 unset に `AUTO_SESSION_ID` を追記 (既存4変数に加えて対象5変数を網羅)
- `tests/emit-event.bats`: setup() で明示 export の直前に `EMIT_ISSUE_NUMBER` / `EMIT_PR_NUMBER` / `EMIT_PHASE_NAME` / `_EXTRA_SELF_ISSUE` / `AUTO_SESSION_ID` の unset を追加 (unset → 明示 export の順を維持し、既存テストの既知値前提は壊さない)

## Verification (pre-merge)
- `tests/run-auto-sub.bats` と `tests/emit-event.bats` の setup() が対象5変数を明示的に unset している (rubric判定: PASS)
- `bats tests/run-auto-sub.bats tests/emit-event.bats` 実行結果: 83/83 green
- 両ファイルに `AUTO_SESSION_ID` の参照が追加されている (file_contains: PASS)
- `python3 scripts/validate-skill-syntax.py skills/` : 0 error
- `bash scripts/check-forbidden-expressions.sh` : PASS

## Verification (post-merge)
- CI (`.github/workflows/test.yml`) 上で bats フルスイートが green であることを確認する (対象2ファイル以外への副作用がないことの最終確認)

closes #989
