### PR TITLE
Issue #1170: observation-trigger --dry-run を検索実行+副作用抑止のセマンティクスに修正

### DIFF
--- a/docs/spec/issue-1170-observation-dry-run-fix.md
+++ b/docs/spec/issue-1170-observation-dry-run-fix.md
@@ -64,16 +64,29 @@
 ### Rework
 - N/A — 各 Implementation Step は一度の Edit で完了し、手戻りは発生しなかった
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- N/A — 実装 (PR #1176 diff) は Spec の Implementation Steps 1〜5 と 1:1 で対応しており、構造的な逸脱は検出されなかった (review-light エージェントの Perspective 1 確認結果)
+
+### Recurring issues
+- N/A — review-light の4観点 (Spec乖離・エッジケース/堅牢性・セキュリティ/安全性・ドキュメント整合性) いずれも指摘なし。同種issueの再発パターンは見られなかった
+
+### Acceptance criteria verification difficulty
+- 6件の Pre-merge AC (rubric×4、command×1、github_check×1) は全て safe mode で自動判定可能だった。`command "bats tests/opportunistic-search.bats"` は safe mode では直接実行できないが、CI job `Run bats tests` への CI reference fallback で代替確認できた — verify command 設計として機能した
+- Spec Notes に記載の通り、本 Issue の Pre-merge 検証項目数 (6件) は light テンプレートの目安 (5件) をわずかに超えていたが、UNCERTAIN や verify command の不備は発生せず、実務上の支障はなかった
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `opportunistic-search.sh` の `--dry-run` フラグのパース自体 (`DRY_RUN=true` 代入) は CLI 後方互換のため残し、参照されない no-op フラグとした (Spec Implementation Step 1 の指示どおり)
-- Pre-merge AC のうち `github_check "gh pr checks" "Run bats tests"` は PR 作成前のため verify-executor 実行時点では UNCERTAIN — Issue チェックボックスは AC1〜5 のみ `[x]` 化し、AC6 は未チェックのまま残した (CI 完了後に `/review` または `/verify` で確認される想定)
+- Step 8 静的検証で Pre-merge AC 6件すべてを PASS 判定 (AC1〜5 は code フェーズで既に `[x]` 化済み、AC6 `github_check "gh pr checks" "Run bats tests"` は CI 完了後の本レビューで `[x]` 化)
+- Step 10.0 軽量統合レビュー (review-light エージェント) で4観点とも指摘なし。MUST/SHOULD/CONSIDER いずれもゼロ件のため Step 12 (issue resolution) は実施せず
+- Base branch conflict pre-check (`git merge-tree`) で `changed in both` ブロックなしを確認、base 側との衝突コンテキストは記録不要と判断
 
 ### Deferred Items
-- Post-merge AC (`observation-trigger.sh --event auto-run --dry-run` の実環境確認、`verify-type: manual`) は未実施 — `/verify` フェーズでの手動確認に委ねる
+- Post-merge AC (`observation-trigger.sh --event auto-run --dry-run` の実環境確認、`verify-type: manual`) は未実施 — `/verify` フェーズでの手動確認に委ねる (code フェーズからの引き継ぎを継続)
 
 ### Notes for Next Phase
-- CI (`Run bats tests` job) の結果を `/review` で確認すること。ローカルでは `bats tests/` フルスイート (1394件) 実行済みで全件 PASS 済み
-- PR #1176 の pre-merge 検証セクションに rubric 判定結果 (AC1〜4 PASS) を記載済み。CI PASS 後に AC6 のチェックボックスを更新すること
+- MUST issue なしのため `/merge 1176` にそのまま進行可能
+- Post-merge AC は手動確認 (`verify-type: manual`) のため、`/verify` 実行時に人手での実環境確認が必要

--- a/docs/spec/issue-1170-observation-dry-run-fix.md
+++ b/docs/spec/issue-1170-observation-dry-run-fix.md
@@ -48,3 +48,32 @@
 ## Consumed Comments
 
 前回フェーズ (triage → spec) 以降の新規コメントなし。Issue #1170 には現時点でコメントが1件も存在しない (cutoff: 直近の `phase/*` ラベル付与時刻 2026-08-05T03:03:25Z、および全件走査でも 0 件を確認)。
+
+### code フェーズ
+
+前回フェーズ (spec → code) 以降の新規コメントなし (cutoff: 直近の `phase/*` ラベル付与時刻 2026-08-05T05:33:30Z)。cross-phase marker (`type=verify-fail` / `type=preview-ac-unverified`) の全件走査でも該当なし。
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜5 を Spec 記載順どおりに実装した。逸脱なし
+
+### Design Gaps/Ambiguities
+- N/A — Notes セクションで既に判断済みの論点 (別フラグ切り出し不要、冪等性マーカーチェックは dry-run でも維持) 以外に、実装中に新たな曖昧点は生じなかった
+
+### Rework
+- N/A — 各 Implementation Step は一度の Edit で完了し、手戻りは発生しなかった
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `opportunistic-search.sh` の `--dry-run` フラグのパース自体 (`DRY_RUN=true` 代入) は CLI 後方互換のため残し、参照されない no-op フラグとした (Spec Implementation Step 1 の指示どおり)
+- Pre-merge AC のうち `github_check "gh pr checks" "Run bats tests"` は PR 作成前のため verify-executor 実行時点では UNCERTAIN — Issue チェックボックスは AC1〜5 のみ `[x]` 化し、AC6 は未チェックのまま残した (CI 完了後に `/review` または `/verify` で確認される想定)
+
+### Deferred Items
+- Post-merge AC (`observation-trigger.sh --event auto-run --dry-run` の実環境確認、`verify-type: manual`) は未実施 — `/verify` フェーズでの手動確認に委ねる
+
+### Notes for Next Phase
+- CI (`Run bats tests` job) の結果を `/review` で確認すること。ローカルでは `bats tests/` フルスイート (1394件) 実行済みで全件 PASS 済み
+- PR #1176 の pre-merge 検証セクションに rubric 判定結果 (AC1〜4 PASS) を記載済み。CI PASS 後に AC6 のチェックボックスを更新すること

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -27,7 +27,7 @@ Each emitter calls the following command when its event fires:
 | Argument | Description |
 |----------|-------------|
 | `--event <event-name>` | Required. The event name from the table in `modules/verify-classifier.md § observation Type` |
-| `--dry-run` | Optional. Skip API calls; return empty array (for testing) |
+| `--dry-run` | Optional. Search runs normally and API calls are not skipped (`opportunistic-search.sh` is originally read-only and has no side effect to suppress here). Accepted as an argument for CLI backward compatibility, but it is a no-op flag with no effect on behavior |
 | `--context-file <path>` | Optional. Gates matches carrying a `keyword=` AC attribute against this file's content. See § Condition Check Gate below |
 
 **Output (stdout):** JSON array

--- a/scripts/observation-trigger.sh
+++ b/scripts/observation-trigger.sh
@@ -63,10 +63,6 @@ if [ -z "$EVENT_NAME" ]; then
     exit 1
 fi
 
-if [ "$DRY_RUN" = true ]; then
-    exit 0
-fi
-
 if [ -n "$CONTEXT_FILE" ]; then
     RESULTS=$("${SCRIPT_DIR}/opportunistic-search.sh" --event "$EVENT_NAME" --context-file "$CONTEXT_FILE" 2>/dev/null || true)
 else
@@ -97,7 +93,7 @@ for N in $NUMBERS; do
             fi
         fi
     fi
-    if [ "$SKIP" = false ]; then
+    if [ "$SKIP" = false ] && [ "$DRY_RUN" = false ]; then
         BODY=$(printf '<!-- wholework-event: type=observation-trigger phase=observation-trigger issue=%s event=%s -->\nobservation event `%s` detected. Run `/verify %s` to verify the condition and update the checkbox.' "$N" "$EVENT_NAME" "$EVENT_NAME" "$N")
         gh issue comment "$N" --body "$BODY" >/dev/null 2>/dev/null || true
     fi

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -113,12 +113,6 @@ if [ -n "$CONTEXT_FILE" ] && [ ! -f "$CONTEXT_FILE" ]; then
     CONTEXT_FILE=""
 fi
 
-# dry-run mode: skip actual API calls and exit successfully
-if [ "$DRY_RUN" = true ]; then
-    echo "[]"
-    exit 0
-fi
-
 # 1. Fetch closed Issues with phase/verify label
 ISSUES_JSON=$(gh issue list --label "phase/verify" --state closed --json number --limit 50)
 ISSUE_NUMBERS=$(echo "$ISSUES_JSON" | jq -r '.[].number')

--- a/tests/observation-trigger.bats
+++ b/tests/observation-trigger.bats
@@ -60,11 +60,22 @@ teardown() {
     [[ "$output" == *"Unknown argument"* ]]
 }
 
-@test "dry-run: exits 0 without calling opportunistic-search.sh" {
+@test "dry-run: runs search and outputs matched issue numbers" {
+    export MOCK_SEARCH_OUTPUT='[{"number": 42, "condition": "watchdog-kill event is observed"}]'
     run bash "$SCRIPT" --event pr-review-full --dry-run
     [ "$status" -eq 0 ]
-    [ -z "$output" ]
-    [ ! -f "$BATS_TEST_TMPDIR/gh-calls.log" ]
+    grep -q "opportunistic-search.sh called" "$BATS_TEST_TMPDIR/search-calls.log"
+    [ "$output" = "42" ]
+}
+
+@test "dry-run: negative case - does not post an issue comment" {
+    export MOCK_SEARCH_OUTPUT='[{"number": 42, "condition": "watchdog-kill event is observed"}]'
+    run bash "$SCRIPT" --event pr-review-full --dry-run
+    [ "$status" -eq 0 ]
+    if [ -f "$BATS_TEST_TMPDIR/gh-calls.log" ]; then
+        ! grep -q "issue comment" "$BATS_TEST_TMPDIR/gh-calls.log"
+    fi
+    [ "$output" = "42" ]
 }
 
 @test "success: no matches exits silently without posting comments" {

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -55,16 +55,31 @@ teardown() {
     [[ "$output" == *"Error"* ]]
 }
 
-@test "dry-run: outputs empty array and exits 0" {
+@test "dry-run: returns the same non-empty result as without --dry-run" {
+    export MOCK_ISSUE_LIST='[{"number": 700}]'
+    export MOCK_ISSUE_BODY_700='- [ ] /issue skill creates Issue after execution <!-- verify-type: opportunistic -->'
+
+    run bash "$SCRIPT" /issue
+    [ "$status" -eq 0 ]
+    without_dry_run="$output"
+
     run bash "$SCRIPT" /issue --dry-run
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    with_dry_run="$output"
+
+    [ "$with_dry_run" = "$without_dry_run" ]
+    echo "$with_dry_run" | jq -e 'length == 1' > /dev/null
+    echo "$with_dry_run" | jq -e '.[0].number == 700' > /dev/null
 }
 
 @test "dry-run: works with --dry-run before skill name" {
+    export MOCK_ISSUE_LIST='[{"number": 701}]'
+    export MOCK_ISSUE_BODY_701='- [ ] /spec skill creates file after execution <!-- verify-type: opportunistic -->'
+
     run bash "$SCRIPT" --dry-run /spec
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 701' > /dev/null
 }
 
 @test "success: no issues found returns empty array" {
@@ -157,10 +172,21 @@ teardown() {
     [ "$output" = "[]" ]
 }
 
-@test "event filter: --event with dry-run returns empty array" {
+@test "event filter: --event with dry-run returns the same non-empty result as without --dry-run" {
+    export MOCK_ISSUE_LIST='[{"number": 702}]'
+    export MOCK_ISSUE_BODY_702='- [ ] Next /review --full auto-checks this condition <!-- verify-type: observation event=pr-review-full -->'
+
+    run bash "$SCRIPT" --event pr-review-full
+    [ "$status" -eq 0 ]
+    without_dry_run="$output"
+
     run bash "$SCRIPT" --event pr-review-full --dry-run
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    with_dry_run="$output"
+
+    [ "$with_dry_run" = "$without_dry_run" ]
+    echo "$with_dry_run" | jq -e 'length == 1' > /dev/null
+    echo "$with_dry_run" | jq -e '.[0].number == 702' > /dev/null
 }
 
 @test "context gate: keyword found in context file includes the issue" {


### PR DESCRIPTION
## Summary
`opportunistic-search.sh` と `observation-trigger.sh` の `--dry-run` を「検索は実行し、副作用のみを抑止する」セマンティクスに修正した。

- `scripts/opportunistic-search.sh`: `--dry-run` 指定時に検索そのものをスキップして無条件に `[]` を返す短絡ブロックを削除。同スクリプトは元々 read-only (`gh issue list` / `gh issue view` のみ) のため、抑止すべき副作用が存在せず、`--dry-run` は無指定時と同じ経路で実際のマッチ結果を返すようになる (CLI 後方互換のためフラグのパース自体は残す)
- `scripts/observation-trigger.sh`: 検索呼び出し前の early-exit ブロックを削除し、`opportunistic-search.sh` 呼び出しに `--dry-run` 時も到達させる。コメント投稿条件を `[ "$SKIP" = false ] && [ "$DRY_RUN" = false ]` に変更し、コメント投稿という副作用のみを抑止する。冪等性マーカーチェック (read-only) は dry-run 有無に関わらず維持
- `modules/observation-trigger.md`: `--dry-run` の説明を新セマンティクスに更新
- `tests/opportunistic-search.bats` / `tests/observation-trigger.bats`: 旧セマンティクス (`--dry-run` は常に空配列/コメント投稿なしで即終了) を前提としたテストを、非空マッチデータで実データが返ることを検証する内容に書き換え。コメント投稿抑止を検証する negative case テストを新規追加

## Verification (pre-merge)
- `opportunistic-search.sh --dry-run` が検索結果を返すことを rubric 判定で確認 (PASS)
- `observation-trigger.sh --dry-run` がコメント投稿なしでマッチ集合を返すことを rubric 判定で確認 (PASS)
- `--dry-run` の新セマンティクスがテストで担保されていることを rubric 判定で確認 (PASS)
- 副作用が発生しないことを検証する negative case の存在を rubric 判定で確認 (PASS)
- `bats tests/opportunistic-search.bats` が PASS (26/26)
- `bats tests/` フルスイートが PASS (1394/1394)
- `github_check "gh pr checks" "Run bats tests"` は CI 実行後に確認 (PR 作成時点では未実行)

## Verification (post-merge)
- `scripts/observation-trigger.sh --event auto-run --dry-run` を実行し、マッチした Issue 番号が出力され、かつ対象 Issue に新規コメントが投稿されていないことを確認する (manual)

closes #1170
