### PR TITLE
Issue #1060: merge: pre-merge AC 全 PASS を merge のゲート条件にする

### DIFF
--- a/docs/guide/workflow.md
+++ b/docs/guide/workflow.md
@@ -108,7 +108,7 @@ For M-size issues, a lightweight single-agent review runs. For L-size, a full mu
 
 ### `/merge` — Merge the PR
 
-Squash-merges the PR and deletes the remote branch.
+Squash-merges the PR and deletes the remote branch. Before merging, checks that the issue's pre-merge acceptance criteria are all checked off; if any are unchecked, it presents them and blocks the merge unless a recorded override exists.
 
 ```
 /merge 88

--- a/docs/ja/guide/workflow.md
+++ b/docs/ja/guide/workflow.md
@@ -104,7 +104,7 @@ M サイズ issue では軽量単一エージェントレビューが実行さ�
 
 ### `/merge` — PR マージ
 
-PR を squash merge してリモートブランチを削除します。
+PR を squash merge してリモートブランチを削除します。マージ前に issue の pre-merge acceptance criteria が全てチェック済みかを確認し、未チェックがあれば提示して merge をブロックします（記録済み override がある場合を除く）。
 
 ```
 /merge 88

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（68 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（69 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -187,6 +187,7 @@ wholework/
 - `scripts/get-auto-session-report.sh` — `.tmp/auto-events.jsonl` から session_id でフィルタし、`/auto` セッション retrospective の `## Metrics` markdown 小節（`--metrics-only`）を出力（`session.md` への埋め込みおよび `/audit auto-session` 用）
 - `scripts/get-verify-iteration.sh` — Issue コメントから `<!-- verify-iteration: N -->` マーカーの最大値を読み取る
 - `scripts/resolve-preview-ac-fallback.sh` — Issue コメントから最新の `type=preview-ac-unverified` マーカーを解決し、`/verify` のフォールバックが必要な 1-based AC インデックスを出力 (無ければ空)
+- `scripts/check-pre-merge-ac.sh` — Issue 本文の `### Pre-merge` サブセクション内の未チェックチェックボックスを走査し、本文全体基準の 1-based index とテキストを JSON で出力。`skills/merge/SKILL.md` Step 1 の pre-merge AC ゲートが使用
 - `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: プロンプトが `/auto` パターンにマッチした場合にセッション名を自動リネーム
 - `scripts/log-permission.sh` — 権限イベントログ（JSON 出力）
 - `scripts/observation-trigger.sh` — イベント発火時に observation AC をディスパッチ: `opportunistic-search.sh --event` を呼び出し、マッチした各 Issue に `/verify` 再実行を促すコメントを投稿し、マッチした Issue 番号一覧を呼び出し元向けに stdout へ出力

--- a/docs/ja/workflow.md
+++ b/docs/ja/workflow.md
@@ -85,7 +85,7 @@ review-bug: false           # Step 9 の review-bug agent を無効化（review-
 
 ### 5. `/merge` — マージ
 
-squash merge を実行してリモートブランチを削除します。コンフリクトがある場合は自動解決を試みます。詳細: [`skills/merge/SKILL.md`](../../skills/merge/SKILL.md)
+squash merge を実行してリモートブランチを削除します。コンフリクトがある場合は自動解決を試みます。マージ前に対象 Issue の pre-merge acceptance criteria が全てチェック済みかを検証し、未チェックがある場合は提示して merge をブロックします (記録済み override がある場合を除く)。詳細: [`skills/merge/SKILL.md`](../../skills/merge/SKILL.md)
 
 ### 6. `/verify` — 受入テスト
 

--- a/docs/spec/issue-1060-pre-merge-ac-gate.md
+++ b/docs/spec/issue-1060-pre-merge-ac-gate.md
@@ -234,24 +234,37 @@ Size L のため検出上限 5 件のうち、影響度の高い 3 件を特定�
 - `tests/gh-pr-merge-status.bats` / `tests/run-merge.bats`: **変更しない**。`git status --short scripts/gh-pr-merge-status.sh scripts/run-merge.sh` で両スクリプト共に無変更であることを再確認した
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- Spec Implementation Steps 1–9 を順序どおりに実装し、設計からの逸脱は無し
-- `docs/guide/workflow.md` / `docs/ja/guide/workflow.md` (sync candidate) はゲートの挙動変更をユーザー向けマニュアルにも反映すべきと判断し、1 文を追記した
-- `modules/phase-state.md` の `merge` 行と `tests/gh-pr-merge-status.bats` / `tests/run-merge.bats` (いずれも sync candidate) は Spec の判断どおり変更不要とした
-- Issue #1060 の pre-merge AC 4 件は全て PASS (rubric 2 件・section_contains 1 件・grep 1 件) のためチェック済みに更新した
+- Step 8 で pre-merge AC 4 件を再判定し全て PASS を確認 (既にチェック済みの状態と一致、更新不要)
+- `HAS_WORKFLOW_CAPABILITY=true` のため Step 10 は静的 Task fan-out ではなく Workflow (finder → adversarial verify) パイプラインを実行。review-spec + review-bug ×2 → adversarial refutation で 21 件中 10 件 (実質ユニーク 7 件) を確認、MUST は 0 件
+- SHOULD 2 件 (pipefail による fail-open、`>` を含む HTML コメント除去失敗) と CONSIDER 4 件 (CRLF trim、checkbox separator、allowed-tools 不足、見出し配置) を修正してコミット・push 済み。CONSIDER 1 件 (jq タブ文字切り詰め、confidence: low) は skip
 
 ### Deferred Items
 
-- `.wholework.yml` によるゲートの有効/無効設定は追加しない (Spec の判断を踏襲)
-- `modules/phase-state.md` の merge precondition 行の更新は本 Issue のスコープ外のまま
-- `docs/structure.md` の `tests/` 件数ドリフト (95 → 実際 103) は本 Issue では修正しない
-- Post-merge AC (「pre-merge AC を意図的に 1 件未チェックのまま `/merge` を実行し、ゲートが機能することを確認する」) は manual verify-type のため `/verify` フェーズでの人手確認が必要
+- `scripts/check-pre-merge-ac.sh:86` の jq タブ文字切り詰め (CONSIDER, confidence: low) — 低頻度な edge case のため今回は見送り
+- Post-merge AC (「pre-merge AC を意図的に 1 件未チェックのまま `/merge` を実行し、ゲートが機能することを確認する」) は manual verify-type のため `/verify` フェーズでの人手確認が必要 (code phase から引き継ぎ、未解消のまま)
 
 ### Notes for Next Phase
 
-- `/review` は `check-pre-merge-ac.sh 1060` (dogfooding) で `unchecked_count:0` を確認済み — pre-merge AC ゲート自体が正しく動作することの一次的な裏付けとして参照可能
-- post-merge の manual AC 検証時は、意図的に pre-merge AC を 1 件未チェックに戻した状態で `/merge` を実行し、非対話モードでの `decision=blocked` マーカー投稿と非ゼロ終了、対話モードでの 3 択提示の両方を確認すること
-- `check-pre-merge-ac.sh` のグローバル index は `gh-issue-edit.sh` の awk パターンと完全一致させてあるため、override マーカーの `ac=` 集合との照合はそのまま機能する
+- `/merge` 実行時、pre-merge AC は 4/4 PASS (チェック済み) のためゲートは素通りする見込み。ゲート自体の動作確認は Post-merge AC の manual 検証で行うこと
+- `check-pre-merge-ac.sh` に bats テストを 4 件追加済み (>64KB body、`>` を含むマーカー、区切り文字なしチェックボックス、CRLF) — 全 15 件 PASS
+- `skills/merge/SKILL.md` の `allowed-tools` に `mkdir:*, rm:*` を追加した。今後 `.tmp/` を使う新しい Bash ステップを他スキルに追加する際は同様の allowlist 漏れに注意
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- 構造的な逸脱は無し。Pre-merge AC 4 件 (rubric ×2 / section_contains ×1 / grep ×1) は Step 8 で全て PASS と再判定でき、Spec Implementation Steps どおりの実装だった
+- ただし Spec / Issue AC のいずれも `check-pre-merge-ac.sh` のテキスト整形ロジック (HTML コメント除去・CRLF・チェックボックス直後の区切り文字) に対する edge case を明示的にカバーしておらず、この部分の 2 件の SHOULD バグ (pipefail による fail-open、`>` を含むコメントの除去失敗) は AC 検証をすり抜けて Step 10 の bug-detection finder で初めて検出された。merge ゲートのような「安全側に倒れるべき」スクリプトについては、Spec の Implementation Steps 段階で「大きな入力」「特殊文字を含む入力」に対する期待動作を明記しておくと、実装時点でこれらのバグを防げた可能性がある
+
+### Recurring issues
+
+- 目立った再発パターンは無し。本 Issue は #1060 の初回 review であり、過去の review サイクルとの比較対象は無い
+
+### Acceptance criteria verification difficulty
+
+- 4 件とも UNCERTAIN や verify command の構文エラーは無く、Step 8 の自動判定は円滑だった (rubric 2 件は Spec 由来の PR diff と Issue 本文から明確に判定可能、section_contains と grep は機械的に確定)
+- Workflow (finder → adversarial verify) パイプラインは 21 件の finding のうち 11 件を adversarial refutation で除外し、確認できた 10 件 (実質ユニーク 7 件) はいずれも MUST ではなかったが、うち 2 件は実際にバグとして再現確認できる質の高い指摘だった。static Task fan-out (Step 10.1–10.3) では検出できたかどうか比較対象がないため、今回の実行だけでは Workflow path の有効性を断定できないが、finder のカバレッジ (specific line + reproduction手順付き) は高かった

--- a/docs/spec/issue-1060-pre-merge-ac-gate.md
+++ b/docs/spec/issue-1060-pre-merge-ac-gate.md
@@ -213,29 +213,45 @@ Size L のため検出上限 5 件のうち、影響度の高い 3 件を特定�
 - **グローバル AC index の整合性**: `scripts/gh-issue-edit.sh` の awk パターン (`/^- \[[ xX]\]/`、本文全体対象、行頭一致のみ) を実際に読み、新スクリプトで同一パターンを使うことで構成上一致させる方針に決めた。行頭一致のみなのでインデントされたチェックボックスは数えられない点も含めて同一挙動になる
 - **非ゼロ終了が `/auto` に与える影響**: `skills/auto/SKILL.md` Step 4 項目 11 (merge 失敗時は completion check → `matches_expected:false` なら Step 6) を確認し、既存の失敗経路にそのまま乗ることを確認した。復旧ループの誘発懸念は解消
 
+## Code Retrospective
+
+### Deviations from Design
+
+- **`docs/guide/workflow.md` / `docs/ja/guide/workflow.md` にゲート説明を追加した**: Spec Notes は sync candidate 扱いで要否判断を `/code` に委ねていた。ユーザー向けマニュアルの `### /merge — Merge the PR` 節は `/merge` の挙動を簡潔に説明する箇所であり、pre-merge AC ゲートは merge がブロックされうる挙動変更のため、1 文の追記価値があると判断し追加した (Changed Files の想定範囲を超える追加だが、Spec が明示的に判断を委任していた項目)
+
+### Design Gaps/Ambiguities
+
+- N/A (Implementation Steps 1–9 は設計どおりに実装でき、実装中に新たな設計上の欠陥や曖昧さは見つからなかった)
+
+### Rework
+
+- N/A
+
+### Steering Docs sync candidate の判断結果
+
+- `modules/phase-state.md` の `merge` 行: **変更しない**。Spec Deferred Items の判断 (`reconcile-phase-state.sh` の precondition 判定は SKILL.md 内ゲートとは別機構) をそのまま踏襲した
+- `docs/guide/workflow.md` / `docs/ja/guide/workflow.md`: **追加した** (上記 Deviations 参照)。`check-translation-sync.sh` で IN_SYNC を確認済み
+- `tests/gh-pr-merge-status.bats` / `tests/run-merge.bats`: **変更しない**。`git status --short scripts/gh-pr-merge-status.sh scripts/run-merge.sh` で両スクリプト共に無変更であることを再確認した
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- AC 状態の取得は新規スクリプト `scripts/check-pre-merge-ac.sh` で行い、`scripts/gh-pr-merge-status.sh` は変更しない (共有 JSON 契約の consumer 影響と、`mergeable:false` 相乗りがゲートとして機能しない問題を回避するため)
-- ゲートは `skills/merge/SKILL.md` Step 1 の項目 2 として挿入する。既存の項目 2 (Determine mergeability) は項目 3 に繰り下げる
-- 非対話モードでは merge せずマーカー投稿 + 非ゼロ終了。対話モードは AskUserQuestion で Abort / Re-run review / Approve の 3 択
-- 再検証の実行責務は `/review` 再実行に割り当て、`/merge` はインライン再検証を行わない (`docs/tech.md` の「merge は機械的操作」決定との衝突回避)
-- 新マーカー `type=pre-merge-ac-gate` (`decision=blocked|override`) を `modules/l0-surfaces.md` に追加し、latest-wins で解決する
+- Spec Implementation Steps 1–9 を順序どおりに実装し、設計からの逸脱は無し
+- `docs/guide/workflow.md` / `docs/ja/guide/workflow.md` (sync candidate) はゲートの挙動変更をユーザー向けマニュアルにも反映すべきと判断し、1 文を追記した
+- `modules/phase-state.md` の `merge` 行と `tests/gh-pr-merge-status.bats` / `tests/run-merge.bats` (いずれも sync candidate) は Spec の判断どおり変更不要とした
+- Issue #1060 の pre-merge AC 4 件は全て PASS (rubric 2 件・section_contains 1 件・grep 1 件) のためチェック済みに更新した
 
 ### Deferred Items
 
-- `.wholework.yml` によるゲートの有効/無効設定は追加しない (Issue の要求外。必要になれば別 Issue)
-- `modules/phase-state.md` の merge precondition 行の更新は sync candidate 扱いで、`reconcile-phase-state.sh` の挙動変更は本 Issue のスコープ外
+- `.wholework.yml` によるゲートの有効/無効設定は追加しない (Spec の判断を踏襲)
+- `modules/phase-state.md` の merge precondition 行の更新は本 Issue のスコープ外のまま
 - `docs/structure.md` の `tests/` 件数ドリフト (95 → 実際 103) は本 Issue では修正しない
-- `docs/guide/workflow.md` / `docs/ja/guide/workflow.md` へのゲート説明追加は sync candidate 扱い (`/code` が要否を判断)
+- Post-merge AC (「pre-merge AC を意図的に 1 件未チェックのまま `/merge` を実行し、ゲートが機能することを確認する」) は manual verify-type のため `/verify` フェーズでの人手確認が必要
 
 ### Notes for Next Phase
 
-- `skills/merge/SKILL.md` の `allowed-tools` には `${CLAUDE_PLUGIN_ROOT}/scripts/check-pre-merge-ac.sh:*` と `Write` の両方を追加すること。`AskUserQuestion` は `validate-skill-syntax.py` の `FORBIDDEN_ALLOWED_TOOLS` に含まれるため追加してはならない
-- Step 5 で追加する再検証責務のサブセクションは **h4 (`####`)** にすること。h3 にすると AC2 の `section_contains "skills/merge/SKILL.md" "Step 1" "pre-merge AC"` の走査範囲が打ち切られる
-- `check-pre-merge-ac.sh` のグローバル index は `scripts/gh-issue-edit.sh` の awk パターン `/^- \[[ xX]\]/` と完全一致させること (本文全体対象・行頭一致のみ)。ずれると override マーカーの `ac=` 集合と照合できなくなる
-- bash 3.2 互換必須 (`mapfile` / 連想配列 / `${var^^}` 禁止)。awk + jq のみで実装する
-- SKILL.md 本文には半角の感嘆符と 3 連バッククォートを書かないこと (`validate-skill-syntax.py` が検出する)
-- `docs/workflow.md` / `docs/structure.md` を変更したら `docs/translation-workflow.md` の Sync Procedure に従って `docs/ja/` ミラーも同一 PR で更新すること (コードフェンス数の一致確認を含む)
+- `/review` は `check-pre-merge-ac.sh 1060` (dogfooding) で `unchecked_count:0` を確認済み — pre-merge AC ゲート自体が正しく動作することの一次的な裏付けとして参照可能
+- post-merge の manual AC 検証時は、意図的に pre-merge AC を 1 件未チェックに戻した状態で `/merge` を実行し、非対話モードでの `decision=blocked` マーカー投稿と非ゼロ終了、対話モードでの 3 択提示の両方を確認すること
+- `check-pre-merge-ac.sh` のグローバル index は `gh-issue-edit.sh` の awk パターンと完全一致させてあるため、override マーカーの `ac=` 集合との照合はそのまま機能する

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (68 files)
+├── scripts/             # Utility scripts used by skills and agents (69 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -195,6 +195,7 @@ Key modules:
 - `scripts/get-auto-session-report.sh` — emit the `## Metrics` markdown section (`--metrics-only`) of a /auto session retrospective from `.tmp/auto-events.jsonl` (filtered by session_id), for embedding into `session.md` and for `/audit auto-session`
 - `scripts/get-verify-iteration.sh` — read highest `<!-- verify-iteration: N -->` marker from Issue comments
 - `scripts/resolve-preview-ac-fallback.sh` — resolve the latest `type=preview-ac-unverified` marker from Issue comments and print the 1-based AC indices needing `/verify` fallback (empty when none)
+- `scripts/check-pre-merge-ac.sh` — scan an Issue body's `### Pre-merge` subsection for unchecked checkboxes and output global 1-based indices + text as JSON; used by `skills/merge/SKILL.md` Step 1's pre-merge AC gate
 - `scripts/hook-rename-on-auto.sh` — UserPromptSubmit hook: auto-rename session title when prompt matches `/auto` pattern
 - `scripts/log-permission.sh` — log permission events (JSON output)
 - `scripts/observation-trigger.sh` — dispatch observation-type ACs on event: calls `opportunistic-search.sh --event`, posts comment to each matched Issue recommending `/verify` re-run, and prints matched Issue numbers to stdout for caller dispatch

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -92,7 +92,7 @@ If `.wholework.yml` does not exist, all settings are treated as default (disable
 
 ### 5. `/merge` — Merge
 
-Executes squash merge and deletes the remote branch. Attempts automatic conflict resolution if conflicts exist. Details: [`skills/merge/SKILL.md`](../skills/merge/SKILL.md)
+Executes squash merge and deletes the remote branch. Attempts automatic conflict resolution if conflicts exist. Before merging, verifies that the target Issue's pre-merge acceptance criteria are all checked, presenting and blocking on any unchecked condition unless a recorded override exists. Details: [`skills/merge/SKILL.md`](../skills/merge/SKILL.md)
 
 ### 6. `/verify` — Acceptance Testing
 

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -117,6 +117,35 @@ that run, so the consumer's fallback set is empty. `/verify`'s pre-merge-preview
 `scripts/resolve-preview-ac-fallback.sh`, to decide whether an `ac-tier: preview` condition was
 actually verified at `/review` or must fall back to a post-merge check.
 
+**`type=pre-merge-ac-gate`**: posted by `/merge` (Step 1's pre-merge AC gate) when one or more
+Pre-merge acceptance conditions are unchecked. Attributes: `decision=blocked` (non-interactive
+mode — merge did not proceed) or `decision=override` (an explicit human/AI decision to merge
+anyway); `ac=` carries a comma-separated list of 1-based indices into the Issue body's full AC
+enumeration (same convention as `gh-issue-edit.sh --checkbox`, and as `check-pre-merge-ac.sh`'s
+`unchecked_indices` output) identifying the unchecked conditions at the time of posting;
+`reason="<one-line reason>"` records why (for `decision=blocked`, the automatic block reason; for
+`decision=override`, the human-supplied justification). Example:
+```
+<!-- wholework-event: type=pre-merge-ac-gate phase=merge issue=42 decision=blocked ac=2,5 reason="2 unchecked pre-merge acceptance conditions" -->
+Merge blocked: 2 unchecked pre-merge acceptance conditions on issue #42.
+
+#2 CI (lint) passes on the merge commit
+#5 preview screenshot matches the design
+```
+```
+<!-- wholework-event: type=pre-merge-ac-gate phase=merge issue=42 decision=override ac=2,5 reason="lint job not yet triggered on this commit; verified manually" -->
+Proceeding with merge despite 2 unchecked pre-merge acceptance conditions, per recorded override.
+```
+Issue comments are append-only (see the L0 Surface SSoT table above), so consumers must always
+resolve **only the single comment with the greatest `createdAt` timestamp among
+`type=pre-merge-ac-gate` markers for this Issue (latest-wins)** — never union `ac=` sets across
+multiple markers. The gate only treats a resolved marker as authorizing merge when it has
+`decision=override` **and** its `ac=` index set is a superset of the currently unchecked
+`unchecked_indices` set; otherwise the gate presents the unchecked conditions again and blocks
+(non-interactive) or asks (interactive) as usual. Because `/merge` resolves this marker directly
+via `gh issue view` within the same phase (not through the Comment Consumption Procedure), no
+change to the Cross-phase marker exception in Processing Steps is needed for this marker type.
+
 When consuming comments (see Processing Steps), a comment containing `<!-- wholework-event:`
 in its body from a bot actor is treated as a Wholework-authored structured comment and consumed (bot exception above).
 

--- a/scripts/check-pre-merge-ac.sh
+++ b/scripts/check-pre-merge-ac.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# check-pre-merge-ac.sh - Check pre-merge acceptance criteria checkbox state
+#
+# Usage: check-pre-merge-ac.sh <issue-number>
+#
+# Output (single JSON line):
+#   {"resolved":true,"pre_merge_total":N,"unchecked_count":M,"unchecked_indices":"2,5","unchecked_items":[{"index":2,"text":"..."}]}
+#
+# Global index definition: 1-based count of every line matching ^- \[[ xX]\] across the
+# entire issue body (same awk pattern as scripts/gh-issue-edit.sh), so indices returned
+# here are directly usable with gh-issue-edit.sh --checkbox and the modules/l0-surfaces.md
+# ac= marker attribute.
+#
+# Pre-merge subsection range: from the line after a heading matching ^### Pre-merge up to
+# (but excluding) the next line matching ^## or ^### .
+#
+# exit codes:
+#   0 - success, including fail-open cases (resolved:false / no Pre-merge heading / all checked)
+#   1 - invalid arguments
+
+set -euo pipefail
+
+USAGE="Usage: $(basename "$0") <issue-number>"
+
+if [[ $# -ne 1 ]]; then
+  echo "Error: exactly one argument (issue number) is required." >&2
+  echo "$USAGE" >&2
+  exit 1
+fi
+
+ISSUE_NUMBER="$1"
+
+if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "Error: issue number must be a positive integer: $ISSUE_NUMBER" >&2
+  echo "$USAGE" >&2
+  exit 1
+fi
+
+fail_open() {
+  echo '{"resolved":false,"pre_merge_total":0,"unchecked_count":0,"unchecked_indices":"","unchecked_items":[]}'
+  exit 0
+}
+
+BODY=$(gh issue view "$ISSUE_NUMBER" --json body -q .body 2>/dev/null) || fail_open
+
+if [[ -z "$BODY" ]]; then
+  fail_open
+fi
+
+if ! printf '%s\n' "$BODY" | grep -q '^### Pre-merge'; then
+  echo '{"resolved":true,"pre_merge_total":0,"unchecked_count":0,"unchecked_indices":"","unchecked_items":[]}'
+  exit 0
+fi
+
+# Emit "<global_index>\t<checked:0|1>\t<text>" for every checkbox line that falls
+# inside the ### Pre-merge subsection (the heading line itself is excluded).
+RECORDS=$(printf '%s\n' "$BODY" | awk '
+  BEGIN { idx = 0; in_section = 0 }
+  /^### Pre-merge/ { in_section = 1; next }
+  /^## / || /^### / {
+    in_section = 0
+    next
+  }
+  /^- \[[ xX]\]/ {
+    idx++
+    if (in_section) {
+      checked = (substr($0, 4, 1) == " ") ? 0 : 1
+      text = $0
+      sub(/^- \[[ xX]\] /, "", text)
+      gsub(/<!--[^>]*-->/, "", text)
+      gsub(/^[ \t]+/, "", text)
+      gsub(/[ \t]+$/, "", text)
+      print idx "\t" checked "\t" text
+    }
+    next
+  }
+  { next }
+')
+
+if [[ -z "$RECORDS" ]]; then
+  echo '{"resolved":true,"pre_merge_total":0,"unchecked_count":0,"unchecked_indices":"","unchecked_items":[]}'
+  exit 0
+fi
+
+printf '%s\n' "$RECORDS" | jq -R -s '
+  split("\n") | map(select(length > 0)) | map(split("\t"))
+  | map({index: (.[0] | tonumber), checked: (.[1] == "1"), text: .[2]}) as $all
+  | ($all | map(select(.checked | not))) as $unchecked
+  | {
+      resolved: true,
+      pre_merge_total: ($all | length),
+      unchecked_count: ($unchecked | length),
+      unchecked_indices: ($unchecked | map(.index | tostring) | join(",")),
+      unchecked_items: ($unchecked | map({index: .index, text: .text}))
+    }
+'

--- a/scripts/check-pre-merge-ac.sh
+++ b/scripts/check-pre-merge-ac.sh
@@ -47,7 +47,7 @@ if [[ -z "$BODY" ]]; then
   fail_open
 fi
 
-if ! printf '%s\n' "$BODY" | grep -q '^### Pre-merge'; then
+if ! grep -q '^### Pre-merge' <<<"$BODY"; then
   echo '{"resolved":true,"pre_merge_total":0,"unchecked_count":0,"unchecked_indices":"","unchecked_items":[]}'
   exit 0
 fi
@@ -66,10 +66,10 @@ RECORDS=$(printf '%s\n' "$BODY" | awk '
     if (in_section) {
       checked = (substr($0, 4, 1) == " ") ? 0 : 1
       text = $0
-      sub(/^- \[[ xX]\] /, "", text)
-      gsub(/<!--[^>]*-->/, "", text)
+      sub(/^- \[[ xX]\][ \t]*/, "", text)
+      gsub(/<!--([^-]|-[^-]|--[^>])*-->/, "", text)
       gsub(/^[ \t]+/, "", text)
-      gsub(/[ \t]+$/, "", text)
+      gsub(/[ \t\r]+$/, "", text)
       print idx "\t" checked "\t" text
     }
     next

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -3,7 +3,7 @@ name: merge
 description: Squash-merge a PR and delete the remote branch (`/merge 88`). Use when merging review-approved, CI-passing PRs. Automatically attempts conflict resolution when conflicts occur.
 context: fork
 model: sonnet
-allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, gh issue view:*, gh issue close:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*), Read, Edit, Grep, Glob, EnterWorktree, ExitWorktree
+allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, gh issue view:*, gh issue close:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-pre-merge-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*), Read, Edit, Write, Grep, Glob, EnterWorktree, ExitWorktree
 ---
 
 # Squash Merge
@@ -59,7 +59,34 @@ Key per-step behavior in non-interactive mode:
    Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Read Procedure" section.
    Parameters: `SPEC_PATH`, `ISSUE_NUMBER`, `PHASE_NAME=merge`. (If ISSUE_NUMBER is not yet determined, skip with log.)
 
-2. Determine mergeability:
+2. Check pre-merge Acceptance Criteria (pre-merge AC gate):
+   - If `ISSUE_NUMBER` could not be extracted (see item 1's Early Issue number extraction), skip the gate — output `[pre-merge-ac] No related Issue resolved — skipping gate.` and proceed to item 3
+   - Otherwise run:
+     ```bash
+     ${CLAUDE_PLUGIN_ROOT}/scripts/check-pre-merge-ac.sh "$ISSUE_NUMBER"
+     ```
+   - Branch on the JSON output (exhaustive):
+     - `resolved` is `false`: output `Warning: pre-merge AC state could not be resolved for issue #$ISSUE_NUMBER; proceeding (fail-open).` and proceed to item 3
+     - `unchecked_count` is `0`: output `[pre-merge-ac] All N pre-merge acceptance conditions are checked.` (`N` = `pre_merge_total`) and proceed to item 3
+     - `unchecked_count` is 1 or more:
+       - **Recorded decision check**: run
+         ```bash
+         gh issue view "$ISSUE_NUMBER" --json comments --jq '[.comments[] | select(.body | contains("<!-- wholework-event: type=pre-merge-ac-gate"))] | sort_by(.createdAt) | .[-1].body // empty'
+         ```
+         and resolve **only the latest matching comment** (latest-wins — do not union `ac=` sets across multiple markers). If that marker has `decision=override` and its `ac=` index set is a superset of the current `unchecked_indices`, output `[pre-merge-ac] Proceeding under recorded override: <reason>` and proceed to item 3
+       - **Present and decide** (no valid recorded override found): output each unchecked pre-merge AC as `#<index> <text>`, one per line, then:
+         - **Interactive mode**: use AskUserQuestion with options `Abort merge` (default), `Re-run /review to re-verify`, `Approve and merge anyway`
+           - `Approve and merge anyway`: ask the user for a one-line reason, post a `decision=override` marker (see Marker format below), then proceed to item 3
+           - either other option: stop processing — do not proceed to any subsequent step
+         - **Non-interactive mode**: do not merge. Post a `decision=blocked` marker (see Marker format below), output `Error: N unchecked pre-merge acceptance conditions on issue #$ISSUE_NUMBER. Merge blocked.`, and exit with non-zero
+   - **Marker format**: write the comment body with the Write tool to `.tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md`. First line: `<!-- wholework-event: type=pre-merge-ac-gate phase=merge issue=$ISSUE_NUMBER decision=blocked ac=<comma-separated 1-based indices> reason="<one-line reason>" -->` (use `decision=override` for the override case), followed by a human-readable list of the unchecked conditions. Post with:
+     ```bash
+     mkdir -p .tmp
+     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh "$ISSUE_NUMBER" .tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md
+     rm -f .tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md
+     ```
+
+3. Determine mergeability:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh "$NUMBER"
    ```
@@ -73,6 +100,14 @@ Note: Always wrap `$NUMBER` in double quotes.
 - **Other (e.g., reason=review_pending)**: Report the error and reason, then use AskUserQuestion to ask the user how to proceed (non-interactive mode: auto-resolve — see "Non-Interactive Mode Behavior" section)
   - User selects "Abort": Stop processing (do not proceed to subsequent steps)
   - User selects "Treat as conflict": Proceed to Step 2 (Resolve Conflicts)
+
+#### Post-Review Re-Verification Responsibility
+
+- `/review` does not block on UNCERTAIN classifications, so `/review` can complete with pre-merge AC checkboxes still unchecked.
+- Detecting that unchecked state is the responsibility of the pre-merge AC gate above (item 2) — a single detection point, not spread across phases.
+- **Re-verification execution is the responsibility of re-running `/review`.** Once the environmental cause has cleared (e.g., CI has since fired, or a missing external binary has since been installed), re-run `/review $PR_NUMBER` — its Step 8 re-verifies against the PR branch and updates the checkboxes.
+- `/verify` is a post-merge phase and does not act as a merge gate, so it does not carry this re-verification responsibility.
+- If the environmental cause does not clear, record the decision explicitly with an override marker (see item 2) and merge under that recorded override.
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="pr", ENTITY_NUMBER=$NUMBER, SKILL_NAME="merge".
 

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -3,7 +3,7 @@ name: merge
 description: Squash-merge a PR and delete the remote branch (`/merge 88`). Use when merging review-approved, CI-passing PRs. Automatically attempts conflict resolution when conflicts occur.
 context: fork
 model: sonnet
-allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, gh issue view:*, gh issue close:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-pre-merge-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*), Read, Edit, Write, Grep, Glob, EnterWorktree, ExitWorktree
+allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, gh issue view:*, gh issue close:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-pre-merge-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*, mkdir:*, rm:*), Read, Edit, Write, Grep, Glob, EnterWorktree, ExitWorktree
 ---
 
 # Squash Merge
@@ -79,11 +79,10 @@ Key per-step behavior in non-interactive mode:
            - `Approve and merge anyway`: ask the user for a one-line reason, post a `decision=override` marker (see Marker format below), then proceed to item 3
            - either other option: stop processing — do not proceed to any subsequent step
          - **Non-interactive mode**: do not merge. Post a `decision=blocked` marker (see Marker format below), output `Error: N unchecked pre-merge acceptance conditions on issue #$ISSUE_NUMBER. Merge blocked.`, and exit with non-zero
-   - **Marker format**: write the comment body with the Write tool to `.tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md`. First line: `<!-- wholework-event: type=pre-merge-ac-gate phase=merge issue=$ISSUE_NUMBER decision=blocked ac=<comma-separated 1-based indices> reason="<one-line reason>" -->` (use `decision=override` for the override case), followed by a human-readable list of the unchecked conditions. Post with:
+   - **Marker format**: run `mkdir -p .tmp`, then write the comment body with the Write tool to `.tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md`. First line: `<!-- wholework-event: type=pre-merge-ac-gate phase=merge issue=$ISSUE_NUMBER decision=blocked ac=<comma-separated 1-based indices> reason="<one-line reason>" -->` (use `decision=override` for the override case), followed by a human-readable list of the unchecked conditions. Post with:
      ```bash
-     mkdir -p .tmp
-     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh "$ISSUE_NUMBER" .tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md
-     rm -f .tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md
+     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh "$ISSUE_NUMBER" ".tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md"
+     rm -f ".tmp/pre-merge-ac-gate-$ISSUE_NUMBER.md"
      ```
 
 3. Determine mergeability:
@@ -101,6 +100,8 @@ Note: Always wrap `$NUMBER` in double quotes.
   - User selects "Abort": Stop processing (do not proceed to subsequent steps)
   - User selects "Treat as conflict": Proceed to Step 2 (Resolve Conflicts)
 
+Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="pr", ENTITY_NUMBER=$NUMBER, SKILL_NAME="merge".
+
 #### Post-Review Re-Verification Responsibility
 
 - `/review` does not block on UNCERTAIN classifications, so `/review` can complete with pre-merge AC checkboxes still unchecked.
@@ -108,8 +109,6 @@ Note: Always wrap `$NUMBER` in double quotes.
 - **Re-verification execution is the responsibility of re-running `/review`.** Once the environmental cause has cleared (e.g., CI has since fired, or a missing external binary has since been installed), re-run `/review $PR_NUMBER` — its Step 8 re-verifies against the PR branch and updates the checkboxes.
 - `/verify` is a post-merge phase and does not act as a merge gate, so it does not carry this re-verification responsibility.
 - If the environmental cause does not clear, record the decision explicitly with an override marker (see item 2) and merge under that recorded override.
-
-Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-banner.md` and display the start banner with ENTITY_TYPE="pr", ENTITY_NUMBER=$NUMBER, SKILL_NAME="merge".
 
 ### Step 2: Worktree Entry
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -302,6 +302,11 @@ return UNCERTAIN) forces the review to post as `REQUEST_CHANGES` and must be
 fixed in Step 12 before `/merge`. UNCERTAIN, SKIPPED, PENDING, and POST-MERGE
 classifications do not block review.
 
+UNCERTAIN does not block review, but a Pre-merge condition left UNCERTAIN stays
+unchecked (`- [ ]`) per the Checkbox Updates rule below, and `skills/merge/SKILL.md`
+Step 1's pre-merge AC gate blocks merge on any unchecked Pre-merge condition. Resolving
+that UNCERTAIN state — not `/verify` — is the responsibility of re-running `/review`.
+
 ### Checkbox Updates
 
 For "Pre-merge (auto-verified)" conditions that PASS in Step 7 verification, update Issue checkboxes:

--- a/tests/check-pre-merge-ac.bats
+++ b/tests/check-pre-merge-ac.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+
+# Tests for check-pre-merge-ac.sh
+# Mock gh command via PATH
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$PROJECT_ROOT/scripts/check-pre-merge-ac.sh"
+
+setup() {
+    cd "$PROJECT_ROOT"
+
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+# make_gh_mock_body: gh mock that prints the given body text regardless of arguments
+# Usage: make_gh_mock_body <<'BODY' ... BODY
+make_gh_mock_body() {
+    local body_file="$BATS_TEST_TMPDIR/body.txt"
+    cat > "$body_file"
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+cat "$body_file"
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+}
+
+@test "error: no arguments exits with code 1" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error" ]]
+}
+
+@test "error: non-numeric issue number exits with code 1" {
+    run bash "$SCRIPT" "abc"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error" ]]
+}
+
+@test "error: too many arguments exits with code 1" {
+    run bash "$SCRIPT" "1" "2"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Error" ]]
+}
+
+@test "(a) all pre-merge checkboxes checked returns unchecked_count 0" {
+    make_gh_mock_body <<'BODY'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [x] item one
+- [x] item two
+
+### Post-merge
+
+- [ ] post item
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.resolved')" = "true" ]
+    [ "$(echo "$result" | jq -r '.pre_merge_total')" = "2" ]
+    [ "$(echo "$result" | jq -r '.unchecked_count')" = "0" ]
+    [ "$(echo "$result" | jq -r '.unchecked_indices')" = "" ]
+    [ "$(echo "$result" | jq -c '.unchecked_items')" = "[]" ]
+}
+
+@test "(b) pre-merge unchecked 2 + post-merge unchecked 1 excludes post-merge index" {
+    make_gh_mock_body <<'BODY'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [ ] pre item one
+- [x] pre item two
+- [ ] pre item three
+
+### Post-merge
+
+- [ ] post item
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.pre_merge_total')" = "3" ]
+    [ "$(echo "$result" | jq -r '.unchecked_count')" = "2" ]
+    [ "$(echo "$result" | jq -r '.unchecked_indices')" = "1,3" ]
+    # index 4 (post item) must not appear in unchecked_indices
+    [[ "$(echo "$result" | jq -r '.unchecked_indices')" != *"4"* ]]
+}
+
+@test "(c) no Pre-merge heading returns pre_merge_total 0" {
+    make_gh_mock_body <<'BODY'
+## Acceptance Criteria
+
+- [ ] item one
+- [x] item two
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.resolved')" = "true" ]
+    [ "$(echo "$result" | jq -r '.pre_merge_total')" = "0" ]
+    [ "$(echo "$result" | jq -r '.unchecked_count')" = "0" ]
+}
+
+@test "(d) gh failure returns resolved false with exit 0" {
+    printf '#!/bin/bash\nexit 1\n' > "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh"
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.resolved')" = "false" ]
+    [ "$(echo "$output" | jq -r '.pre_merge_total')" = "0" ]
+    [ "$(echo "$output" | jq -r '.unchecked_count')" = "0" ]
+}
+
+@test "(d) empty body returns resolved false with exit 0" {
+    printf '#!/bin/bash\necho -n ""\n' > "$MOCK_DIR/gh"
+    chmod +x "$MOCK_DIR/gh"
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.resolved')" = "false" ]
+}
+
+@test "(e) invalid argument exits with code 1" {
+    run bash "$SCRIPT" "-1"
+    [ "$status" -eq 1 ]
+}
+
+@test "(f) global index counts checkboxes outside Acceptance Criteria too" {
+    make_gh_mock_body <<'BODY'
+## Some Other Section
+
+- [ ] outside item zero
+
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [ ] pre item one
+- [x] pre item two
+
+### Post-merge
+
+- [ ] post item
+
+## Notes
+
+- [ ] outside item after
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    # global index: 1=outside item zero, 2=pre item one, 3=pre item two, 4=post item, 5=outside item after
+    [ "$(echo "$result" | jq -r '.pre_merge_total')" = "2" ]
+    [ "$(echo "$result" | jq -r '.unchecked_count')" = "1" ]
+    [ "$(echo "$result" | jq -r '.unchecked_indices')" = "2" ]
+    [ "$(echo "$result" | jq -r '.unchecked_items[0].index')" = "2" ]
+    [ "$(echo "$result" | jq -r '.unchecked_items[0].text')" = "pre item one" ]
+}
+
+@test "text strips HTML comments and marker" {
+    make_gh_mock_body <<'BODY'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [ ] <!-- verify: rubric "x" --> <!-- ac-tier: preview --> visible text here
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.unchecked_items[0].text')" = "visible text here" ]
+}

--- a/tests/check-pre-merge-ac.bats
+++ b/tests/check-pre-merge-ac.bats
@@ -174,3 +174,67 @@ BODY
     result="$output"
     [ "$(echo "$result" | jq -r '.unchecked_items[0].text')" = "visible text here" ]
 }
+
+@test "text strips HTML comment containing a > character" {
+    make_gh_mock_body <<'BODY'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [ ] <!-- verify: command "python3 bin/daily_routine.py 2>&1 | grep foo" --> new column appears
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.unchecked_items[0].text')" = "new column appears" ]
+}
+
+@test "large Pre-merge body (>64KB following heading) still resolves the section" {
+    {
+        echo "## Acceptance Criteria"
+        echo
+        echo "### Pre-merge (auto-verified)"
+        echo
+        echo "- [ ] pre item one"
+        head -c 70000 < /dev/zero | tr '\0' 'x'
+        echo
+    } > "$BATS_TEST_TMPDIR/body.txt"
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+cat "$BATS_TEST_TMPDIR/body.txt"
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.pre_merge_total')" = "1" ]
+    [ "$(echo "$result" | jq -r '.unchecked_count')" = "1" ]
+}
+
+@test "checkbox with no trailing space after bracket still strips prefix" {
+    make_gh_mock_body <<'BODY'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [ ]
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.unchecked_items[0].text')" = "" ]
+}
+
+@test "CRLF body does not leave trailing carriage return in text" {
+    printf '## Acceptance Criteria\r\n\r\n### Pre-merge (auto-verified)\r\n\r\n- [ ] item one\r\n' > "$BATS_TEST_TMPDIR/body.txt"
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+cat "$BATS_TEST_TMPDIR/body.txt"
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    text="$(echo "$result" | jq -r '.unchecked_items[0].text')"
+    [ "$text" = "item one" ]
+}


### PR DESCRIPTION
## Summary
- `/merge` の Step 1 に pre-merge AC ゲートを追加。対象 Issue の `### Pre-merge` チェックボックスが未チェックのまま残っている場合、一覧を提示し (非対話モードでは merge をブロックし `decision=blocked` マーカーを投稿、対話モードでは Abort/Re-run review/Approve の3択)、明示的な承認 (`decision=override` マーカー、latest-wins で解決) がない限り merge を中断する
- 新規スクリプト `scripts/check-pre-merge-ac.sh`: Issue 本文の `### Pre-merge` サブセクション内チェックボックスを走査し、本文全体基準の 1-based index・未チェック件数・テキストを JSON で出力 (bash 3.2+ 互換、awk + jq のみ)
- `skills/review/SKILL.md` に、UNCERTAIN のまま残った pre-merge AC の再検証責務は `/review` の再実行が担う旨を明記 (`/verify` は post-merge フェーズのため対象外)
- `modules/l0-surfaces.md` に新マーカー `type=pre-merge-ac-gate` (`decision=blocked|override`) を追加、latest-wins で解決するルールを規定
- `docs/workflow.md` / `docs/guide/workflow.md` およびそれぞれの `docs/ja/` ミラーにゲートの説明を追記
- `docs/structure.md` / `docs/ja/structure.md` に `check-pre-merge-ac.sh` を追加し、`scripts/` のファイル数を 68 → 69 に更新

## Verification (pre-merge)
- `/merge` に pre-merge AC ゲートが追加されている (rubric)
- `/merge` Step 1 に pre-merge AC ゲート関連の記述がある (section_contains、上記の補助検証)
- review 完了後の再検証責務が明確になっている (rubric)
- `skills/merge/SKILL.md` に acceptance criteria への言及がある (grep)

## Verification (post-merge)
- pre-merge AC を意図的に 1 件未チェックのまま `/merge` を実行し、ゲートが機能することを確認する (manual)

closes #1060
