### PR TITLE
Issue #1101: review: add base branch conflict pre-check step

### DIFF
--- a/docs/spec/issue-1101-review-base-conflict-check.md
+++ b/docs/spec/issue-1101-review-base-conflict-check.md
@@ -77,3 +77,34 @@ AC1 の rubric と AC2 の `grep "merge-tree"` はいずれも `changed in both`
 ### Domain Classification
 
 `/issue` フェーズで Core (`skills/review/SKILL.md`) 対象と確定済み (`skills/review/skill-dev-recheck.md` は `scripts/validate-skill-syntax.py` が存在する skill 開発リポジトリ限定の Domain file であり対象外)。本 Spec も同じ判断を継承する。
+
+## Code Retrospective
+
+### Deviations from Design
+
+N/A — Implementation Steps 1〜4 をそのままの順序・挿入位置で実装した。
+
+### Design Gaps/Ambiguities
+
+- Implementation Steps 3/4 の「conflict context をプロンプトに追記する」は、`.tmp/base-conflict-context-$NUMBER.md` が存在しない場合の扱いを明示していなかった。実装では各 Task プロンプト文字列に `[, base branch conflict context: <contents ..., if present>]` という条件付き断片を埋め込み、ファイル不在時は何も追記されない形にした (Workflow パス側は `args.conflictContext` が空文字列なら `CONFLICT_SUFFIX` も空文字列になる同等のロジック)。プロンプト文字列自体は静的なテンプレートであり実行時分岐を書けないため、この表現が妥当と判断した。
+
+### Rework
+
+N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Base Branch Conflict Pre-check を Step 10 の分岐点 (light/full/Workflow) より前に無番号セクションとして挿入し、どの経路でも共通実行されるようにした (Spec Implementation Steps 2 の指示通り)
+- `git merge-tree` は非推奨の 3 引数 `--trivial-merge` 形式を意図的にそのまま使用 (`--write-tree` 2 引数形式には置き換えない) — `changed in both` 文字列の検出に依存する AC2 のため
+- conflict context をプロンプトに渡す際は、`.tmp/base-conflict-context-$NUMBER.md` の有無で分岐する条件付きテンプレート断片として各 Task プロンプト文字列 (static 側 10.0/10.2 の3箇所、Workflow 側 finderPrompts の3箇所、計6箇所) に埋め込んだ
+
+### Deferred Items
+- Post-merge の手動検証 (「ベースブランチ側と同一行を変更する PR を実際にレビューし、conflict が MUST 指摘として検出されることを確認する」) は本 PR のマージ後に人手で実施する
+- `docs/workflow.md` の更新は Spec Notes で不要と判断済み (フェーズ境界やルーティングを変えない内部品質強化のため)
+
+### Notes for Next Phase
+- AC4 (`github_check "gh pr checks" "Run bats tests"`) は PR 作成前は UNCERTAIN (対象 PR が存在しないため) — PR #1145 作成後の CI 結果で確認すること
+- ローカルで `bats tests/` を実行し 1325 件全て pass を確認済み (behavioral change 検出により full suite 実行)
+- Post-merge 手動検証時は Issue #1102 (`event=REQUEST_CHANGES` の 422 既知問題) と評価軸を分けること (Spec Notes 参照)

--- a/docs/spec/issue-1101-review-base-conflict-check.md
+++ b/docs/spec/issue-1101-review-base-conflict-check.md
@@ -93,18 +93,33 @@ N/A — Implementation Steps 1〜4 をそのままの順序・挿入位置で実
 N/A
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Base Branch Conflict Pre-check を Step 10 の分岐点 (light/full/Workflow) より前に無番号セクションとして挿入し、どの経路でも共通実行されるようにした (Spec Implementation Steps 2 の指示通り)
-- `git merge-tree` は非推奨の 3 引数 `--trivial-merge` 形式を意図的にそのまま使用 (`--write-tree` 2 引数形式には置き換えない) — `changed in both` 文字列の検出に依存する AC2 のため
-- conflict context をプロンプトに渡す際は、`.tmp/base-conflict-context-$NUMBER.md` の有無で分岐する条件付きテンプレート断片として各 Task プロンプト文字列 (static 側 10.0/10.2 の3箇所、Workflow 側 finderPrompts の3箇所、計6箇所) に埋め込んだ
+- `/review` (`--light --non-interactive`) を実行し、Pre-merge AC 4件 (rubric / grep merge-tree / grep SSoT / github_check bats) を全て PASS 判定、Issue #1101 のチェックボックスを更新した
+- `review-light` エージェントが SHOULD 指摘 1件を検出: `skills/review/SKILL.md` の "Workflow path (opt-in)" / "In light mode" 段落が新設の "Base Branch Conflict Pre-check" サブセクションより前に配置されており、`HAS_WORKFLOW_CAPABILITY=true` かつ `REVIEW_DEPTH=full` の場合に Workflow path 段落を「即座に飛ぶべき指示」と読んだ agent が Pre-check を素通りしうるリスクを指摘。妥当な指摘と判断し、Pre-check セクションを `## Step 10` 見出い直後・両段落より前に並べ替える修正を適用しコミット・push 済み (`fa0a54e7`)
+- 上記の並べ替えは Spec Implementation Steps 2 が指定した挿入位置 (「In light mode 段落の直後、### 10.0 見出しの直前」) とは異なる配置になった。AC1 (rubric)/AC2/AC3 (grep) はいずれも文字列の存在のみを検証するため再確認後も PASS を維持しており、Issue 本文の Acceptance Criteria 文言・検証コマンドの更新は不要と判断した (Step 13 Policy Change Detection: AC の意味論を変えない並べ替えのため policy change 扱いとしなかった)
 
 ### Deferred Items
-- Post-merge の手動検証 (「ベースブランチ側と同一行を変更する PR を実際にレビューし、conflict が MUST 指摘として検出されることを確認する」) は本 PR のマージ後に人手で実施する
-- `docs/workflow.md` の更新は Spec Notes で不要と判断済み (フェーズ境界やルーティングを変えない内部品質強化のため)
+- Post-merge の手動検証 (「ベースブランチ側と同一行を変更する PR を実際にレビューし、conflict が MUST 指摘として検出されることを確認する」) は本 PR のマージ後に人手で実施する (未解決、`- [ ]` のまま)
+- `docs/workflow.md` の更新は Spec Notes で不要と判断済み (フェーズ境界やルーティングを変えない内部品質強化のため) — 変更なし
 
 ### Notes for Next Phase
-- AC4 (`github_check "gh pr checks" "Run bats tests"`) は PR 作成前は UNCERTAIN (対象 PR が存在しないため) — PR #1145 作成後の CI 結果で確認すること
-- ローカルで `bats tests/` を実行し 1325 件全て pass を確認済み (behavioral change 検出により full suite 実行)
-- Post-merge 手動検証時は Issue #1102 (`event=REQUEST_CHANGES` の 422 既知問題) と評価軸を分けること (Spec Notes 参照)
+- `/merge 1145` 実行前提: MUST 指摘なし、CI 全ジョブ SUCCESS
+- Spec の `## Implementation Steps` セクション (2番目の項目) は、レビューで確定した最終配置 (Pre-check が両分岐段落より前) と字面上ずれている。将来この Spec を参照する際は、コード側の実配置 (`skills/review/SKILL.md` の実ファイル) を正とすること
+- Post-merge 手動検証時は Issue #1102 (`event=REQUEST_CHANGES` の 422 既知問題) と評価軸を分けること (Spec Notes 参照、変更なし)
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- 実装 (code フェーズ) は Spec Implementation Steps 2 の指定通り、Base Branch Conflict Pre-check を「In light mode 段落の直後・### 10.0 見出しの直前」に挿入しており、Code Retrospective の "Deviations from Design: N/A" は正確だった。
+- レビューで新たな乖離が発生した: `review-light` が「Workflow path (opt-in)」段落を最初に読んだ agent が Pre-check セクションへ到達せずワークフローツールへ即座に分岐しうる (`workflow-guidance.md` は conflict context ファイル不在時に「conflict なし」として黙って処理を続行する) というロバスト性上の懸念を SHOULD として報告した。妥当な指摘と判断しコミット `fa0a54e7` で Pre-check セクションを両分岐段落より前に並べ替えた。この結果、実装の最終配置は Spec Implementation Steps 2 の記述と字面上ずれている (AC1〜AC3 の検証コマンドは文字列存在チェックのみのため実害なし)。Spec 側は更新していない — Spec は HOW のスナップショットであり、この乖離は本 review retrospective と Phase Handoff `Notes for Next Phase` に明記することで足りると判断した。
+
+### Recurring issues
+
+- `review-light` の指摘カテゴリ名 ("Spec Deviation") が実態と一致していなかった: 実装は Spec の指示通りであり、指摘の本質は「新設サブセクションの文書内配置が、既存の分岐記述段落に対して読み手の実行順を誤誘導しうる」というロバスト性/ドキュメント設計の懸念だった。Spec 本文を直接参照せずに "Spec Deviation" と分類したため、レビュー結果を読む側 (このセッション) が一次情報 (Spec Implementation Steps) に立ち返って確認する追加のステップが必要になった。今後同種の指摘を見た場合、まず Spec の該当 Implementation Step 本文を直接 grep/読み合わせてから分類の妥当性を検証するとよい。
+
+### Acceptance criteria verification difficulty
+
+- Nothing to note — rubric / grep / github_check の4条件はいずれも一意に PASS 判定でき、UNCERTAIN は発生しなかった。

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -2,7 +2,7 @@
 name: review
 description: PR review (`/review 88`). Automatically runs acceptance criteria verification, multi-perspective code review, issue resolution, and summary posting. Use after `/code` creates a PR and before `/merge` (`--light`/`--full` to adjust depth).
 context: fork
-allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, Workflow, Skill
+allowed-tools: Bash(gh pr view:*, gh pr diff:*, gh pr comment:*, gh issue view:*, gh issue edit:*, gh issue create:*, gh issue list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-pr-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-external-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-extract-issue-from-pr.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, wc:*, diff:*, git log:*, git diff:*, git show:*, git add:*, git commit:*, git push:*, git fetch:*, git checkout:*, git worktree:*, git branch:*, git merge-tree:*, git merge-base:*, python3:*), Read, Write, Edit, Glob, Grep, Task, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, Workflow, Skill
 ---
 
 # PR Review
@@ -355,6 +355,28 @@ until a follow-up Issue defines an allowlist.
 
 **In light mode**: if `REVIEW_DEPTH=light` and Issue number was extracted (Step 7 ran), run 1-agent lightweight integrated review instead of 2-agent parallel (see 10.0). If Issue number was not extracted and Step 7 was skipped, run full mode (10.1–10.3) regardless of `REVIEW_DEPTH`.
 
+### Base Branch Conflict Pre-check
+
+Run before any of 10.0/10.1–10.3/the Workflow path below — this applies to every review path (light, full, and Workflow) equally. CI runs on the branch alone and stays green even when the branch and the base have edited the same line in conflicting ways; `git merge-tree` is the only step in `/review` that inspects the base branch's own concurrent changes, so it must run first regardless of which review path follows.
+
+1. Update the base ref and compute the merge base:
+   ```bash
+   git fetch origin "$BASE_REF"
+   MERGE_BASE_SHA=$(git merge-base HEAD "origin/$BASE_REF")
+   ```
+2. Run the merge-tree conflict scan. **Use this exact deprecated 3-argument `--trivial-merge` form — do not replace it with the current `--write-tree` 2-argument form.** The 3-argument form emits a `changed in both` header for same-line conflicts; the 2-argument form reports the same case as `CONFLICT (content): Merge conflict in <path>` and never emits the string `changed in both`, which the parsing step below depends on:
+   ```bash
+   git merge-tree "$MERGE_BASE_SHA" HEAD "origin/$BASE_REF"
+   ```
+3. Parse the output block by block. For each `changed in both` block, extract the file path from its `their` line.
+4. For each extracted path, fetch the base side's change:
+   ```bash
+   git diff "$MERGE_BASE_SHA" "origin/$BASE_REF" -- "<path>"
+   ```
+   Flag the path `[SSoT]` if it matches `modules/*.md` or `docs/*.md` — these are documents referenced by multiple Skills, so a base-side change lost during conflict resolution has wider blast radius than an ordinary file.
+5. If one or more paths were found, write path / `[SSoT]` flag / base-side diff for each to `.tmp/base-conflict-context-$NUMBER.md`. If zero paths were found, do not write the file — no additional context is passed to the review agents below.
+6. Add `.tmp/base-conflict-context-$NUMBER.md` to the `rm -f` cleanup list in 14.2.
+
 ### 10.0. Lightweight Integrated Review (REVIEW_DEPTH=light only)
 
 Run only when `REVIEW_DEPTH=light` and Issue number is extractable.
@@ -376,11 +398,13 @@ If `SKIP_REVIEW_BUG=true`, specify in the prompt to run only review-light's spec
 
 4. **Launch 1 `review-light` agent**:
 
+   If `.tmp/base-conflict-context-$NUMBER.md` exists (written by the Base Branch Conflict Pre-check above), append its content to the prompt below, followed by: "For the files listed above, if the PR's current resolution loses either side's change, report it as MUST. Files flagged `[SSoT]` are referenced by multiple Skills — check them with priority."
+
    ```text
    Task(
      subagent_type="review-light",
      description="Lightweight integrated review (all 4 aspects)",
-     prompt="Run review: PR=$NUMBER, Issue=$ISSUE_NUMBER, Type=$TYPE, Spec=$DESIGN_FILE_PATH, Steering Documents=$STEERING_DOCS_FILES, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json"
+     prompt="Run review: PR=$NUMBER, Issue=$ISSUE_NUMBER, Type=$TYPE, Spec=$DESIGN_FILE_PATH, Steering Documents=$STEERING_DOCS_FILES, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json[, base branch conflict context: <contents of .tmp/base-conflict-context-$NUMBER.md, if present>]"
    )
    ```
 
@@ -430,23 +454,25 @@ Split into 2 groups and run in parallel using Task tool (`REVIEW_DEPTH=full` or 
 
    Launch these subagents in a single message to ensure parallel fan-out (single-message fan-out prevents serialization regardless of model generation):
 
+   If `.tmp/base-conflict-context-$NUMBER.md` exists (written by the Base Branch Conflict Pre-check above), append its content to each of the 3 prompts below, followed by: "For the files listed above, if the PR's current resolution loses either side's change, report it as MUST. Files flagged `[SSoT]` are referenced by multiple Skills — check them with priority."
+
    ```text
    Task(
      subagent_type="wholework:review-spec",
      description="Spec review",
-     prompt="Run review: PR=$NUMBER, Issue=$ISSUE_NUMBER, Type=$TYPE, Spec=$DESIGN_FILE_PATH, Steering Documents=$STEERING_DOCS_FILES, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json"
+     prompt="Run review: PR=$NUMBER, Issue=$ISSUE_NUMBER, Type=$TYPE, Spec=$DESIGN_FILE_PATH, Steering Documents=$STEERING_DOCS_FILES, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json[, base branch conflict context: <contents of .tmp/base-conflict-context-$NUMBER.md, if present>]"
    )
 
    Task(
      subagent_type="wholework:review-bug",
      description="Bug review (diff bug scan)",
-     prompt="Run review: PR=$NUMBER, Type=$TYPE, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json. Focus on + lines in the diff; detect clear bugs and logic errors using HIGH SIGNAL principles."
+     prompt="Run review: PR=$NUMBER, Type=$TYPE, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json. Focus on + lines in the diff; detect clear bugs and logic errors using HIGH SIGNAL principles.[ base branch conflict context: <contents of .tmp/base-conflict-context-$NUMBER.md, if present>]"
    )
 
    Task(
      subagent_type="wholework:review-bug",
      description="Bug review (security scan)",
-     prompt="Run review: PR=$NUMBER, Type=$TYPE, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json. Detect security issues and invalid logic in changed code using HIGH SIGNAL principles."
+     prompt="Run review: PR=$NUMBER, Type=$TYPE, PR diff=.tmp/pr-diff-$NUMBER.txt, changed files=.tmp/pr-files-$NUMBER.json. Detect security issues and invalid logic in changed code using HIGH SIGNAL principles.[ base branch conflict context: <contents of .tmp/base-conflict-context-$NUMBER.md, if present>]"
    )
    ```
 
@@ -791,7 +817,7 @@ The `<!-- review-summary -->` marker line must be included verbatim even when th
 ```bash
 mkdir -p .tmp
 gh pr comment "$NUMBER" --body-file .tmp/review-summary-$NUMBER.md
-rm -f .tmp/review-summary-$NUMBER.md .tmp/pr-diff-$NUMBER.txt .tmp/pr-files-$NUMBER.json .tmp/issue-body-$ISSUE_NUMBER.md
+rm -f .tmp/review-summary-$NUMBER.md .tmp/pr-diff-$NUMBER.txt .tmp/pr-files-$NUMBER.json .tmp/issue-body-$ISSUE_NUMBER.md .tmp/base-conflict-context-$NUMBER.md
 ```
 
 **On failure**: output summary to terminal (fallback).

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -351,13 +351,9 @@ until a follow-up Issue defines an allowlist.
 
 ## Step 10: Multi-perspective Code Review (parallel execution)
 
-**Workflow path (opt-in)**: When `HAS_WORKFLOW_CAPABILITY=true` and `REVIEW_DEPTH=full`, first run the "Pre-flight: agentType Availability Check" in `skills/review/workflow-guidance.md` (loaded in Step 3), then follow that file's Processing Steps to run a finder → adversarial verify pipeline using the Workflow tool. When `HAS_WORKFLOW_CAPABILITY=false` or unset (the default), run the static Task fan-out below (Steps 10.0–10.3) unchanged.
-
-**In light mode**: if `REVIEW_DEPTH=light` and Issue number was extracted (Step 7 ran), run 1-agent lightweight integrated review instead of 2-agent parallel (see 10.0). If Issue number was not extracted and Step 7 was skipped, run full mode (10.1–10.3) regardless of `REVIEW_DEPTH`.
-
 ### Base Branch Conflict Pre-check
 
-Run before any of 10.0/10.1–10.3/the Workflow path below — this applies to every review path (light, full, and Workflow) equally. CI runs on the branch alone and stays green even when the branch and the base have edited the same line in conflicting ways; `git merge-tree` is the only step in `/review` that inspects the base branch's own concurrent changes, so it must run first regardless of which review path follows.
+Run this section first, before evaluating either branch-decision paragraph below (Workflow path / light mode) — this applies to every review path (light, full, and Workflow) equally. CI runs on the branch alone and stays green even when the branch and the base have edited the same line in conflicting ways; `git merge-tree` is the only step in `/review` that inspects the base branch's own concurrent changes, so it must run first regardless of which review path follows.
 
 1. Update the base ref and compute the merge base:
    ```bash
@@ -376,6 +372,10 @@ Run before any of 10.0/10.1–10.3/the Workflow path below — this applies to e
    Flag the path `[SSoT]` if it matches `modules/*.md` or `docs/*.md` — these are documents referenced by multiple Skills, so a base-side change lost during conflict resolution has wider blast radius than an ordinary file.
 5. If one or more paths were found, write path / `[SSoT]` flag / base-side diff for each to `.tmp/base-conflict-context-$NUMBER.md`. If zero paths were found, do not write the file — no additional context is passed to the review agents below.
 6. Add `.tmp/base-conflict-context-$NUMBER.md` to the `rm -f` cleanup list in 14.2.
+
+**Workflow path (opt-in)**: After the Base Branch Conflict Pre-check above, when `HAS_WORKFLOW_CAPABILITY=true` and `REVIEW_DEPTH=full`, first run the "Pre-flight: agentType Availability Check" in `skills/review/workflow-guidance.md` (loaded in Step 3), then follow that file's Processing Steps to run a finder → adversarial verify pipeline using the Workflow tool. When `HAS_WORKFLOW_CAPABILITY=false` or unset (the default), run the static Task fan-out below (Steps 10.0–10.3) unchanged.
+
+**In light mode**: after the Base Branch Conflict Pre-check above, if `REVIEW_DEPTH=light` and Issue number was extracted (Step 7 ran), run 1-agent lightweight integrated review instead of 2-agent parallel (see 10.0). If Issue number was not extracted and Step 7 was skipped, run full mode (10.1–10.3) regardless of `REVIEW_DEPTH`.
 
 ### 10.0. Lightweight Integrated Review (REVIEW_DEPTH=light only)
 

--- a/skills/review/workflow-guidance.md
+++ b/skills/review/workflow-guidance.md
@@ -59,7 +59,7 @@ When `HAS_WORKFLOW_CAPABILITY=true` and `REVIEW_DEPTH=full`, replace Steps 10.1�
    - Glob for `$STEERING_DOCS_PATH/product.md`, `$STEERING_DOCS_PATH/tech.md`, `$STEERING_DOCS_PATH/structure.md`
    - Record comma-separated as `STEERING_DOCS_FILES`
 
-4. **Run Workflow pipeline** using the inline script below. Call the Workflow tool with `args: { number: NUMBER, issueNumber: ISSUE_NUMBER, type: TYPE, specPath: DESIGN_FILE_PATH, steeringDocs: STEERING_DOCS_FILES, skipReviewBug: SKIP_REVIEW_BUG === 'true' }` — these are accessed inside the script as `args.*`.
+4. **Run Workflow pipeline** using the inline script below. Call the Workflow tool with `args: { number: NUMBER, issueNumber: ISSUE_NUMBER, type: TYPE, specPath: DESIGN_FILE_PATH, steeringDocs: STEERING_DOCS_FILES, skipReviewBug: SKIP_REVIEW_BUG === 'true', conflictContext: <contents of .tmp/base-conflict-context-$NUMBER.md, or '' if the file does not exist> }` — these are accessed inside the script as `args.*`. `conflictContext` carries the same Base Branch Conflict Pre-check output consumed by the static path's 10.2 step 3.
 
 5. **Integrate results** the same way as Step 10.2 step 4: extract `path`, `line`, `body`, `severity` from confirmed findings; write `review-comments-$NUMBER.json` and `review-body-$NUMBER.md`.
 
@@ -119,10 +119,14 @@ const FINDERS = SKIP_BUG
 
 if (!args) throw new Error('Workflow args required: number, issueNumber, type, specPath, steeringDocs, skipReviewBug')
 
+const CONFLICT_SUFFIX = args.conflictContext
+  ? `\n\nBase branch conflict context:\n${args.conflictContext}\n\nFor the files listed above, if the PR's current resolution loses either side's change, report it as MUST. Files flagged [SSoT] are referenced by multiple Skills — check them with priority.`
+  : ''
+
 const finderPrompts = {
-  'find:spec': `Run review: PR=${args.number}, Issue=${args.issueNumber}, Type=${args.type}, Spec=${args.specPath}, Steering Documents=${args.steeringDocs}, PR diff=.tmp/pr-diff-${args.number}.txt, changed files=.tmp/pr-files-${args.number}.json`,
-  'find:bug-diff': `Run review: PR=${args.number}, Type=${args.type}, PR diff=.tmp/pr-diff-${args.number}.txt, changed files=.tmp/pr-files-${args.number}.json. Focus on + lines in the diff; detect clear bugs and logic errors using HIGH SIGNAL principles.`,
-  'find:bug-security': `Run review: PR=${args.number}, Type=${args.type}, PR diff=.tmp/pr-diff-${args.number}.txt, changed files=.tmp/pr-files-${args.number}.json. Detect security issues and invalid logic in changed code using HIGH SIGNAL principles.`,
+  'find:spec': `Run review: PR=${args.number}, Issue=${args.issueNumber}, Type=${args.type}, Spec=${args.specPath}, Steering Documents=${args.steeringDocs}, PR diff=.tmp/pr-diff-${args.number}.txt, changed files=.tmp/pr-files-${args.number}.json${CONFLICT_SUFFIX}`,
+  'find:bug-diff': `Run review: PR=${args.number}, Type=${args.type}, PR diff=.tmp/pr-diff-${args.number}.txt, changed files=.tmp/pr-files-${args.number}.json. Focus on + lines in the diff; detect clear bugs and logic errors using HIGH SIGNAL principles.${CONFLICT_SUFFIX}`,
+  'find:bug-security': `Run review: PR=${args.number}, Type=${args.type}, PR diff=.tmp/pr-diff-${args.number}.txt, changed files=.tmp/pr-files-${args.number}.json. Detect security issues and invalid logic in changed code using HIGH SIGNAL principles.${CONFLICT_SUFFIX}`,
 }
 
 const finderResults = await pipeline(


### PR DESCRIPTION
## Summary
- `/review` の Step 10 (Multi-perspective Code Review) 実行前に、ベースブランチとの conflict 事前検査ステップを追加した
- `git merge-tree "$MERGE_BASE_SHA" HEAD "origin/$BASE_REF"` (意図的に非推奨の 3 引数 `--trivial-merge` 形式を使用) で `changed in both` を検出し、該当ファイルのベース側 diff を `.tmp/base-conflict-context-$NUMBER.md` に書き出す。`modules/*.md` / `docs/*.md` は `[SSoT]` フラグを付与し優先的な扱いとする
- static Task fan-out (10.0 review-light / 10.2 review-spec・review-bug×2) と Workflow パス (`skills/review/workflow-guidance.md` の finder プロンプト) の両方に conflict context + MUST/SSoT 指示を伝搬させ、どちらの実行経路でも一貫して検知できるようにした
- `skills/review/SKILL.md` frontmatter `allowed-tools` に `git merge-tree:*`, `git merge-base:*` を追加

## Verification (pre-merge)
- `skills/review/SKILL.md` に conflict 事前検査ステップ (git merge-tree による changed in both 検出、両方の変更が保持されるかの確認、SSoT 文書の重点的な扱い) が追加されている
- `skills/review/SKILL.md` が `merge-tree` に言及している
- `skills/review/SKILL.md` が SSoT 文書の重点的な扱いに言及している
- bats テストスイート (1325 tests) が全て pass する (ローカル実行済み、CI でも確認)

## Verification (post-merge)
- ベースブランチ側と同一行を変更する PR を実際にレビューし、conflict が MUST 指摘として検出されることを確認する (manual)

closes #1101
