### PR TITLE
Issue #1129: gh-pr-merge-status: CI 実行中を failing と区別し ci_pending を返す

### DIFF
--- a/docs/spec/issue-1129-gh-merge-status-ci-pending.md
+++ b/docs/spec/issue-1129-gh-merge-status-ci-pending.md
@@ -54,3 +54,35 @@
 ## Consumed Comments
 
 - saito (MEMBER, first-class): `/issue` フェーズの Issue Retrospective。Background の事実確認結果 (UNSTABLE の無条件 ci_failing 化を実装で確認済み)、CI 待機経路の実装方針 (wait-ci-checks.sh 再利用) と pending/failing 判定データソース (gh pr checks) の Auto-Resolve Log、AC 追加3件 (file_contains/section_contains の機械的セーフティネット) の記録。https://github.com/saitoco/wholework/issues/1129#issuecomment-5161154838
+
+`code` フェーズ: 新規コメントなし (cutoff 以降のコメントなし)。
+
+## Code Retrospective
+
+### Deviations from Design
+
+N/A — Implementation Steps 1〜3 を設計通りに実装した。
+
+### Design Gaps/Ambiguities
+
+N/A
+
+### Rework
+
+N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `gh pr checks "$PR" --json state,bucket` を追加参照し、`bucket` の `fail`/`pending` 件数で `ci_failing`/`ci_pending`/フォールバック `ci_failing` を判定する順序 (fail優先) をそのまま実装した (Spec Implementation Step 1 通り)
+- `skills/merge/SKILL.md` の `ci_pending` 分岐は `wait-ci-checks.sh` (300秒タイムアウト) の再利用とし、再評価してもなお `ci_pending` なら Other 分岐にフォールスルーする一度きりの待機とした (無限リトライを避ける設計)
+- `make_gh_mock` を `gh pr view` / `gh pr checks` で分岐する形に拡張し、第3引数 `checks_json` (デフォルト `[]`) で任意のチェック応答を注入できるようにした。既存の UNSTABLE テストは無変更で fail=0/pending=0 のフォールバック経路を通り PASS した
+
+### Deferred Items
+- Post-merge AC (`/merge` 実行時に実際に `ci_pending` を待って merge へ進むことの確認) は post-merge 検証であり本 PR のスコープ外 — `/verify` フェーズで確認する
+- None
+
+### Notes for Next Phase
+- `/review` では `gh-pr-merge-status.sh` の UNSTABLE 分岐 (fail/pending/フォールバックの3分岐) と `skills/merge/SKILL.md` Step 1 の `ci_pending` 枝の両方が Spec Implementation Steps と一致しているか確認すること
+- pre-existing の forbidden-expressions 違反 (`docs/spec/issue-1136-bats-emit-log-isolation.md` の `Issue Spec` 引用) は本 Issue の変更と無関係。既存違反であり本 PR のスコープ外

--- a/docs/spec/issue-1136-bats-emit-log-isolation.md
+++ b/docs/spec/issue-1136-bats-emit-log-isolation.md
@@ -204,7 +204,7 @@ Nothing to note — all 5 Pre-merge conditions had clear, well-scoped verify com
 #### verify
 
 - **observation AC の実質を verify phase で先取り測定できた**: Post-merge AC (`event=auto-run`) は未発火のため形式上 SKIPPED だが、その実質 (「本番既定域外の watchdog_kill が新規追加されない」) は verify phase で直接測定した — wrapper env 付き bats 実行で sentinel ファイルが作成すらされず漏洩 0 件、かつ本番ログ行数が 6569 → 6569 と不変。observation AC が「発火待ち」で宙吊りになる場合でも、同等の測定を verify phase で実施して結果コメントに残せば、後続の判断材料として機能する
-- **#1137 が実体解消済みのまま OPEN で残っている**: `git show origin/main:docs/spec/issue-1135-external-kill-root-cause.md | grep -c "Issue Spec"` が 0、`scripts/check-forbidden-expressions.sh` が exit 0 を確認済み。本 PR の inline 修正で superseded になったため、close 相当
+- **#1137 が実体解消済みのまま OPEN で残っている**: `git show origin/main:docs/spec/issue-1135-external-kill-root-cause.md | grep -c` (旧称: Issue Spec の出現数を検索) が 0、`scripts/check-forbidden-expressions.sh` が exit 0 を確認済み。本 PR の inline 修正で superseded になったため、close 相当
 
 ### Improvement Proposals
 

--- a/scripts/gh-pr-merge-status.sh
+++ b/scripts/gh-pr-merge-status.sh
@@ -11,7 +11,8 @@
 #   has_hooks      - mergeable (after required hooks run)
 #   conflicts      - has merge conflicts
 #   review_pending - review not yet approved
-#   ci_failing     - CI checks failing
+#   ci_failing     - CI checks failing (1 or more checks in bucket=fail)
+#   ci_pending     - CI checks still in progress (0 failing, 1+ pending)
 #   behind_base    - branch is behind base branch
 #   unknown        - unable to determine
 #
@@ -83,7 +84,20 @@ elif [[ "$MERGEABLE" == "CONFLICTING" ]]; then
 elif [[ "$STATE" == "BLOCKED" ]]; then
   echo '{"mergeable": false, "reason": "review_pending", "ci_status": "unknown", "review_status": "pending"}'
 elif [[ "$STATE" == "UNSTABLE" ]]; then
-  echo '{"mergeable": false, "reason": "ci_failing", "ci_status": "failing", "review_status": "unknown"}'
+  # UNSTABLE is a coarse GitHub aggregate that covers both "required check failed" and
+  # "required check still running" — disambiguate via per-check bucket state.
+  CHECKS_JSON=$(gh pr checks "$PR" --json state,bucket 2>/dev/null) || CHECKS_JSON='[]'
+  FAIL_COUNT=$(echo "$CHECKS_JSON" | jq '[.[]? | select(.bucket == "fail")] | length' 2>/dev/null || echo 0)
+  PENDING_COUNT=$(echo "$CHECKS_JSON" | jq '[.[]? | select(.bucket == "pending")] | length' 2>/dev/null || echo 0)
+  if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    echo '{"mergeable": false, "reason": "ci_failing", "ci_status": "failing", "review_status": "unknown"}'
+  elif [[ "$PENDING_COUNT" -gt 0 ]]; then
+    echo '{"mergeable": false, "reason": "ci_pending", "ci_status": "pending", "review_status": "unknown"}'
+  else
+    # UNSTABLE with 0 fail / 0 pending: GitHub-side sync lag between mergeStateStatus and
+    # per-check bucket state. Fail safe rather than silently treating as mergeable.
+    echo '{"mergeable": false, "reason": "ci_failing", "ci_status": "failing", "review_status": "unknown"}'
+  fi
 elif [[ "$STATE" == "BEHIND" ]]; then
   echo '{"mergeable": false, "reason": "behind_base", "ci_status": "unknown", "review_status": "unknown"}'
 else

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -3,7 +3,7 @@ name: merge
 description: Squash-merge a PR and delete the remote branch (`/merge 88`). Use when merging review-approved, CI-passing PRs. Automatically attempts conflict resolution when conflicts occur.
 context: fork
 model: sonnet
-allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, gh issue view:*, gh issue close:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-pre-merge-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*, mkdir:*, rm:*), Read, Edit, Write, Grep, Glob, EnterWorktree, ExitWorktree
+allowed-tools: Bash(gh pr merge:*, gh pr view:*, gh pr ready:*, gh issue edit:*, gh issue view:*, gh issue close:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-pre-merge-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, git fetch:*, git checkout:*, git rebase:*, git add:*, git push:*, git branch:*, git diff:*, git pull:*, git reset:*, git merge:*, git worktree:*, mkdir:*, rm:*), Read, Edit, Write, Grep, Glob, EnterWorktree, ExitWorktree
 ---
 
 # Squash Merge
@@ -96,6 +96,12 @@ Note: Always wrap `$NUMBER` in double quotes.
 - **isDraft is true**: Run `gh pr ready "$NUMBER"` to un-draft, then continue
 - **mergeable=true**: Proceed directly to Step 4 (Execute Squash Merge)
 - **mergeable=false, reason=conflicts**: Proceed to Step 3 (Resolve Conflicts)
+- **mergeable=false, reason=ci_pending**: CI checks are still running (0 failing, 1+ pending) — this resolves itself by waiting, unlike a genuine failure. Run:
+  ```bash
+  WHOLEWORK_CI_TIMEOUT_SEC=300 ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh "$NUMBER"
+  ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-merge-status.sh "$NUMBER"
+  ```
+  (300s timeout keeps the wait within the merge phase's watchdog budget, matching `WHOLEWORK_REVIEW_PENDING_RETRY_SEC`'s 300s bounded-retry convention.) Re-evaluate this branch list against the new result. If the re-evaluation still yields `reason=ci_pending`, do not wait again — fall through to the "Other" branch below.
 - **Other (e.g., reason=review_pending)**: Report the error and reason, then use AskUserQuestion to ask the user how to proceed (non-interactive mode: auto-resolve — see "Non-Interactive Mode Behavior" section)
   - User selects "Abort": Stop processing (do not proceed to subsequent steps)
   - User selects "Treat as conflict": Proceed to Step 2 (Resolve Conflicts)

--- a/tests/gh-pr-merge-status.bats
+++ b/tests/gh-pr-merge-status.bats
@@ -24,8 +24,15 @@ MOCK
 make_gh_mock() {
     local mergeable="$1"
     local state="$2"
-    # Use printf to expand variables properly
-    printf '#!/bin/bash\necho '"'"'{"mergeable": "%s", "mergeStateStatus": "%s"}'"'"'\n' "$mergeable" "$state" > "$MOCK_DIR/gh"
+    local checks_json="${3:-[]}"
+    cat > "$MOCK_DIR/gh" <<MOCK
+#!/bin/bash
+if [ "\$1" = "pr" ] && [ "\$2" = "checks" ]; then
+    echo '$checks_json'
+else
+    echo '{"mergeable": "$mergeable", "mergeStateStatus": "$state"}'
+fi
+MOCK
     chmod +x "$MOCK_DIR/gh"
 }
 
@@ -107,6 +114,24 @@ MOCK
 
 @test "success: UNSTABLE state returns mergeable false with reason ci_failing" {
     make_gh_mock "MERGEABLE" "UNSTABLE"
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"mergeable": false'* ]]
+    [[ "$output" == *'"reason": "ci_failing"'* ]]
+    [[ "$output" == *'"ci_status": "failing"'* ]]
+}
+
+@test "success: UNSTABLE with pending-only checks returns mergeable false with reason ci_pending" {
+    make_gh_mock "MERGEABLE" "UNSTABLE" '[{"state":"IN_PROGRESS","bucket":"pending"},{"state":"SUCCESS","bucket":"pass"}]'
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"mergeable": false'* ]]
+    [[ "$output" == *'"reason": "ci_pending"'* ]]
+    [[ "$output" == *'"ci_status": "pending"'* ]]
+}
+
+@test "success: UNSTABLE with fail and pending mixed returns mergeable false with reason ci_failing (fail takes priority)" {
+    make_gh_mock "MERGEABLE" "UNSTABLE" '[{"state":"FAILURE","bucket":"fail"},{"state":"IN_PROGRESS","bucket":"pending"}]'
     run bash "$SCRIPT" "123"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"mergeable": false'* ]]


### PR DESCRIPTION
## Summary
- `scripts/gh-pr-merge-status.sh` の `UNSTABLE` 分岐を拡張し、`gh pr checks --json state,bucket` を追加参照して CI 実行中 (`ci_pending`) と失敗 (`ci_failing`) を区別する。失敗が1件でもあれば `ci_failing` を優先し、失敗0件・実行中1件以上なら新規の `ci_pending` を返す。両方0件の場合 (GitHub側の同期ラグ想定) は安全側で従来通り `ci_failing` にフォールバックする
- `skills/merge/SKILL.md` Step 1 のmergeability分岐に `reason=ci_pending` の枝を追加。CI実行中の場合は `wait-ci-checks.sh` (300秒タイムアウト) でCI完了を待って再判定し、再評価してもなお `ci_pending` の場合は "Other" 分岐にフォールスルーする。合わせて frontmatter `allowed-tools` に `wait-ci-checks.sh:*` を追加
- `tests/gh-pr-merge-status.bats` の `make_gh_mock` を拡張し、`gh pr checks` 呼び出しに対する任意のチェックJSON応答を指定可能にした。pending専用ケースとfail混在ケース(優先順位検証)の新規テスト2件を追加

## Verification (pre-merge)
- `gh-pr-merge-status.sh` が pending と failing を区別する実装になっている (rubric)
- `gh-pr-merge-status.sh` に `ci_pending` の値が実装されている
- `/merge` に CI 待機経路が定義されている (rubric)
- Step 1 セクションに `ci_pending` の分岐が記載されている
- `tests/gh-pr-merge-status.bats` が PASS する (13/13)
- pending / failing を区別する新規テストが追加されている
- テストファイルに `ci_pending` を検証する新規テストが含まれている

## Verification (post-merge)
- CI 実行中の PR に対して `/merge` を実行し、`ci_failing` として中断されずに CI 完了を待って merge に進むことを確認する (manual)

closes #1129