### PR TITLE
Issue #1026: Add config= gate to observation AC condition check

### DIFF
--- a/docs/spec/issue-1026-observation-config-gate.md
+++ b/docs/spec/issue-1026-observation-config-gate.md
@@ -70,17 +70,29 @@
 - N/A — 巻き戻しや設計変更は発生しなかった。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `config=<key>` ゲートは `keyword=`/`CONTEXT_FILE` ゲートブロックの直後、`# Extract text with HTML comments...` コメントの直前に実装した (Spec 指定の挿入位置どおり)。新規 CLI 引数は追加せず、`get-config-value.sh` を `${SCRIPT_DIR}/get-config-value.sh` 経由で直接呼び出す設計を採用した。
-- `modules/observation-trigger.md` の `config=` セクションは既存の `keyword=` セクションと同型の構成 (Problem → AC 例 → Matching specification) で追加し、スコープ制約 (フラット kebab-case キーのみ、真偽値のみ) を明記した。
-- テストは 3 ケース (有効時マッチ / 無効時除外 / 属性なし無条件マッチ) を `tests/opportunistic-search.bats` に追加し、`WHOLEWORK_CONFIG_PATH` によるヘルメティックなオーバーライドパターン (既存の `get-config-value.bats` 等と同型) を踏襲した。
+- REVIEW_DEPTH=light (`--light` 明示指定、Issue Size=M とも一致) のため、review-light エージェント1体による4観点統合レビュー (Spec乖離 / エッジケース・堅牢性 / セキュリティ / ドキュメント整合性) を実施した。
+- Pre-merge AC 5件は verify command (rubric / file_contains) に加え、`bats tests/opportunistic-search.bats` (25/25 PASS) および関連スイート (`get-config-value.bats`, `observation-trigger.bats`) をローカル実行して機械的に PASS 判定した。
+- 検出された CONSIDER 1件 (`config=` ゲートに「`-->` 前スペースなし」回帰テストがない) は修正を見送った。抽出ロジックは `keyword=` ゲートと共有コードパスであり、同シナリオは既存の `keyword=` 用テストで既にカバー済みと判断。
 
 ### Deferred Items
-- #797 等、既存 observation AC への `config=` 属性の付与は本 Issue のスコープ外 (Spec Notes に明記済み)。follow-up Issue 化は本 PR 範囲外。
-- `capabilities.*` ネストキーおよび enum 値キー (`auto-stop-at` 等) への対応拡張 (`config=key:value` 形式等) は将来の follow-up 候補として `modules/observation-trigger.md` に記録済み。
+- CONSIDER: `config=some-flag-->` (スペースなし) パターンの回帰テスト追加は任意対応として見送り。follow-up Issue 化はしない (severity が低いため)。
+- Post-merge の observation AC (`event=auto-run`) は未検証のまま。次回 `/auto` 完走後の observation dispatch で観察が必要。
 
 ### Notes for Next Phase
-- Behavioral Change Detection により `tests/observation-trigger.bats` が `opportunistic-search.sh` を参照していることが検出され、フルスイート (`bats tests/`, 1210 件) を実行して全件 PASS を確認済み。`/review`/`/verify` でも同様の再確認は不要 (CI で担保される)。
-- Pre-merge AC 5 件はすべて PASS 判定済みで Issue の該当チェックボックスを更新済み。Post-merge の observation AC (`event=auto-run`) は本 PR merge 後、次回 `/auto` 完走時に発火する。
+- MUST issue は 0 件、CI は全ジョブ SUCCESS。レビューは `COMMENTED` (REQUEST_CHANGES ではない) で投稿済みのため、`/merge 1030` をそのまま実行可能。
+- 本レビューでの実装変更は発生していないため、Issue 受け入れ条件・verify command の更新は不要 (Step 13 スキップ)。
+- Post-merge AC (observation コメント蓄積の抑止) は merge 後の `/verify 1026` 実行、または次回 `/auto` 完走時の L3 observation dispatch で確認すること。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- N/A — Spec の Implementation Steps (挿入位置・抽出パターン・ゲート判定ロジック) と実装が完全に一致しており、構造的な乖離は検出されなかった。
+
+### Recurring issues
+- N/A — review-light (4観点統合レビュー) で検出された問題は CONSIDER 1件のみで、同種の問題が複数観測されるパターンはなかった。
+
+### Acceptance criteria verification difficulty
+- N/A — Pre-merge AC 5件すべてに `rubric` または `file_contains` の verify command が付与されており、いずれもコード読解とローカルテスト実行 (`bats tests/opportunistic-search.bats` 25/25 PASS) で機械的に PASS 判定できた。UNCERTAIN は 0 件。

--- a/docs/spec/issue-1026-observation-config-gate.md
+++ b/docs/spec/issue-1026-observation-config-gate.md
@@ -57,3 +57,30 @@
 ## Consumed Comments
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / 要旨: Issue #1026 の triage フェーズ Issue Retrospective。Size M / Type Feature / Value 3 の判定根拠、実装場所を `opportunistic-search.sh` 軸と想定する Auto-Resolve Log の追記、`file_contains` 補助 verify command 2 件の追加を記録。`capabilities.*` ネストキーの扱いと #797 等既存 Issue への適用スコープは `/spec` 判断に委任する旨を明記。 / URL: https://github.com/saitoco/wholework/issues/1026#issuecomment-5030312095
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps に記載された挿入位置・抽出パターン・ゲート判定ロジックをそのまま実装した。逸脱なし。
+
+### Design Gaps/Ambiguities
+- N/A — Spec の Notes セクションで実装箇所・スコープ境界 (`capabilities.*` 対象外、真偽値のみ)・既存 Issue への適用範囲があらかじめ確定していたため、実装時に新たな曖昧点は生じなかった。
+
+### Rework
+- N/A — 巻き戻しや設計変更は発生しなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `config=<key>` ゲートは `keyword=`/`CONTEXT_FILE` ゲートブロックの直後、`# Extract text with HTML comments...` コメントの直前に実装した (Spec 指定の挿入位置どおり)。新規 CLI 引数は追加せず、`get-config-value.sh` を `${SCRIPT_DIR}/get-config-value.sh` 経由で直接呼び出す設計を採用した。
+- `modules/observation-trigger.md` の `config=` セクションは既存の `keyword=` セクションと同型の構成 (Problem → AC 例 → Matching specification) で追加し、スコープ制約 (フラット kebab-case キーのみ、真偽値のみ) を明記した。
+- テストは 3 ケース (有効時マッチ / 無効時除外 / 属性なし無条件マッチ) を `tests/opportunistic-search.bats` に追加し、`WHOLEWORK_CONFIG_PATH` によるヘルメティックなオーバーライドパターン (既存の `get-config-value.bats` 等と同型) を踏襲した。
+
+### Deferred Items
+- #797 等、既存 observation AC への `config=` 属性の付与は本 Issue のスコープ外 (Spec Notes に明記済み)。follow-up Issue 化は本 PR 範囲外。
+- `capabilities.*` ネストキーおよび enum 値キー (`auto-stop-at` 等) への対応拡張 (`config=key:value` 形式等) は将来の follow-up 候補として `modules/observation-trigger.md` に記録済み。
+
+### Notes for Next Phase
+- Behavioral Change Detection により `tests/observation-trigger.bats` が `opportunistic-search.sh` を参照していることが検出され、フルスイート (`bats tests/`, 1210 件) を実行して全件 PASS を確認済み。`/review`/`/verify` でも同様の再確認は不要 (CI で担保される)。
+- Pre-merge AC 5 件はすべて PASS 判定済みで Issue の該当チェックボックスを更新済み。Post-merge の observation AC (`event=auto-run`) は本 PR merge 後、次回 `/auto` 完走時に発火する。

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -150,6 +150,37 @@ This is a lighter-weight alternative to adding a new fine-grained event name for
 pattern (see the `KNOWN_EVENTS` addition steps below) — it reuses the existing grep-based
 event-matching mechanism instead of growing the event namespace combinatorially.
 
+## Condition Check Gate (`config=`)
+
+Problem: an `event=<name>` fires for any completion of the triggering action, even when the
+Issue's observation condition depends on a specific project-local `.wholework.yml` setting.
+If that setting is not enabled in the target repository, the condition is principled
+unobservable, yet the notification comment still accumulates on every dispatch. Issue #1026
+observed this with #797's `always-pr` observation: `always-pr` is unset in this repository, so
+the condition can never resolve, but notification comments piled up past 30 and all 4 `/verify`
+re-runs resolved SKIPPED.
+
+The gate adds an optional `config=<key>` attribute to the observation AC tag:
+
+```
+<!-- verify-type: observation event=auto-run config=always-pr -->
+```
+
+`opportunistic-search.sh` resolves `<key>` against the current repository's `.wholework.yml` via
+`scripts/get-config-value.sh` and only includes Issues whose matched AC line carries a `config=`
+value that resolves to `"true"` (case-insensitive). ACs without `config=` match unconditionally —
+the existing behavior is preserved. Unlike `keyword=`, this gate needs no `--context-file`
+argument: `.wholework.yml` is read directly from the working directory, so no new CLI argument is
+added to either script.
+
+**Matching specification:**
+
+- Extraction: `config=<key>` is read from the AC line via `grep -oE 'config=[^ >]+'` (stops at the next space or `-->`).
+- Resolution: `<key>`'s value is resolved via `"${SCRIPT_DIR}/get-config-value.sh" "$CONFIG_KEY" "false"`, then lowercased.
+- Comparison: the resolved value must equal `"true"` exactly; any other value (including the `"false"` fallback) excludes the Issue from match results.
+- Gate disabled (unconditional match) when: no `config=` attribute is present on the AC line.
+- Scope: `<key>` must be a flat kebab-case key, matching `get-config-value.sh`'s own constraint — nested keys (e.g. `capabilities.browser`) are not supported. The comparison is boolean-only (`true`/`false`); enum-valued keys (e.g. `auto-stop-at`) are out of scope. Both are candidates for a `config=key:value` extension if a future Issue needs them.
+
 ## Notes
 
 - `opportunistic-search.sh` is the single source of truth for event-name validation (`KNOWN_EVENTS` list)

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -19,6 +19,14 @@
 # without `keyword=`, or runs without --context-file, match unconditionally
 # (backward compatible). See modules/observation-trigger.md § Condition Check Gate.
 #
+# `config=<key>` gates event-mode matches on .wholework.yml validity: when a
+# matched AC line carries a `config=<key>` attribute, the Issue is only
+# included if that flat kebab-case key resolves to "true" (case-insensitive)
+# in the current repository's .wholework.yml (via get-config-value.sh). ACs
+# without `config=` match unconditionally (backward compatible). No new CLI
+# argument is needed — .wholework.yml is read directly from CWD. See
+# modules/observation-trigger.md § Condition Check Gate (config=).
+#
 # Output: JSON array [{"number": N, "condition": "condition text"}]
 #         Empty array [] when no matches found
 
@@ -146,6 +154,17 @@ for N in $ISSUE_NUMBERS; do
         KEYWORD=$(echo "$line" | grep -oE 'keyword=[^ >]+' | sed -e 's/^keyword=//' -e 's/-*$//' || true)
         if [ -n "$KEYWORD" ] && [ -n "$CONTEXT_FILE" ]; then
             if ! grep -qi -- "$KEYWORD" "$CONTEXT_FILE"; then
+                continue
+            fi
+        fi
+
+        # Config check gate: skip lines whose config= attribute names a
+        # .wholework.yml key that is not "true" in this repository. No
+        # config= attribute means unconditional match (backward compatible).
+        CONFIG_KEY=$(echo "$line" | grep -oE 'config=[^ >]+' | sed -e 's/^config=//' -e 's/-*$//' || true)
+        if [ -n "$CONFIG_KEY" ]; then
+            CONFIG_VALUE=$("${SCRIPT_DIR}/get-config-value.sh" "$CONFIG_KEY" "false" | tr '[:upper:]' '[:lower:]')
+            if [ "$CONFIG_VALUE" != "true" ]; then
                 continue
             fi
         fi

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -227,6 +227,42 @@ teardown() {
     echo "$output" | jq -e '.[0].number == 505' > /dev/null
 }
 
+@test "config gate: enabled config key includes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 600}]'
+    export MOCK_ISSUE_BODY_600='- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run config=some-flag -->'
+    echo "some-flag: true" > "$BATS_TEST_TMPDIR/config-enabled.yml"
+    export WHOLEWORK_CONFIG_PATH="$BATS_TEST_TMPDIR/config-enabled.yml"
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_CONFIG_PATH
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 600' > /dev/null
+}
+
+@test "config gate: disabled config key excludes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 601}]'
+    export MOCK_ISSUE_BODY_601='- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run config=some-flag -->'
+    export WHOLEWORK_CONFIG_PATH=/dev/null
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_CONFIG_PATH
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "config gate: AC without config= matches unconditionally" {
+    export MOCK_ISSUE_LIST='[{"number": 602}]'
+    export MOCK_ISSUE_BODY_602='- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run -->'
+    export WHOLEWORK_CONFIG_PATH=/dev/null
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_CONFIG_PATH
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 602' > /dev/null
+}
+
 @test "event filter: unknown event emits warning and falls back" {
     export MOCK_ISSUE_LIST='[{"number": 403}]'
     export MOCK_ISSUE_BODY_403='- [ ] /review skill creates review after execution <!-- verify-type: opportunistic -->'


### PR DESCRIPTION
## Summary
- `scripts/opportunistic-search.sh` の event モードマッチングループに `config=<key>` 属性ゲートを追加。マッチした observation AC 行が `config=<key>` を持つ場合、`.wholework.yml` の該当キーが `true`（大小文字非依存）でなければ match から除外する。新規 CLI 引数は追加せず、既存の `scripts/get-config-value.sh` を経由して `.wholework.yml` を CWD 相対で読む
- `modules/observation-trigger.md` に既存の `keyword=` ゲート節と同型の `## Condition Check Gate (config=)` 節を追加し、属性書式・判定仕様・スコープ制約（フラット kebab-case キーのみ、真偽値のみ）をドキュメント化
- `tests/opportunistic-search.bats` に `config=` ゲートの 3 ケース（有効時マッチ / 無効時除外 / 属性なし無条件マッチ）を追加

## Verification (pre-merge)
- observation AC の設定前提宣言属性の仕様定義とゲート判定実装
- `config=` 属性の仕様が `modules/observation-trigger.md` にドキュメント化されている
- 属性なし AC の無条件マッチ（後方互換）が確認できる
- ゲート判定のテスト（3 ケース）が追加されている
- `config=` ゲートのテストケースが `tests/opportunistic-search.bats` に追加されている

## Verification (post-merge)
- 設定無効なプロジェクトで該当 observation AC への notification コメントが蓄積しなくなることを観察 (observation event=auto-run)

closes #1026
