### PR TITLE
Issue #1045: run-auto-sub.sh に wrapper_alive heartbeat event を追加

### DIFF
--- a/docs/spec/issue-1045-run-auto-sub-wrapper-alive.md
+++ b/docs/spec/issue-1045-run-auto-sub-wrapper-alive.md
@@ -10,6 +10,10 @@
   - 内容: `/issue 1045 --non-interactive` の retrospective コメント。AC 分類 (post-merge 条件の verify-type を `manual` に修正) の経緯を記録するとともに、Pre-merge AC の Option A/B/C 実装方式決定は `/issue` (What) / `/spec` (How) の責務境界 (`docs/product.md`) に従い `/spec` フェーズに委譲する旨を明記。
   - URL: https://github.com/saitoco/wholework/issues/1045#issuecomment-5058895944
 
+### code phase (cutoff: 2026-07-23T13:43:22Z, phase/ready label assignment)
+
+No new comments since last phase.
+
 ## Changed Files
 
 - `scripts/run-auto-sub.sh`: `run_phase_with_recovery()` 内および top-level 制御フローに `wrapper_alive` heartbeat event の emit を追加 (bash 3.2+ compatible、既存構文のみ使用)

--- a/docs/spec/issue-1045-run-auto-sub-wrapper-alive.md
+++ b/docs/spec/issue-1045-run-auto-sub-wrapper-alive.md
@@ -65,3 +65,32 @@ No new comments since last phase.
 - **Recovery type**: respawn
 - **Wrapper exit code**: unknown
 - **Outcome**: success
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note. PR diff (`scripts/run-auto-sub.sh`, `scripts/emit-event.sh`, `tests/run-auto-sub.bats`, `tests/auto-sub-observability.bats`) matched Implementation Steps 1–3 exactly, including checkpoint names, `phase=` field presence/absence per checkpoint, and the `_maybe_emit_phase_complete()` backfill extension. No structural divergence found.
+
+### Recurring issues
+
+One recurring pattern worth naming: a PR that changes shared control-flow logic (`_maybe_emit_phase_complete()`'s OR-condition) can silently invalidate an existing test's premise without the test itself failing. Here, adding `emit_event "wrapper_alive" ...` immediately after `emit_event "phase_start" ...` meant the existing "phase_start only" backfill test could no longer produce a bare-`phase_start`-as-last-event scenario through the real code path — it kept passing, but for the wrong reason (it started exercising a different OR-branch). The only test that still constructed that raw scenario did so via a hand-duplicated, unsynced copy of the function, so the real branch had silently lost coverage. This class of bug (test still green, but no longer covering what its name claims) is not caught by CI pass/fail alone — worth flagging in review whenever a diff touches a helper function that tests duplicate inline via heredoc/mock rather than sourcing directly. No process change proposed here (fixed inline this cycle), but noting the pattern for future `/review` passes on this file.
+
+### Acceptance criteria verification difficulty
+
+Nothing to note. Both pre-merge ACs had unambiguous verify commands (`file_contains` + `rubric`) and resolved cleanly to PASS; the post-merge AC's `manual` verify-type was already confirmed appropriate at `/spec` time (see Notes section above).
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- Reviewed at `--light` depth (Size M, review-light single-agent covering all 4 aspects); no MUST issues found, review posted as `COMMENTED` (not `REQUEST_CHANGES`).
+- Fixed the one SHOULD finding (stale test duplicate of `_maybe_emit_phase_complete()` no longer covering the real `phase_start`-only backfill branch) by syncing the SIGTERM helper's inline function copy to current production logic and adding a companion test for the `wrapper_alive`/`pre_subprocess` last-event case.
+- Skipped the one CONSIDER finding (duplicate `"phase"` JSON key in a test mock) — harmless per jq's last-value-wins, not worth the churn at light-review depth.
+
+### Deferred Items
+- Post-merge AC ("次回 external kill 発生時に control-flow kill vs subprocess kill が判別できる", `verify-type: manual`) remains open — requires an actual future external-kill observation against `.tmp/auto-events.jsonl`, out of scope for `/merge`.
+
+### Notes for Next Phase
+- No policy/design changes were made during review (fix was test-only), so Step 13 (AC consistency check) found nothing to update in the Issue body.
+- CI is green (DCO, bats, skill-syntax, forbidden-expressions, macOS shell compat all SUCCESS) and the review-response fix commit (`9a5ced81`) has already been pushed to `worktree-code+issue-1045` — `/merge` should not need to wait on additional CI cycles beyond re-confirming the new commit's checks.

--- a/scripts/emit-event.sh
+++ b/scripts/emit-event.sh
@@ -69,6 +69,27 @@
 #   cwd=<path>                    working directory at block time
 #   file_path=<path>              the blocked absolute path
 #   worktree_root=<path>          the worktree root the session was inside
+#
+# wrapper_alive: run-auto-sub.sh control-flow heartbeat, emitted at wrapper-only
+#   checkpoints (never while a child `claude -p` subprocess is running) to let
+#   external-kill diagnosis distinguish control-flow kills from subprocess kills
+#   (see #1045, [[project_external_kill_pattern]]).
+#   checkpoint=<name>             pre_subprocess | pre_phase_dispatch | post_code_pre_review
+#                                  pre_subprocess: run_phase_with_recovery(), immediately after
+#                                    phase_start and before the blocking run_with_retry_on_kill
+#                                    call — last point the wrapper is known alive before the
+#                                    subprocess blocks it
+#                                  pre_phase_dispatch: top-level, right before the
+#                                    Size-based `case "$EFFECTIVE_SIZE" in` dispatch
+#                                  post_code_pre_review: Size M/L route, right before the
+#                                    `gh pr list` PR_NUMBER lookup that follows the code phase
+#                                    (the exact gap where #1042's kill was observed)
+#   phase=<phase>                 phase name; present only for the pre_subprocess checkpoint
+#                                  (the other two checkpoints are not scoped to a single phase)
+#   Diagnosis: compare a kill's observed time against the most recent wrapper_alive event in
+#   .tmp/auto-events.jsonl. A short gap indicates a control-flow kill (wrapper itself was
+#   killed between checkpoints); a gap approaching the phase's typical duration indicates a
+#   subprocess-execution kill (no heartbeat could be emitted while blocked on the subprocess).
 
 emit_event() {
   local event_type="$1"; shift

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -416,11 +416,20 @@ _maybe_emit_phase_complete() {
   [[ -z "${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "${EMIT_ISSUE_NUMBER:-}" ]] && return 0
   [[ -z "${EMIT_PHASE_NAME:-}" ]] && return 0
-  local _last_event
-  _last_event=$(grep "\"session_id\":\"${AUTO_SESSION_ID}\"" "${AUTO_EVENTS_LOG}" 2>/dev/null \
+  local _last_event _last_checkpoint _last_json
+  _last_json=$(grep "\"session_id\":\"${AUTO_SESSION_ID}\"" "${AUTO_EVENTS_LOG}" 2>/dev/null \
       | jq -rs --argjson n "${EMIT_ISSUE_NUMBER}" \
-        '[.[] | select(.issue == $n)] | last // empty | .event // ""' 2>/dev/null || true)
-  if [[ "${_last_event}" == "phase_start" ]]; then
+        '[.[] | select(.issue == $n)] | last // empty' 2>/dev/null || true)
+  _last_event=$(echo "${_last_json}" | jq -r '.event // ""' 2>/dev/null || true)
+  _last_checkpoint=$(echo "${_last_json}" | jq -r '.checkpoint // ""' 2>/dev/null || true)
+  # wrapper_alive checkpoint=pre_subprocess is emitted right after phase_start and before the
+  # blocking subprocess call, so it carries the same "phase not yet complete" meaning as
+  # phase_start for backfill purposes. The other checkpoints (pre_phase_dispatch,
+  # post_code_pre_review) occur in gaps AFTER a phase has already completed normally, so they
+  # must NOT trigger a backfill here — doing so would emit a duplicate phase_complete for a
+  # phase that already recorded one. (#1045)
+  if [[ "${_last_event}" == "phase_start" ]] || \
+     { [[ "${_last_event}" == "wrapper_alive" ]] && [[ "${_last_checkpoint}" == "pre_subprocess" ]]; }; then
     local _ts; _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     local _pr_field=""
     [[ -n "${EMIT_PR_NUMBER:-}" ]] && _pr_field=",\"pr\":${EMIT_PR_NUMBER}"
@@ -663,6 +672,7 @@ run_phase_with_recovery() {
   local PHASE_START
   PHASE_START=$(date +%s)
   emit_event "phase_start" "phase=${phase}"
+  emit_event "wrapper_alive" "checkpoint=pre_subprocess" "phase=${phase}"
 
   set +e
   # See modules/orchestration-fallbacks.md#wrapper-retry-on-kill
@@ -863,6 +873,8 @@ if [[ "$ALWAYS_PR" == "true" ]] && [[ "$SIZE" =~ ^(XS|S)$ ]]; then
   EFFECTIVE_SIZE="M"
 fi
 
+emit_event "wrapper_alive" "checkpoint=pre_phase_dispatch"
+
 # Execute phases according to Size-based route.
 # verify is deferred to the parent /auto session (issue #485)
 case "$EFFECTIVE_SIZE" in
@@ -947,6 +959,7 @@ case "$EFFECTIVE_SIZE" in
       "$SCRIPT_DIR/auto-checkpoint.sh" write_milestone "$SUB_NUMBER" "post-PR-create" || true
     fi
 
+    emit_event "wrapper_alive" "checkpoint=post_code_pre_review"
     PR_NUMBER=$(gh pr list --json number,headRefName 2>/dev/null | jq -r ".[] | select(.headRefName == \"worktree-code+issue-${SUB_NUMBER}\") | .number" | head -1 || true)
     if [[ -z "$PR_NUMBER" ]]; then
       echo "${LOG_PREFIX} Error: Could not retrieve PR number for issue #${SUB_NUMBER}" >&2
@@ -1025,6 +1038,7 @@ case "$EFFECTIVE_SIZE" in
       "$SCRIPT_DIR/auto-checkpoint.sh" write_milestone "$SUB_NUMBER" "post-PR-create" || true
     fi
 
+    emit_event "wrapper_alive" "checkpoint=post_code_pre_review"
     PR_NUMBER=$(gh pr list --json number,headRefName 2>/dev/null | jq -r ".[] | select(.headRefName == \"worktree-code+issue-${SUB_NUMBER}\") | .number" | head -1 || true)
     if [[ -z "$PR_NUMBER" ]]; then
       echo "${LOG_PREFIX} Error: Could not retrieve PR number for issue #${SUB_NUMBER}" >&2

--- a/tests/auto-sub-observability.bats
+++ b/tests/auto-sub-observability.bats
@@ -108,6 +108,13 @@ teardown() {
     grep -q '"event":' "$AUTO_EVENTS_LOG"
 }
 
+@test "wrapper-alive-check: AUTO_EVENTS_LOG contains a wrapper_alive event" {
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    [ -f "$AUTO_EVENTS_LOG" ]
+    grep -q '"event":"wrapper_alive"' "$AUTO_EVENTS_LOG"
+}
+
 @test "append-no-clobber: two runs produce at least two log entries" {
     run bash "$SCRIPT" 42
     [ "$status" -eq 0 ]
@@ -122,14 +129,22 @@ teardown() {
     # Override emit-event.sh to suppress completion events, leaving phase_start as last event
     cat > "$MOCK_DIR/emit-event.sh" <<'MOCK'
 emit_event() {
-    local event_name="$1"
+    local event_name="$1"; shift
     case "$event_name" in
         phase_complete|sub_complete|wrapper_exit) return 0 ;;
     esac
+    # Pass remaining kv args through as extra JSON fields (e.g. checkpoint=...)
+    # so the real backfill logic's checkpoint check can be exercised faithfully.
+    local extra=""
+    while [[ $# -gt 0 ]]; do
+        local kv="$1"; local k="${kv%%=*}"; local v="${kv#*=}"
+        extra="${extra},\"${k}\":\"${v}\""
+        shift
+    done
     mkdir -p "$(dirname "${AUTO_EVENTS_LOG}")"
-    printf '{"ts":"%s","issue":%s,"event":"%s","session_id":"%s","phase":"%s"}\n' \
+    printf '{"ts":"%s","issue":%s,"event":"%s","session_id":"%s","phase":"%s"%s}\n' \
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${EMIT_ISSUE_NUMBER:-0}" "${event_name}" \
-        "${AUTO_SESSION_ID:-}" "${EMIT_PHASE_NAME:-}" >> "${AUTO_EVENTS_LOG}"
+        "${AUTO_SESSION_ID:-}" "${EMIT_PHASE_NAME:-}" "${extra}" >> "${AUTO_EVENTS_LOG}"
 }
 _emit_comments_consumed() { :; }
 MOCK

--- a/tests/auto-sub-observability.bats
+++ b/tests/auto-sub-observability.bats
@@ -172,11 +172,14 @@ _maybe_emit_phase_complete() {
   [[ -z "\${AUTO_SESSION_ID:-}" ]] && return 0
   [[ -z "\${EMIT_ISSUE_NUMBER:-}" ]] && return 0
   [[ -z "\${EMIT_PHASE_NAME:-}" ]] && return 0
-  local _last_event
-  _last_event=\$(grep "\\"session_id\\":\\"\${AUTO_SESSION_ID}\\"" "\${AUTO_EVENTS_LOG}" 2>/dev/null \
+  local _last_event _last_checkpoint _last_json
+  _last_json=\$(grep "\\"session_id\\":\\"\${AUTO_SESSION_ID}\\"" "\${AUTO_EVENTS_LOG}" 2>/dev/null \
       | jq -rs --argjson n "\${EMIT_ISSUE_NUMBER}" \
-        '[.[] | select(.issue == \$n)] | last // empty | .event // ""' 2>/dev/null || true)
-  if [[ "\${_last_event}" == "phase_start" ]]; then
+        '[.[] | select(.issue == \$n)] | last // empty' 2>/dev/null || true)
+  _last_event=\$(echo "\${_last_json}" | jq -r '.event // ""' 2>/dev/null || true)
+  _last_checkpoint=\$(echo "\${_last_json}" | jq -r '.checkpoint // ""' 2>/dev/null || true)
+  if [[ "\${_last_event}" == "phase_start" ]] || \
+     { [[ "\${_last_event}" == "wrapper_alive" ]] && [[ "\${_last_checkpoint}" == "pre_subprocess" ]]; }; then
     local _ts; _ts=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
     printf '%s\n' \
       "{\\"ts\\":\\"\${_ts}\\",\\"issue\\":\${EMIT_ISSUE_NUMBER},\\"event\\":\\"phase_complete\\",\\"session_id\\":\\"\${AUTO_SESSION_ID}\\",\\"phase\\":\\"\${EMIT_PHASE_NAME}\\",\\"backfilled\\":true}" \
@@ -187,6 +190,48 @@ trap '_maybe_emit_phase_complete' EXIT
 exit 143
 HELPER
     run bash "$BATS_TEST_TMPDIR/sigterm-helper.sh"
+    [ "$status" -eq 143 ]
+    grep -q '"backfilled":true' "$AUTO_EVENTS_LOG"
+}
+
+@test "backfill-emit: SIGTERM (exit 143) with wrapper_alive checkpoint=pre_subprocess as last event also backfills" {
+    export AUTO_SESSION_ID="test-session-sigterm-heartbeat"
+    export EMIT_ISSUE_NUMBER="42"
+    export EMIT_PHASE_NAME="code-pr"
+    mkdir -p "$(dirname "$AUTO_EVENTS_LOG")"
+    printf '{"ts":"2026-01-01T00:00:00Z","issue":42,"event":"phase_start","session_id":"test-session-sigterm-heartbeat","phase":"code-pr"}\n' \
+        >> "$AUTO_EVENTS_LOG"
+    printf '{"ts":"2026-01-01T00:00:01Z","issue":42,"event":"wrapper_alive","session_id":"test-session-sigterm-heartbeat","phase":"code-pr","checkpoint":"pre_subprocess"}\n' \
+        >> "$AUTO_EVENTS_LOG"
+
+    cat > "$BATS_TEST_TMPDIR/sigterm-heartbeat-helper.sh" <<HELPER
+#!/usr/bin/env bash
+source "$MOCK_DIR/emit-event.sh"
+_maybe_emit_phase_complete() {
+  local _exit_code=\$?
+  [[ "\$_exit_code" -ne 0 && "\$_exit_code" -ne 143 ]] && return 0
+  [[ -z "\${AUTO_EVENTS_LOG:-}" ]] && return 0
+  [[ -z "\${AUTO_SESSION_ID:-}" ]] && return 0
+  [[ -z "\${EMIT_ISSUE_NUMBER:-}" ]] && return 0
+  [[ -z "\${EMIT_PHASE_NAME:-}" ]] && return 0
+  local _last_event _last_checkpoint _last_json
+  _last_json=\$(grep "\\"session_id\\":\\"\${AUTO_SESSION_ID}\\"" "\${AUTO_EVENTS_LOG}" 2>/dev/null \
+      | jq -rs --argjson n "\${EMIT_ISSUE_NUMBER}" \
+        '[.[] | select(.issue == \$n)] | last // empty' 2>/dev/null || true)
+  _last_event=\$(echo "\${_last_json}" | jq -r '.event // ""' 2>/dev/null || true)
+  _last_checkpoint=\$(echo "\${_last_json}" | jq -r '.checkpoint // ""' 2>/dev/null || true)
+  if [[ "\${_last_event}" == "phase_start" ]] || \
+     { [[ "\${_last_event}" == "wrapper_alive" ]] && [[ "\${_last_checkpoint}" == "pre_subprocess" ]]; }; then
+    local _ts; _ts=\$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    printf '%s\n' \
+      "{\\"ts\\":\\"\${_ts}\\",\\"issue\\":\${EMIT_ISSUE_NUMBER},\\"event\\":\\"phase_complete\\",\\"session_id\\":\\"\${AUTO_SESSION_ID}\\",\\"phase\\":\\"\${EMIT_PHASE_NAME}\\",\\"backfilled\\":true}" \
+      >> "\${AUTO_EVENTS_LOG}" 2>/dev/null || true
+  fi
+}
+trap '_maybe_emit_phase_complete' EXIT
+exit 143
+HELPER
+    run bash "$BATS_TEST_TMPDIR/sigterm-heartbeat-helper.sh"
     [ "$status" -eq 143 ]
     grep -q '"backfilled":true' "$AUTO_EVENTS_LOG"
 }

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -937,6 +937,30 @@ MOCK
     grep -q "model=claude-sonnet-5" "$BATS_TEST_TMPDIR/emit.log"
 }
 
+@test "wrapper_alive: emit_event called with checkpoint=pre_subprocess before the phase runner blocks" {
+    export AUTO_EVENTS_LOG="$BATS_TEST_TMPDIR/auto-events.jsonl"
+    export EMIT_ISSUE_NUMBER="42"
+
+    # Override emit-event.sh mock to record calls
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() {
+  echo "emit_event \$*" >> "$BATS_TEST_TMPDIR/emit.log"
+}
+_emit_comments_consumed() { :; }
+MOCK
+
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    grep -q "wrapper_alive checkpoint=pre_subprocess phase=code-patch" "$BATS_TEST_TMPDIR/emit.log"
+}
+
 @test "compute: modelUsage jq expression selects single key directly" {
     local input='{"model":null,"modelUsage":{"claude-sonnet-5":{"inputTokens":100,"outputTokens":50}}}'
     local result


### PR DESCRIPTION
## Summary

`run-auto-sub.sh` の wrapper 制御フロー中に `wrapper_alive` heartbeat event を追加し、次回の external kill ([[project_external_kill_pattern]]、通算25回以上) 発生時に「claude subprocess 実行中の kill」か「wrapper 制御フロー中の kill」かを `.tmp/auto-events.jsonl` から機械的に判別できるようにする。

- `run_phase_with_recovery()` 内、`phase_start` 直後・ブロッキングする subprocess 呼び出し前に `checkpoint=pre_subprocess` を emit
- top-level の Size 別 route dispatch (`case "$EFFECTIVE_SIZE"`) の直前に `checkpoint=pre_phase_dispatch` を emit
- Size M/L route の code phase 完了後、`gh pr list` 呼び出し直前 (#1042 で実際に kill が発生した gap) に `checkpoint=post_code_pre_review` を emit
- `scripts/emit-event.sh` のヘッダーコメントブロックに `wrapper_alive` event スキーマと判別ロジックを追記
- `_maybe_emit_phase_complete()` の backfill 判定ロジックを、新設の `wrapper_alive checkpoint=pre_subprocess` も "phase 未完了" 相当として認識するよう拡張 (既存の `phase_start` のみの判定だと、subprocess 呼び出し直前に割り込む新 heartbeat のせいで backfill が発火しなくなる回帰があったため)

## Verification (pre-merge)

- `scripts/run-auto-sub.sh` に `wrapper_alive` が含まれる (`file_contains`)
- `wrapper_alive` heartbeat が phase 呼び出し間の kill 検出材料として機能する (`rubric`)
- `tests/run-auto-sub.bats` / `tests/auto-sub-observability.bats` に `wrapper_alive` emit / event 記録を検証するテストを追加し、全 bats テストスイート (1236 tests) が pass することを確認済み (`rubric`)

## Verification (post-merge)

- 次回 external kill 発生時に、`.tmp/auto-events.jsonl` の直近 `wrapper_alive` event と kill 時刻の差分から control-flow kill vs subprocess kill が判別できる (実観測必要・manual)

closes #1045
