### PR TITLE
Issue #1171: collect-run-facts に operate route / recovery tier / mode を追加

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -194,7 +194,7 @@ wholework/
 - `scripts/observation-trigger.sh` — イベント発火時に observation AC をディスパッチ: `opportunistic-search.sh --event` を呼び出し、マッチした各 Issue に `/verify` 再実行を促すコメントを投稿し、マッチした Issue 番号一覧を呼び出し元向けに stdout へ出力
 - `scripts/opportunistic-search.sh` — opportunistic スキル検索と observation イベントスキャン
 - `scripts/post_merge_check.sh` — 複数 Issue の post-merge 手動 AC（verify-type: manual）を 1 セッションでバンドル実行; AC ごとに P/F/S を対話入力; 全 PASS で phase/done 遷移、FAIL で reopen
-- `scripts/collect-run-facts.sh` — 完走した `/auto` 実行の事実 (route・Size・各 phase の結果・PR 状態・anomaly 件数・fact token) を `.tmp/auto-events.jsonl` から JSON に構造化する。run-fact AC 照合 (`modules/run-fact-matching.md`) の入力
+- `scripts/collect-run-facts.sh` — 完走した `/auto` 実行の事実 (diff-less な operate 値を含む route・実行 mode・Size・各 phase の結果・PR 状態・anomaly 件数・recovery tier・fact token) を `.tmp/auto-events.jsonl` から JSON に構造化する。run-fact AC 照合 (`modules/run-fact-matching.md`) の入力
 - `scripts/scan-pending-ac.sh` — `phase/verify` の closed Issue から未チェックの post-merge AC を列挙し、`collect-run-facts.sh` の fact token で事前絞り込みする
 - `scripts/apply-run-fact-match.sh` — run-fact AC 照合の verdict (satisfied/not_satisfied/ambiguous) に対する決定的な autonomy tier ゲート: チェックボックスの自動チェック、`Recommend:` 候補提示、または無処理のいずれかを実行
 - `scripts/triage-backlog-filter.sh` — triage 向けバックログフィルタ

--- a/docs/spec/issue-1171-run-facts-three-axes.md
+++ b/docs/spec/issue-1171-run-facts-three-axes.md
@@ -184,23 +184,36 @@ No new comments since last phase.
 - `scripts/validate-skill-syntax.py` と `scripts/check-forbidden-expressions.sh` はいずれも新規エラーなし (`skills/auto/SKILL.md` の既存 warning `unknown field: 'loop-paths-fallback'` は本 Issue の変更と無関係の既存項目)
 - `scripts/check-translation-sync.sh` で `docs/structure.md` / `docs/ja/structure.md` が IN_SYNC であることを確認した (他ファイルの MISSING_JA/OUTDATED は本 Issue のスコープ外の既存項目)
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Spec 自体と実装の間に構造的な divergence はなかった (Code Retrospective で確認済み)。ただし SSoT ドキュメント (`modules/run-fact-matching.md`) の記述と実装の意味論が食い違う事例が複数見つかった: `mode` フィールドの定義文が「処理した Issue 数」ベースで書かれていたが、実際の実装 (および同 PR が `skills/auto/SKILL.md` に追記した規則) は「`--batch` フラグが渡されたか」ベースだった。XL sub-issue fan-out が複数 Issue を処理しながら `mode: single` を返すという non-obvious な仕様のため、定義文を書く際に「処理した Issue 数」という直感的だが誤った表現を選びやすい。次回同種のフィールド追加時は、定義文を書いた直後に「この定義文だけを読んだ第三者が実装のエッジケースを正しく予測できるか」を自問する一手間が有効と考えられる。
+
+### Recurring issues
+
+- 今回の MUST/CONSIDER 指摘 5 件中 3 件 (`mode` 定義、route の `--no-github` caveat 文言、`phase-state.md` の第2消費側未反映) が「SSoT ドキュメントの記述が実装や同一 PR 内の別ファイルの変更に追従できていない」という同じ形の問題だった。1 PR 内で SSoT を更新しつつ実装も変更する場合、SSoT 側の記述は実装の「最終形」を見てから書く (実装より先にドキュメントを確定させない) ワークフローが有効かもしれない。
+- `scripts/gh-pr-review.sh` の self-review `REQUEST_CHANGES` 422 (単一アカウント自己ホスト運用の既知の構造的制約、`modules/phase-state.md:77` に記録済み、Issue #1102 で追跡中) が本レビューでも再現した。今回は `event=COMMENT` への手動フォールバック + line comments の個別 `gh api` 投稿で対応した。#1102 の解決 (script 側の自動フォールバック実装) が着地すれば、この種の手動対応は不要になる。
+
+### Acceptance criteria verification difficulty
+
+- Nothing to note — Pre-merge AC 7 件すべてが rubric / command / github_check で明確に PASS 判定でき、UNCERTAIN は 0 件だった。verify command の欠落や不正確さもなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- Spec の Implementation Steps 1-8 を設計どおりの順序で実装。逸脱・設計判断の再検討は発生しなかった (`## Code Retrospective` 参照)
-- Pre-merge AC のうち rubric 系 5 件と `bats tests/run-fact-matching.bats` の command 系 1 件はこの phase 内でチェック済み。`github_check "gh pr checks" "Run bats tests"` は CI 実行後でないと確認できないため未チェックのまま残した
-- `skills/auto/SKILL.md` の変更が既存の behavioral change 検出条件 (直接対応テスト以外からの参照) に該当したため、`bats tests/run-fact-matching.bats` の単体実行に加えてフルスイート `bats tests/` (1402件) を実行して回帰がないことを確認した
+- MUST 1件 (mode 定義の齟齬) + CONSIDER 4件を Step 12 で修正・commit・push 済み。CI 全件 SUCCESS (最終コミット `dc026f4e` 時点)
+- `skills/audit/SKILL.md` の CONSIDER 指摘 (pre-existing gap) は本 PR の diff に含まれないファイルのためスコープ外と判断し、修正せず PR コメントで記録するに留めた
+- self-review 422 制約により `event=REQUEST_CHANGES` を `event=COMMENT` に手動フォールバックし、line comments は個別 `gh api pulls/comments` で投稿した (review retrospective 参照)
 
 ### Deferred Items
 
-- `--no-github` 実行時は operate 判別をスキップし `route` は `patch` に留まる (spec Uncertainty 記載どおり、設計上の既知の制約であり本 Issue では対応しない)
-- イベント由来フォールバックによる XL fan-out の `batch` 誤判定は修正しない (spec Uncertainty 記載どおり)
-- Post-merge AC (operate route での `/auto` 完走確認) は `/verify` で検証する
+- Post-merge AC (operate route での `/auto` 完走確認) は引き続き `/verify` で検証する (spec Uncertainty / Phase Handoff 記載どおり、変更なし)
+- `--no-github` 実行時の operate 判別スキップ、イベント由来フォールバックの XL fan-out 誤判定は、いずれも spec Uncertainty 記載どおり本 Issue のスコープ外のまま
 
 ### Notes for Next Phase
 
-- `github_check "gh pr checks" "Run bats tests"` の Pre-merge AC は CI 結果待ちのため未チェック。`/review` で CI green を確認したうえでチェックすること
-- Post-merge AC は operate route の `/auto` を実際に完走させ、`route: operate` と `fact_tokens` の `operate route` トークンが出力されることを確認する必要がある (hermetic テストでは `--no-github` のため代替不可)
-- `docs/guide/index.md` (OUTDATED) と `docs/guide/autonomy.md` (MISSING_JA) の翻訳ギャップは `scripts/check-translation-sync.sh` で検出済みだが、本 Issue のスコープ外の既存項目 (本 Issue が変更した `docs/structure.md` とは無関係)
+- `/merge 1177` を実行してよい。CI green、Pre-merge AC 全件チェック済み、MUST issue 修正済み
+- Post-merge AC は operate route の `/auto` を実際に完走させて `route: operate` / `fact_tokens` の `operate route` トークン / top-level `mode` の一致を確認する必要がある (`/verify` 側で実施)

--- a/docs/spec/issue-1171-run-facts-three-axes.md
+++ b/docs/spec/issue-1171-run-facts-three-axes.md
@@ -164,26 +164,43 @@ No new comments since last phase.
 - **設計時の不確実性「mode を決定的に取れるか」**: `emit_event` の全 kv を洗い出した結果、batch/single を区別する既存イベントは存在しないことを確認した。`auto-checkpoint.sh write_batch` は List mode 専用で Count mode が通らないため bash 側の決定的フックにならない、という点まで確認したうえで session metadata 宣言方式を採った
 - **未解決のまま残した点**: イベント由来フォールバックが XL sub-issue fan-out を `batch` と誤判定する。`sub_start` は batch 経路と XL 経路の双方で `run-auto-sub.sh` から emit されるため、イベントだけでは区別する信号がない。宣言が第一優先なので新規 session では発生せず、宣言の無い過去 session に限る既知の劣化として Uncertainty 節に記録した
 
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — 実装は Spec の Implementation Steps 1-8 をそのままの順序・内容で実装した
+
+### Design Gaps/Ambiguities
+
+- N/A — Spec の設計判断 (marker コメント方式、加算的フィールド追加、2段ラダー) はいずれも実装時に迷いなく適用できた
+
+### Rework
+
+- N/A
+
+### Verification notes
+
+- 実装後 `bats tests/run-fact-matching.bats` を単体実行して 26/26 PASS を確認し、続けて `skills/auto/SKILL.md` の変更が behavioral change 検出 (テスト参照チェック) に該当したためフルスイート `bats tests/` を実行し 1402/1402 PASS を確認した
+- `scripts/validate-skill-syntax.py` と `scripts/check-forbidden-expressions.sh` はいずれも新規エラーなし (`skills/auto/SKILL.md` の既存 warning `unknown field: 'loop-paths-fallback'` は本 Issue の変更と無関係の既存項目)
+- `scripts/check-translation-sync.sh` で `docs/structure.md` / `docs/ja/structure.md` が IN_SYNC であることを確認した (他ファイルの MISSING_JA/OUTDATED は本 Issue のスコープ外の既存項目)
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- operate route の判別は marker コメント (`type=execution-log` / `type=execution-plan`) 参照方式。`reconcile-phase-state.sh` の `_operate_signal_ts()` と同一クエリを使い、freshness gate だけ session スコープ (この run の最初のイベント時刻) に読み替える
-- `route` は 4 値目 `operate` を追加する加算的変更。`recovery_tiers` も `anomalies.recovery` の件数を残したまま並置する。受け入れ条件 4 の後方互換要求を満たすため、既存フィールドの意味は一切変えない
-- `mode` は top-level フィールドで、session metadata 宣言 → イベント由来推定 → `unknown` の 3 段ラダー。判定は **`--issue` フィルタ適用前**の全 session イベントに対して行う (これが受け入れ条件 3 の中核)
-- `fact_tokens` に追加するのは `tier N` (各 tier) と `batch` (mode=batch のときのみ)。`operate route` は既存の `(.route + " route")` 式が自動生成する
+- Spec の Implementation Steps 1-8 を設計どおりの順序で実装。逸脱・設計判断の再検討は発生しなかった (`## Code Retrospective` 参照)
+- Pre-merge AC のうち rubric 系 5 件と `bats tests/run-fact-matching.bats` の command 系 1 件はこの phase 内でチェック済み。`github_check "gh pr checks" "Run bats tests"` は CI 実行後でないと確認できないため未チェックのまま残した
+- `skills/auto/SKILL.md` の変更が既存の behavioral change 検出条件 (直接対応テスト以外からの参照) に該当したため、`bats tests/run-fact-matching.bats` の単体実行に加えてフルスイート `bats tests/` (1402件) を実行して回帰がないことを確認した
 
 ### Deferred Items
 
-- `--no-github` 実行時は operate 判別をスキップし `route` は `patch` に留まる。bats の hermetic 実行は全て `--no-github` なので、operate テストだけ `gh` mock を使って非 `--no-github` で回す必要がある
-- イベント由来フォールバックによる XL fan-out の `batch` 誤判定は修正しない。`modules/run-fact-matching.md` に既知の劣化として記載するに留める
-- `modules/phase-state.md` の operate シグネチャを shared helper に切り出す案は本 Issue のスコープ外 (消費側が 3 つになった時点で再評価)
+- `--no-github` 実行時は operate 判別をスキップし `route` は `patch` に留まる (spec Uncertainty 記載どおり、設計上の既知の制約であり本 Issue では対応しない)
+- イベント由来フォールバックによる XL fan-out の `batch` 誤判定は修正しない (spec Uncertainty 記載どおり)
+- Post-merge AC (operate route での `/auto` 完走確認) は `/verify` で検証する
 
 ### Notes for Next Phase
 
-- `emit_event()` は kv 値をすべて文字列で書くため、`recovery` イベントの `tier` は `"2"` のような文字列。`recovery_tiers` を整数配列にするには `tonumber?` が必須で、`?` を落とすと破損値で jq 全体が失敗する
-- 既存テスト `collect-run-facts: missing events log yields empty issues array` は出力を完全一致で assert している。`mode` 追加で必ず落ちるので、実装と同時に `{"session_id":"sess1","mode":"unknown","issues":[]}` へ更新する
-- operate テストで `--no-github` を外すと `$SCRIPT_DIR/get-issue-size.sh` が呼ばれる。bats setup が `WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` を export しているため、`$MOCK_DIR/get-issue-size.sh` の mock 追加が必要
-- `skills/auto/SKILL.md` を触るので `scripts/validate-skill-syntax.py` の制約 (本文に半角感嘆符・triple backtick を書かない、frontmatter に YAML block scalar を使わない) に注意
-- `docs/structure.md` を変更するため `docs/ja/structure.md` を同一 PR で同期する (`docs/translation-workflow.md` の Sync Procedure)
+- `github_check "gh pr checks" "Run bats tests"` の Pre-merge AC は CI 結果待ちのため未チェック。`/review` で CI green を確認したうえでチェックすること
+- Post-merge AC は operate route の `/auto` を実際に完走させ、`route: operate` と `fact_tokens` の `operate route` トークンが出力されることを確認する必要がある (hermetic テストでは `--no-github` のため代替不可)
+- `docs/guide/index.md` (OUTDATED) と `docs/guide/autonomy.md` (MISSING_JA) の翻訳ギャップは `scripts/check-translation-sync.sh` で検出済みだが、本 Issue のスコープ外の既存項目 (本 Issue が変更した `docs/structure.md` とは無関係)

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -202,7 +202,7 @@ Key modules:
 - `scripts/observation-trigger.sh` — dispatch observation-type ACs on event: calls `opportunistic-search.sh --event`, posts comment to each matched Issue recommending `/verify` re-run, and prints matched Issue numbers to stdout for caller dispatch
 - `scripts/opportunistic-search.sh` — opportunistic skill search and observation event scan
 - `scripts/post_merge_check.sh` — bundle and run post-merge manual (verify-type: manual) ACs for multiple Issues in one session; prompts P/F/S per AC; transitions to phase/done on all-PASS or reopens on FAIL
-- `scripts/collect-run-facts.sh` — structure a completed `/auto` run's facts (route, Size, phase outcomes, PR state, anomaly counts, fact tokens) as JSON from `.tmp/auto-events.jsonl`, for run-fact AC reconciliation (`modules/run-fact-matching.md`)
+- `scripts/collect-run-facts.sh` — structure a completed `/auto` run's facts (route including the diff-less operate value, run mode, Size, phase outcomes, PR state, anomaly counts, recovery tiers, fact tokens) as JSON from `.tmp/auto-events.jsonl`, for run-fact AC reconciliation (`modules/run-fact-matching.md`)
 - `scripts/scan-pending-ac.sh` — enumerate unchecked post-merge acceptance conditions across closed `phase/verify` Issues, optionally pre-filtered by `collect-run-facts.sh` fact tokens
 - `scripts/apply-run-fact-match.sh` — deterministic autonomy-tier gate for a run-fact AC match verdict (satisfied/not_satisfied/ambiguous): auto-checks the checkbox, prints an advisory `Recommend:` line, or does nothing
 - `scripts/triage-backlog-filter.sh` — filter backlog for triage

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -58,6 +58,8 @@ To close this gap, `_completion_code_patch()` in `scripts/reconcile-phase-state.
 
 **Known limitation**: if a reopen timestamp is unavailable and an Issue's Spec is rewritten from operate route to patch route without being reopened, a stale marker from the previous operate cycle can mask a genuine patch route silent no-op. This mirrors the same-shaped limitation already present in the `closes #N` fallback (unbounded grep when no reopen timestamp is available) and is accepted for the same reason — adding asymmetric freshness handling for only one signature would introduce a new class of failure mode.
 
+**Second consumer**: `scripts/collect-run-facts.sh` reuses the same marker query to label a `code-patch` run as `route: operate`, but with a session-scoped freshness gate (the run's first event timestamp) instead of the reopen timestamp — the two consumers answer different questions (phase completion vs. what happened in this `/auto` session). See `modules/run-fact-matching.md` § Fact JSON Fields.
+
 ### Stray PR Completion Signature
 
 Route misdetection (#979-series) can leave the `code-patch` phase's actual artifact as a pushed branch + open PR (a pr-route-shaped outcome) instead of the expected `closes #N` commit to `main`. Without a dedicated signature for this, `_completion_code_patch()` reports `matches_expected: false` even though the Issue's work is genuinely done, which causes `spawn-recovery-subagent.sh`'s `skip)` dispatch guard to reject a correct `action=skip` recovery recommendation (see #993).

--- a/modules/run-fact-matching.md
+++ b/modules/run-fact-matching.md
@@ -33,16 +33,23 @@ Processing Steps drive.
 Full field definitions live in `scripts/collect-run-facts.sh`'s header comment (SSoT for the
 JSON shape). Fields most relevant to Step 3's rubric judgment:
 
-- Top-level `mode`: `batch` | `single` | `unknown` — whether this run processed multiple
-  Issues (`/auto --batch`) or a single Issue. Resolved from session metadata declared by
-  `/auto` first, with an event-based fallback second; `unknown` only when the session has no
-  events at all. See `collect-run-facts.sh`'s header comment for the full resolution ladder.
+- Top-level `mode`: `batch` | `single` | `unknown` — whether `/auto` was invoked with
+  `--batch`, not how many Issues the run actually processed. Resolved from session metadata
+  declared by `/auto` first, with an event-based fallback second; `unknown` only when the
+  session has no events at all. See `collect-run-facts.sh`'s header comment for the full
+  resolution ladder. **Caveat**: the XL sub-issue fan-out path is not `--batch` and therefore
+  declares `single` even though it processes multiple Issues (`skills/auto/SKILL.md` Step 1).
+  For sessions with no `mode` declaration (e.g. a session started before this field existed),
+  the event-based fallback cannot distinguish an XL fan-out from a `--batch` run (`sub_start`
+  is emitted by `run-auto-sub.sh` on both paths) — treat a `mode`-dependent condition as
+  `ambiguous` rather than trusting `mode` alone when the session predates this field.
 - Per-issue `route`: `pr` | `patch` | `operate` | `unknown`. `operate` distinguishes the
   diff-less operate route (`docs/tech.md` § operate route) from a regular patch-route commit
   — both emit `code-patch` phase events, so `route` is the only fact-JSON signal that tells
-  them apart. **Caveat**: when `collect-run-facts.sh` is invoked with `--no-github` (all
-  hermetic bats execution), the operate-route marker probe is skipped and `route` stays
-  `patch` even for an operate-route run.
+  them apart. **Caveat**: when `collect-run-facts.sh` is invoked with `--no-github` (used by
+  most hermetic bats execution; the operate-route tests instead run without `--no-github`
+  against a `gh` mock), the operate-route marker probe is skipped and `route` stays `patch`
+  even for an operate-route run.
 - Per-issue `recovery_tiers`: sorted unique array of recovery tiers (`1`/`2`/`3`) seen for the
   issue, or `[]` if no recovery event fired. `anomalies.recovery` keeps its existing
   count-only semantics unchanged (additive, backward-compatible).
@@ -78,8 +85,11 @@ JSON shape). Fields most relevant to Step 3's rubric judgment:
      a valid `ambiguous` reason for them. Exception: when the facts JSON's `route` is `patch`
      and the condition specifically asserts operate route, still return `ambiguous` if the run
      was collected with `--no-github` (operate detection is skipped in that mode — see the
-     `route` caveat above); when `--no-github` is not in play, `route: patch` is a direct
-     `not_satisfied` signal instead.
+     `route` caveat above). Step 1 of this module's own Processing Steps never passes
+     `--no-github`, so in practice this exception does not apply to run-fact reconciliation —
+     `route: patch` is always a direct `not_satisfied` signal for operate-route claims here.
+     The exception exists for completeness against direct `collect-run-facts.sh` invocations
+     outside this module's pipeline (e.g. ad-hoc debugging), where `--no-github` may be passed.
    - The condition text asserts something did **not** happen, and the corresponding signal
      is not one of the five `anomalies` keys (`recovery` / `watchdog_kill` /
      `manual_intervention` / `concurrent_commit_detected` / `code_retry_fire`) **and not a

--- a/modules/run-fact-matching.md
+++ b/modules/run-fact-matching.md
@@ -28,6 +28,25 @@ Processing Steps drive.
   (`autonomy` key in `.wholework.yml`, default `L1`); consumed by
   `apply-run-fact-match.sh`'s tier gate
 
+## Fact JSON Fields (matching-relevant)
+
+Full field definitions live in `scripts/collect-run-facts.sh`'s header comment (SSoT for the
+JSON shape). Fields most relevant to Step 3's rubric judgment:
+
+- Top-level `mode`: `batch` | `single` | `unknown` — whether this run processed multiple
+  Issues (`/auto --batch`) or a single Issue. Resolved from session metadata declared by
+  `/auto` first, with an event-based fallback second; `unknown` only when the session has no
+  events at all. See `collect-run-facts.sh`'s header comment for the full resolution ladder.
+- Per-issue `route`: `pr` | `patch` | `operate` | `unknown`. `operate` distinguishes the
+  diff-less operate route (`docs/tech.md` § operate route) from a regular patch-route commit
+  — both emit `code-patch` phase events, so `route` is the only fact-JSON signal that tells
+  them apart. **Caveat**: when `collect-run-facts.sh` is invoked with `--no-github` (all
+  hermetic bats execution), the operate-route marker probe is skipped and `route` stays
+  `patch` even for an operate-route run.
+- Per-issue `recovery_tiers`: sorted unique array of recovery tiers (`1`/`2`/`3`) seen for the
+  issue, or `[]` if no recovery event fired. `anomalies.recovery` keeps its existing
+  count-only semantics unchanged (additive, backward-compatible).
+
 ## Processing Steps
 
 1. Run `${CLAUDE_PLUGIN_ROOT}/scripts/collect-run-facts.sh` (with `--session
@@ -52,11 +71,23 @@ Processing Steps drive.
      facts JSON's `phases` entries carry only a phase name (`review`), never a depth value,
      because `scripts/run-review.sh` sets a fixed `EMIT_PHASE_NAME="review"` regardless of
      depth (see `modules/event-emission.md` Wrapper Coverage Table; confirmed empirically —
-     `docs/spec/issue-1157-run-fact-ac-match.md` § Uncertainty).
+     `docs/spec/issue-1157-run-fact-ac-match.md` § Uncertainty). **This no longer applies to
+     conditions naming operate route, a specific recovery tier, or batch/single mode** — those
+     three axes are now directly readable from `route`, `recovery_tiers`, and top-level `mode`
+     respectively (see Fact JSON Fields above), so "no representation in the facts JSON" is not
+     a valid `ambiguous` reason for them. Exception: when the facts JSON's `route` is `patch`
+     and the condition specifically asserts operate route, still return `ambiguous` if the run
+     was collected with `--no-github` (operate detection is skipped in that mode — see the
+     `route` caveat above); when `--no-github` is not in play, `route: patch` is a direct
+     `not_satisfied` signal instead.
    - The condition text asserts something did **not** happen, and the corresponding signal
      is not one of the five `anomalies` keys (`recovery` / `watchdog_kill` /
-     `manual_intervention` / `concurrent_commit_detected` / `code_retry_fire`) — there is no
-     general-purpose "nothing happened" fact to check absence-claims against.
+     `manual_intervention` / `concurrent_commit_detected` / `code_retry_fire`) **and not a
+     specific recovery tier** — a condition asserting "Tier N recovery did not fire" is
+     directly decidable from whether `N` is absent from `recovery_tiers`, so it is not subject
+     to this fail-safe branch. Absent a `recovery_tiers`-backed tier claim or one of the five
+     `anomalies` keys, there is no general-purpose "nothing happened" fact to check
+     absence-claims against.
    - The condition text is a conjunction of multiple sub-conditions and only some of them
      are backed by the facts JSON.
    - Any other case where the judgment is unclear — `ambiguous` is the default when in doubt,

--- a/scripts/collect-run-facts.sh
+++ b/scripts/collect-run-facts.sh
@@ -14,27 +14,47 @@
 #   route). Omit for the batch route to collect facts for every Issue in the
 #   session.
 #
-# Output: single-line JSON {"session_id":"<id>","issues":[{...}, ...]} on
-#   stdout. When ${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl} does not exist,
-#   prints {"session_id":"<id>","issues":[]} and exits 0 (fail-open).
+# Output: single-line JSON {"session_id":"<id>","mode":"<batch|single|unknown>","issues":[{...}, ...]}
+#   on stdout. When ${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl} does not exist, or the session has
+#   no events, prints {"session_id":"<id>","mode":"unknown","issues":[]} and exits 0 (fail-open).
+#
+# mode (top-level): batch | single | unknown. Resolution ladder, evaluated against ALL session
+#   events *before* --issue narrowing (so mode does not depend on whether --issue was passed):
+#   (a) .tmp/auto-session-<session-id>.json's "mode" key, when "batch" or "single"
+#   (b) event fallback: >=2 distinct non-zero issue numbers with a sub_start event => "batch",
+#       else "single" (only reached when the session has at least one event)
+#   (c) "unknown" when the session has no events (events log absent, or session id not found)
 #
 # Per-issue fields:
-#   number      - issue number (int)
-#   size        - Size label (XS/S/M/L/XL), or "" if unresolved
-#                 (or when --no-github is set and no size event exists)
-#   route       - pr | patch | unknown (derived from code-pr / code-patch phase presence)
-#   pr          - PR number seen in this issue's events, or null
-#   pr_state    - `gh pr view <pr> --json state` result, or "" when unavailable
-#   phases      - [{"name":...,"status":"complete"|"started","backfilled":bool}]
-#   anomalies   - counts for the exhaustive event set: recovery, watchdog_kill,
-#                 manual_intervention, concurrent_commit_detected, code_retry_fire
-#   fact_tokens - token array for scan-pending-ac.sh's pre-filtering. Deliberately
-#                 excludes the generic "/auto" token: measured against 414 pending
-#                 post-merge AC (docs/spec/issue-1157-run-fact-ac-match.md § population),
-#                 "/auto" alone matched 84 of them and made the pre-filter a no-op.
+#   number         - issue number (int)
+#   size           - Size label (XS/S/M/L/XL), or "" if unresolved
+#                    (or when --no-github is set and no size event exists)
+#   route          - pr | patch | operate | unknown (derived from code-pr / code-patch phase
+#                    presence; code-patch is further probed for an operate-route marker comment
+#                    — see below. Skipped when --no-github is set, so route stays "patch" then)
+#   pr             - PR number seen in this issue's events, or null
+#   pr_state       - `gh pr view <pr> --json state` result, or "" when unavailable
+#   phases         - [{"name":...,"status":"complete"|"started","backfilled":bool}]
+#   anomalies      - counts for the exhaustive event set: recovery, watchdog_kill,
+#                    manual_intervention, concurrent_commit_detected, code_retry_fire
+#   recovery_tiers - sorted unique array of recovery event tiers (1/2/3) seen for this issue,
+#                    or [] if none. anomalies.recovery keeps its existing count-only semantics.
+#   fact_tokens    - token array for scan-pending-ac.sh's pre-filtering. Deliberately
+#                    excludes the generic "/auto" token: measured against 414 pending
+#                    post-merge AC (docs/spec/issue-1157-run-fact-ac-match.md § population),
+#                    "/auto" alone matched 84 of them and made the pre-filter a no-op. Also
+#                    excludes the generic "single" mode token for the same reason (Issue #1171).
 #
-# --no-github suppresses all `gh` calls (get-issue-size.sh fallback, `gh pr view`),
-# for hermetic bats execution.
+# operate route detection: when an issue's route resolves to "patch" (and --no-github is not
+#   set), probe the Issue's comments for a `type=execution-log` or `type=execution-plan`
+#   wholework-event marker (the same signature `reconcile-phase-state.sh`'s _operate_signal_ts()
+#   uses). If the marker's createdAt is newer than this issue's first event timestamp in this
+#   run (freshness gate — guards against a stale marker from a prior operate cycle mislabeling a
+#   later patch run), route is reported as "operate" instead of "patch".
+#
+# --no-github suppresses all `gh` calls (get-issue-size.sh fallback, `gh pr view`, the operate
+# marker probe), for hermetic bats execution. Under --no-github, operate route can never be
+# detected and route stays "patch" for diff-less runs.
 #
 # bash 3.2+ compatible (macOS system bash): no mapfile, no ${VAR,,}.
 
@@ -96,7 +116,7 @@ fi
 EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 
 if [ ! -f "$EVENTS_LOG" ]; then
-  printf '{"session_id":"%s","issues":[]}\n' "$SESSION_ID"
+  printf '{"session_id":"%s","mode":"unknown","issues":[]}\n' "$SESSION_ID"
   exit 0
 fi
 
@@ -106,7 +126,7 @@ SESSION_EVENTS=$(jq -c --arg sid "$SESSION_ID" 'select(.session_id == $sid)' "$E
 }
 
 if [ -z "$SESSION_EVENTS" ]; then
-  printf '{"session_id":"%s","issues":[]}\n' "$SESSION_ID"
+  printf '{"session_id":"%s","mode":"unknown","issues":[]}\n' "$SESSION_ID"
   exit 0
 fi
 
@@ -117,6 +137,25 @@ ISSUE_NUMBERS=$(printf '%s\n' "$SESSION_EVENTS" | jq -r '.issue' 2>/dev/null | s
 
 if [ -n "$ISSUE_FILTER" ]; then
   ISSUE_NUMBERS=$(printf '%s\n' "$ISSUE_NUMBERS" | awk -v n="$ISSUE_FILTER" '$0 == n')
+fi
+
+# Session-level mode resolution ladder. Evaluated against $SESSION_EVENTS (all session events,
+# before the --issue narrowing above) so mode does not depend on whether --issue was passed.
+MODE=""
+SESSION_META_FILE=".tmp/auto-session-${SESSION_ID}.json"
+if [ -f "$SESSION_META_FILE" ]; then
+  META_MODE=$(jq -r '.mode // ""' "$SESSION_META_FILE" 2>/dev/null || true)
+  case "$META_MODE" in
+    batch|single) MODE="$META_MODE" ;;
+  esac
+fi
+if [ -z "$MODE" ]; then
+  BATCH_ISSUE_COUNT=$(printf '%s\n' "$SESSION_EVENTS" | jq -s '[.[] | select(.event == "sub_start" and .issue != 0) | .issue] | unique | length')
+  if [ "$BATCH_ISSUE_COUNT" -ge 2 ]; then
+    MODE="batch"
+  else
+    MODE="single"
+  fi
 fi
 
 JQ_PASS1='
@@ -141,6 +180,8 @@ def phase_entry($events; $p):
       elif ($events | map(select(.phase == "code-patch")) | length) > 0 then "patch"
       else "unknown" end
     ),
+    first_ts: ($events | map(.ts) | min),
+    recovery_tiers: ([$events[] | select(.event == "recovery") | .tier // empty | tonumber?] | unique),
     phases: ($phase_names | map(phase_entry($events; .))),
     anomalies: (
       ["recovery","watchdog_kill","manual_intervention","concurrent_commit_detected","code_retry_fire"]
@@ -156,11 +197,12 @@ def wrapper_for(p):
 {
   number: $n,
   size: $size,
-  route: $partial.route,
+  route: $route,
   pr: $partial.pr,
   pr_state: $pr_state,
   phases: $partial.phases,
-  anomalies: $partial.anomalies
+  anomalies: $partial.anomalies,
+  recovery_tiers: $partial.recovery_tiers
 }
 | . + {
     fact_tokens: (
@@ -170,6 +212,8 @@ def wrapper_for(p):
          | $names + ($names | map(wrapper_for(.)) | map(select(. != null))))
       + (if .pr != null then [("#" + (.pr | tostring))] else [] end)
       + (.anomalies | to_entries | map(select(.value >= 1) | .key))
+      + (.recovery_tiers | map("tier " + (. | tostring)))
+      + (if $mode == "batch" then ["batch"] else [] end)
     )
   }
 '
@@ -201,10 +245,29 @@ for N in $ISSUE_NUMBERS; do
     PR_STATE=$(gh pr view "$PR_NUMBER" --json state -q .state 2>/dev/null || true)
   fi
 
+  # Operate route probe: only meaningful when route is "patch" (operate route always emits
+  # code-patch phase events — see reconcile-phase-state.sh's identical assumption).
+  ROUTE=$(printf '%s' "$FACTS_PARTIAL" | jq -r '.route')
+  FIRST_TS=$(printf '%s' "$FACTS_PARTIAL" | jq -r '.first_ts')
+  if [ "$ROUTE" = "patch" ] && [ "$NO_GITHUB" = false ]; then
+    OPERATE_TS=$(gh issue view "$N" --json comments \
+      --jq "[.comments[] | select(.body | contains(\"<!-- wholework-event: type=execution-log phase=code issue=${N}\") or contains(\"<!-- wholework-event: type=execution-plan phase=code issue=${N}\")) | .createdAt] | sort | last // empty" \
+      2>/dev/null) || OPERATE_TS=""
+    case "$OPERATE_TS" in
+      [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T*) ;;
+      *) OPERATE_TS="" ;;
+    esac
+    if [ -n "$OPERATE_TS" ] && [ "$OPERATE_TS" \> "$FIRST_TS" ]; then
+      ROUTE="operate"
+    fi
+  fi
+
   ISSUE_FACT=$(jq -n \
     --argjson n "$N" \
     --arg size "$SIZE" \
+    --arg route "$ROUTE" \
     --arg pr_state "$PR_STATE" \
+    --arg mode "$MODE" \
     --argjson partial "$FACTS_PARTIAL" \
     "$JQ_PASS2") || {
     echo "Error: failed to assemble fact object for issue #${N}" >&2
@@ -217,4 +280,4 @@ for N in $ISSUE_NUMBERS; do
   }
 done
 
-jq -n --arg sid "$SESSION_ID" --argjson issues "$ISSUES_JSON" '{session_id: $sid, issues: $issues}' -c
+jq -n --arg sid "$SESSION_ID" --arg mode "$MODE" --argjson issues "$ISSUES_JSON" '{session_id: $sid, mode: $mode, issues: $issues}' -c

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -60,6 +60,7 @@ Generate a session identifier and record it in a PGID-specific pointer file so s
    {
      "session_id": "<SESSION_ID>",
      "session_start": "<current UTC timestamp in ISO8601>",
+     "mode": "<batch|single>",
      "skill_versions": {
        "skills/auto/SKILL.md": "<SKILL_AUTO_HASH>",
        "skills/code/SKILL.md": "<SKILL_CODE_HASH>",
@@ -72,7 +73,7 @@ Generate a session identifier and record it in a PGID-specific pointer file so s
      }
    }
    ```
-   Substitute the actual `SESSION_ID`, current UTC timestamp, and skill hash values before writing.
+   Substitute the actual `SESSION_ID`, current UTC timestamp, and skill hash values before writing. `mode` is `batch` when ARGUMENTS contains `--batch`, otherwise `single` — this includes the XL sub-issue fan-out path, which is not `--batch` and therefore resolves to `single`.
 4. Set `AUTO_SESSION_ID="$SESSION_ID"` in the current Bash context (does not persist across separate Bash tool calls; sub-processes read from the pointer file instead):
    ```bash
    export AUTO_SESSION_ID="$SESSION_ID"

--- a/tests/run-fact-matching.bats
+++ b/tests/run-fact-matching.bats
@@ -35,7 +35,7 @@ setup() {
     export AUTO_EVENTS_LOG="$BATS_TEST_TMPDIR/nonexistent.jsonl"
     run bash "$COLLECT_SCRIPT" --session sess1 --no-github
     [ "$status" -eq 0 ]
-    [ "$output" = '{"session_id":"sess1","issues":[]}' ]
+    [ "$output" = '{"session_id":"sess1","mode":"unknown","issues":[]}' ]
 }
 
 @test "collect-run-facts: route/pr/phases/anomalies/fact_tokens derived from fixture events" {
@@ -98,6 +98,172 @@ EOF
     [ "$size" = "M" ]
     route=$(echo "$output" | jq -r '.issues[0].route')
     [ "$route" = "patch" ]
+}
+
+@test "collect-run-facts: operate route detected via fresh execution-log marker comment" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":800,"event":"phase_start","session_id":"sess1","phase":"code-patch"}
+{"ts":"2026-08-05T00:01:00Z","issue":800,"event":"phase_complete","session_id":"sess1","phase":"code-patch"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo ""
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$4" == "--json" && "$5" == "comments" ]]; then
+  echo "2026-08-05T00:05:00Z"
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  echo ""
+  exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$COLLECT_SCRIPT" --session sess1
+    [ "$status" -eq 0 ]
+    route=$(echo "$output" | jq -r '.issues[0].route')
+    [ "$route" = "operate" ]
+    tokens=$(echo "$output" | jq -r '.issues[0].fact_tokens | join(",")')
+    [[ "$tokens" == *"operate route"* ]]
+}
+
+@test "collect-run-facts: route stays patch when no execution marker comment exists" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":801,"event":"phase_start","session_id":"sess1","phase":"code-patch"}
+{"ts":"2026-08-05T00:01:00Z","issue":801,"event":"phase_complete","session_id":"sess1","phase":"code-patch"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo ""
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$4" == "--json" && "$5" == "comments" ]]; then
+  echo ""
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  echo ""
+  exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$COLLECT_SCRIPT" --session sess1
+    [ "$status" -eq 0 ]
+    route=$(echo "$output" | jq -r '.issues[0].route')
+    [ "$route" = "patch" ]
+    tokens=$(echo "$output" | jq -r '.issues[0].fact_tokens | join(",")')
+    [[ "$tokens" != *"operate route"* ]]
+}
+
+@test "collect-run-facts: recovery_tiers captures tier values with tier N fact_tokens" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":900,"event":"recovery","session_id":"sess1","phase":"code-patch","tier":"2"}
+{"ts":"2026-08-05T00:01:00Z","issue":900,"event":"recovery","session_id":"sess1","phase":"code-patch","tier":"3"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+    tiers=$(echo "$output" | jq -c '.issues[0].recovery_tiers')
+    [ "$tiers" = "[2,3]" ]
+    recovery_count=$(echo "$output" | jq -r '.issues[0].anomalies.recovery')
+    [ "$recovery_count" = "2" ]
+    tokens=$(echo "$output" | jq -r '.issues[0].fact_tokens | join(",")')
+    [[ "$tokens" == *"tier 2"* ]]
+    [[ "$tokens" == *"tier 3"* ]]
+}
+
+@test "collect-run-facts: recovery_tiers empty and no tier tokens when no recovery events" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":901,"event":"phase_start","session_id":"sess1","phase":"code-patch"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+    tiers=$(echo "$output" | jq -c '.issues[0].recovery_tiers')
+    [ "$tiers" = "[]" ]
+    tokens=$(echo "$output" | jq -r '.issues[0].fact_tokens | join(",")')
+    [[ "$tokens" != *"tier "* ]]
+}
+
+@test "collect-run-facts: mode batch from session metadata declaration" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":1000,"event":"phase_start","session_id":"sess1","phase":"spec"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+    mkdir -p .tmp
+    echo '{"mode":"batch"}' > ".tmp/auto-session-sess1.json"
+
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+    mode=$(echo "$output" | jq -r '.mode')
+    [ "$mode" = "batch" ]
+    tokens=$(echo "$output" | jq -r '.issues[0].fact_tokens | join(",")')
+    [[ "$tokens" == *"batch"* ]]
+}
+
+@test "collect-run-facts: mode batch fallback from >=2 sub_start issues without metadata" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":1100,"event":"sub_start","session_id":"sess1","size":"S"}
+{"ts":"2026-08-05T00:00:00Z","issue":1200,"event":"sub_start","session_id":"sess1","size":"S"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+    mode=$(echo "$output" | jq -r '.mode')
+    [ "$mode" = "batch" ]
+}
+
+@test "collect-run-facts: mode single when only one issue and no metadata" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":1300,"event":"sub_start","session_id":"sess1","size":"S"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+    mode=$(echo "$output" | jq -r '.mode')
+    [ "$mode" = "single" ]
+    tokens=$(echo "$output" | jq -r '.issues[0].fact_tokens | join(",")')
+    [[ "$tokens" != *"batch"* ]]
+}
+
+@test "collect-run-facts: mode stays batch under --issue filter" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":1400,"event":"sub_start","session_id":"sess1","size":"S"}
+{"ts":"2026-08-05T00:00:00Z","issue":1500,"event":"sub_start","session_id":"sess1","size":"S"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+
+    run bash "$COLLECT_SCRIPT" --session sess1 --issue 1400 --no-github
+    [ "$status" -eq 0 ]
+    mode=$(echo "$output" | jq -r '.mode')
+    [ "$mode" = "batch" ]
+    count=$(echo "$output" | jq '.issues | length')
+    [ "$count" = "1" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/run-fact-matching.bats
+++ b/tests/run-fact-matching.bats
@@ -38,6 +38,17 @@ setup() {
     [ "$output" = '{"session_id":"sess1","mode":"unknown","issues":[]}' ]
 }
 
+@test "collect-run-facts: session id not found in existing events log yields mode unknown" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":1600,"event":"phase_start","session_id":"other-session","phase":"code-pr"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+    [ "$output" = '{"session_id":"sess1","mode":"unknown","issues":[]}' ]
+}
+
 @test "collect-run-facts: route/pr/phases/anomalies/fact_tokens derived from fixture events" {
     EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
     cat > "$EVENTS_FILE" <<'EOF'


### PR DESCRIPTION
## Summary

`scripts/collect-run-facts.sh` が出力する実行事実 JSON に、`/auto` 実行時には確定しているのに欠落・潰されていた 3 軸を追加する。

- **operate route**: `route` の 4 値目として `operate` を追加。`run-code.sh --patch` 経由で `code-patch` phase を emit するため phase 名では operate/patch を区別できず、`reconcile-phase-state.sh` の `_operate_signal_ts()` と同一の marker コメント (`type=execution-log` / `type=execution-plan`) をこの run の最初のイベント時刻 (`first_ts`) と比較する freshness gate で判別する。
- **recovery tier**: `anomalies.recovery` の件数はそのまま維持しつつ、`recovery_tiers` (昇順ユニークな整数配列) を追加。既存フィールドの意味は変えない加算的変更。
- **mode**: top-level に `mode` (`batch` / `single` / `unknown`) を追加。`/auto` が session metadata (`.tmp/auto-session-${SESSION_ID}.json`) に宣言した値を第一優先、`sub_start` イベント数によるフォールバック推定を次点とする 2 段ラダー。判定は `--issue` フィルタ適用前の全 session イベントに対して行う。

`fact_tokens` にも `tier N` (recovery tier ごと) と `batch` (mode=batch のときのみ) を追加した。`modules/run-fact-matching.md` を fact JSON の SSoT として更新し、`skills/auto/SKILL.md` の session metadata 書き込みに `mode` キーを追加した。

## Verification (pre-merge)

- `collect-run-facts.sh` が operate route を patch route と区別して表現できる (rubric)
- recovery tier (1/2/3) が fact JSON に保持される (rubric)
- mode が fact JSON で表現できる (rubric)
- 既存の消費側 (`scan-pending-ac.sh` の fact_tokens 事前絞り込み、`modules/run-fact-matching.md` の rubric 判定手順) との互換が保たれている (rubric)
- 3 軸それぞれのテストが negative case 込みで存在する (rubric)
- `bats tests/run-fact-matching.bats` が PASS する (26/26 確認済み)
- bats テスト全件が CI で PASS する (`gh pr checks` — CI 実行待ち)

## Verification (post-merge)

- operate route の `/auto` を完走させ、`scripts/collect-run-facts.sh` の出力で当該 Issue の `route` が `operate` (patch と区別) になっていること、`fact_tokens` に `operate route` が含まれること、top-level `mode` が実行形態と一致することを確認する

closes #1171
