### PR TITLE
Issue #1009: run-auto-sub の wrapper-retry-on-kill エントリを canonical な H2 形式に修正

### DIFF
--- a/docs/spec/issue-1009-wrapper-retry-h2-format.md
+++ b/docs/spec/issue-1009-wrapper-retry-h2-format.md
@@ -73,3 +73,30 @@ Steering Docs sync candidate grep (`grep -l "run-auto-sub.sh" docs/*.md docs/ja/
 ## Consumed Comments
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / 一行要約: `/issue 1009 --non-interactive` の Issue Retrospective コメント。Type=Bug, Size=M, Value=2 の判定根拠と、rubric AC への補助 `file_not_contains` 追加理由、Auto-Resolve Log (Diagnosis 文言・Recovery Applied 参照先・Improvement Candidate 記入方法の 3 点) を記録 / URL: https://github.com/saitoco/wholework/issues/1009#issuecomment-4978480709
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜4 を設計どおりの順序・内容で実装した。4 番目の引数 `RUNNER_SCRIPT_NAME` の追加も Notes に記載された設計判断のとおり。
+
+### Design Gaps/Ambiguities
+- N/A — Spec の Notes (Steering Docs sync 不要の判断根拠、バックフィル不要の判断根拠) が実装時に発生しうる疑問を先回りして解消しており、追加の曖昧点は発生しなかった。
+
+### Rework
+- N/A — テスト追加を含め、最初の実装で `bats tests/run-auto-sub.bats tests/collect-recovery-candidates.bats` (76 tests) が PASS した。
+
+## Phase Handoff
+
+<!-- phase: code -->
+
+### Key Decisions
+- `_write_wrapper_retry_recovery()` を `_write_manual_recovery_to_recoveries_log()` (#1005) と同型の H2 5 セクション構成 (Context/Diagnosis/Recovery Applied/Outcome/Improvement Candidate) に書き換えた。既存の success/escalated 判定ロジックは変更せず `### Outcome` に流用した。
+- `RUNNER_SCRIPT_NAME` を 4 番目の引数として追加し、デフォルト値 `run-auto-sub.sh` を持たせた。呼び出し箇所は `$(basename "$runner_script")` を渡す。
+- 新規テストは `tests/run-auto-sub.bats` の既存 `retry-on-kill: child runner killed once then succeeds` テストの直後に、`tests/collect-recovery-candidates.bats` の既存 `normal detection` テストの直後に、それぞれ Spec 指定どおりの位置に追加した。
+
+### Deferred Items
+- Post-merge AC (次回 wrapper-retry-on-kill recovery 発生時の H2 形式観察) は `/verify` の `auto-run` イベント発火時の再評価に委ねる。バックフィルは対象外 (Spec Notes のとおり既存データ 0 件を確認済み)。
+
+### Notes for Next Phase
+- Steering Docs (`docs/tech.md` 等) への同期は Spec Notes で不要と判断済み。`/review` で再度同じ grep 確認をやり直す必要はない。
+- `file_not_contains "scripts/run-auto-sub.sh" "### wrapper-retry-on-kill ("` の pre-merge AC は grep で直接確認済み (旧 H3 テンプレート文字列は完全に除去)。

--- a/docs/spec/issue-1009-wrapper-retry-h2-format.md
+++ b/docs/spec/issue-1009-wrapper-retry-h2-format.md
@@ -87,16 +87,28 @@ Steering Docs sync candidate grep (`grep -l "run-auto-sub.sh" docs/*.md docs/ja/
 
 ## Phase Handoff
 
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `_write_wrapper_retry_recovery()` を `_write_manual_recovery_to_recoveries_log()` (#1005) と同型の H2 5 セクション構成 (Context/Diagnosis/Recovery Applied/Outcome/Improvement Candidate) に書き換えた。既存の success/escalated 判定ロジックは変更せず `### Outcome` に流用した。
-- `RUNNER_SCRIPT_NAME` を 4 番目の引数として追加し、デフォルト値 `run-auto-sub.sh` を持たせた。呼び出し箇所は `$(basename "$runner_script")` を渡す。
-- 新規テストは `tests/run-auto-sub.bats` の既存 `retry-on-kill: child runner killed once then succeeds` テストの直後に、`tests/collect-recovery-candidates.bats` の既存 `normal detection` テストの直後に、それぞれ Spec 指定どおりの位置に追加した。
+- `--light` モードのため review-light エージェント1体で全4観点 (Spec乖離/edge case/security/documentation) を統合実施した。MUST/SHOULD issue はゼロ、CONSIDER 1件のみだったため Step 12 の修正作業はスキップした。
+- Step 8 の Pre-merge AC 4件は rubric ×2 / file_not_contains ×1 / command ×1 の全てが safe mode で PASS 判定できた (`command` は CI 参照フォールバックで `Run bats tests` job SUCCESS を確認)。
+- CONSIDER 1件 (`_write_wrapper_retry_recovery()` の `escalated` 分岐に対するテストカバレッジ不足) は PR 起因の regression ではなく既存分岐の未着手ギャップと判断し、General Comments に記録のみ行い修正は見送った。
 
 ### Deferred Items
-- Post-merge AC (次回 wrapper-retry-on-kill recovery 発生時の H2 形式観察) は `/verify` の `auto-run` イベント発火時の再評価に委ねる。バックフィルは対象外 (Spec Notes のとおり既存データ 0 件を確認済み)。
+- Post-merge AC (次回 wrapper-retry-on-kill recovery 発生時の H2 形式観察) は `/verify` の `auto-run` イベント発火時の再評価に委ねる (Spec Notes / code フェーズの Handoff から継続)。
+- CONSIDER issue (`escalated` 分岐のテストカバレッジ) は任意対応のため今回は着手せず、要望があれば別 Issue 化を検討。
 
 ### Notes for Next Phase
-- Steering Docs (`docs/tech.md` 等) への同期は Spec Notes で不要と判断済み。`/review` で再度同じ grep 確認をやり直す必要はない。
-- `file_not_contains "scripts/run-auto-sub.sh" "### wrapper-retry-on-kill ("` の pre-merge AC は grep で直接確認済み (旧 H3 テンプレート文字列は完全に除去)。
+- MUST issue がないため `event=COMMENT` でレビュー投稿済み。`/merge 1021` にそのまま進行可能。
+- Post-merge AC の observation rubric は `/verify` 側で `auto-run` イベント発火を待つ。該当する recovery 発火が観測されない場合は対象外として扱ってよい (Issue本文/Spec双方に明記済み)。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — review-light の Perspective 1 (Spec Deviation) で「No issues found」と判定された。H2 5セクション構成、見出しフォーマット、`RUNNER_SCRIPT_NAME` 引数追加、`_find_known_recoveries_issue` の再利用は Spec の Implementation Steps と一致していた。
+
+### Recurring issues
+- Nothing to note — CONSIDER 1件 (`tests/run-auto-sub.bats` の `escalated` 分岐に対するテストカバレッジ不足) のみで、他の Issue と共通するパターンとは言えない (PR 起因の regression ではなく、`_write_wrapper_retry_recovery()` の既存分岐に対する未着手のテストギャップ)。
+
+### Acceptance criteria verification difficulty
+- Nothing to note — 4件の Pre-merge AC (rubric ×2, file_not_contains ×1, command ×1) はいずれも UNCERTAIN なく PASS 判定できた。`command` hint は safe mode のため CI 参照フォールバック (`Run bats tests` job SUCCESS) で解決した。

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -492,14 +492,18 @@ Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" \
   fi
 }
 
-# _write_wrapper_retry_recovery ISSUE PHASE EXIT_CODE
-# Records a wrapper-retry-on-kill recovery event to orchestration-recoveries.md.
+# _write_wrapper_retry_recovery ISSUE PHASE EXIT_CODE [RUNNER_SCRIPT_NAME]
+# Records a wrapper-retry-on-kill recovery event to orchestration-recoveries.md, in the
+# canonical H2 entry format so scripts/collect-recovery-candidates.sh can pick it up for
+# frequency detection / recoveries-auto-fire (see #1009; previously an H3 entry that the
+# H2-only parser skipped over).
 # Skips silently if the file does not exist (file not in repo → return 0).
 # See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
 _write_wrapper_retry_recovery() {
   local issue="$1"
   local phase="$2"
   local exit_code_arg="$3"
+  local runner_name="${4:-run-auto-sub.sh}"
   local _repo_root="$REPO_ROOT"
   local _recoveries_file="${_repo_root}/docs/reports/orchestration-recoveries.md"
   if [[ ! -f "$_recoveries_file" ]]; then
@@ -512,16 +516,29 @@ _write_wrapper_retry_recovery() {
   else
     _outcome="escalated (retry also killed)"
   fi
+  local _matched_issue
+  _matched_issue="$(_find_known_recoveries_issue "wrapper-retry-on-kill")"
+  local _improvement_candidate="未起票"
+  if [[ -n "$_matched_issue" ]]; then
+    _improvement_candidate="起票済み #${_matched_issue}"
+  fi
   python3 << PYEOF 2>/dev/null || true
 fpath = "${_recoveries_file}"
 marker = "<!-- Log entries appear below, newest first. -->"
 entry = (
-    "\n### wrapper-retry-on-kill (${phase})\n"
-    "- **Date**: ${_date}\n"
-    "- **Issue**: #${issue}, phase: ${phase}\n"
-    "- **Source**: retry-on-kill.sh\n"
-    "- **Exit code**: ${exit_code_arg}\n"
-    "- **Outcome**: ${_outcome}\n"
+    "\n## ${_date}: wrapper-retry-on-kill\n"
+    "\n### Context\n"
+    "- Issue #${issue}, phase: ${phase}\n"
+    "- Source: retry-on-kill.sh\n"
+    "- Wrapper: ${runner_name}, exit code: ${exit_code_arg}\n"
+    "\n### Diagnosis\n"
+    "- wrapper (${runner_name}) が early-kill window (WHOLEWORK_RETRY_ON_KILL_MAX_SEC) 内に exit code ${exit_code_arg} で終了し、retry-on-kill.sh が自動再試行した\n"
+    "\n### Recovery Applied\n"
+    "- modules/orchestration-fallbacks.md#wrapper-retry-on-kill\n"
+    "\n### Outcome\n"
+    "- ${_outcome}\n"
+    "\n### Improvement Candidate\n"
+    "- ${_improvement_candidate}\n"
 )
 try:
     content = open(fpath).read()
@@ -627,7 +644,7 @@ run_phase_with_recovery() {
   set -e
 
   if [[ "${_RETRY_ON_KILL_FIRED:-false}" == "true" ]]; then
-    _write_wrapper_retry_recovery "$EMIT_ISSUE_NUMBER" "$phase" "$exit_code"
+    _write_wrapper_retry_recovery "$EMIT_ISSUE_NUMBER" "$phase" "$exit_code" "$(basename "$runner_script")"
   fi
 
   emit_event "wrapper_exit" "phase=${phase}" "exit_code=${exit_code}"

--- a/tests/collect-recovery-candidates.bats
+++ b/tests/collect-recovery-candidates.bats
@@ -76,3 +76,42 @@ FIXTURE_EOF
   echo "$output" | grep -qF "target-symptom"
   echo "$output" | grep -E $'^target-symptom\t3$'
 }
+
+@test "wrapper-retry-on-kill: H2 entries detected by frequency parser" {
+  cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
+## 2026-06-01 10:00 UTC: wrapper-retry-on-kill
+
+### Context
+- Issue #100, phase: code-patch
+- Source: retry-on-kill.sh
+- Wrapper: run-code.sh, exit code: 0
+
+### Outcome
+- success
+
+## 2026-06-02 10:00 UTC: wrapper-retry-on-kill
+
+### Context
+- Issue #200, phase: code-pr
+- Source: retry-on-kill.sh
+- Wrapper: run-code.sh, exit code: 0
+
+### Outcome
+- success
+
+## 2026-06-03 10:00 UTC: wrapper-retry-on-kill
+
+### Context
+- Issue #300, phase: review
+- Source: retry-on-kill.sh
+- Wrapper: run-review.sh, exit code: 0
+
+### Outcome
+- success
+
+FIXTURE_EOF
+
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 3
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -E $'^wrapper-retry-on-kill\t3$'
+}

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -2178,6 +2178,68 @@ MOCK
     [ "$(cat "$COUNTER_FILE")" -eq 2 ]
 }
 
+@test "retry-on-kill: wrapper-retry-on-kill recovery writes canonical H2 entry" {
+    export GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+    mkdir -p "$BATS_TEST_TMPDIR/docs/reports"
+    printf '%s\n' "# Orchestration Recovery Log" "<!-- Log entries appear below, newest first. -->" > "$BATS_TEST_TMPDIR/docs/reports/orchestration-recoveries.md"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+echo "$@" >> "$GIT_LOG"
+if [[ "$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$BATS_TEST_TMPDIR"
+    exit 0
+fi
+if [[ "$*" == *"diff"* && "$*" == *"orchestration-recoveries.md"* ]]; then
+    exit 1
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo "[]"
+    exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+    echo "[]"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    COUNTER_FILE="$BATS_TEST_TMPDIR/call_counter"
+    echo "0" > "$COUNTER_FILE"
+    export COUNTER_FILE
+    # XS route: only code-patch phase, shortest path
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+    # Counter mock: 1st call exits 143 (SIGTERM), 2nd call exits 0
+    cat > "$MOCK_DIR/run-code.sh" <<'MOCK'
+#!/bin/bash
+N=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+N=$((N + 1))
+echo "$N" > "$COUNTER_FILE"
+if [[ $N -eq 1 ]]; then exit 143; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/run-code.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    [ "$(cat "$COUNTER_FILE")" -eq 2 ]
+    grep -qE "^## [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2} UTC: wrapper-retry-on-kill$" "$BATS_TEST_TMPDIR/docs/reports/orchestration-recoveries.md"
+    grep -q "Wrapper: run-code.sh, exit code: 0" "$BATS_TEST_TMPDIR/docs/reports/orchestration-recoveries.md"
+    ! grep -q -- "### wrapper-retry-on-kill (" "$BATS_TEST_TMPDIR/docs/reports/orchestration-recoveries.md"
+}
+
 @test "session-isolation: exit 1 causes abort with error" {
     cat > "$MOCK_DIR/check-verify-dirty.sh" <<'MOCK'
 #!/bin/bash


### PR DESCRIPTION
## Summary

`scripts/run-auto-sub.sh` の `_write_wrapper_retry_recovery()` が `docs/reports/orchestration-recoveries.md` に書き込むエントリ形式を、旧 H3 形式 (`### wrapper-retry-on-kill (phase)`) から canonical な H2 形式 (`## YYYY-MM-DD HH:MM UTC: wrapper-retry-on-kill`、Context/Diagnosis/Recovery Applied/Outcome/Improvement Candidate の 5 セクション構成) に書き換えた。これにより `scripts/collect-recovery-candidates.sh` の H2 専用パーサから wrapper-retry-on-kill の記録が可視化され、`/audit recoveries` の頻度検出と `recoveries-auto-fire` の閾値判定 (threshold 3) の対象になる。

- `_write_wrapper_retry_recovery()` に 4 番目の引数 `RUNNER_SCRIPT_NAME` を追加し、Wrapper フィールドに実際にリトライされた leaf runner (`run-code.sh` 等) の basename を記載するようにした (デフォルトは `run-auto-sub.sh`)
- `_find_known_recoveries_issue "wrapper-retry-on-kill"` を再利用し、Improvement Candidate を `起票済み #NNN` / `未起票` で埋めるようにした
- 呼び出し箇所 (`run_phase_with_recovery()`) を更新し、`$(basename "$runner_script")` を渡すようにした

## Verification (pre-merge)

- `_write_wrapper_retry_recovery()` が canonical な H2 形式 (5 セクション構成) でエントリを書く
- 旧 H3 形式のエントリテンプレート文字列が `scripts/run-auto-sub.sh` から除去されている
- `collect-recovery-candidates.sh` が wrapper-retry-on-kill エントリを頻度検出できることをテストで検証
- `bats tests/run-auto-sub.bats tests/collect-recovery-candidates.bats` が PASS する (76 tests, 0 failures)

## Verification (post-merge)

- 次回 wrapper-retry-on-kill recovery 発生時、エントリが H2 形式で記録され頻度検出対象になることを観察

closes #1009
