### PR TITLE
Issue #1042: run-auto-sub.sh batch mode で auto-stop-at 未対応を修正

### DIFF
--- a/docs/spec/issue-1042-batch-auto-stop-at.md
+++ b/docs/spec/issue-1042-batch-auto-stop-at.md
@@ -4,6 +4,10 @@
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / 要約: 「Issue Retrospective」— `/issue` non-interactive 実行時の Auto-Resolve Log (AC スコープを List+Count 両モードに拡張、stop-at 到達時の粒度を明確化) と、`run-auto-sub.sh` grep による Background 事実確認 (pr route 主系列に stop-at check が無いことを確認)、Triage 結果 (Type=Bug, Size=M, Value=3) を記録。本 Spec の設計判断 (Changed Files を `run-auto-sub.sh` 内部修正に一本化する方針) と整合していることを確認済み / URL: https://github.com/saitoco/wholework/issues/1042#issuecomment-5053468973
 
+### /code phase (cutoff: phase/ready assigned 2026-07-23T02:10:33Z)
+
+No new comments since last phase.
+
 ## Overview
 
 `/auto --batch` (Count mode `--batch N` / List mode `--batch N1 N2 ...`) 経由で呼ばれる `scripts/run-auto-sub.sh` の pr route (Size M/L) 主系列は、`code-pr` phase 完了後に `review` phase を、`review` phase 完了後に `merge` phase を、`.wholework.yml` の `auto-stop-at` 設定を一切確認せず無条件に実行する。このため `auto-stop-at: review` を設定していても、batch mode 経由の Issue は human review を経ずに auto-merge される (tofas repo での実インシデントとして報告済み)。
@@ -82,3 +86,30 @@
 ## Smoke Test
 
 該当なし (Issue body に外部/MCP ツール呼び出しの verify command は含まれない)。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1–4 の通りに実装した (AUTO_STOP_AT のホイスト、M)/L) への stop-at gate 追加、bats テスト2件追加)。
+
+### Design Gaps/Ambiguities
+- N/A — Spec Notes の auto-resolve 決定 (spec/code 同一視、共通ヘルパー化見送り) が実装時の判断をすべてカバーしており、新たな曖昧点は発生しなかった。
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec Notes の「共通ヘルパー化の見送り」方針に従い、M)/L) の stop-at gate は既存 Tier3 skip 分岐と同型の if/elif 複製として実装した (新規ヘルパー関数は導入せず)。
+- `AUTO_STOP_AT` を `ALWAYS_PR` 直後で一度だけ読み込み、Tier3 skip 分岐の局所的な `_STOP_AT` 読み込みをこの変数の再利用に置き換えた (読み込み一本化、挙動変更なし)。
+
+### Deferred Items
+- Post-merge AC (tofas repo など実際の `auto-stop-at` 設定リポジトリでの `/auto --batch` 実行確認) は本 PR では未実施 — `/verify` フェーズで manual 検証として扱う。
+- stop-at 判定箇所が4箇所目に増えた時点での共通ヘルパー化再検討は、Spec Notes の記載通り本 Issue のスコープ外のまま維持。
+
+### Notes for Next Phase
+- M)/L) の stop-at gate 追加箇所の echo メッセージ ("Stopped at phase: X (auto-stop-at=Y)") は単独 `/auto N` (`skills/auto/SKILL.md` L439, L442) と同一文言に揃えてある — レビュー時に文言一致を確認すると良い。
+- Behavioral Change Detection により `bats tests/` (1232件) をフル実行済み、全件 PASS。`tests/auto-sub-observability.bats` が `scripts/run-auto-sub.sh` を参照しているため full suite 実行がトリガーされたが、本 Issue の変更とは無関係な既存参照。
+- Issue AC 2件 (rubric) は pre-merge で PASS 判定し、Issue body のチェックボックスを更新済み。Post-merge AC 1件 (manual) は未消化のまま残っている。

--- a/docs/spec/issue-1042-batch-auto-stop-at.md
+++ b/docs/spec/issue-1042-batch-auto-stop-at.md
@@ -98,18 +98,29 @@ No new comments since last phase.
 ### Rework
 - N/A
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- N/A — Implementation Steps 1–4 と PR diff の間に構造的な乖離は見られなかった。`AUTO_STOP_AT` のホイスト位置、M)/L) の stop-at gate の分岐構造、echo メッセージ文言 (単独 `/auto N` との整合) はいずれも Spec 記載通りに実装されていた。
+
+### Recurring issues
+- rubric 検証で PASS と判定した後の追加調査で、`auto-stop-at: merge` がバッチモードの `/verify` 呼び出し抑制には反映されないという別種のギャップを発見した (PR #1043 review コメントに記録)。ただしこれは本 Issue が対象とする「review 停止インシデント」とは異なる箇所 (`skills/auto/SKILL.md` の Verify orchestration ステップ) に起因し、Tier3 skip 分岐 (#980) にも同型の限界が既に存在していたため、本 PR による新規回帰ではなく既存の設計限界と判断した。
+- Spec Notes が指摘した「`auto-stop-at` を読み取る箇所が複数箇所に分散している」構造的懸念 (共通ヘルパー化見送りの判断根拠) は、今回の追加調査でさらに裏付けられた形になる — stop-at 判定箇所は `run-auto-sub.sh` 内の3箇所に加え、`skills/auto/SKILL.md` の単独 `/auto N` 経路とバッチモード Verify orchestration ステップにも分散しており、後者は今回未対応のまま残っている。共通ヘルパー化の再検討タイミングで、この分散範囲全体 (SKILL.md 側も含む) を対象に含めることを推奨する。
+
+### Acceptance criteria verification difficulty
+- N/A — 2件の rubric 条件はいずれも UNCERTAIN なく明確に PASS 判定できた。Issue Notes に auto-resolve 済みのスコープ決定 (spec/code 同一視、粒度定義) が明記されていたため、rubric grader の判断材料が十分だった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec Notes の「共通ヘルパー化の見送り」方針に従い、M)/L) の stop-at gate は既存 Tier3 skip 分岐と同型の if/elif 複製として実装した (新規ヘルパー関数は導入せず)。
-- `AUTO_STOP_AT` を `ALWAYS_PR` 直後で一度だけ読み込み、Tier3 skip 分岐の局所的な `_STOP_AT` 読み込みをこの変数の再利用に置き換えた (読み込み一本化、挙動変更なし)。
+- MUST issue なし、CI 全 SUCCESS のため `COMMENT` イベントでレビューを投稿 (event=REQUEST_CHANGES には該当せず)。
+- CONSIDER 2件 (サブプロセス呼び出しコスト、`auto-stop-at: merge` のバッチモード非対応) はいずれも本 Issue のスコープ外と判断し、修正は行わずフォローアップ候補として記録するに留めた。
 
 ### Deferred Items
-- Post-merge AC (tofas repo など実際の `auto-stop-at` 設定リポジトリでの `/auto --batch` 実行確認) は本 PR では未実施 — `/verify` フェーズで manual 検証として扱う。
-- stop-at 判定箇所が4箇所目に増えた時点での共通ヘルパー化再検討は、Spec Notes の記載通り本 Issue のスコープ外のまま維持。
+- Post-merge AC (tofas repo での `/auto --batch` 実行確認) は未消化のまま — `/verify` フェーズで manual 検証として扱う (Code Retrospective からの引き継ぎ、変更なし)。
+- `auto-stop-at: merge` がバッチモードの Verify orchestration ステップ (`skills/auto/SKILL.md`) に反映されない件は、別 Issue としての起票を推奨 (本 PR のスコープ外)。
 
 ### Notes for Next Phase
-- M)/L) の stop-at gate 追加箇所の echo メッセージ ("Stopped at phase: X (auto-stop-at=Y)") は単独 `/auto N` (`skills/auto/SKILL.md` L439, L442) と同一文言に揃えてある — レビュー時に文言一致を確認すると良い。
-- Behavioral Change Detection により `bats tests/` (1232件) をフル実行済み、全件 PASS。`tests/auto-sub-observability.bats` が `scripts/run-auto-sub.sh` を参照しているため full suite 実行がトリガーされたが、本 Issue の変更とは無関係な既存参照。
-- Issue AC 2件 (rubric) は pre-merge で PASS 判定し、Issue body のチェックボックスを更新済み。Post-merge AC 1件 (manual) は未消化のまま残っている。
+- `/merge` 実行時に追加の確認事項なし。CI 全 SUCCESS、AC 2件 PASS 済み。
+- Post-merge AC (manual) は `/verify` フェーズで tofas repo 等での実行確認が必要。

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -855,6 +855,7 @@ fi
 echo "${LOG_PREFIX} Size: ${SIZE}"
 
 ALWAYS_PR=$("$SCRIPT_DIR/get-config-value.sh" always-pr false 2>/dev/null || echo false)
+AUTO_STOP_AT=$("$SCRIPT_DIR/get-config-value.sh" auto-stop-at verify 2>/dev/null || echo verify)
 EFFECTIVE_SIZE="$SIZE"
 if [[ "$ALWAYS_PR" == "true" ]] && [[ "$SIZE" =~ ^(XS|S)$ ]]; then
   echo "${LOG_PREFIX} always-pr: true is set in .wholework.yml. Promoting to pr route."
@@ -871,10 +872,9 @@ case "$EFFECTIVE_SIZE" in
     if [[ "${_TIER3_RECOVERY_ACTION:-}" == "skip" ]]; then
       _SKIP_PR_NUMBER=$(gh pr list --json number,headRefName 2>/dev/null | jq -r ".[] | select(.headRefName == \"worktree-code+issue-${SUB_NUMBER}\") | .number" | head -1 || true)
       if [[ -n "$_SKIP_PR_NUMBER" ]]; then
-        _STOP_AT=$("$SCRIPT_DIR/get-config-value.sh" auto-stop-at verify 2>/dev/null || echo verify)
-        if [[ "$_STOP_AT" == "code" || "$_STOP_AT" == "spec" ]]; then
-          echo "${LOG_PREFIX} [recovery] tier3 skip revealed PR #${_SKIP_PR_NUMBER} for issue #${SUB_NUMBER}, but auto-stop-at=${_STOP_AT}: not continuing"
-        elif [[ "$_STOP_AT" == "review" ]]; then
+        if [[ "$AUTO_STOP_AT" == "code" || "$AUTO_STOP_AT" == "spec" ]]; then
+          echo "${LOG_PREFIX} [recovery] tier3 skip revealed PR #${_SKIP_PR_NUMBER} for issue #${SUB_NUMBER}, but auto-stop-at=${AUTO_STOP_AT}: not continuing"
+        elif [[ "$AUTO_STOP_AT" == "review" ]]; then
           echo "${LOG_PREFIX} [recovery] tier3 skip revealed PR #${_SKIP_PR_NUMBER} for issue #${SUB_NUMBER}; continuing to review only (auto-stop-at=review)"
           echo "${LOG_PREFIX} --- review phase (light): PR #${_SKIP_PR_NUMBER} ---"
           _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "review" "$_SKIP_PR_NUMBER" "$SCRIPT_DIR/run-review.sh" --light
@@ -954,11 +954,19 @@ case "$EFFECTIVE_SIZE" in
     fi
     echo "${LOG_PREFIX} PR number: ${PR_NUMBER}"
 
-    echo "${LOG_PREFIX} --- review phase (light): PR #${PR_NUMBER} ---"
-    _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "review" "$PR_NUMBER" "$SCRIPT_DIR/run-review.sh" --light
+    if [[ "$AUTO_STOP_AT" == "spec" || "$AUTO_STOP_AT" == "code" ]]; then
+      echo "${LOG_PREFIX} Stopped at phase: code (auto-stop-at=${AUTO_STOP_AT})"
+    else
+      echo "${LOG_PREFIX} --- review phase (light): PR #${PR_NUMBER} ---"
+      _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "review" "$PR_NUMBER" "$SCRIPT_DIR/run-review.sh" --light
 
-    echo "${LOG_PREFIX} --- merge phase: PR #${PR_NUMBER} ---"
-    _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "merge" "$PR_NUMBER" "$SCRIPT_DIR/run-merge.sh"
+      if [[ "$AUTO_STOP_AT" == "review" ]]; then
+        echo "${LOG_PREFIX} Stopped at phase: review (auto-stop-at=review)"
+      else
+        echo "${LOG_PREFIX} --- merge phase: PR #${PR_NUMBER} ---"
+        _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "merge" "$PR_NUMBER" "$SCRIPT_DIR/run-merge.sh"
+      fi
+    fi
     ;;
   L)
     # Resume preamble (same logic as M, pr route)
@@ -1024,11 +1032,19 @@ case "$EFFECTIVE_SIZE" in
     fi
     echo "${LOG_PREFIX} PR number: ${PR_NUMBER}"
 
-    echo "${LOG_PREFIX} --- review phase (full): PR #${PR_NUMBER} ---"
-    _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "review" "$PR_NUMBER" "$SCRIPT_DIR/run-review.sh" --full
+    if [[ "$AUTO_STOP_AT" == "spec" || "$AUTO_STOP_AT" == "code" ]]; then
+      echo "${LOG_PREFIX} Stopped at phase: code (auto-stop-at=${AUTO_STOP_AT})"
+    else
+      echo "${LOG_PREFIX} --- review phase (full): PR #${PR_NUMBER} ---"
+      _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "review" "$PR_NUMBER" "$SCRIPT_DIR/run-review.sh" --full
 
-    echo "${LOG_PREFIX} --- merge phase: PR #${PR_NUMBER} ---"
-    _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "merge" "$PR_NUMBER" "$SCRIPT_DIR/run-merge.sh"
+      if [[ "$AUTO_STOP_AT" == "review" ]]; then
+        echo "${LOG_PREFIX} Stopped at phase: review (auto-stop-at=review)"
+      else
+        echo "${LOG_PREFIX} --- merge phase: PR #${PR_NUMBER} ---"
+        _EXTRA_SELF_ISSUE="$SUB_NUMBER" run_phase_with_recovery "merge" "$PR_NUMBER" "$SCRIPT_DIR/run-merge.sh"
+      fi
+    fi
     ;;
   *)
     echo "${LOG_PREFIX} Error: Unknown Size: ${SIZE}" >&2

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -278,6 +278,28 @@ MOCK
     [ ! -f "$BATS_TEST_TMPDIR/run-verify.log" ]
 }
 
+@test "Size M + auto-stop-at: review: run-review.sh is called, run-merge.sh is not called" {
+    echo "auto-stop-at: review" >> "$BATS_TEST_TMPDIR/.wholework.yml"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "42 --pr" "$RUN_CODE_LOG"
+    [ -f "$RUN_REVIEW_LOG" ]
+    [ ! -f "$RUN_MERGE_LOG" ]
+    [[ "$output" == *"Stopped at phase: review"* ]]
+}
+
+@test "Size M + auto-stop-at: code: run-review.sh and run-merge.sh are not called" {
+    echo "auto-stop-at: code" >> "$BATS_TEST_TMPDIR/.wholework.yml"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "42 --pr" "$RUN_CODE_LOG"
+    [ ! -f "$RUN_REVIEW_LOG" ]
+    [ ! -f "$RUN_MERGE_LOG" ]
+    [[ "$output" == *"Stopped at phase: code"* ]]
+}
+
 @test "Size XL: exits with error about sub-issue splitting" {
     cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
 #!/bin/bash


### PR DESCRIPTION
## Summary
- `scripts/run-auto-sub.sh` の `M)`/`L)` ケース (pr route 通常系列) に `auto-stop-at` の stop-at gate を追加。`.wholework.yml` の `auto-stop-at` 値に応じて code phase 完了後に review/merge phase の呼び出しを止める
- `AUTO_STOP_AT` を `ALWAYS_PR` の直後で一度だけ読み込み (`get-config-value.sh auto-stop-at verify`)、Tier3 skip 分岐の局所的な `_STOP_AT` 読み込みをこのホイストされた変数の再利用に置き換え (重複読み込みの解消、挙動変更なし)
- `run-auto-sub.sh` は List mode / Count mode の共通呼び出し先のため、この 1 ファイルの修正で `/auto --batch` の両モードを同時にカバー
- stop-at 到達時は該当 Issue の後続フェーズ呼び出しのみ停止し、バッチ内の他 Issue の処理は継続 (`run-auto-sub.sh` はスクリプト末尾まで正常終了するため、呼び出し元の batch ループには影響しない)
- `tests/run-auto-sub.bats` に Size M + `auto-stop-at: review` / `auto-stop-at: code` の新規テストを2件追加

## Verification (pre-merge)
- rubric: `auto-stop-at` が batch mode (List mode / Count mode 双方) 経由でも honor される実装 — PASS
- rubric: `auto-stop-at: review` 設定下でのテスト追加 (bats) — PASS (新規2テスト + 既存 Size M/L 回帰テストとも PASS)
- フルテストスイート `bats tests/`: 1232 件全て PASS
- `bash scripts/check-forbidden-expressions.sh`: 違反なし
- `python3 scripts/validate-skill-syntax.py skills/`: 0 error (既存の無関係な警告1件のみ)

## Verification (post-merge)
- tofas repo (または他の `auto-stop-at` 設定 repo) で `/auto --batch` を実行し、指定 phase で停止することを確認 (manual)

closes #1042
