### PR TITLE
Issue #1028: Record preview AC unverified state and fallback in /verify

### DIFF
--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -197,7 +197,7 @@ export PREVIEW_URL="https://my-pr-123.example-preview.com"
 
 - `PREVIEW_URL` set at `/review` time: preview-tier ACs are executed against the preview URL.
 - `PREVIEW_URL` not set: preview-tier ACs are SKIPPED (the `--when` guard fires) and remain unchecked for human follow-up.
-- At `/verify` (post-merge): all `ac-tier: preview` ACs are skipped to prevent double verification. To also verify against production, duplicate the AC in the `### Post-merge` section without the tag.
+- At `/verify` (post-merge): `ac-tier: preview` ACs are skipped by default to prevent double verification. If `/review` left a preview-tier AC UNCERTAIN (e.g., preview URL unresolved, external constraints), it posts a `type=preview-ac-unverified` marker comment on the Issue; `/verify` detects this marker and falls back — verifying against `production-url` if configured, or recording an explicit "unverified" warning if not — instead of silently marking it as SKIPPED. To also verify against production regardless of this fallback, duplicate the AC in the `### Post-merge` section without the tag.
 
 ## `.wholework/domains/`
 

--- a/docs/ja/guide/customization.md
+++ b/docs/ja/guide/customization.md
@@ -184,7 +184,7 @@ export PREVIEW_URL="https://my-pr-123.example-preview.com"
 
 - `/review` 時に `PREVIEW_URL` が設定されている: preview 層 AC を preview URL に対して実行する。
 - `/review` 時に `PREVIEW_URL` が未設定: `--when` ガードが発動し preview 層 AC は SKIPPED になる（人間がフォローアップ）。
-- `/verify` (post-merge) 時: `ac-tier: preview` 付き AC はすべて skip される（二重検証防止）。本番でも同 AC を検証したい場合は、`### Post-merge` セクションへタグなしで複製する。
+- `/verify` (post-merge) 時: `ac-tier: preview` 付き AC はデフォルトで skip される (二重検証防止)。`/review` が preview 層 AC を UNCERTAIN のまま終えた場合 (preview URL 未解決・外部制約など) は `type=preview-ac-unverified` マーカーコメントを Issue に投稿し、`/verify` がそのマーカーを検出して SKIPPED にせずフォールバックする — `production-url` が設定されていればそれに対して実際に検証し、未設定なら明示的な「未検証」警告を記録する。このフォールバックとは別に本番でも同 AC を検証したい場合は、`### Post-merge` セクションへタグなしで複製する。
 
 ## `.wholework/domains/`
 

--- a/docs/spec/issue-1028-preview-ac-unverified-marker.md
+++ b/docs/spec/issue-1028-preview-ac-unverified-marker.md
@@ -73,3 +73,33 @@ triage retrospective コメント (2026-07-21) で「マーカーの記録場所
 ### Doc sync scope note
 
 Steering Docs sync candidate check の一般手順 (skill 名 "review"/"verify" での grep) は、これらが一般的な英単語のため大量の無関係ヒットを生む。代わりに `ac-tier: preview` / `pre-merge-preview` というより特異的なキーワードで直接調査し、`docs/guide/customization.md` (と ja ミラー) のみが該当することを確認した。`docs/tech.md` は新規 `.wholework.yml` キーを追加しないため変更不要。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜4 を Spec 記載順・記載内容通りに実施した。追加/省略/並べ替えはない。
+
+### Design Gaps/Ambiguities
+- N/A — Spec Notes の Auto-Resolve Log で記録場所・粒度・cutoff 越境問題が事前に解決済みだったため、実装時に新たな曖昧性は発生しなかった。
+
+### Rework
+- N/A — 手戻りは発生しなかった。
+
+### Test scope note (out-of-spec observation)
+- `skills/code/SKILL.md` Step 9 の Behavioral Change Detection は、変更ファイル名 (パス抜き) で `tests/` 配下を grep する経験則を持つが、`SKILL.md` は全 Skill 共通のファイル名であるため、`skills/review/SKILL.md` / `skills/verify/SKILL.md` という狭い変更に対しても常に `bats tests/` フルスイート (1213 件) が発火した。実測は PASS (0 failures) だったため本 Issue の実装自体には影響しないが、経験則の汎用ファイル名対応漏れという `/code` 自体の改善余地であり、本 Issue のスコープ外のため follow-up Issue #1034 (`retro/code`) として起票した。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の設計通り、preview AC 未検証マーカーは Issue コメント (PR コメントではなく) に `<!-- wholework-event: type=preview-ac-unverified ac=<indices> -->` として記録する方式を採用 (Spec Notes の Auto-Resolve Log 通り、実装からの逸脱なし)。
+- `modules/l0-surfaces.md` の「verify-fail marker exception」を「Cross-phase marker exception」に汎化し、`type=verify-fail` と `type=preview-ac-unverified` の両方を cutoff 越境スキャン対象にした (新規の並行 bypass 機構は作らず既存機構を再利用)。
+- `skills/verify/SKILL.md` Step 5 のフォールバックは、`PRODUCTION_URL` の有無で分岐 (設定時は実検証、未設定時は明示的 UNCERTAIN 警告) する Spec 記載の仕様通りに実装した。
+
+### Deferred Items
+- 新規 bats テストは追加していない (Spec Notes の判断を踏襲: 両 AC が `rubric` のみのため既存 content-assertion テストと衝突しない)。`/verify` 実行時、両 rubric AC が実際に PASS 判定されるかは post-merge の実地確認が必要。
+- Behavioral Change Detection の汎用ファイル名対応漏れは follow-up Issue #1034 に切り出し、本 Issue では対応していない。
+
+### Notes for Next Phase
+- 本 Issue はコードレベルの変更のみで、`.wholework.yml` の新規キー追加はない。`docs/tech.md` の更新も不要と判断済み (Doc sync scope note 参照)。
+- `skills/review/SKILL.md` Step 8 の新規段落と `skills/verify/SKILL.md` Step 5 の書き換えが、既存の Step 見出し構造・番号を変更していないことを Spec Notes で確認済み — `/review`/`/merge` フェーズは通常のフローで進行してよい。

--- a/docs/spec/issue-1028-preview-ac-unverified-marker.md
+++ b/docs/spec/issue-1028-preview-ac-unverified-marker.md
@@ -89,17 +89,35 @@ Steering Docs sync candidate check の一般手順 (skill 名 "review"/"verify" 
 - `skills/code/SKILL.md` Step 9 の Behavioral Change Detection は、変更ファイル名 (パス抜き) で `tests/` 配下を grep する経験則を持つが、`SKILL.md` は全 Skill 共通のファイル名であるため、`skills/review/SKILL.md` / `skills/verify/SKILL.md` という狭い変更に対しても常に `bats tests/` フルスイート (1213 件) が発火した。実測は PASS (0 failures) だったため本 Issue の実装自体には影響しないが、経験則の汎用ファイル名対応漏れという `/code` 自体の改善余地であり、本 Issue のスコープ外のため follow-up Issue #1034 (`retro/code`) として起票した。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の設計通り、preview AC 未検証マーカーは Issue コメント (PR コメントではなく) に `<!-- wholework-event: type=preview-ac-unverified ac=<indices> -->` として記録する方式を採用 (Spec Notes の Auto-Resolve Log 通り、実装からの逸脱なし)。
-- `modules/l0-surfaces.md` の「verify-fail marker exception」を「Cross-phase marker exception」に汎化し、`type=verify-fail` と `type=preview-ac-unverified` の両方を cutoff 越境スキャン対象にした (新規の並行 bypass 機構は作らず既存機構を再利用)。
-- `skills/verify/SKILL.md` Step 5 のフォールバックは、`PRODUCTION_URL` の有無で分岐 (設定時は実検証、未設定時は明示的 UNCERTAIN 警告) する Spec 記載の仕様通りに実装した。
+- REVIEW_DEPTH=light (`--light` 明示指定) で review-light エージェント 1 体による 4 アスペクト統合レビューを実施した。
+- Issue 本文の両 AC (`rubric`) は verify-executor により両方 PASS と判定 (既に `[x]` 済みのためチェックボックス変更なし)。CI 5 ジョブすべて SUCCESS。
+- review-light が検出した SHOULD レベル指摘 2 件 (マーカー陳腐化・テストカバレッジ不足) は、いずれも Issue #1028 のスコープを超える設計変更または Spec の Deferred Items で既に認識済みの内容のため、修正せず PR ラインコメントとして記録するに留めた (MUST 相当の指摘なし、event=COMMENT で投稿)。
 
 ### Deferred Items
-- 新規 bats テストは追加していない (Spec Notes の判断を踏襲: 両 AC が `rubric` のみのため既存 content-assertion テストと衝突しない)。`/verify` 実行時、両 rubric AC が実際に PASS 判定されるかは post-merge の実地確認が必要。
-- Behavioral Change Detection の汎用ファイル名対応漏れは follow-up Issue #1034 に切り出し、本 Issue では対応していない。
+- マーカー陳腐化問題 (`skills/verify/SKILL.md:181`): 後続の fix-cycle 再レビューで preview AC が実際に検証済みになっても新規マーカーが投稿されず、`/verify` が古いマーカーを誤って参照し続ける可能性がある。follow-up Issue 化を検討の余地あり (未起票)。
+- 新規マーカー投稿・フォールバックロジックの自動テストは未追加のまま (Spec Deferred Items を踏襲)。`/verify` 実行時の post-merge 実地確認が引き続き必要。
 
 ### Notes for Next Phase
-- 本 Issue はコードレベルの変更のみで、`.wholework.yml` の新規キー追加はない。`docs/tech.md` の更新も不要と判断済み (Doc sync scope note 参照)。
-- `skills/review/SKILL.md` Step 8 の新規段落と `skills/verify/SKILL.md` Step 5 の書き換えが、既存の Step 見出し構造・番号を変更していないことを Spec Notes で確認済み — `/review`/`/merge` フェーズは通常のフローで進行してよい。
+- `/merge` はこのまま通常フローで進行してよい。MUST issue はなく、CI もすべて green。
+- `/verify` 実行時は、両 rubric AC が実際に PASS 判定されるか (post-merge の実地確認) と、preview-ac-unverified マーカー関連のフォールバック分岐が意図通り動作するかを重点確認すること。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — PR diff は Spec の Implementation Steps 1〜4 と 1:1 対応しており (`modules/l0-surfaces.md`、`skills/review/SKILL.md` Step 8、`skills/verify/SKILL.md` Step 5、`docs/guide/customization.md` + ja ミラー)、`ac=` インデックス規約 (`gh-issue-edit.sh --checkbox` と同一) も 3 ファイル間で一貫していた。review-light の Perspective 1 (Spec Deviation) でも issue なしと判定された。
+
+### Recurring issues
+
+review-light が SHOULD レベルの指摘を 2 件検出した:
+- マーカーの陳腐化問題 (`skills/verify/SKILL.md:181`): `/review` が preview AC を UNCERTAIN のまま終えた後、後続の fix-cycle 再レビューで実際には検証済みになっても新規マーカーが投稿されないため、`/verify` が古いマーカーを「最新」として誤って参照し続ける可能性がある。Issue #1028 のスコープを超える設計変更 (マーカーを常時投稿する、または無効化用の counter-marker を追加する) が必要なため、本 PR では対応せず follow-up 候補として記録するに留めた。
+- テストカバレッジ不足 (`docs/spec/issue-1028-preview-ac-unverified-marker.md:100`): 新規マーカー投稿ロジック・フォールバックロジックに対する自動テストが未追加。Spec の Deferred Items が既にこの点を認識しており、prose-driven な SKILL.md Step への bats カバレッジの実務上の難しさから post-merge の手動確認に委ねる判断を維持した。
+
+いずれも既存の workflow パターン内で対処可能な水準であり、`/review` プロセス自体の改善が必要な再発パターンではない。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note — 両 AC (`rubric`) は Issue 本文記載時点で triage により defective な grep 系 supplementary check が意図的に除去されていたため、`rubric` 単体での判定が明確に行えた。UNCERTAIN は発生しなかった。

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -88,6 +88,19 @@ in the codebase (`<!-- verify-type: ... -->`, `<!-- verify: ... -->`).
 ```
 Consumers matching on the `<!-- wholework-event: type=verify-fail` prefix (see Notes below) are unaffected by this attribute, since it is appended after the existing fields rather than altering them.
 
+**`type=preview-ac-unverified`**: posted by `/review` (Step 8) when one or more `ac-tier: preview`
+acceptance conditions were classified `UNCERTAIN` — i.e., `/review` could not actually verify them
+against the preview URL before the PR merges and the preview environment disappears. The `ac=`
+attribute carries a comma-separated list of 1-based indices into the Issue body's full AC
+enumeration, using the same indexing convention as `gh-issue-edit.sh --checkbox`. Example:
+```
+<!-- wholework-event: type=preview-ac-unverified phase=review issue=42 ac=2,5 -->
+Preview-tier AC 2 and 5 could not be verified against the preview URL (UNCERTAIN) before merge.
+```
+`/verify`'s pre-merge-preview AC skip rule (`skills/verify/SKILL.md` Step 5) consults this marker
+to decide whether an `ac-tier: preview` condition was actually verified at `/review` or must fall
+back to a post-merge check.
+
 When consuming comments (see Processing Steps), a comment containing `<!-- wholework-event:`
 in its body from a bot actor is treated as a Wholework-authored structured comment and consumed (bot exception above).
 
@@ -122,16 +135,20 @@ If CUTOFF is empty, omit the `select` filter (fetch all comments).
 
 ISO 8601 UTC strings are lexicographically comparable, so `date` conversion is not needed.
 
-**verify-fail marker exception (defense in depth):** After fetching cutoff-filtered comments,
+**Cross-phase marker exception (defense in depth):** After fetching cutoff-filtered comments,
 additionally scan all comments regardless of cutoff for any comment whose body contains
-`<!-- wholework-event: type=verify-fail`. Include any such comments in the consume set even
-if their `createdAt` is before or equal to `CUTOFF`. This ensures that `/verify` FAIL marker
-comments posted before the current phase's cutoff are never silently dropped. Deduplicate
-by comment URL so that comments already included by the cutoff filter are not injected twice.
+`<!-- wholework-event: type=verify-fail` or `<!-- wholework-event: type=preview-ac-unverified`.
+Include any such comments in the consume set even if their `createdAt` is before or equal to
+`CUTOFF`. This ensures that marker comments posted before the current phase's cutoff are never
+silently dropped — `/verify` FAIL markers can predate a later fix-cycle's cutoff, and
+`preview-ac-unverified` markers posted by `/review` always predate `/verify`'s cutoff (the
+`phase/verify` label is assigned by `/merge`, not `/review`, so the marker is necessarily older
+than the timestamp `/verify`'s Step 1 resolves as cutoff). Deduplicate by comment URL so that
+comments already included by the cutoff filter are not injected twice.
 
 ```
 gh issue view "$ISSUE_NUMBER" --json comments \
-  --jq '.comments[] | select(.body | contains("<!-- wholework-event: type=verify-fail"))'
+  --jq '.comments[] | select(.body | contains("<!-- wholework-event: type=verify-fail") or contains("<!-- wholework-event: type=preview-ac-unverified"))'
 ```
 
 If `COMMENT_SCOPE=issue+pr`: also fetch PR comments with `gh pr view <PR_NUMBER> --json comments`

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -257,6 +257,23 @@ Verify each condition:
    - UNCERTAIN — cannot auto-determine
    - POST-MERGE — condition to verify after merge
 
+**Preview-tier unverified marker (defense in depth):** After classification, collect the
+1-based indices (counted across the full Issue body AC enumeration, same convention as
+`gh-issue-edit.sh --checkbox`) of every Pre-merge condition tagged `<!-- ac-tier: preview -->`
+that was classified UNCERTAIN in this step. If this set is non-empty, write a comment body to
+`.tmp/preview-ac-unverified-$ISSUE_NUMBER.md` with the Write tool — first line
+`<!-- wholework-event: type=preview-ac-unverified phase=review issue=$ISSUE_NUMBER ac=<comma-separated indices> -->`
+(see `modules/l0-surfaces.md` § "Machine-Readable Event Marker"), followed by a short
+human-readable note listing which preview-tier ACs could not be verified and why — then post it:
+```bash
+mkdir -p .tmp
+${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh "$ISSUE_NUMBER" .tmp/preview-ac-unverified-$ISSUE_NUMBER.md
+rm -f .tmp/preview-ac-unverified-$ISSUE_NUMBER.md
+```
+This records the unverified state so `/verify`'s pre-merge-preview AC skip rule (Step 5) does
+not silently treat these conditions as verified once the PR merges and the preview environment
+disappears. If no preview-tier AC was classified UNCERTAIN, skip this comment entirely.
+
 **`file_contains` exact match check:**
 
 For `file_contains` verify commands, verify that the pattern is an exact substring of the implementation code in the PR diff. Shell quoting causes false negatives: `get-config-value.sh permission-mode auto` will not match `"$SCRIPT_DIR/get-config-value.sh" permission-mode auto`. When a FAIL result stems from a quoting or path-prefix discrepancy rather than a genuine implementation gap, report it as a spec quality issue requiring a verify command update.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -174,11 +174,18 @@ This is an early Spec read specifically for Phase Handoff context; SPEC_PATH is 
 
 **Scope**: This step processes **pre-merge conditions only**. Post-merge conditions (hint-based and manual) are processed in Steps 7–8, after pre-merge results are locked into the Issue. If the Issue has no section divisions, treat all conditions as pre-merge and process them here.
 
-**pre-merge-preview AC skip rule (double-verification prevention):**
+**pre-merge-preview AC skip rule (double-verification prevention, with unverified fallback):**
 
-Within the `### Pre-merge` section, any AC line that carries a `<!-- ac-tier: preview -->` tag is classified as a preview-tier AC. These ACs were verified at `/review` time against the preview URL and must be skipped here to prevent double verification. Record each skipped AC as SKIPPED in the results table with the note "preview-tier AC; verified at /review against preview URL".
+Within the `### Pre-merge` section, any AC line that carries a `<!-- ac-tier: preview -->` tag is classified as a preview-tier AC. These ACs are normally treated as already verified at `/review` time against the preview URL and skipped here to prevent double verification — but this assumption must be checked against the `type=preview-ac-unverified` marker collected during Step 4's comment consumption, since `/review` may have ended some preview-tier ACs as UNCERTAIN instead of actually verifying them.
 
-If the same URL/UX verification is also needed against the production URL, duplicate the AC in the `### Post-merge` section without the `<!-- ac-tier: preview -->` tag; `/verify` will then execute it against `PRODUCTION_URL` (resolved via `{{base_url}}` and the `production-url` key in `.wholework.yml`).
+From the comments consumed in Step 4, identify the most recent (`createdAt` maximum) comment whose body contains `<!-- wholework-event: type=preview-ac-unverified`, and read its `ac=` attribute (comma-separated 1-based indices, per `modules/l0-surfaces.md` § "Machine-Readable Event Marker"). For each `ac-tier: preview` AC in this Pre-merge section, using its own 1-based index in the Issue body's full AC enumeration:
+
+- **No such marker comment exists, or this AC's index is not in the marker's `ac=` list**: unchanged — record as SKIPPED with the note "preview-tier AC; verified at /review against preview URL".
+- **This AC's index is in the marker's `ac=` list** (i.e., `/review` left it UNCERTAIN and never actually verified it against the preview URL): do not record as SKIPPED. Instead:
+  - **`PRODUCTION_URL` is non-empty**: resolve the verify command's `{{base_url}}` to `PRODUCTION_URL` and actually execute it, exactly as a normal post-merge AC would be. Record the resulting PASS/FAIL/UNCERTAIN classification with the note "preview-tier AC unverified at /review; fallback-verified against production URL".
+  - **`PRODUCTION_URL` is empty**: record as UNCERTAIN with the note "preview-tier AC unverified at /review; no production-url configured for fallback — manual verification required".
+
+If the same URL/UX verification is also needed against the production URL regardless of this fallback (e.g., to cover both a preview-time check and a standing production check), duplicate the AC in the `### Post-merge` section without the `<!-- ac-tier: preview -->` tag; `/verify` will then execute it against `PRODUCTION_URL` (resolved via `{{base_url}}` and the `production-url` key in `.wholework.yml`).
 
 **Patch route detection (run before verification):**
 


### PR DESCRIPTION
## Summary
- `/review` (Step 8) が `ac-tier: preview` タグ付き AC を UNCERTAIN のまま処理を終えた場合、`type=preview-ac-unverified` マーカー (対象 AC の 1-based インデックス付き) を Issue コメントとして機械可読で記録するようにした
- `/verify` (Step 5) の pre-merge-preview AC skip rule を、このマーカーを検出した場合は無条件 SKIPPED ではなく production URL への代替検証 (`production-url` 設定時) または明示的な未検証警告 (未設定時) にフォールバックするよう書き換えた
- `modules/l0-surfaces.md` に `type=preview-ac-unverified` マーカーの属性説明を追加し、`/verify` の cutoff 越境問題に対する既存の「verify-fail marker exception」を汎化 (`Cross-phase marker exception`) して両マーカー種別に対応させた
- `docs/guide/customization.md` / `docs/ja/guide/customization.md` の pre-merge-preview skip 挙動の説明を新しい条件付きフォールバック仕様に更新

## Verification (pre-merge)
- skills/review/SKILL.md に、preview AC を実行できなかった場合 (UNCERTAIN 等) にその状態を機械可読マーカー (Issue コメント) で記録する手順が定義されている
- skills/verify/SKILL.md の pre-merge-preview AC skip rule が、review 時未検証マーカーを検出した場合に SKIPPED ではなく production URL への代替検証 (または明示的な未検証警告) にフォールバックする

## Verification (post-merge)
- なし (Issue 本文の Post-merge AC 指定なし)

closes #1028
