### PR TITLE
Issue #1109: event 発火済み observation AC の評価手順を定義

### DIFF
--- a/docs/spec/issue-1109-verify-observation-eval.md
+++ b/docs/spec/issue-1109-verify-observation-eval.md
@@ -71,6 +71,10 @@
 - **`config=` ゲートとの役割分担**: `opportunistic-search.sh` の `config=` ゲート (`modules/observation-trigger.md` 参照) は、フラットな boolean キー1つで表現できる前提条件を通知コメント投稿前にフィルタする。Step 8c の「前提不成立時は SKIPPED」判定はこれと重複するものではなく、`config=` で表現しきれない前提 (ディレクトリ構成など) を証拠収集後に発見した場合の受け皿として設けている。
 - **Issue Retrospective からの引き継ぎ**: `/issue` フェーズの Auto-Resolve Log により、「対応方針 (案) 4.」の記録先は "Notes" ではなく `## Acceptance Test Results` の Details 列に統一済み。本 Spec の Implementation Steps 3 もこの用語に合わせている。
 
+## Autonomous Auto-Resolve Log
+
+- **`/code 1109 --pr --non-interactive` Step 3 (phase/ready ラベルチェック)**: Issue のラベルは `phase/ready` ではなく既に `phase/code` だった。タイムライン (`labeled phase/ready` → 3分後に `unlabeled phase/ready` / `labeled phase/code`) から、前回の `/code` 実行がラベル遷移 (Step 4) までは完了したが、ブランチ・worktree・PR を残さず中断したと判断した。Spec (`docs/spec/issue-1109-verify-observation-eval.md`) は Design Complete まで完了しており内容も完備しているため、AskUserQuestion による確認を経ずに既存 Spec を使って実装を続行した。
+
 ## Consumed Comments
 
 - saito (MEMBER, first-class): `/issue 1109 --non-interactive` の Issue Retrospective。曖昧ポイント1件 (「対応方針 (案) 4.」の記録先を Notes から Details 列へ) を自動解決し、Background の事実確認 (`modules/verify-executor.md:244` と `scripts/observation-trigger.sh:79` の矛盾) を実施した記録。AC 変更なし。 (https://github.com/saitoco/wholework/issues/1109#issuecomment-5138255302)

--- a/docs/spec/issue-1109-verify-observation-eval.md
+++ b/docs/spec/issue-1109-verify-observation-eval.md
@@ -78,3 +78,34 @@
 ## Consumed Comments
 
 - saito (MEMBER, first-class): `/issue 1109 --non-interactive` の Issue Retrospective。曖昧ポイント1件 (「対応方針 (案) 4.」の記録先を Notes から Details 列へ) を自動解決し、Background の事実確認 (`modules/verify-executor.md:244` と `scripts/observation-trigger.sh:79` の矛盾) を実施した記録。AC 変更なし。 (https://github.com/saitoco/wholework/issues/1109#issuecomment-5138255302)
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Spec の Notes 節はステアリングドキュメント同期の監査対象として `docs/structure.md` / `docs/workflow.md` のみを検討しており、`modules/observation-trigger.md` と `modules/verify-classifier.md` が漏れていた。両ファイルとも本 Issue が修正した「常に SKIPPED」という pre-fix の記述をそのまま残しており、`modules/verify-executor.md` だけが更新される非対称な状態になっていた。監査対象の選定は「PR diff で変更したファイル」に閉じず、「同じ仕様事項を別の角度から記述している既存ドキュメント」まで広げる必要がある。今回は `/review` の Documentation Consistency 観点で検出・修正したが、次回以降は Spec 作成時点で `grep -rl "verify-type: observation"` 等の横断検索を Implementation Steps に含めることを検討したい。
+
+### Recurring issues
+
+新設した Step 8c のロジックに対する回帰テストが Implementation Steps に明記されておらず、Pre-merge AC `command "bats tests/verify.bats"` の PASS が新ロジックを実際には検証していなかった (既存スイートに `observation` 関連ケースが皆無)。`skill-dev-recheck.md` の Type=Bug 重み付けにより `/review` の review-light エージェントがこれを検出したが、本来は Spec の Implementation Steps に「対応する bats ケースを追加する」ことを明記すべきだった。新しい分岐ロジックを追加する Issue では、Verification 節の command AC を「既存スイートが PASS すること」だけでなく「新ロジックを検証する新規ケースを追加すること」まで含めて記述する運用を検討したい。
+
+### Acceptance criteria verification difficulty
+
+3件の rubric 系 AC は diff の内容と一致しており UNCERTAIN なく判定できた。ただし `/review` の修正作業中、Step 8c の説明文に二重バッククォート形式のインラインコード (`` `text` `` ``) を導入したところ、`scripts/validate-skill-syntax.py` の素朴な単一バッククォート正規表現ストリッパーが誤マッチし、文書の広い範囲を巻き込んで無関係な `<!-- verify: ... -->` プレースホルダーを「未知の verify コマンド」として誤検出した。この地雷は AC 自体には現れないが、SKILL.md 本文を編集する際は二重バッククォートのインラインコード表記を避けるべきという運用上の注意点として記録する。
+
+## Phase Handoff
+<!-- phase: review -->
+
+### Key Decisions
+- Pre-merge AC 4件 (rubric×3 + command×1) はすべて PASS 判定。CI 全9チェック SUCCESS。MUST issue はゼロのため review は COMMENT で投稿。
+- review-light エージェントが検出した SHOULD 4件はすべて修正 (ドキュメント不整合2ファイル、Step 8c のエッジケース2件、bats 回帰テスト追加)。Spec 自体の監査ノート更新は Spec が disposable であるため見送った。
+- Step 8c の説明文修正中に validate-skill-syntax.py の二重バッククォート地雷を踏んだため、二重バッククォートを使わない書き方に書き直した。
+
+### Deferred Items
+- Post-merge の観察系 AC (`event 発火後に /verify を実行し checkbox が更新されることを確認する`) は `verify-type: manual` のため引き続き人手確認待ち。
+- None
+
+### Notes for Next Phase
+- `/merge` 実行時、CI は全 SUCCESS 済みなので追加の CI 待ちは不要。
+- `/verify` 実行時、Post-merge の manual AC 1件が残っている点に注意。
+- SKILL.md / モジュールファイルを編集する際は二重バッククォートのインラインコード表記 (`` `text` ``) を避けること — `scripts/validate-skill-syntax.py` の正規表現ストリッパーがこれを誤処理する。

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -4,8 +4,7 @@ Design specification for the observation AC trigger mechanism.
 
 ## Purpose
 
-`verify-type: observation event=<name>` ACs are not verified during a normal `/verify` run.
-Instead, they are re-evaluated automatically when the specified event fires.
+`verify-type: observation event=<name>` ACs are not verified during a normal `/verify` run **until the specified event has fired**. Once the event has fired (a detection comment has been posted on the Issue), the condition is evaluated during the next normal `/verify` run per `skills/verify/SKILL.md` Step 8c — it is no longer SKIPPED at that point.
 This module documents the trigger interface: who calls the trigger, with what arguments, and what the output contract is.
 
 The actual dispatch is handled by `scripts/opportunistic-search.sh --event <name>`, which:

--- a/modules/verify-classifier.md
+++ b/modules/verify-classifier.md
@@ -28,7 +28,7 @@ Skills that Read this file should evaluate each post-merge condition against the
 ### observation Type: Event Values and Syntax
 
 `<!-- verify-type: observation event=<event-name> -->` marks a condition as an event-driven observation.
-The condition is **not** verified during a normal `/verify` run; instead, it is re-evaluated automatically when the specified event fires.
+The condition is **not** verified during a normal `/verify` run **while the specified event has not yet fired**; instead, it is re-evaluated once the event fires. After the event fires, the condition is evaluated (not skipped) during the next normal `/verify` run per `skills/verify/SKILL.md` Step 8c.
 
 **Valid `event-name` values (restricted by convention):**
 

--- a/modules/verify-executor.md
+++ b/modules/verify-executor.md
@@ -241,7 +241,7 @@ When a condition carries a `<!-- verify-type: ... -->` marker, apply the followi
 |-------------|-------------------------------|
 | `auto` | Normal verify command processing (Steps 1–4 above) |
 | `opportunistic` | Processed by opportunistic-search.sh at skill completion; during normal `/verify` run, execute the attached verify command if present |
-| `observation` | **Skip during normal `/verify` run** — the condition is re-evaluated when the specified `event=<name>` fires via `opportunistic-search.sh --event <name>`. During skip, record as SKIPPED with detail: "observation: waiting for event=<event-name>". If the event is unknown, emit a warning and fall back to opportunistic treatment. |
+| `observation` | **Branches on whether the specified `event=<name>` has already fired** (fired = `opportunistic-search.sh --event <name>` has posted a detection comment on this Issue): if not yet fired, record as SKIPPED with detail: "observation: waiting for event=<event-name>" (unchanged from prior behavior). If already fired, do **not** SKIP — evaluate the condition per `skills/verify/SKILL.md` Step 8c (fired-event detection, evidence collection, PASS/FAIL/UNCERTAIN/SKIPPED judgment). If the event name is unknown, emit a warning and fall back to opportunistic treatment. |
 | `manual` | Processed in Step 8b (Claude executability judgment + verification guide or AskUserQuestion) |
 
 5. Treat syntax errors (unknown command names, missing arguments, etc.) as UNCERTAIN

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -171,6 +171,7 @@ This is an early Spec read specifically for Phase Handoff context; SPEC_PATH is 
   - **Pre-merge**: treat all conditions as auto-verification targets (with or without hints)
   - **Post-merge + with hints** (`<!-- verify: ... -->`): auto-verification targets — processed in Step 8a
   - **Post-merge + without hints**: manual conditions — processed in Step 8b (Claude executability judgment + verification guide or per-condition AskUserQuestion)
+  - **Post-merge + `<!-- verify-type: observation event=<name> -->`**: routed to Step 8c (fired-event detection, evidence collection, PASS/FAIL/UNCERTAIN/SKIPPED judgment) regardless of whether the condition also carries a verify command
 
 ### Step 5: Verify Each Condition (Pre-merge Only)
 
@@ -328,7 +329,7 @@ Output the following overview to terminal:
 **Column guidance:**
 - **N**: total count of post-merge ACs
 - **Type**: `auto-verify (hint)` if `<!-- verify: ... -->` is present; `observation (<event-name>)` if `<!-- verify-type: observation event=* -->` is present; `manual` if `<!-- verify-type: manual -->` or no hint
-- **Claude Executable?**: for manual conditions only — quick preview judgment based on condition text (rubric detailed in Step 8b). For executable conditions, show the candidate command or approach. For non-executable conditions, show "No (requires manual inspection)". For auto-verify conditions, show "—". For observation conditions, show "— (waiting for event)".
+- **Claude Executable?**: for manual conditions only — quick preview judgment based on condition text (rubric detailed in Step 8b). For executable conditions, show the candidate command or approach. For non-executable conditions, show "No (requires manual inspection)". For auto-verify conditions, show "—". For observation conditions, branch on fired status: not yet fired → "— (waiting for event)"; already fired → "Yes — evaluate now (event fired)" (evaluated in Step 8c).
 
 ### Step 8: Post-merge Processing
 
@@ -375,9 +376,40 @@ If "Claude Execute" is selected: run the command/approach → judge PASS or FAIL
 
 Output a verification guide to terminal (specific URL / expected command / expected state). Do **not** invoke `AskUserQuestion`. Leave checkbox unchecked. The user completes manual verification and re-runs `/verify $NUMBER` when ready.
 
+#### Step 8c: Observation Post-merge Conditions
+
+For each unchecked post-merge condition marked `<!-- verify-type: observation event=<name> -->`:
+
+**1. Fired detection**
+
+Extract `<name>` from the `event=<name>` attribute. Fired status is not subject to Step 4's comment-consumption cutoff — search the Issue's full comment history directly:
+
+```bash
+gh issue view "$NUMBER" --json comments --jq '.comments[].body' \
+  | grep -F "observation event" | grep -F "detected" | grep -F -- "$EVENT_NAME"
+```
+
+- **No match**: the event has not fired yet. Record as SKIPPED with detail: "observation: waiting for event=<event-name>" (unchanged from prior behavior). Do not proceed to evidence collection.
+- **Match found**: the event has fired. Proceed to evidence collection.
+
+**2. Evidence collection (best-effort — not every source is available every time)**
+
+- Recent `/auto` execution logs and phase output
+- `.tmp/auto-events.jsonl` events for the relevant session_id, if the file currently exists
+- Read-only re-run of `${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event <name>` (no side effects — confirmed it never calls `gh issue comment` / `gh issue edit`)
+- The target repository's `.wholework.yml` configuration and directory/file layout (whether the condition's premise holds in this repository)
+
+**3. Judgment**
+
+Based on the collected evidence:
+- Condition is satisfied → **PASS**
+- Evidence contradicts the condition → **FAIL**
+- Evidence is insufficient or ambiguous → **UNCERTAIN**
+- The observed premise itself does not hold in this repository (e.g., a referenced `config=` key is unset/false, or a referenced directory/feature does not exist) → **SKIPPED** (record the reason in the Details column of the Step 9 `## Acceptance Test Results` comment)
+
 **Post-Step 8 checkpoint: flip post-merge PASS checkboxes**
 
-After all post-merge conditions are processed, identify conditions that resulted in PASS (Step 8a auto-verify PASS or Step 8b "Claude Execute" PASS) and update their checkboxes:
+After all post-merge conditions are processed, identify conditions that resulted in PASS (Step 8a auto-verify PASS, Step 8b "Claude Execute" PASS, or Step 8c fired-and-evaluated PASS) and update their checkboxes:
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh "$NUMBER" --checkbox <post-merge-pass-indices> --check
@@ -467,6 +499,7 @@ gh issue view "$NUMBER" --json state --jq '.state'
 - All pre-merge conditions (with or without hints)
 - Post-merge conditions with hints (`<!-- verify: ... -->`)
 - Post-merge `<!-- verify-type: manual -->` conditions confirmed as PASS or FAIL in Step 8 (SKIP responses are excluded)
+- Post-merge `<!-- verify-type: observation ... -->` conditions confirmed as PASS or FAIL in Step 8c (conditions remaining SKIPPED — not yet fired, or prerequisite unmet — are excluded)
 - **Post-merge conditions without hints (and no verify-type marker) are excluded** (user verification items)
 
 Apply the following judgment based on the verification results (exhaustive):
@@ -482,12 +515,12 @@ if [[ -n "${AUTO_EVENTS_LOG:-}" ]]; then
 fi
 ```
 
-- Check if any unchecked (`- [ ]`) `<!-- verify-type: opportunistic -->`, `<!-- verify-type: observation ... -->`, or `<!-- verify-type: manual -->` conditions remain in the post-merge section of the Issue body (manual conditions SKIPped in Step 8 remain unchecked; observation conditions remain unchecked until their event fires)
+- Check if any unchecked (`- [ ]`) `<!-- verify-type: opportunistic -->`, `<!-- verify-type: observation ... -->`, or `<!-- verify-type: manual -->` conditions remain in the post-merge section of the Issue body (manual conditions SKIPped in Step 8 remain unchecked; observation conditions remain unchecked while unfired, and also remain unchecked if Step 8c evaluates a fired event as FAIL/UNCERTAIN/SKIPPED — only fired-and-PASS observation conditions are checked)
 - **If unchecked opportunistic, observation, or manual conditions remain**: assign `phase/verify` (Issue state unchanged):
     ```bash
     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" verify
     ```
-    Inform the user: "Unchecked opportunistic/observation/manual conditions remain. Re-run `/verify $NUMBER` when ready to confirm them (observation conditions are checked automatically when the specified event fires)."
+    Inform the user: "Unchecked opportunistic/observation/manual conditions remain. Re-run `/verify $NUMBER` when ready to confirm them (observation conditions are evaluated automatically once the specified event fires; only a PASS result checks the box)."
 - **If all conditions are checked**: assign `phase/done`, then close the Issue only when `ISSUE_STATE` is `OPEN` (handles both auto-close disabled repos and XL parent Issues not auto-closed by PR's `closes #N`):
     ```bash
     ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh "$NUMBER" done

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -385,12 +385,19 @@ For each unchecked post-merge condition marked `<!-- verify-type: observation ev
 Extract `<name>` from the `event=<name>` attribute. Fired status is not subject to Step 4's comment-consumption cutoff — search the Issue's full comment history directly:
 
 ```bash
-gh issue view "$NUMBER" --json comments --jq '.comments[].body' \
-  | grep -F "observation event" | grep -F "detected" | grep -F -- "$EVENT_NAME"
+COMMENTS_JSON=$(gh issue view "$NUMBER" --json comments --jq '.comments[].body' 2>&1)
+GH_EXIT=$?
 ```
 
-- **No match**: the event has not fired yet. Record as SKIPPED with detail: "observation: waiting for event=<event-name>" (unchanged from prior behavior). Do not proceed to evidence collection.
-- **Match found**: the event has fired. Proceed to evidence collection.
+- **`gh issue view` fails** (`GH_EXIT` non-zero — auth/network/rate-limit error): do not treat this as "not fired." Record as UNCERTAIN with detail: "could not confirm fired status (gh error)". Do not proceed to evidence collection.
+- **`gh issue view` succeeds**: search `$COMMENTS_JSON` for the exact event token as posted by `scripts/observation-trigger.sh:79` (the event name surrounded by backticks, immediately followed by "detected"), not a bare unanchored substring — this avoids one event name matching as a substring of another (e.g. a future `event=auto` vs. `event=auto-run`):
+
+  ```bash
+  echo "$COMMENTS_JSON" | grep -F -- "\`${EVENT_NAME}\` detected"
+  ```
+
+  - **No match**: the event has not fired yet. Record as SKIPPED with detail: "observation: waiting for event=<event-name>" (unchanged from prior behavior). Do not proceed to evidence collection.
+  - **Match found**: the event has fired. Proceed to evidence collection.
 
 **2. Evidence collection (best-effort — not every source is available every time)**
 

--- a/tests/verify.bats
+++ b/tests/verify.bats
@@ -4,7 +4,8 @@
 # Structural tests: verify that skills/verify/SKILL.md Step 2 runs the
 # foreign-worktree guard ahead of the base branch checkout.
 
-SKILL_FILE="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/skills/verify/SKILL.md"
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SKILL_FILE="$PROJECT_ROOT/skills/verify/SKILL.md"
 
 # Extract the "### Step 2: Detect and Update Base Branch" section from SKILL.md.
 # The section ends at the next level-3 (### Step ) heading.
@@ -16,6 +17,12 @@ step2_section() {
 # The section ends at the next level-3 (### Step ) heading.
 step5_section() {
     awk '/^### Step 5: /{found=1} /^### Step / && !/Step 5: /{found=0} found{print}' "$SKILL_FILE"
+}
+
+# Extract the "#### Step 8c: Observation Post-merge Conditions" section from SKILL.md.
+# The section ends at the next heading (level-3 or level-4).
+step8c_section() {
+    awk '/^#### Step 8c: /{found=1} (/^#### / || /^### /) && !/Step 8c: /{found=0} found{print}' "$SKILL_FILE"
 }
 
 @test "Step 2 guard: detect-foreign-worktree.sh runs before base branch checkout" {
@@ -57,4 +64,42 @@ step5_section() {
 @test "Step 5 pre-merge-preview AC skip rule checks for a Review Response Summary via reconcile-phase-state.sh" {
     step5_section | grep -q -F "Review Response Summary"
     step5_section | grep -q -F "reconcile-phase-state.sh"
+}
+
+@test "Step 8c: fired observation ACs are evaluated, not always SKIPPED" {
+    step8c_section | grep -q -F "Match found"
+    step8c_section | grep -q -F "Proceed to evidence collection"
+}
+
+@test "Step 8c: unfired observation ACs still record SKIPPED" {
+    step8c_section | grep -q -F "No match"
+    step8c_section | grep -q -F "waiting for event=<event-name>"
+}
+
+@test "Step 8c: judgment covers PASS/FAIL/UNCERTAIN/SKIPPED" {
+    step8c_section | grep -q -F "**PASS**"
+    step8c_section | grep -q -F "**FAIL**"
+    step8c_section | grep -q -F "**UNCERTAIN**"
+    step8c_section | grep -q -F "**SKIPPED**"
+}
+
+@test "Step 8c: evidence collection lists auto logs, auto-events.jsonl, and opportunistic-search.sh" {
+    step8c_section | grep -q -F "/auto"
+    step8c_section | grep -q -F "auto-events.jsonl"
+    step8c_section | grep -q -F "opportunistic-search.sh --event"
+}
+
+@test "Step 8c: gh issue view failure is not silently treated as unfired" {
+    step8c_section | grep -q -F "GH_EXIT"
+    step8c_section | grep -q -F "could not confirm fired status"
+}
+
+@test "Step 8c: fired-event match is anchored to the backtick-quoted token" {
+    step8c_section | grep -q -F '\`${EVENT_NAME}\` detected'
+}
+
+@test "verify-executor.md: observation row branches on fired status instead of always SKIPPED" {
+    run grep -F "Branches on whether the specified" "$PROJECT_ROOT/modules/verify-executor.md"
+    [ "$status" -eq 0 ]
+    ! grep -q -F "Skip during normal \`/verify\` run" "$PROJECT_ROOT/modules/verify-executor.md"
 }


### PR DESCRIPTION
Closes #1109

## 概要

`verify-type: observation` の AC について、**event 発火後にどう評価するか**が `/verify` に定義されておらず、仕様と実装が矛盾していた問題を解消する。

- `modules/verify-executor.md:244` — observation を「**Skip during normal `/verify` run**」と規定し、常に SKIPPED として記録するよう指示
- `scripts/observation-trigger.sh:79` — event 発火時に「Run `/verify N` to verify the condition and update the checkbox」というコメントを投稿

規定どおりに動くと、event 発火後に `/verify` を実行しても checkbox は永久に更新されない。

Spec: `docs/spec/issue-1109-verify-observation-eval.md`

## 変更内容

| ファイル | 変更 |
|---|---|
| `modules/verify-executor.md` | verify-type 表の `observation` 行を「常に SKIPPED」から「event 発火済みなら評価 / 未発火なら従来どおり SKIPPED」の分岐に変更。評価手順は `skills/verify/SKILL.md` Step 8c を参照 |
| `skills/verify/SKILL.md` Step 4 | post-merge 条件の振り分けに observation 専用の分岐 (Step 8c へのルーティング) を追加 |
| `skills/verify/SKILL.md` Step 7 | Post-merge Briefing の "Claude Executable?" 列を発火済み/未発火で出し分ける記述に更新 |
| `skills/verify/SKILL.md` Step 8c (新設) | 発火判定 → 証拠収集 → PASS/FAIL/UNCERTAIN/SKIPPED 判定 |
| `skills/verify/SKILL.md` Post-Step 8 | checkbox flip の PASS 判定元に Step 8c を追加 |
| `skills/verify/SKILL.md` Step 11(a) | reopen 判定対象に Step 8c で PASS/FAIL 確定した observation 条件を追加 |

### Step 8c の設計

**発火判定**: Step 4 の comment consumption cutoff の影響を受けないよう、Issue の全コメント履歴を直接検索する。

**証拠収集 (best-effort)**: 直近の `/auto` 実行ログ / `.tmp/auto-events.jsonl` / read-only な `opportunistic-search.sh --event <name>` の再実行 / 対象リポジトリの `.wholework.yml` とファイル構成。

`opportunistic-search.sh` は `observation-trigger.sh` が内部で呼ぶ検索そのもので、コメント投稿は trigger 側にしかないため副作用なく再実行できる。

**判定**: 条件充足→PASS / 証拠が矛盾→FAIL / 不十分→UNCERTAIN / **前提自体が当該リポジトリで成立しない**(参照する `config=` キーが未設定、参照するディレクトリ・機能が存在しない等)→SKIPPED。

## 検証

- `bats tests/verify.bats tests/verify-executor.bats tests/observation-trigger.bats tests/opportunistic-search.bats tests/verify-heuristics.bats tests/verify-rubric.bats tests/run-verify.bats tests/verify-dirty-detection.bats` — **90 件すべて PASS** (`not ok` 0 件)
- `python3 scripts/validate-skill-syntax.py skills/verify/SKILL.md` — 0 error / 0 warning
- `bash scripts/check-forbidden-expressions.sh` — 違反なし

## 注記: code フェーズの silent no-op からの復旧

このブランチの実装コミットは、`/auto 1109` の code フェーズが **3 回連続で silent no-op に陥った**あと、親セッションが復旧として作成したものである。

`/code` セッションが headless (`claude -p`) で bats テストスイートをバックグラウンド実行し、届かない完了通知を待ってターンを終える — **#1097 として起票済みのパターン**そのものが再現した。

```
長時間実行タスクとしてバックグラウンドに移行した bats テストスイートの完了を待ちます。
Warning: claude exited 0 but code-pr phase did not complete (silent no-op).
auto-retry: code phase silent no-op, retry 1/3
...
auto-retry: code phase silent no-op, retry 2/3
```

3 回目は並行セッションが main に未コミット変更を持っていたため `check-verify-dirty` のガードで停止した (このガード自体は並行セッションの作業を保護する正しい挙動)。

親セッションによる復旧の手順:

- worktree の変更ファイル 3 件が Spec の `## Changed Files` と完全一致することを確認
- Spec の Implementation Steps 5 箇所すべてが実装されていることを diff で確認
- worktree 内で上記の検証 (bats 90 件・syntax validator・forbidden expressions) を実行し全 green を確認
- そのうえで commit → `origin/main` へ rebase → push → PR 作成

`/code` 自身の commit ステップは実行されていないため、`## Code Retrospective` は存在しない。`/review` では diff と Spec の照合を通常より丁寧に行うことを推奨する。
