### PR TITLE
Issue #1107: append-consumed-comments dedup guard by URL, not heading

### DIFF
--- a/docs/spec/issue-1107-consumed-comments-dedup-fix.md
+++ b/docs/spec/issue-1107-consumed-comments-dedup-fix.md
@@ -74,18 +74,29 @@ L36-38 の dedup ガードは「`## Consumed Comments` という文字列が Spe
 ### Rework
 - jq フィルタ `select(($body | contains(.url // "")) | not)` は jq のパイプスコープ規則により `.url` が `$body` context (文字列) に対して評価されてしまい `Cannot index string with string ("url")` エラーとなっていた。エラーは `2>/dev/null` に隠蔽され `NEW_COMMENTS` が常に `[]` にフォールバックし、新規テストが無言で FAIL していた。`(.url // "") as $u | ($body | contains($u)) | not` の形に修正し、`.url` をオブジェクトコンテキストで先に束縛することで解消した。jq のパイプ内で `.` を再束縛する式に他のフィールド参照を混在させる際は、参照対象を `as` で先に固定してからパイプする必要がある。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- なし。実装は Spec Implementation Steps 1-5 通りで、構造的な乖離は見られなかった。ただし Spec の方針 B 記述には URL 一致方式の詳細 (完全一致 vs 部分一致) までは規定されておらず、実装が `contains()` (部分一致) を選んだ結果、後述のエッジケースが生じた。次回同種の Spec では「URL 一致は完全一致で行うこと」まで明記すると実装時の解釈揺れを防げる。
+
+### Recurring issues
+- `/review` (review-light agent) が、GitHub issuecomment ID が固定長でないために `contains()` (部分一致) ベースの重複判定が偽陽性を起こしうるエッジケースを検出した (`scripts/append-consumed-comments-section.sh:116`)。ID 的トークン (URL, ハッシュ, 連番 ID など) に対する `contains()`/文字列部分一致は、この Issue 自体が修正しようとした「サイレントな取りこぼし」を別の形で再発させやすい一般的な落とし穴であり、`review-bug` エージェントの HIGH SIGNAL チェック観点、または `skill-dev-recheck.md` に「ID 的トークンの重複判定に部分一致を使っていないか」を追加する価値がある。単発の指摘に留め、Issue 起票は見送る (再現頻度が低く、今回の PR 内で修正済みのため)。
+
+### Acceptance criteria verification difficulty
+- なし。Pre-merge AC 4件 (rubric x3, file_not_contains x1) はいずれも diff と grep/bats 実行のみで機械的に PASS 判定でき、UNCERTAIN は発生しなかった。file_not_contains (不在検証型) の参照点も Issue Notes に事前記録されており判定が容易だった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の方針 B (URL 単位の重複排除 + 既存セクション追記) をそのまま採用し、実装は Spec Implementation Steps 1-5 通りに完了した
-- 既存セクションに新規エントリが 0 件の場合はファイルを一切変更せず `exit 0` する設計とした (プレースホルダー "No new comments since last phase." を上書きしない仕様も Spec 通り維持)
-- behavioral change detection (`tests/run-verify.bats` が対象ファイルを参照) によりフルスイート `bats tests/` (1285 tests) を実行し全て PASS を確認
+- レビュー (light mode, review-light agent) で SHOULD 指摘 1 件を検出: 既存セクションへの新規 URL 判定が `contains()` (部分一致) を使っており、issuecomment ID の桁数非固定により偽陽性で新規コメントが永久に取りこぼされうるエッジケースを jq で再現確認のうえ修正
+- 修正は既存行を `\n` 分割し各行の最後フィールド (URL) との完全一致 (`index($u) != null`) に置き換える方式を採用。既存 6 テスト + 修正シナリオの単体再現の両方で確認
+- Pre-merge AC 4件・CI 9 ジョブは修正前後とも PASS/SUCCESS のまま変化なし。ポリシー変更 (Step 13) には該当しないため Issue 本文・AC は未更新
 
 ### Deferred Items
 - なし
 
 ### Notes for Next Phase
-- Pre-merge AC 4件 (rubric x3, file_not_contains x1) は本フェーズで目視検証済みで Issue チェックボックスを更新済み。`/review` では念のため再確認を推奨
-- Post-merge AC (observation, event=auto-run) は次回 `/verify` 実行時に別 Issue でのコメント投稿を待って自然検証される想定。今回の PR 内では検証不要
+- Post-merge AC (observation, event=auto-run) は次回 `/verify` 実行時に別 Issue でのコメント投稿を待って自然検証される想定。`/merge` 後の `/verify` で確認すること
 - `#1078` (worktree fresh 作成時の Consumed Comments 追記消失) は本 Issue のスコープ外の別機構の問題として明示的に残置されている
+- review retrospective の Recurring issues に、ID 的トークンの重複判定における `contains()` 部分一致の一般的リスクを記録した。将来 `review-bug`/`skill-dev-recheck.md` の観点追加を検討する際の参考にすること

--- a/docs/spec/issue-1107-consumed-comments-dedup-fix.md
+++ b/docs/spec/issue-1107-consumed-comments-dedup-fix.md
@@ -57,3 +57,35 @@ L36-38 の dedup ガードは「`## Consumed Comments` という文字列が Spe
 ## Consumed Comments
 
 - saito (MEMBER, first-class): `/issue 1107 --non-interactive` の Issue Retrospective。#1054 の opportunistic verification で、本 Issue の Pre-merge AC 2 番目 (不在検証型) に参照点が authoring 時点で未記録だったことを検出し、`## Notes` セクションに 2026-07-30 時点の参照点 (`scripts/append-consumed-comments-section.sh` L36 に該当コメントが存在) を追加した経緯を記録したもの。この追加は Issue 本文に既に反映済みで、本 Spec の `## Notes` に引き継ぎ済み。あわせて Type=Bug・Size=M・タイトル/AC分類/sub-issue分割は変更なしと確認。 (https://github.com/saitoco/wholework/issues/1107#issuecomment-5132340110)
+
+## Autonomous Auto-Resolve Log
+
+- **`phase/ready` ラベル不在のまま実行を継続** — reason: Issue のラベルは `phase/code` (Spec は既に存在) であり、`/spec` フェーズがラベルを `phase/ready` を経由せず直接 `phase/code` に遷移させたと推測される。`reconcile-phase-state.sh --check-precondition code-pr` は `matches_expected: false` を返したが、Spec ファイル自体は存在し内容も完備しているため、SKILL.md の非対話モード既定 (「warn and continue」) に従い、警告を出力のうえ Spec を使用して実装を続行した。
+  - Other candidates: 実行を中断し `/spec 1107` の再実行を促す (Spec が既に存在するため不要と判断)
+
+## Code Retrospective
+
+### Deviations from Design
+- なし。Spec の Implementation Steps 1-5 をそのまま実装した。
+
+### Design Gaps/Ambiguities
+- なし。Spec の `## Notes` (方針 B 採用理由) が十分具体的で、実装中に追加の解釈判断は不要だった。
+
+### Rework
+- jq フィルタ `select(($body | contains(.url // "")) | not)` は jq のパイプスコープ規則により `.url` が `$body` context (文字列) に対して評価されてしまい `Cannot index string with string ("url")` エラーとなっていた。エラーは `2>/dev/null` に隠蔽され `NEW_COMMENTS` が常に `[]` にフォールバックし、新規テストが無言で FAIL していた。`(.url // "") as $u | ($body | contains($u)) | not` の形に修正し、`.url` をオブジェクトコンテキストで先に束縛することで解消した。jq のパイプ内で `.` を再束縛する式に他のフィールド参照を混在させる際は、参照対象を `as` で先に固定してからパイプする必要がある。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の方針 B (URL 単位の重複排除 + 既存セクション追記) をそのまま採用し、実装は Spec Implementation Steps 1-5 通りに完了した
+- 既存セクションに新規エントリが 0 件の場合はファイルを一切変更せず `exit 0` する設計とした (プレースホルダー "No new comments since last phase." を上書きしない仕様も Spec 通り維持)
+- behavioral change detection (`tests/run-verify.bats` が対象ファイルを参照) によりフルスイート `bats tests/` (1285 tests) を実行し全て PASS を確認
+
+### Deferred Items
+- なし
+
+### Notes for Next Phase
+- Pre-merge AC 4件 (rubric x3, file_not_contains x1) は本フェーズで目視検証済みで Issue チェックボックスを更新済み。`/review` では念のため再確認を推奨
+- Post-merge AC (observation, event=auto-run) は次回 `/verify` 実行時に別 Issue でのコメント投稿を待って自然検証される想定。今回の PR 内では検証不要
+- `#1078` (worktree fresh 作成時の Consumed Comments 追記消失) は本 Issue のスコープ外の別機構の問題として明示的に残置されている

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -33,10 +33,29 @@ if [[ -z "$SPEC_FILE" ]]; then
   exit 0
 fi
 
-# Check if section already exists; skip if present (deduplicate guard)
-if grep -q "^## Consumed Comments" "$SPEC_FILE" 2>/dev/null; then
-  exit 0
-fi
+# Format a JSON comment array into "## Consumed Comments" entry lines, applying
+# trust boundary classification. Trust tiers: OWNER/MEMBER/COLLABORATOR =
+# first-class, CONTRIBUTOR/NONE = external. Logins ending with [bot] = bot
+# (skip), unless body contains <!-- wholework-event:
+format_entries() {
+  echo "$1" | jq -r '
+    .[] |
+    ((.author.login) // "unknown") as $login |
+    (.authorAssociation // "NONE") as $assoc |
+    (.url // "") as $url |
+    (.body // "") as $body |
+    (if ($login | test("\\[bot\\]$"))
+     then (if ($body | contains("<!-- wholework-event:")) then "first-class" else "bot" end)
+     elif ($assoc == "OWNER" or $assoc == "MEMBER" or $assoc == "COLLABORATOR") then "first-class"
+     else "external"
+     end) as $tier |
+    if $tier == "bot" then empty
+    else
+      ($body | split("\n") | .[0] // "" | .[0:80]) as $summary |
+      "- \($login) / \($assoc) / \($tier) / \($summary) / \($url)"
+    end
+  ' 2>/dev/null
+}
 
 # Get cutoff timestamp from GitHub Issue timeline (most recent phase/* label assignment)
 CUTOFF=$(gh api "repos/{owner}/{repo}/issues/${ISSUE_NUMBER}/timeline" --paginate \
@@ -66,37 +85,54 @@ ALL_COMMENTS=$(jq -n \
   --argjson b "$VERIFYFAIL" \
   '($a + $b) | unique_by(.url)' 2>/dev/null || echo "[]")
 
-# Format entries applying trust boundary classification
-# Trust tiers: OWNER/MEMBER/COLLABORATOR = first-class, CONTRIBUTOR/NONE = external
-# Logins ending with [bot] = bot (skip), unless body contains <!-- wholework-event:
-ENTRIES=$(echo "$ALL_COMMENTS" | jq -r '
-  .[] |
-  ((.author.login) // "unknown") as $login |
-  (.authorAssociation // "NONE") as $assoc |
-  (.url // "") as $url |
-  (.body // "") as $body |
-  (if ($login | test("\\[bot\\]$"))
-   then (if ($body | contains("<!-- wholework-event:")) then "first-class" else "bot" end)
-   elif ($assoc == "OWNER" or $assoc == "MEMBER" or $assoc == "COLLABORATOR") then "first-class"
-   else "external"
-   end) as $tier |
-  if $tier == "bot" then empty
+HEADING_LINE=$(grep -n "^## Consumed Comments" "$SPEC_FILE" 2>/dev/null | head -1 | cut -d: -f1 || true)
+
+if [[ -z "$HEADING_LINE" ]]; then
+  # No existing section: create it (current behavior, unchanged).
+  ENTRIES=$(format_entries "$ALL_COMMENTS")
+
+  printf '\n%s\n' "## Consumed Comments" >> "$SPEC_FILE" 2>/dev/null || {
+    echo "append-consumed-comments-section.sh: WARNING — skip (cannot append to spec file)" >&2
+    exit 0
+  }
+
+  if [[ -z "$ENTRIES" ]]; then
+    printf '%s\n' "No new comments since last phase." >> "$SPEC_FILE" 2>/dev/null || true
   else
-    ($body | split("\n") | .[0] // "" | .[0:80]) as $summary |
-    "- \($login) / \($assoc) / \($tier) / \($summary) / \($url)"
-  end
-' 2>/dev/null || true)
-
-# Append section to spec file
-printf '\n%s\n' "## Consumed Comments" >> "$SPEC_FILE" 2>/dev/null || {
-  echo "append-consumed-comments-section.sh: WARNING — skip (cannot append to spec file)" >&2
-  exit 0
-}
-
-if [[ -z "$ENTRIES" ]]; then
-  printf '%s\n' "No new comments since last phase." >> "$SPEC_FILE" 2>/dev/null || true
+    printf '%s\n' "$ENTRIES" >> "$SPEC_FILE" 2>/dev/null || true
+  fi
 else
-  printf '%s\n' "$ENTRIES" >> "$SPEC_FILE" 2>/dev/null || true
+  # Existing section: append only entries whose URL is not already recorded in
+  # the existing section body. If nothing new, leave the file untouched.
+  TOTAL_LINES=$(wc -l < "$SPEC_FILE" 2>/dev/null | tr -d ' ')
+  BOUNDARY_LINE=$(awk -v start="$HEADING_LINE" 'NR>start && /^## /{print NR; exit}' "$SPEC_FILE" 2>/dev/null || true)
+  if [[ -z "$BOUNDARY_LINE" ]]; then
+    BOUNDARY_LINE=$((TOTAL_LINES + 1))
+  fi
+
+  EXISTING_BODY=$(sed -n "$((HEADING_LINE + 1)),$((BOUNDARY_LINE - 1))p" "$SPEC_FILE" 2>/dev/null || true)
+
+  NEW_COMMENTS=$(echo "$ALL_COMMENTS" | \
+    jq --arg body "$EXISTING_BODY" '[.[] | select((.url // "") as $u | ($body | contains($u)) | not)]' \
+    2>/dev/null || echo "[]")
+
+  NEW_ENTRIES=$(format_entries "$NEW_COMMENTS")
+
+  if [[ -z "$NEW_ENTRIES" ]]; then
+    # No new entries for this run — nothing to change (also covers a same-phase
+    # re-run where every comment is already recorded).
+    exit 0
+  fi
+
+  {
+    sed -n "1,$((BOUNDARY_LINE - 1))p" "$SPEC_FILE"
+    printf '%s\n' "$NEW_ENTRIES"
+    sed -n "${BOUNDARY_LINE},\$p" "$SPEC_FILE"
+  } > "$SPEC_FILE.tmp" 2>/dev/null && mv "$SPEC_FILE.tmp" "$SPEC_FILE" || {
+    echo "append-consumed-comments-section.sh: WARNING — skip (cannot update spec file)" >&2
+    rm -f "$SPEC_FILE.tmp" 2>/dev/null || true
+    exit 0
+  }
 fi
 
 # Defense-in-depth: warn if not running inside an isolated worktree (was

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -112,9 +112,17 @@ else
 
   EXISTING_BODY=$(sed -n "$((HEADING_LINE + 1)),$((BOUNDARY_LINE - 1))p" "$SPEC_FILE" 2>/dev/null || true)
 
+  # Match on the exact last "/"-delimited field of each existing entry line
+  # (the URL), not raw substring containment: GitHub issuecomment IDs are not
+  # fixed-width, so a shorter new URL can be a literal string-prefix of an
+  # already-recorded longer URL (e.g. "issuecomment-5123" vs
+  # "issuecomment-51230"), which would falsely match via `contains()` and
+  # silently drop a legitimate new comment forever.
   NEW_COMMENTS=$(echo "$ALL_COMMENTS" | \
-    jq --arg body "$EXISTING_BODY" '[.[] | select((.url // "") as $u | ($body | contains($u)) | not)]' \
-    2>/dev/null || echo "[]")
+    jq --arg body "$EXISTING_BODY" '
+      ($body | split("\n") | map(split(" / ") | last)) as $existing_urls |
+      [.[] | select((.url // "") as $u | ($existing_urls | index($u) != null) | not)]
+    ' 2>/dev/null || echo "[]")
 
   NEW_ENTRIES=$(format_entries "$NEW_COMMENTS")
 

--- a/tests/append-consumed-comments-section.bats
+++ b/tests/append-consumed-comments-section.bats
@@ -84,6 +84,56 @@ MOCK
     [ "$section_count" -eq 1 ]
 }
 
+@test "existing section with new comment: appends new entry without removing existing one" {
+    SPEC_FILE="$BATS_TEST_TMPDIR/repo/docs/spec/issue-42-some-title.md"
+    printf '# Issue #42\n\n## Consumed Comments\n- alice / MEMBER / first-class / old comment / https://github.com/org/repo/issues/42#issuecomment-1\n\n## Phase Handoff\n- placeholder\n' > "$SPEC_FILE"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "api" ]]; then
+    echo ""
+    exit 0
+fi
+cat <<'JSON'
+[{"author":{"login":"bob"},"authorAssociation":"MEMBER","url":"https://github.com/org/repo/issues/42#issuecomment-2","body":"new comment body","createdAt":"2026-07-31T00:00:00Z"}]
+JSON
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run "$SCRIPT" 42 verify
+    [ "$status" -eq 0 ]
+    grep -q "issuecomment-1" "$SPEC_FILE"
+    grep -q "issuecomment-2" "$SPEC_FILE"
+    section_count=$(grep -c "^## Consumed Comments" "$SPEC_FILE")
+    [ "$section_count" -eq 1 ]
+    # The new entry must land inside the Consumed Comments section, before the next "## " heading.
+    [[ "$(sed -n '/^## Phase Handoff/,$p' "$SPEC_FILE")" != *"issuecomment-2"* ]]
+}
+
+@test "existing section re-run with same comment: no duplicate entry added" {
+    SPEC_FILE="$BATS_TEST_TMPDIR/repo/docs/spec/issue-42-some-title.md"
+    printf '# Issue #42\n\n## Consumed Comments\n- bob / MEMBER / first-class / new comment body / https://github.com/org/repo/issues/42#issuecomment-2\n' > "$SPEC_FILE"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "api" ]]; then
+    echo ""
+    exit 0
+fi
+cat <<'JSON'
+[{"author":{"login":"bob"},"authorAssociation":"MEMBER","url":"https://github.com/org/repo/issues/42#issuecomment-2","body":"new comment body","createdAt":"2026-07-31T00:00:00Z"}]
+JSON
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run "$SCRIPT" 42 verify
+    [ "$status" -eq 0 ]
+    occurrence_count=$(grep -c "issuecomment-2" "$SPEC_FILE")
+    [ "$occurrence_count" -eq 1 ]
+}
+
 @test "not in worktree: emits defense-in-depth warning" {
     SPEC_FILE="$BATS_TEST_TMPDIR/repo/docs/spec/issue-42-some-title.md"
     printf '# Issue #42: some title\n\n## Overview\nSome content.\n' > "$SPEC_FILE"


### PR DESCRIPTION
## Summary
- `scripts/append-consumed-comments-section.sh` の dedup ガードを、`## Consumed Comments` 見出しの存在のみで `exit 0` する方式 (見出しが存在すれば常にスキップ) から、URL 単位の重複排除つき既存セクション追記方式 (方針 B) に置き換えた
- 見出しが存在しない場合は現行動作 (見出し新規作成 + エントリまたは "No new comments since last phase.") を維持
- 見出しが存在する場合は、既存セクション本文に含まれない URL のコメントのみを新規エントリとして算出し、次の `## ` 見出しの直前 (または EOF) に追記する。新規エントリが 0 件ならファイルを一切変更せず `exit 0` する
- `tests/append-consumed-comments-section.bats` に、既存セクションへの新規エントリ追記ケースと、同一 phase 再実行時の重複防止ケースの2テストを追加

## Verification (pre-merge)
- `bats tests/append-consumed-comments-section.bats` (6 tests) — PASS
- Behavioral change detection: `tests/run-verify.bats` が本ファイルを参照するため `bats tests/` フルスイート (1285 tests) を実行 — PASS
- `python3 scripts/validate-skill-syntax.py skills/` — 0 error(s)
- `bash scripts/check-forbidden-expressions.sh` — PASS
- Issue #1107 Pre-merge AC 4件 (rubric x3, file_not_contains x1) — 手動照合の上 PASS 済み、Issue チェックボックス更新済み

## Verification (post-merge)
- 次回 `/verify` 実行時に cutoff より後の Issue コメントが `## Consumed Comments` に記録されることを観察 (observation, event=auto-run)

closes #1107
