### PR TITLE
Issue #1044: batch mode List mode Step 7 に auto-stop-at=merge の verify skip gate を追加

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -1096,6 +1096,10 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh write_batch "$BATCH_ID" "N1 N2 
 ```
 (`BATCH_ID` is used for all subsequent checkpoint calls in this batch session; first list arg: space-separated full list in double quotes — quoting is required when the list contains spaces; remaining args: empty strings for completed and failed)
 
+**Load stop-at setting (List mode only):**
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `AUTO_STOP_AT` for use in step 7's verify orchestration gate below.
+
 Process each Issue in `BATCH_LIST` in order:
 
 1. Check Issue labels: `gh issue view $NUMBER --json labels -q '.labels[].name'`
@@ -1123,10 +1127,11 @@ Process each Issue in `BATCH_LIST` in order:
 7. **Verify orchestration** (after run-auto-sub.sh success):
    - Re-fetch current labels: `gh issue view $NUMBER --json labels -q '.labels[].name'`
    - If `phase/verify` is present in labels:
-     - If `--non-interactive` is NOT in ARGUMENTS: invoke `Skill(skill="wholework:verify", args="$NUMBER")` in the parent session
+     - If `AUTO_STOP_AT == "merge"`: output "Skipping verify for #$NUMBER (auto-stop-at=merge); phase/verify remains"; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
+     - Else if `--non-interactive` is NOT in ARGUMENTS: invoke `Skill(skill="wholework:verify", args="$NUMBER")` in the parent session
        - On success: call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
        - On failure or output contains `MAX_ITERATIONS_REACHED`: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER fail`; skip to the next Issue
-     - If `--non-interactive` IS in ARGUMENTS: output "Skipping verify for #$NUMBER (non-interactive mode); phase/verify remains"; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
+     - Else (`--non-interactive` IS in ARGUMENTS): output "Skipping verify for #$NUMBER (non-interactive mode); phase/verify remains"; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
    - If `phase/verify` is NOT in labels: call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER complete`
 
 After all Issues are processed, delete the batch checkpoint:

--- a/tests/auto-batch.bats
+++ b/tests/auto-batch.bats
@@ -51,6 +51,16 @@ count_mode_section() {
     [ "$status" -eq 0 ]
 }
 
+@test "List mode section: AUTO_STOP_AT retained for verify gate" {
+    run bash -c "awk '/^### List mode/{found=1} /^### / && !/List mode/{found=0} found{print}' '$SKILL_FILE' | grep -q 'AUTO_STOP_AT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "List mode section: auto-stop-at merge skip behavior present" {
+    run bash -c "awk '/^### List mode/{found=1} /^### / && !/List mode/{found=0} found{print}' '$SKILL_FILE' | grep -q 'auto-stop-at=merge'"
+    [ "$status" -eq 0 ]
+}
+
 @test "Count mode section: Issue Retrospective Transcription reference present" {
     run bash -c "awk '/^### Count mode/{found=1} /^### / && !/Count mode/{found=0} found{print}' '$SKILL_FILE' | grep -q 'Step 4b'"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- `skills/auto/SKILL.md` の Batch Mode List mode Step 7 で `AUTO_STOP_AT` を読み、`merge` の場合 verify dispatch を skip し `phase/verify` を維持する gate を追加
- `tests/auto-batch-verify-stop-at.bats` (もしくは既存 auto-batch テストへ追加) で gate の挙動を検証する

closes #1044

## Test plan
- [x] bats テストが追加され、`auto-stop-at=merge` 設定下で verify dispatch がスキップされることを検証
- [x] 既存の verify dispatch 経路 (`auto-stop-at` 未設定 / `verify` 設定) は回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRb3DiTD1VTkCi15nRB9TL