### PR TITLE
Issue #1061: Size 由来の route 判定で always-pr 設定を honor

### DIFF
--- a/docs/spec/issue-1061-honor-always-pr-in-route.md
+++ b/docs/spec/issue-1061-honor-always-pr-in-route.md
@@ -243,15 +243,40 @@ Background 内の技術的主張 (`ALWAYS_PR` を参照する箇所、`skills/sp
 - AC の 4 つの `grep` パターン (`ALWAYS_PR Override` / `ALWAYS_PR` × 2 / `always-pr`) が対象ファイルに現在含まれていないことを実行して確認済み。いずれも実装後にのみ PASS する検証シグナルになる
 - `/triage` Bulk Execution から Configuration Detection の結果を参照できるかはセクション順序からの推定であり、明示的な引き継ぎ記述はない。Uncertainty セクションに代替案 (`get-config-value.sh` 直接呼び出し) 付きで記録した
 
+## Code Retrospective
+
+**この節は `/code` 自身ではなく親セッション (`/auto --batch`) が再構成したものである。** code フェーズは実装編集の完了後・commit の直前に外部 kill され (`run-auto-sub.sh` の wrapper が自身の終了経路を通らずに停止)、`/code` による retrospective の書き込みまで到達しなかった。以下は親セッションが worktree の状態から観測できた事実のみを記録している。`/code` 内部の試行錯誤や判断過程は記録されていない。
+
+### Deviations from Design
+
+- 観測範囲では逸脱なし。worktree の変更ファイルは Spec の `## Changed Files` に列挙された 9 件と完全に一致していた (`modules/size-workflow-table.md`, `modules/verify-classifier.md`, `skills/code/SKILL.md`, `skills/issue/SKILL.md`, `skills/issue/spec-test-guidelines.md`, `skills/spec/SKILL.md`, `skills/triage/SKILL.md`, `skills/triage/skill-dev-verify-audit.md`, `tests/size-workflow-table.bats`)。過不足はない
+- Spec の「Steering Docs sync candidate」6 件はいずれも変更されていない。Spec 側の「更新不要の見込み」という事前判断と一致するが、`/code` が各ファイルを実際に読んで判断したかどうかは観測できない
+
+### Design Gaps/Ambiguities
+
+- 観測不能 (`/code` が記録する前に kill されたため)
+
+### Rework
+
+- 観測不能。worktree に commit が 1 件も存在しなかったため、commit 履歴からの fixup/amend パターン検出はできない
+
+### Verification at recovery time
+
+親セッションが worktree 内で実施した検証:
+
+- `bats tests/*.bats` — 1266 件すべて PASS (`not ok` ゼロ)
+- `python3 scripts/validate-skill-syntax.py skills/code/SKILL.md skills/issue/SKILL.md skills/spec/SKILL.md skills/triage/SKILL.md` — 4 件すべて PASS
+- `bash scripts/check-forbidden-expressions.sh` — 出力なし (違反なし)
+- `bats tests/size-workflow-table.bats` — 新規追加の 2 件 (`ALWAYS_PR Override section is documented`, `ALWAYS_PR Override documents patch to pr promotion`) を含む 10 件 PASS
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- route 決定の SSoT を `modules/size-workflow-table.md` の新 `ALWAYS_PR Override` 節に置き、Size から route または route 依存の挙動を導出する全 caller がそこを参照する形にした。個別 caller への条件分岐追加だけでは今後の caller で同じ欠落が再発するため
-- 優先順位は `skills/code/SKILL.md` Step 0 の**列挙ルールの実挙動** (operate > `--pr` > `ALWAYS_PR` > `--patch` > Size) を SSoT に記述する。Step 0 の見出し文字列 (「explicit flag > ALWAYS_PR」) は実挙動と食い違うが、本 Issue では変更しない
-- スコープを Issue 本文 対応方針 B の 4 箇所から 8 箇所へ拡大 (`/code` Step 10、`skills/issue/spec-test-guidelines.md`、`skills/triage/skill-dev-verify-audit.md` Pattern 4、`skills/triage/SKILL.md`)。Purpose の「全箇所」に従った
-- `ALWAYS_PR` の取得手段は SKILL.md 系すべてで `modules/detect-config-markers.md` の retain に統一する。Domain file からの `get-config-value.sh` 直接呼び出しは採らない
+- (spec フェーズからの引き継ぎ) route 決定の SSoT を `modules/size-workflow-table.md` の新 `ALWAYS_PR Override` 節に置き、Size から route または route 依存の挙動を導出する全 caller がそこを参照する形にした
+- (spec フェーズからの引き継ぎ) 優先順位は `skills/code/SKILL.md` Step 0 の列挙ルールの実挙動 (operate > `--pr` > `ALWAYS_PR` > `--patch` > Size) を SSoT に記述した
+- 実装は上記の設計どおりに完了しているが、**commit は親セッションが外部 kill からの復旧として行った**。`/code` 自身の commit ステップは実行されていない
 
 ### Deferred Items
 
@@ -261,8 +286,6 @@ Background 内の技術的主張 (`ALWAYS_PR` を参照する箇所、`skills/sp
 
 ### Notes for Next Phase
 
-- `modules/size-workflow-table.md` の `ALWAYS_PR Override` 節は「Size-to-Workflow Mapping Table」の表の直後・`### Diff-less Axis (operate route)` 見出しの直前に h3 で挿入すること。`tests/operate-route.bats` は operate route 節の文言をアサートしているため、operate route 節そのものは変更しない
-- `skills/*/SKILL.md` の編集では half-width `!`・小数 Step 番号・triple backtick を本文に入れないこと (`scripts/validate-skill-syntax.py` が検出する)
-- `tests/code.bats` は Step 0 セクションのみをアサートしている。`/code` の変更対象は Step 10 内なので既存テストには影響しないが、Step 0 の文言を巻き込んで編集しないこと
-- Changed Files の「Steering Docs sync candidate」6 件はいずれも「更新不要の見込み」と記載しているが、`/code` 側で各ファイルを実際に読んで最終判断すること
-- AC 8・9 の `grep` パターン (`always-pr` / `ALWAYS_PR`) は対象ファイルに現在含まれていない。実装時にこの文字列が実際に出現する形で記述すること
+- **`/review` への注意**: code フェーズの retrospective は親セッションによる再構成であり、`/code` 自身が記録した設計逸脱・rework の情報は存在しない。diff と Spec の照合を通常より丁寧に行うこと
+- Pre-merge AC 10 件のうち 4 件は決定的な `grep` で、`/spec` 時点で「パターンが対象ファイルに存在しないこと」を実行確認済み (常時 PASS ではない)。実装後は出現するはずなので PASS になることを確認すること
+- `tests/operate-route.bats` は operate route 節の文言をアサートしている。`ALWAYS_PR Override` 節は operate route 節の**前**に挿入されており、既存アサーションには影響していない (全テスト PASS で確認済み)

--- a/modules/size-workflow-table.md
+++ b/modules/size-workflow-table.md
@@ -65,6 +65,22 @@ Note: This override is additive — if Axes 1–2 already produce L or XL, that 
 | L    | pr        | Branch + PR, full review | Required | Yes |
 | XL   | split guidance | Guide to split into sub-issues | Required | — |
 
+### ALWAYS_PR Override
+
+When `.wholework.yml` sets `always-pr: true` (`modules/detect-config-markers.md` provides this as `ALWAYS_PR=true`), a Size-derived `patch` route is promoted to `pr` regardless of Size. Only `patch` is promoted — `pr` and `split guidance` (XL) are unaffected, since their result already matches or is orthogonal to the override.
+
+**Priority order (exhaustive)**, applied before any caller uses the Size-to-Workflow Mapping Table's result:
+
+1. operate route (`### Diff-less Axis (operate route)` below) — takes priority over both `always-pr: true` and explicit `--patch`/`--pr` flags
+2. explicit `--pr` flag
+3. `ALWAYS_PR=true` — overrides an explicit `--patch` flag too (a caller honoring this override outputs a warning that `--patch` is ignored and pr route is forced)
+4. explicit `--patch` flag
+5. Size-to-Workflow Mapping Table above
+
+This override applies not only to the route value itself but to any **route-dependent behavior** derived from Size. A rule that assumes "Size XS/S implies patch route, therefore no PR exists" is in scope of this override: under `always-pr: true`, Size XS/S resolves to pr route, a PR does exist, and a `github_check "gh pr checks"` acceptance condition is valid and must not be rewritten to `gh run list` form. See `modules/verify-classifier.md` § "Patch Route CI Verification Note".
+
+**Callers that must apply this override (exhaustive)**: `skills/auto/SKILL.md` (Step 2, Step 3a), `skills/code/SKILL.md` (Step 0, Patch route verify command check), `skills/spec/SKILL.md` (Patch route verify command check, Step 18), `skills/issue/SKILL.md` (Acceptance Criteria Writing Guide), `skills/issue/spec-test-guidelines.md` (Route selection), `skills/triage/skill-dev-verify-audit.md` (Pattern 4), `scripts/run-auto-sub.sh`.
+
 ### Diff-less Axis (operate route)
 
 Orthogonal to Axes 1–2 above. Size (Axis 1–2) measures change scope/effort (XS–XL); the diff-less axis determines whether a route produces a git diff at all. This axis contributes a third route value, `operate`, alongside `patch` and `pr` in the Size-to-Workflow Mapping Table above — `operate` is a route value, not a Size value, so it does not replace or extend the Size scale.

--- a/modules/verify-classifier.md
+++ b/modules/verify-classifier.md
@@ -95,6 +95,8 @@ When a keyword cannot be identified, fall back to `grep` with a broader pattern:
 
 For Issues implemented via the patch route (direct commit to main, no PR), `github_check "gh pr checks"` **cannot be used** — no PR exists in the patch route.
 
+This note applies only when the Issue actually takes the patch route. When `.wholework.yml` sets `always-pr: true`, Size XS/S is promoted to pr route (see `modules/size-workflow-table.md` § "ALWAYS_PR Override"), a PR does exist, and `github_check "gh pr checks"` is the correct form. Derive the route from `ALWAYS_PR` first, not from Size alone.
+
 Use the `github_check "gh run list"` form instead:
 
 ```

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -419,7 +419,7 @@ After completing implementation — especially when a refactor changes the imple
 
 **Patch route verify command check:**
 
-If patch route (Size is `XS`/`S` or `--patch` flag), before running verify-executor, scan the Issue body's `## Acceptance Criteria > Pre-merge` for `github_check "gh pr checks"` entries.
+If ROUTE is `patch` (resolved in Step 0, which already applies the ALWAYS_PR override and operate route detection — under `ALWAYS_PR=true` a Size XS/S Issue resolves to `pr` route here, not `patch`), before running verify-executor, scan the Issue body's `## Acceptance Criteria > Pre-merge` for `github_check "gh pr checks"` entries.
 - If found: output "Warning: patch route — `github_check "gh pr checks"` is incompatible. Auto-fixing to `github_check "gh run list"` form." and replace each with `github_check "gh run list"` form (add `--workflow=<filename>` if there are multiple workflow files under `.github/workflows/`). Update Issue body via `gh-issue-edit.sh`. Also update Spec verify commands (`$SPEC_PATH/issue-$NUMBER-*.md`) with the same fix.
 
 **Resolving `{{base_url}}` to localhost**: If verify commands contain `{{base_url}}`, resolve it before passing to verify-executor:

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -33,7 +33,7 @@ Use AskUserQuestion to collect:
 
 ### Step 2: Reference Steering Documents (if present)
 
-Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, and `HAS_PR_PREVIEW_CAPABILITY` for use in subsequent steps.
+Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, `HAS_PR_PREVIEW_CAPABILITY`, and `ALWAYS_PR` for use in subsequent steps.
 
 Check whether the following steering documents exist using Glob, then read only those that exist:
 
@@ -414,7 +414,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh $NUMBER issue
 
 ### Step 4: Reference Steering Documents (if present)
 
-Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, and `HAS_PR_PREVIEW_CAPABILITY` for use in subsequent steps.
+Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, `HAS_PR_PREVIEW_CAPABILITY`, and `ALWAYS_PR` for use in subsequent steps.
 
 Check whether the following steering documents exist using Glob, then read only those that exist:
 
@@ -746,6 +746,8 @@ Good:
 - [ ] <!-- verify: github_check "gh run list --workflow=test.yml --limit=1 --json conclusion --jq '.[0].conclusion'" "success" --> CI (test.yml) all jobs pass (patch route)
 
 Note: Size XS/S → patch route → `gh run list` form; Size M/L → PR route → `gh pr checks` form (details: `modules/verify-classifier.md`).
+
+Exception: when `ALWAYS_PR=true` (`.wholework.yml` `always-pr: true`, retained in Step 2 / Step 4), Size XS/S is promoted to pr route, so use the `gh pr checks` form regardless of Size (see `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` § "ALWAYS_PR Override").
 
 **Do not embed implementation means in ACs:**
 

--- a/skills/issue/spec-test-guidelines.md
+++ b/skills/issue/spec-test-guidelines.md
@@ -79,7 +79,7 @@ patch route (Size XS/S):
 - [ ] <!-- verify: github_check "gh run list --workflow=test.yml --commit=$(git rev-parse HEAD) --limit=1 --json conclusion --jq '.[0].conclusion'" "success" --> CI (test.yml) all jobs pass (patch route)
 ```
 
-**Route selection:** Size XS/S → patch route → use `gh run list` form; Size M/L → PR route → use `gh pr checks` form. For detailed routing logic (UNCERTAIN handling when PR_NUMBER is absent, etc.), see `modules/verify-classifier.md` § Patch Route CI Verification Note.
+**Route selection:** Size XS/S → patch route → use `gh run list` form; Size M/L → PR route → use `gh pr checks` form. For detailed routing logic (UNCERTAIN handling when PR_NUMBER is absent, etc.), see `modules/verify-classifier.md` § Patch Route CI Verification Note. Exception: when `.wholework.yml` sets `always-pr: true` (`ALWAYS_PR=true`), Size XS/S is promoted to pr route, so use the `gh pr checks` form regardless of Size (see `modules/size-workflow-table.md` § "ALWAYS_PR Override").
 
 **Pattern to avoid (requires local execution or fallback inference):**
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -98,7 +98,7 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh $NUMBER --dry-run
 
 ### Step 5: Reference Steering Documents (if present)
 
-Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH` and `STEERING_DOCS_PATH` for use in subsequent steps.
+Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `SPEC_PATH`, `STEERING_DOCS_PATH`, and `ALWAYS_PR` for use in subsequent steps.
 
 Check whether the following steering documents exist using Glob, then read only those that exist:
 
@@ -545,7 +545,9 @@ Note: verify-executor uses ripgrep (ERE); \| in BRE means OR but is a literal | 
 
 **Patch route verify command check:**
 
-After `## Verification > Pre-merge` is finalized and the Issue body is updated, if Size is `XS` or `S` (patch route — no PR exists), scan `## Verification > Pre-merge` in the Spec for `github_check "gh pr checks"` entries.
+If `ALWAYS_PR=true` (retained in Step 5), skip this entire check — `always-pr: true` promotes Size XS/S to pr route (see `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` § "ALWAYS_PR Override"), so a PR does exist and `github_check "gh pr checks"` is the correct form; auto-fixing it to `gh run list` form here would be incorrect.
+
+After `## Verification > Pre-merge` is finalized and the Issue body is updated, if `ALWAYS_PR=false` and Size is `XS` or `S` (patch route — no PR exists), scan `## Verification > Pre-merge` in the Spec for `github_check "gh pr checks"` entries.
 - If found: output "Warning: patch route — `github_check "gh pr checks"` is incompatible (no PR exists in patch route). Auto-fixing to `github_check "gh run list"` form." and replace each with `github_check "gh run list --limit=1 --json conclusion --jq '.[0].conclusion'" "success"` (change `expected_value` from the job name to `"success"` — `gh run list` outputs run-level conclusion, not job names; add `--workflow=<filename>` if there are multiple workflow files under `.github/workflows/`). Update Spec file using Edit tool. Also update Issue body via `gh-issue-edit.sh`.
 
 **Changed-file modification types (examples, both templates):**
@@ -891,6 +893,8 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` and re-evaluate Size
    - `XS` or `S` → `patch`
    - `M` or `L` → `pr`
    - `XL` → `sub_issue`
+
+   **ALWAYS_PR override**: after deriving the Size-based route above, if `ALWAYS_PR=true` (retained in Step 5) and the derived route is `patch`, promote it to `pr` and output "always-pr: true is set in .wholework.yml. Promoting to pr route." (see `${CLAUDE_PLUGIN_ROOT}/modules/size-workflow-table.md` § "ALWAYS_PR Override"). Routes other than `patch` (`pr`, `sub_issue`) are unaffected.
 
 ### Step 19: Completion Message
 

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -66,7 +66,7 @@ gh issue view 123 --json number,title,body,labels && echo "---" && gh issue view
 
 ## Configuration Detection
 
-Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `STEERING_DOCS_PATH` for use in subsequent steps.
+Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Processing Steps" section. Retain `STEERING_DOCS_PATH` and `ALWAYS_PR` for use in subsequent steps.
 
 ---
 

--- a/skills/triage/skill-dev-verify-audit.md
+++ b/skills/triage/skill-dev-verify-audit.md
@@ -79,7 +79,7 @@ Fix: Update the expected string to match what the implementation will actually p
 
 ### Pattern 4: patch route × `gh pr checks` 不整合
 
-Detect: Issues with Size XS or S (patch route) whose AC uses
+Detect: Issues with Size XS or S and `ALWAYS_PR=false` (patch route) whose AC uses
 `github_check "gh pr checks"`.
 
 The patch route commits directly to `main` without creating a PR. Therefore,
@@ -89,6 +89,11 @@ Detection approach:
 - In Single Issue Execution: read the Size assigned in Step 6 (Size Assignment)
 - In Bulk Execution (Step 3 substep 8): read the `size` field from the Step 2 classification
   JSON for the current issue
+- `ALWAYS_PR` is retained from `skills/triage/SKILL.md`'s "Configuration Detection" section
+  (a common section that precedes both Single Issue Execution and Bulk Execution). When
+  `ALWAYS_PR=true`, skip Pattern 4 entirely — `always-pr: true` promotes Size XS/S to pr route,
+  so `github_check "gh pr checks"` is the correct form (see `modules/size-workflow-table.md`
+  § "ALWAYS_PR Override")
 
 Fix: Replace `github_check "gh pr checks"` with a `github_check "gh run list"` form,
 for example:

--- a/tests/size-workflow-table.bats
+++ b/tests/size-workflow-table.bats
@@ -38,3 +38,12 @@ SIZE_WORKFLOW_TABLE="$PROJECT_ROOT/modules/size-workflow-table.md"
 @test "size-workflow-table: pr workflow route is documented" {
     grep -q "pr" "$SIZE_WORKFLOW_TABLE"
 }
+
+@test "size-workflow-table: ALWAYS_PR Override section is documented" {
+    grep -q "ALWAYS_PR Override" "$SIZE_WORKFLOW_TABLE"
+}
+
+@test "size-workflow-table: ALWAYS_PR Override documents patch to pr promotion" {
+    grep -q "always-pr: true" "$SIZE_WORKFLOW_TABLE"
+    grep -qi "promot" "$SIZE_WORKFLOW_TABLE"
+}


### PR DESCRIPTION
Closes #1061

## 概要

Size 由来の route 判定が `.wholework.yml` の `always-pr: true` を無視していた問題を修正する。route 決定の SSoT を `modules/size-workflow-table.md` の新設 `### ALWAYS_PR Override` 節に置き、Size から route または route 依存の挙動を導出するすべての caller がそこを参照する形に統一した。

個別 caller に条件分岐を足すだけでは今後追加される caller で同じ欠落が再発するため、SSoT 節 + caller 一覧 (exhaustive) という構成を採っている。

Spec: `docs/spec/issue-1061-honor-always-pr-in-route.md`

## 変更内容

| ファイル | 変更 |
|---|---|
| `modules/size-workflow-table.md` | `### ALWAYS_PR Override` 節を新設。override 規則、優先順位 (exhaustive: operate > `--pr` > `ALWAYS_PR` > `--patch` > Size)、route 依存挙動への適用、caller 一覧 (exhaustive) を記述 |
| `modules/verify-classifier.md` | 「Patch Route CI Verification Note」に `always-pr: true` 例外を追加。Size だけでなく `ALWAYS_PR` から route を導出する旨を明記 |
| `skills/spec/SKILL.md` | Step 5 の retain に `ALWAYS_PR` を追加。`ALWAYS_PR=true` 時は「Patch route verify command check」自体をスキップ。Step 18 に override 適用を追加 |
| `skills/code/SKILL.md` | 「Patch route verify command check」の発火条件を Size ベースから Step 0 で解決済みの ROUTE ベースへ変更 |
| `skills/issue/SKILL.md` | Step 2 / Step 4 の retain に `ALWAYS_PR` を追加。AC Writing Guide に `always-pr: true` 例外を追記 |
| `skills/issue/spec-test-guidelines.md` | 「Route selection」に `always-pr: true` 時は Size によらず `gh pr checks` 形式を使う旨を追記 |
| `skills/triage/SKILL.md` | 「Configuration Detection」の retain に `ALWAYS_PR` を追加 |
| `skills/triage/skill-dev-verify-audit.md` | Pattern 4 の Detect 条件に `ALWAYS_PR=false` を追加し、`ALWAYS_PR=true` 時のスキップを明記 |
| `tests/size-workflow-table.bats` | `ALWAYS_PR Override` 節の shallow test を 2 件追加 |

## 検証

- `bats tests/*.bats` — 1266 件すべて PASS
- `python3 scripts/validate-skill-syntax.py skills/code/SKILL.md skills/issue/SKILL.md skills/spec/SKILL.md skills/triage/SKILL.md` — 4 件すべて PASS
- `bash scripts/check-forbidden-expressions.sh` — 違反なし

## 注記: code フェーズの外部 kill からの復旧

このブランチの実装コミットは、`/auto --batch` の code フェーズが**実装編集の完了後・commit の直前に外部 kill された**あと、親セッションが復旧として作成したものである (wrapper が自身の終了経路を通らず停止)。

- worktree の変更ファイルは Spec の `## Changed Files` 9 件と完全一致しており、過不足のない状態だった
- 親セッションが上記の検証 (bats 1266 件・syntax validator・forbidden expressions) を worktree 内で実行し、すべて green であることを確認したうえで commit した
- `## Code Retrospective` は `/code` 自身ではなく親セッションによる再構成であり、その旨を節の冒頭に明記している。`/code` 内部の試行錯誤・rework の記録は存在しない

`/review` では、この点を踏まえて diff と Spec の照合を通常より丁寧に行うことを推奨する。
