### PR TITLE
Issue #993: reconcile-phase-state _completion_code_patch にスタライ PR 検出を追加

### DIFF
--- a/docs/spec/issue-993-reconcile-code-patch-stray-pr.md
+++ b/docs/spec/issue-993-reconcile-code-patch-stray-pr.md
@@ -78,3 +78,33 @@ AC3 の Issue 本文は `tests/reconcile-phase-state.bats` を主候補としつ
 ## Consumed Comments
 
 - saito / MEMBER / first-class / `/issue` フェーズの Issue Retrospective (トリアージ結果 Type=Bug・Size=M、Background 記載の行番号事実誤認の修正、曖昧点 3 件の自動解決、Pre-merge AC 3 件全てへの verify command 新規付与、Related Issues への #998 追加) — https://github.com/saitoco/wholework/issues/993#issuecomment-4979750986
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Implementation Step 1 は `gh pr list ... -q 'length'` の結果をそのまま `-gt 0` 比較する記述だったが、既存 bats テスト (`tests/reconcile-phase-state.bats` の「same phase: precondition passes but completion not yet reached」) の汎用 `gh` モックが `_completion_code_patch()` 内の全 `gh` 呼び出しに対して非数値文字列 (`phase/ready`) を返す構成だったため、そのまま比較すると bash の算術評価が変数参照として `phase` を解釈しようとし `unbound variable` エラーで異常終了した。`stray_pr_count`・`stray_pr_num` の双方に `=~ ^[0-9]+$` の正規表現ガードを追加し、非数値出力を安全に `0`/シグナル無効として扱うよう変更した。これは `_operate_signal_ts()` が既に採用しているタイムスタンプ形式ガードと同じ防御方針であり、実装全体の一貫性は保たれている。
+
+### Design Gaps/Ambiguities
+
+- Spec の Implementation Step 1 は `gh pr list` の戻り値が常に数値であることを暗黙の前提としていたが、`gh` 呼び出しが失敗した場合や予期しない出力を返した場合の非数値フォールバックは明記されていなかった。今回のテスト回帰で顕在化したため、`_completion_code_pr()` 側の既存コードには存在しないこの種の正規表現ガードを stray PR 検出側にのみ追加した。将来 `_completion_code_pr()` を改修する際は同様のガードの要否を再検討する価値がある。
+
+### Rework
+
+- なし (Implementation Step 1 のガード追加は上記 Deviations に記載の1回の修正で完了し、以降の re-work は発生していない)
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- stray PR 検出条件は Issue 本文 Auto-Resolved Ambiguity Points の方針通り `_completion_code_pr()` と同一のブランチ名パターン (`worktree-code+issue-N`) を再利用した
+- freshness gate は `operate_signal` と同型 (`reopen_ts` 比較) を踏襲し、挿入位置も operate marker の直後・label/state fallback の直前とした (#998 と同じ配置方針)
+- AC3 のテストは `tests/spawn-recovery-subagent.bats` に「reconcile-phase-state.sh を実スクリプトのまま動作させる」統合テストとして追加 (Spec Notes の判断を踏襲)
+
+### Deferred Items
+- `agents/orchestration-recovery.md` への code-patch 向け probe セクション追加は Spec Notes の判断通り不要と確認済み (追加作業なし)
+- `_completion_code_pr()` 側の非数値ガード追加は本 Issue のスコープ外 (Code Retrospective の Design Gaps/Ambiguities 参照)。再改修の機会があれば検討対象
+
+### Notes for Next Phase
+- `review` フェーズでは、既存 `_completion_code_patch` 呼び出し元 (`run-auto-sub.sh` Tier1, `/auto` SKILL.md Step 6) が本変更で回帰していないことを CI (`gh pr checks`) で確認すること (AC2 は github_check のため /code 時点では UNCERTAIN 扱い)
+- bats フルスイート (1206件) はローカルで PASS 済み。CI 上でも同様に PASS するか確認すること

--- a/docs/spec/issue-993-reconcile-code-patch-stray-pr.md
+++ b/docs/spec/issue-993-reconcile-code-patch-stray-pr.md
@@ -93,18 +93,31 @@ AC3 の Issue 本文は `tests/reconcile-phase-state.bats` を主候補としつ
 
 - なし (Implementation Step 1 のガード追加は上記 Deviations に記載の1回の修正で完了し、以降の re-work は発生していない)
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note。review-light agent による Spec Deviation 観点の検証で乖離なし (Implementation Steps 1–4、freshness gate、JSON field 追加、ドキュメント更新のいずれも Spec 記載通り)。
+
+### Recurring issues
+
+コメント内のコード行番号への直接参照 (`_completion_code_pr() (line 289)`) が、同一 PR 内の別箇所への挿入 (29行) だけで陳腐化するという指摘 (CONSIDER) を検出・修正した。行番号を直接埋め込むコメントは今後の diff で容易にずれるため、関数名参照のみに留める書き方を今後の実装でも意識する価値がある。
+
+### Acceptance criteria verification difficulty
+
+AC2 (`github_check "gh pr checks" "Run bats tests"`) の初回検証で、本 PR が変更していない `tests/worktree-merge-push.bats` の無関係なテストが CI 上で FAILURE となった。ローカルで単体・フルスイート双方で複数回実行し安定して PASS することを確認した上で CI 環境固有の flaky failure と判断し、`gh run rerun --failed` で再実行して解消した。`github_check` タイプの verify command は対象ジョブ名のみを見るため、無関係な同名ジョブ内の他テストの偶発的失敗も FAIL 判定に巻き込まれる — レビュー側での flaky 判定と再実行の判断ロジック自体は verify command の記述だけでは自動化できておらず、引き続き人間/AIの判断に依存する。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- stray PR 検出条件は Issue 本文 Auto-Resolved Ambiguity Points の方針通り `_completion_code_pr()` と同一のブランチ名パターン (`worktree-code+issue-N`) を再利用した
-- freshness gate は `operate_signal` と同型 (`reopen_ts` 比較) を踏襲し、挿入位置も operate marker の直後・label/state fallback の直前とした (#998 と同じ配置方針)
-- AC3 のテストは `tests/spawn-recovery-subagent.bats` に「reconcile-phase-state.sh を実スクリプトのまま動作させる」統合テストとして追加 (Spec Notes の判断を踏襲)
+- review-light agent (全4観点) を Size=M / `--light` 指定に従い実行、Spec 記載の実装方針との乖離なしと確認
+- CONSIDER 2件のうち、行番号記述のみ修正 (低リスク・高価値)。複数 `gh pr list` 呼び出しの統合は既存の自己ガードで機能的リスクがないため見送り、レビューコメントに理由を記録済み
+- AC2 の CI 初回 FAILURE は無関係ファイルのテストであることを確認した上で flaky と判断し再実行で解消 (コード変更なし)
 
 ### Deferred Items
-- `agents/orchestration-recovery.md` への code-patch 向け probe セクション追加は Spec Notes の判断通り不要と確認済み (追加作業なし)
-- `_completion_code_pr()` 側の非数値ガード追加は本 Issue のスコープ外 (Code Retrospective の Design Gaps/Ambiguities 参照)。再改修の機会があれば検討対象
+- `scripts/reconcile-phase-state.sh:277` の複数 `gh pr list` 呼び出しの単一呼び出しへの統合 (CONSIDER、efficiency/robustness) は未対応のまま。再改修の機会があれば検討対象
 
 ### Notes for Next Phase
-- `review` フェーズでは、既存 `_completion_code_patch` 呼び出し元 (`run-auto-sub.sh` Tier1, `/auto` SKILL.md Step 6) が本変更で回帰していないことを CI (`gh pr checks`) で確認すること (AC2 は github_check のため /code 時点では UNCERTAIN 扱い)
-- bats フルスイート (1206件) はローカルで PASS 済み。CI 上でも同様に PASS するか確認すること
+- `/merge` 時点で追加の懸念事項なし。MUST/SHOULD issue はゼロ、CI 全ジョブ SUCCESS
+- Post-merge Verification 条件なし (Issue 本文 Post-merge セクションは「なし」)

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -381,21 +381,23 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 - code (patch route — `_completion_code_patch` in `scripts/reconcile-phase-state.sh`)
 
 ### Fallback Steps
-- No manual intervention required. `_completion_code_patch` includes a built-in three-stage check:
+- No manual intervention required. `_completion_code_patch` includes a built-in four-stage check:
   1. Primary: `git log origin/main --grep="closes #${ISSUE_NUMBER}"` (existing check)
   2. Operate marker (when primary finds nothing): `_operate_signal_ts` checks for an execution-log/execution-plan marker comment on the Issue, confirming a diff-less operate route completion (`modules/phase-state.md` § "Operate Route Completion Signature")
-  3. Label/state fallback (when both above find nothing): `gh issue view "$ISSUE_NUMBER" --json labels` and `--json state` to confirm `phase/verify`, `phase/done`, or `CLOSED` state
-- If either fallback stage confirms completion, `_completion_code_patch` returns `matches_expected:true` automatically, preventing Tier 3 sub-agent escalation
+  3. Stray PR (when both above find nothing): `gh pr list --head "worktree-code+issue-${ISSUE_NUMBER}" --state open` checks for an open PR on the SSoT worktree branch, confirming a route-misdetection outcome where the phase's actual artifact is a PR instead of a `closes #N` commit (`modules/phase-state.md` § "Stray PR Completion Signature")
+  4. Label/state fallback (when all three above find nothing): `gh issue view "$ISSUE_NUMBER" --json labels` and `--json state` to confirm `phase/verify`, `phase/done`, or `CLOSED` state
+- If any fallback stage confirms completion, `_completion_code_patch` returns `matches_expected:true` automatically, preventing Tier 3 sub-agent escalation
 
 ### Escalation
-- If both the git log check and the phase label / state fallback fail to confirm completion, the reconciler returns `matches_expected:false` and Tier 2 / Tier 3 escalation proceeds normally
+- If the git log check, operate marker, stray PR check, and the phase label / state fallback all fail to confirm completion, the reconciler returns `matches_expected:false` and Tier 2 / Tier 3 escalation proceeds normally
 - If the `gh` API call fails (network error, rate limit), `labels` and `state` are empty strings; the fallback condition evaluates to false and falls through to the existing mismatch path — no silent false-positive
 
 ### Rationale
 - Introduced in Issue #461: patch Issues whose only artifact is an external-tool auto-commit (no `closes #N` in commit message) caused systematic false-negatives in `_completion_code_patch`, triggering unnecessary Tier 3 sub-agent spawning on every orchestrator re-run
 - Mirrors the two-stage pattern already used in `_completion_spec` (spec file presence + ready-or-later label), keeping the reconciler consistent
 - `phase/verify` is set by `/review` skill after merge confirmation, making it a reliable proxy for code-patch completion when the commit does not carry `closes #N`
-- See also: Issue #461 (introducing this fallback), Issue #460 (`git_committed` verify command), Issue #462 (`verify-patterns.md` recommended pattern)
+- Stage 3 (stray PR) introduced in Issue #993: route misdetection (#979-series) can leave `code-patch`'s actual artifact as an open PR instead of a `closes #N` commit, which none of the original two fallback stages recognized; reuses the branch-name pattern already established by `_completion_code_pr()`
+- See also: Issue #461 (introducing this fallback), Issue #460 (`git_committed` verify command), Issue #462 (`verify-patterns.md` recommended pattern), Issue #993 (stray PR stage)
 
 ---
 

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -35,7 +35,7 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 |-------|-------------|-------------------------------|----------------------|
 | issue | Issue exists and state != CLOSED | `triaged` label on issue | Implemented |
 | spec | `phase/issue` or `phase/spec` label on issue | `$SPEC_PATH/issue-N-*.md` exists AND `phase/(ready\|code\|review\|merge\|verify\|done)` label | Implemented |
-| code-patch | `phase/ready` label on issue, Spec exists OR Size=XS | `git log origin/main --after=<reopen_ts> --grep="closes #N"` returns ≥1 fresh commit (reopen timestamp obtained via `get-last-reopen`); falls back to `git log origin/main --grep="closes #N"` when reopen timestamp unavailable; OR an operate route completion marker comment is found (see "Operate Route Completion Signature" below) | Precondition: `phase/ready` — Implemented; Spec exists OR Size=XS — Implemented (Spec exists OR Size=XS). Completion: Implemented |
+| code-patch | `phase/ready` label on issue, Spec exists OR Size=XS | `git log origin/main --after=<reopen_ts> --grep="closes #N"` returns ≥1 fresh commit (reopen timestamp obtained via `get-last-reopen`); falls back to `git log origin/main --grep="closes #N"` when reopen timestamp unavailable; OR an operate route completion marker comment is found (see "Operate Route Completion Signature" below); OR an open PR on the `worktree-code+issue-N` branch is found (see "Stray PR Completion Signature" below) | Precondition: `phase/ready` — Implemented; Spec exists OR Size=XS — Implemented (Spec exists OR Size=XS). Completion: Implemented |
 | code-pr | `phase/ready` label on issue, Spec exists OR Size=XS | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists OR Size=XS — Implemented (Spec exists OR Size=XS). Completion: Implemented |
 | review | PR is OPEN | PR has a comment containing `<!-- review-summary -->` marker (primary); or `## Review Response Summary` / `## レビュー回答サマリ` (fallback for marker-absent posts) | Implemented |
 | merge | PR is OPEN and reviewDecision is APPROVED | `gh pr view --json state == MERGED` | Implemented |
@@ -57,6 +57,18 @@ To close this gap, `_completion_code_patch()` in `scripts/reconcile-phase-state.
 **Check order**: commit (`closes #N`) → operate marker → label/state fallback (`phase/verify`/`phase/done`/`CLOSED`). The operate marker check runs before the label/state fallback so that it also applies during a fix-cycle re-run (when `reopen_ts` is non-null, the label/state fallback is unconditionally skipped — placing the operate marker check earlier lets it still catch a successful operate route re-run and prevents `run-code.sh` from re-executing the external write).
 
 **Known limitation**: if a reopen timestamp is unavailable and an Issue's Spec is rewritten from operate route to patch route without being reopened, a stale marker from the previous operate cycle can mask a genuine patch route silent no-op. This mirrors the same-shaped limitation already present in the `closes #N` fallback (unbounded grep when no reopen timestamp is available) and is accepted for the same reason — adding asymmetric freshness handling for only one signature would introduce a new class of failure mode.
+
+### Stray PR Completion Signature
+
+Route misdetection (#979-series) can leave the `code-patch` phase's actual artifact as a pushed branch + open PR (a pr-route-shaped outcome) instead of the expected `closes #N` commit to `main`. Without a dedicated signature for this, `_completion_code_patch()` reports `matches_expected: false` even though the Issue's work is genuinely done, which causes `spawn-recovery-subagent.sh`'s `skip)` dispatch guard to reject a correct `action=skip` recovery recommendation (see #993).
+
+`_completion_code_patch()` closes this gap by checking for an open PR on the SSoT worktree branch name, `worktree-code+issue-N` — the same branch-name pattern `_completion_code_pr()` already uses (`gh pr list --head "worktree-code+issue-N" --state open`).
+
+**Detection method**: query the open PR count for the branch; when ≥1, fetch the PR's `createdAt` and apply the freshness gate below; on pass, fetch the PR number and emit `matches_expected: true` with `actual.stray_pr_signal: true` and `actual.pr_number` set.
+
+**Freshness gate**: identical semantics to the "Operate Route Completion Signature" gate above — when a reopen timestamp is available (via `get-last-reopen`), the PR's `createdAt` must be after it; when unavailable, no freshness constraint is applied. This prevents a stray PR left over from *before* a fix-cycle reopen from masking a genuine re-run failure.
+
+**Check order**: commit (`closes #N`) → operate marker → stray PR → label/state fallback (`phase/verify`/`phase/done`/`CLOSED`). The stray PR check runs immediately after the operate marker check and before the label/state fallback, for the same reason the operate marker check is positioned there: when `reopen_ts` is non-null the label/state fallback is unconditionally skipped, so placing the stray PR check earlier lets it still catch a stray PR created during a fix-cycle re-run.
 
 ### JSON Schema (v1)
 
@@ -92,6 +104,7 @@ To close this gap, `_completion_code_patch()` in `scripts/reconcile-phase-state.
 | `actual.pr_number` | number\|null | When PR is checked | PR number, or `null` if not found |
 | `actual.commits_found` | boolean | When git log is checked | `true` if matching commit found on origin/main |
 | `actual.operate_signal` | boolean | When `code-patch` completion does not find a `closes #N` commit | `true` if an operate route completion marker comment (execution-log or execution-plan) was found; see "Operate Route Completion Signature" above |
+| `actual.stray_pr_signal` | boolean | When `code-patch` completion does not find a `closes #N` commit or operate marker | `true` if an open PR on the `worktree-code+issue-N` branch was found and passed the freshness gate; see "Stray PR Completion Signature" above. When `true`, `actual.pr_number` is also set to the PR number |
 | `actual.spec_file` | string\|null | When spec is checked | Path to spec file, or `null` if not found |
 | `actual.issue_state` | string | When issue state is checked | `"OPEN"` or `"CLOSED"` |
 | `actual.size` | string | When spec precondition is checked with Size check | Issue size value (e.g., `"M"`, `"XS"`, `""`) returned by `get-issue-size.sh`. Present when Spec is missing and Size check is performed. |

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -265,6 +265,35 @@ _completion_code_patch() {
   fi
   actual_json="${actual_json%\}},\"operate_signal\":false}"
 
+  # Stray PR completion signal: route misdetection (#979-series) can leave code-patch
+  # phase's actual artifact as a PR (pushed to worktree-code+issue-N branch) instead of
+  # a closes #N commit to main. Detect an open PR on the SSoT worktree branch name as an
+  # alternate success signature, reusing the same branch-name pattern as
+  # _completion_code_pr() (line 289) and the same freshness gate as operate_signal above.
+  # Checked before the label/state fallback so it also applies during a fix-cycle re-run
+  # (reopen_ts non-null skips the label/state fallback below).
+  # See modules/phase-state.md#stray-pr-completion-signature
+  local stray_pr_count
+  stray_pr_count=$(gh pr list --head "worktree-code+issue-${ISSUE_NUMBER}" --state open --json number -q 'length' 2>/dev/null) || stray_pr_count=0
+  [[ "$stray_pr_count" =~ ^[0-9]+$ ]] || stray_pr_count=0
+  local stray_pr_signal=false
+  local stray_pr_num=""
+  if [[ "$stray_pr_count" -gt 0 ]]; then
+    local stray_pr_created_at
+    stray_pr_created_at=$(gh pr list --head "worktree-code+issue-${ISSUE_NUMBER}" --state open --json createdAt -q '.[0].createdAt' 2>/dev/null) || stray_pr_created_at=""
+    if [[ -z "$reopen_ts" || "$reopen_ts" == "null" ]] || [[ "$stray_pr_created_at" > "$reopen_ts" ]]; then
+      stray_pr_num=$(gh pr list --head "worktree-code+issue-${ISSUE_NUMBER}" --state open --json number -q '.[0].number' 2>/dev/null) || stray_pr_num=""
+      [[ "$stray_pr_num" =~ ^[0-9]+$ ]] && stray_pr_signal=true
+    fi
+  fi
+
+  if [[ "$stray_pr_signal" == "true" ]]; then
+    actual_json="${actual_json%\}},\"stray_pr_signal\":true,\"pr_number\":${stray_pr_num}}"
+    _emit_result "true" "stray PR completion: open PR #${stray_pr_num} found for worktree-code+issue-${ISSUE_NUMBER} branch (route misdetection recovery)" "$actual_json"
+    return
+  fi
+  actual_json="${actual_json%\}},\"stray_pr_signal\":false}"
+
   # Fallback: check phase labels or issue state for async external commit areas.
   # See modules/orchestration-fallbacks.md#async-external-commit
   local labels state

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -269,7 +269,7 @@ _completion_code_patch() {
   # phase's actual artifact as a PR (pushed to worktree-code+issue-N branch) instead of
   # a closes #N commit to main. Detect an open PR on the SSoT worktree branch name as an
   # alternate success signature, reusing the same branch-name pattern as
-  # _completion_code_pr() (line 289) and the same freshness gate as operate_signal above.
+  # _completion_code_pr() and the same freshness gate as operate_signal above.
   # Checked before the label/state fallback so it also applies during a fix-cycle re-run
   # (reopen_ts non-null skips the label/state fallback below).
   # See modules/phase-state.md#stray-pr-completion-signature

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -1229,6 +1229,122 @@ MOCK_EOF
     [[ "$output" == *'"operate_signal":false'* ]]
 }
 
+@test "code-patch completion: stray PR - open PR on worktree branch, no reopen -> matches_expected true, stray_pr_signal true" {
+    cat > "$MOCK_DIR/gh-graphql.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "null"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    # Route misdetection (#979-series) scenario: patch route ended up pushing a
+    # branch + PR instead of a closes #N commit. No reopen has happened yet, so
+    # the freshness gate's "reopen_ts empty" branch applies unconditionally.
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$*" == *"--json comments"* ]]; then echo ""; exit 0; fi
+if [[ "$*" == *"--json labels"* ]]; then echo "triaged"; exit 0; fi
+if [[ "$*" == *"--json state"* ]]; then echo "OPEN"; exit 0; fi
+if [[ "$*" == *"-q length"* ]]; then echo "1"; exit 0; fi
+if [[ "$*" == *"-q .[0].createdAt"* ]]; then echo "2026-07-14T00:00:00Z"; exit 0; fi
+if [[ "$*" == *"-q .[0].number"* ]]; then echo "1234"; exit 0; fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "log" ]]; then echo ""; fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/git"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" code-patch 55 --check-completion --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+    [[ "$output" == *'"stray_pr_signal":true'* ]]
+    [[ "$output" == *'"pr_number":1234'* ]]
+    [[ "$output" == *"stray PR completion"* ]]
+}
+
+@test "code-patch completion: stray PR - reopen present + PR created after reopen -> matches_expected true (fix-cycle re-run prevention)" {
+    cat > "$MOCK_DIR/gh-graphql.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "2026-06-01T00:00:00Z"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    # Fix-cycle re-run: the stray PR was (re-)created after the reopen, so it
+    # reflects the current cycle's actual output rather than a stale artifact
+    # from before the reopen.
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$*" == *"--json comments"* ]]; then echo ""; exit 0; fi
+if [[ "$*" == *"--json labels"* ]]; then echo "phase/code"; exit 0; fi
+if [[ "$*" == *"--json state"* ]]; then echo "OPEN"; exit 0; fi
+if [[ "$*" == *"-q length"* ]]; then echo "1"; exit 0; fi
+if [[ "$*" == *"-q .[0].createdAt"* ]]; then echo "2026-07-14T00:00:00Z"; exit 0; fi
+if [[ "$*" == *"-q .[0].number"* ]]; then echo "5678"; exit 0; fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "log" ]]; then echo ""; fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/git"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" code-patch 55 --check-completion --strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"matches_expected":true'* ]]
+    [[ "$output" == *'"stray_pr_signal":true'* ]]
+}
+
+@test "code-patch completion: stray PR - reopen present + PR created before reopen (stale) -> freshness gate rejects" {
+    cat > "$MOCK_DIR/gh-graphql.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "2026-06-01T00:00:00Z"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    # The open PR predates the reopen — it is a leftover artifact from before
+    # the fix-cycle started and must not be treated as evidence that this
+    # cycle's work is complete.
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$*" == *"--json comments"* ]]; then echo ""; exit 0; fi
+if [[ "$*" == *"--json labels"* ]]; then echo "phase/code"; exit 0; fi
+if [[ "$*" == *"--json state"* ]]; then echo "OPEN"; exit 0; fi
+if [[ "$*" == *"-q length"* ]]; then echo "1"; exit 0; fi
+if [[ "$*" == *"-q .[0].createdAt"* ]]; then echo "2026-01-01T00:00:00Z"; exit 0; fi
+if [[ "$*" == *"-q .[0].number"* ]]; then echo "9999"; exit 0; fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "log" ]]; then echo ""; fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/git"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" code-patch 55 --check-completion --strict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"matches_expected":false'* ]]
+    [[ "$output" == *'"stray_pr_signal":false'* ]]
+}
+
 @test "code-patch precondition: Spec missing and Size != XS -> mismatch" {
     export MOCK_SPEC_PATH="$BATS_TEST_TMPDIR/empty-spec-patch"
     mkdir -p "$BATS_TEST_TMPDIR/empty-spec-patch"

--- a/tests/spawn-recovery-subagent.bats
+++ b/tests/spawn-recovery-subagent.bats
@@ -168,6 +168,58 @@ MOCK
     [ ! -f "$RUNNER_LOG" ]
 }
 
+@test "spawn-recovery: stray PR completion via real reconcile-phase-state.sh (no mock) -> action=skip accepted (issue #993)" {
+    # Unlike every other skip) test above, this one does NOT replace
+    # reconcile-phase-state.sh with a canned matches_expected mock — it runs the
+    # real script (only its gh/git/gh-graphql.sh dependencies are mocked). This
+    # exercises the skip) dispatch guard's actual re-validation of
+    # matches_expected against live state (#980 review found no existing test
+    # did this: every skip) test mocked reconcile-phase-state.sh directly,
+    # so the guard's own re-check logic was never really executed). The live
+    # state simulated here is the #993 stray-PR scenario: route misdetection
+    # left an open PR on the worktree-code+issue-N branch instead of a
+    # closes #N commit, which _completion_code_patch's new stray-PR signature
+    # must recognize as completion for action=skip to be accepted.
+    cp "$REAL_SCRIPTS_DIR/reconcile-phase-state.sh" "$MOCK_DIR/reconcile-phase-state.sh"
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
+    cat > "$MOCK_DIR/gh-graphql.sh" <<'MOCK'
+#!/bin/bash
+echo "null"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$*" == *"--json comments"* ]]; then echo ""; exit 0; fi
+if [[ "$*" == *"--json labels"* ]]; then echo "triaged"; exit 0; fi
+if [[ "$*" == *"--json state"* ]]; then echo "OPEN"; exit 0; fi
+if [[ "$*" == *"-q length"* ]]; then echo "1"; exit 0; fi
+if [[ "$*" == *"-q .[0].createdAt"* ]]; then echo "2026-07-14T00:00:00Z"; exit 0; fi
+if [[ "$*" == *"-q .[0].number"* ]]; then echo "42"; exit 0; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "log" ]]; then echo ""; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    make_claude_mock '{"action":"skip","rationale":"open PR found for the issue worktree branch, treat as complete","steps":[]}'
+    cd "$BATS_TEST_TMPDIR"
+
+    run bash "$SCRIPT" code-patch 55 --log "$LOG_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"action=skip"* ]]
+    [[ "$output" != *"rejected"* ]]
+    [ ! -f "$RUNNER_LOG" ]
+}
+
 @test "spawn-recovery: CLAUDE_BIN mock returns plan with forbidden op force_push: validation aborts" {
     make_claude_mock '{"action":"recover","rationale":"fix","steps":[{"op":"force_push","cmd":"git push -f"}]}'
     cd "$BATS_TEST_TMPDIR"


### PR DESCRIPTION
## Summary
- `_completion_code_patch()`（`scripts/reconcile-phase-state.sh`）に stray PR completion signature を追加。`closes #N` コミット・operate route マーカーがいずれも見つからない場合に、issue の worktree ブランチ (`worktree-code+issue-N`) に紐づく open PR を completion signature として検出する（`_completion_code_pr()` と同一のブランチ名パターンを再利用）。
- freshness gate は既存の `operate_signal` と同型 (`reopen_ts` が空/null、または signal の `createdAt` が `reopen_ts` より後) を適用し、fix-cycle 再実行時に古い stray PR を誤検出しないようにした。
- `modules/phase-state.md` に Stray PR Completion Signature サブセクションと `actual.stray_pr_signal` フィールドを追記、`modules/orchestration-fallbacks.md` の `async-external-commit` フォールバックを three-stage → four-stage に更新。
- `tests/reconcile-phase-state.bats` に stray PR 検出分岐のテストを3件追加（open PR あり・reopen なし / reopen あり+PR が後 / reopen あり+PR が前でfreshness gate拒否）。
- `tests/spawn-recovery-subagent.bats` に、`reconcile-phase-state.sh` を実スクリプトのまま (canned mock で置き換えず) 動作させ、stray PR 検出により `spawn-recovery-subagent.sh` の `skip)` 分岐が `action=skip` を受理することを検証する統合テストを1件追加（#980 review が指摘した「skip ガードの再検証ロジックが一度も実運動されないテスト構成」のギャップを解消）。

## Verification (pre-merge)
- `_completion_code_patch()` が open PR を検出した場合に `matches_expected:true` を返すロジックが実装されている (rubric + `grep -A 80 '^_completion_code_patch()' scripts/reconcile-phase-state.sh | grep -q 'pr list'` で確認済み)
- フルスイート bats 実行 1206件 PASS (behavioral change detection によりフルスイート実行)
- `tests/spawn-recovery-subagent.bats` にモックなしの `skip)` 分岐到達テストを追加済み

## Verification (post-merge)
- 既存の `_completion_code_patch` 呼び出し元 (`run-auto-sub.sh` Tier1, `/auto` SKILL.md Step 6) の既存テストが回帰なく CI 上で PASS することを `gh pr checks` で確認

closes #993
