### PR TITLE
Issue #1172: observation AC に when= 実行文脈ゲートを追加

### DIFF
--- a/docs/spec/issue-1172-observation-when-gate.md
+++ b/docs/spec/issue-1172-observation-when-gate.md
@@ -140,28 +140,40 @@ No new comments since last phase.
 - **設計時の不確実性「遅延収集時に session を解決できるか」**: `collect-run-facts.sh` の解決ラダー (`--session` > `AUTO_SESSION_ID` env > `.tmp/auto-session-current`) と `skills/auto/SKILL.md` Step 1 のポインタ書き込みを読み合わせ、`/auto` 実行中は必ず現在の session に解決されることを確認した。`AUTO_SESSION_ID` は wrapper 経由でしか export されないため、env だけに依存する設計にしなくて正解だった
 - **未解決のまま残した点**: `/review` の `pr-review-full` emitter や手動実行では `.tmp/auto-session-current` が直前の `/auto` session を指したままになりうる。`when=` は run facts が `/auto` 実行を記述する以上 `event=auto-run` 前提である旨をドキュメントに明記する対処にとどめ、機構的な強制 (event 名による gate の有効/無効切り替え) は入れないことにした。強制すると将来 `/auto` 以外の run facts が現れたときに再度剥がす必要が出るため
 
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Implementation Steps 1-9 を記載順にそのまま実装した。逸脱なし
+
+### Design Gaps/Ambiguities
+
+- N/A — Spec の各ステップが対象ファイル・挿入位置・jq パターンまで具体的に指定しており、実装中に解釈の余地が生じる箇所はなかった
+
+### Rework
+
+- N/A
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- 対応方針 B (`when=<axis>:<value>` 属性) を採用し、A (event 名の細分化) は組み合わせ爆発のため不採用。C (表現不能条件の明文化) は B の補完として併用採用した
-- 実行文脈は `scripts/collect-run-facts.sh` の出力をそのまま消費する。`--facts-file <path>` の明示指定を第一、引数なし遅延呼び出しを fallback とする二本立てで、`skills/auto/SKILL.md` の実行順序を変更せずに済ませる
-- 判定不能時・未知軸時は fail-open (無条件マッチ + stderr 警告)。#1055 の silent 常時除外の再生産を避けるため
-- 軸は `route` / `mode` / `recovery-tier` の 3 つに確定し、軸表を **(exhaustive)** で明示する。`pr-state` / `anomaly` は同じ jq パターンで後から足せる拡張余地として Notes に記録
-- Issue #995 の post-merge AC 1 行のみに `when=route:operate` を注釈する (Post-merge 条件の参照ケース)。既存 12 件の一括書き換えは行わない
+- `when=` の comma-separated AND 評価は、1 つの節が不成立でも残りの節を評価し続ける実装にした (early-break しない)。不正な節・未知軸の警告を実行1回で全て出し切るため。挙動としては Spec の「fail-open」要件を満たしつつ、診断性を優先した実装判断
+- Step 9 (Behavioral Change Detection) で `modules/verify-classifier.md` への追記が `tests/verify-executor.bats` から参照されていることを検出し、`bats tests/opportunistic-search.bats` 単体ではなく `bats tests/` フルスイート (1412 件) を実行した。全件 PASS を確認済み
+- Pre-merge AC 7 件のうち、`github_check "gh pr checks" "Run bats tests"` (AC7) は PR 未作成の Step 10 時点では検証不能なため未チェックのまま残した。AC1–6 はすべて Step 10 で PASS 判定し Issue のチェックボックスを更新済み
+- Issue #995 の post-merge AC 更新 (Implementation Step 9) はリポジトリ外の変更のため、この Spec ファイルへの diff や commit には現れない
 
 ### Deferred Items
 
-- 既存 observation AC 11 件 (#995 を除く) への `when=` 注釈は本 Issue のスコープ外。運用の中で個別に判断する
+- 既存 observation AC 11 件 (#995 を除く) への `when=` 注釈は本 Issue のスコープ外のまま。運用の中で個別に判断する
 - `pr-state` 軸 / `anomaly` 軸の追加は必要が生じた時点で軸表に行を足す形で対応する
 - `/auto` 側で facts JSON を observation scan の前に生成し `--facts-file` で渡す最適化 (Alternatives Considered D) は将来の課題
 - `keyword=` / `config=` / `when=` の 3 ゲートに共通する属性抽出処理の関数切り出しは、4 つ目のゲートが現れた時点で検討する
+- AC7 (`github_check "gh pr checks" "Run bats tests"`) のチェックは CI 完了後、`/review` または `/verify` フェーズで行う
 
 ### Notes for Next Phase
 
-- `grep "when=" "modules/observation-trigger.md"` の Pre-merge AC は Implementation Step 5 で初めて成立する。Step 5 を飛ばすと AC 4 が FAIL する
-- `modules/verify-executor.md` の `--when="shell condition"` は別機構。実装中に混同しないこと。`scripts/validate-skill-syntax.py` の `--when=` 除去ロジック (L620 / L626) は `verify:` タグ側のみを扱うため本変更の影響を受けない
-- `tests/opportunistic-search.bats` は現状 `WHOLEWORK_SCRIPT_DIR` を設定していない。`when=` テストでは `$MOCK_DIR/collect-run-facts.sh` のモック追加と `export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` の設定が必要 (既存の `config=` テストは `WHOLEWORK_CONFIG_PATH` 経由で実スクリプトを使っている点に注意 — 設定方法が異なる)
-- `set -euo pipefail` 配下で jq の非ゼロ終了を扱うため、判定は `if ! ... ; then` 形式で受けること。`|| true` でエラーを握り潰すと fail-open と実エラーの区別がつかなくなる
-- `skills/code/SKILL.md` の `allowed-tools` には `gh issue edit:*` と `gh-issue-edit.sh:*` の双方が登録済みのため、Implementation Step 9 (#995 の body 更新) に frontmatter の変更は不要
+- AC7 は未チェックのまま。PR #1178 の CI (`gh pr checks`) が green になった時点でチェックすること
+- `bats tests/` フルスイート (1412 件) はこの Code フェーズ時点でローカル実行済み・全件 PASS。CI 側でも同じ結果になるはず — 差異が出た場合は環境依存 (bash バージョン等) を疑うこと
+- Issue #995 の post-merge AC 1 行を `when=route:operate` 付きに更新済み。この PR の post-merge 条件 (「次回 `/auto` 実行時に operate route の AC がマッチ集合から除外される」) を検証する際は #995 側の現在の AC 文言を直接参照すること

--- a/docs/spec/issue-1172-observation-when-gate.md
+++ b/docs/spec/issue-1172-observation-when-gate.md
@@ -155,25 +155,41 @@ No new comments since last phase.
 - N/A
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- `when=` の comma-separated AND 評価は、1 つの節が不成立でも残りの節を評価し続ける実装にした (early-break しない)。不正な節・未知軸の警告を実行1回で全て出し切るため。挙動としては Spec の「fail-open」要件を満たしつつ、診断性を優先した実装判断
-- Step 9 (Behavioral Change Detection) で `modules/verify-classifier.md` への追記が `tests/verify-executor.bats` から参照されていることを検出し、`bats tests/opportunistic-search.bats` 単体ではなく `bats tests/` フルスイート (1412 件) を実行した。全件 PASS を確認済み
-- Pre-merge AC 7 件のうち、`github_check "gh pr checks" "Run bats tests"` (AC7) は PR 未作成の Step 10 時点では検証不能なため未チェックのまま残した。AC1–6 はすべて Step 10 で PASS 判定し Issue のチェックボックスを更新済み
-- Issue #995 の post-merge AC 更新 (Implementation Step 9) はリポジトリ外の変更のため、この Spec ファイルへの diff や commit には現れない
+- ARGUMENTS に `--non-interactive` が含まれ fork context (再実行保証なし) と判定されたため、`.wholework.yml` の `capabilities.workflow: true` にもかかわらず Workflow path (10.1–10.3 差し替え) はスキップし、`skills/review/workflow-guidance.md` の Pre-flight 指示どおり static Task fan-out (`run_in_background: false`) を使用した
+- review-bug×2 (diff bug scan / security scan) が独立に同一根本原因 (`when=` 属性抽出のマルチライン衝突) を検出し、2 段階アドバーサリアル検証で 7 件中 6 件が PASS (問題確認) となった。MUST 相当の指摘はゼロだったが、SHOULD 判定の 3 件 (抽出のマルチライン衝突・glob 展開・contextless AND guard) は機能の correctness 根幹に関わるため Step 12 で修正した
+- CONSIDER 判定 5 件のうち 1 件 (validity check の `type == "object"` 厳格化) のみ SHOULD 群と合わせて修正し、残り 4 件 (doc 文言の曖昧さ・malformed clause テスト欠如・spec retrospective の記述精度) は PR サイズとのバランスで見送った
 
 ### Deferred Items
 
-- 既存 observation AC 11 件 (#995 を除く) への `when=` 注釈は本 Issue のスコープ外のまま。運用の中で個別に判断する
-- `pr-state` 軸 / `anomaly` 軸の追加は必要が生じた時点で軸表に行を足す形で対応する
-- `/auto` 側で facts JSON を observation scan の前に生成し `--facts-file` で渡す最適化 (Alternatives Considered D) は将来の課題
-- `keyword=` / `config=` / `when=` の 3 ゲートに共通する属性抽出処理の関数切り出しは、4 つ目のゲートが現れた時点で検討する
-- AC7 (`github_check "gh pr checks" "Run bats tests"`) のチェックは CI 完了後、`/review` または `/verify` フェーズで行う
+- `keyword=` / `config=` ゲートも `when=` と同じ「行全体から `grep -oE` で抽出」パターンを共有しており、理論上同じ脆弱性 (prose 内の属性名衝突) を持つ。本 PR では `when=` のみ修正し、既存 2 ゲートへの横展開は別 Issue に委ねる
+- `modules/observation-trigger.md:270` の `--facts-file` パス異常時の説明の軽微な不一致 (CONSIDER) は未修正
+- `tests/opportunistic-search.bats` の malformed clause (コロンなし/空値) テスト欠如 (CONSIDER) は未修正
+- `docs/spec/issue-1172-observation-when-gate.md` の Code Retrospective 「Deviations from Design」の記述精度 (CONSIDER) は未修正 — 本 review retrospective に記録した
+- `scripts/observation-trigger.sh:87` の stderr discard (本番経路での `when=` 警告不可視) は本 PR 以前からの既存動作と判定し対象外 (却下)
 
 ### Notes for Next Phase
 
-- AC7 は未チェックのまま。PR #1178 の CI (`gh pr checks`) が green になった時点でチェックすること
-- `bats tests/` フルスイート (1412 件) はこの Code フェーズ時点でローカル実行済み・全件 PASS。CI 側でも同じ結果になるはず — 差異が出た場合は環境依存 (bash バージョン等) を疑うこと
-- Issue #995 の post-merge AC 1 行を `when=route:operate` 付きに更新済み。この PR の post-merge 条件 (「次回 `/auto` 実行時に operate route の AC がマッチ集合から除外される」) を検証する際は #995 側の現在の AC 文言を直接参照すること
+- Pre-merge AC 7 件全て PASS、Issue #1172 のチェックボックスは Post-merge 1 件を除き更新済み。CI は 9/9 SUCCESS
+- Step 12 の修正コミット (`e9a51a2b`) を push 済み。`bats tests/opportunistic-search.bats` 36/36 PASS、`bats tests/observation-trigger.bats` 19/19 PASS、`validate-skill-syntax.py` 0 error を再確認済み
+- MUST 指摘ゼロのため review は `COMMENT` (REQUEST_CHANGES ではない) で投稿済み。`/merge 1178` にそのまま進める
+- Post-merge 条件 (Issue #995 の operate route AC がマッチ集合から除外されることの確認) は `/verify` 側で扱う
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Spec Implementation Step 3 が「`grep -oE 'when=[^ >]+'` で値を抽出 (既存 2 ゲートと同一の抽出方式)」と明記しており、実装はこれをそのまま踏襲した。しかし review-bug×2 の検証で、この抽出パターンが AC の行全体 (HTML コメントタグ外の prose も含む) を対象にしているため、条件文が `when=...` という文字列を説明目的で引用すると `grep -o` の複数マッチが改行区切りで返り、カンマのみで分割するクローズパーサが破損することが判明した (本 PR で修正済み)。Spec 段階では「既存ゲートと同一パターンを踏襲する」ことが安全側の判断として書かれていたが、実際には `keyword=` / `config=` ゲートも同じ脆弱性を潜在的に持っている (本 Issue のスコープ外として今回は未修正)。既存パターンの踏襲は「実績があるから安全」とは限らないことを示す一例
+- Spec の Implementation Step 3 は「1 つでも不成立なら `continue` で除外」という記述だったが、Code フェーズでは意図的に early-break しない実装を選択した (Phase Handoff の Key Decisions に記録済み)。この逸脱は Code Retrospective の「Deviations from Design」に N/A と記載されていたが、実際には記録すべき逸脱だった (review-spec が指摘、Notes へ追記は見送り)
+
+### Recurring issues
+
+- review-bug の 2 エージェント (diff bug scan / security scan) が独立に同一の根本原因 (`when=` 属性抽出のマルチライン衝突) を異なる再現手順で検出し、2 段階検証でも揃って PASS 判定となった。並列 diff scan と security scan という異なる着眼点からの収束は、bash の unquoted 展開・`grep -o` の複数マッチという「見た目は動くが境界値で壊れる」クラスの bug に対して有効なシグナルだった
+- `keyword=` (#794) → `config=` (#1088) → `when=` (本 Issue) と 3 つ目の condition check gate が追加され、3 節とも同一の「行全体から属性を `grep -oE` で抽出」パターンを共有している。Spec の Notes は「4 つ目のゲートが現れた時点で共通ヘルパーへの切り出しを検討する」としているが、今回 3 つ目の時点で潜在バグが顕在化した。抽出パターンの共通化は「重複除去」ではなく「同じバグを 3 箇所に埋め込まない」という正当化も持つため、次に `keyword=` / `config=` のいずれかを触る Issue が出た時点で本 PR の修正 (HTML コメントタグ内への抽出範囲限定) を横展開する価値がある
+
+### Acceptance criteria verification difficulty
+
+- Pre-merge AC 7 件中 5 件が `rubric` (意味論的判断) で、実装の存在・ドキュメント化・テスト網羅性を検証した。これらは全て PASS だったが、rubric は「設計判断が記録されているか」「軸が文書化されているか」を検証するものであり、bash の unquoted 展開や `grep -o` の複数行マッチといったコードレベルの correctness bug は検出対象外だった。今回それらのバグは `/review` Step 10 の multi-perspective review (review-bug×2 + 2 段階アドバーサリアル検証) で初めて発見された。Feature タイプかつ bash ロジックが複雑な Issue では、rubric ベースの AC 設計だけでは correctness を担保できず、`--full` review の code-level bug detection が実質的な安全網として機能した

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -29,6 +29,7 @@ Each emitter calls the following command when its event fires:
 | `--event <event-name>` | Required. The event name from the table in `modules/verify-classifier.md § observation Type` |
 | `--dry-run` | Optional. Search runs normally and API calls are not skipped (`opportunistic-search.sh` is originally read-only and has no side effect to suppress here). Accepted as an argument for CLI backward compatibility, but it is a no-op flag with no effect on behavior |
 | `--context-file <path>` | Optional. Gates matches carrying a `keyword=` AC attribute against this file's content. See § Condition Check Gate below |
+| `--facts-file <path>` | Optional. Gates matches carrying a `when=<axis>:<value>` AC attribute against `/auto` run facts JSON. See § Condition Check Gate (`when=`) below |
 
 **Output (stdout):** JSON array
 

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -225,10 +225,78 @@ added to either script.
 - Gate disabled (unconditional match) when: no `config=` attribute is present on the AC line.
 - Scope: `<key>` must be a flat kebab-case key or a single-level nested key in block format (e.g. `capabilities.workflow`), matching `get-config-value.sh`'s own constraint — inline hash format and keys with two or more dots are not supported. The comparison is boolean-only (`true`/`false`); enum-valued keys (e.g. `auto-stop-at`) are out of scope. Both are candidates for a `config=key:value` extension if a future Issue needs them.
 
+## Condition Check Gate (`when=`)
+
+Problem: many `event=<name>` conditions depend not just on the triggering action completing, but
+on the *execution context* of that run — which route `/auto` took, whether it ran in batch or
+single mode, or whether a recovery fired. Without a way to declare that dependency, the condition
+dispatches on every completion of the event regardless of context and resolves SKIPPED whenever
+the context doesn't match. The parent Issue #1118 measured this against 12 real observation ACs:
+7 of the 12 depend on run context (route / mode / recovery tier) that `event=` alone cannot
+express, and each SKIPPED dispatch still costs a full `/verify` round-trip.
+
+The gate adds an optional `when=<axis>:<value>` attribute to the observation AC tag. Multiple
+clauses may be comma-separated and are combined with AND:
+
+```
+<!-- verify-type: observation event=auto-run when=route:operate -->
+<!-- verify-type: observation event=auto-run when=mode:batch,recovery-tier:2 -->
+```
+
+**Declarable axes (exhaustive):**
+
+| Axis | Fact JSON field | Values |
+|------|------------------|--------|
+| `route` | per-issue `.issues[].route` | `pr` \| `patch` \| `operate` \| `unknown` |
+| `mode` | top-level `.mode` | `batch` \| `single` \| `unknown` |
+| `recovery-tier` | per-issue `.issues[].recovery_tiers` | `1` \| `2` \| `3` |
+
+`opportunistic-search.sh` matches `when=` clauses against the run facts JSON produced by
+`scripts/collect-run-facts.sh` (see `modules/run-fact-matching.md` § Fact JSON Fields for the
+full field definitions). It never collects its own execution context independently.
+
+**Arguments table addition (both scripts):**
+
+| Argument | Description |
+|----------|-------------|
+| `--facts-file <path>` | Optional. Path to a run facts JSON file (`collect-run-facts.sh` output) to match `when=` clauses against. If omitted, `opportunistic-search.sh` lazily calls `collect-run-facts.sh` with no arguments the first time a `when=`-tagged AC line is processed, and caches the result for the rest of the process. If the given path does not exist, a warning is printed to stderr and the gate falls back to lazy collection. `observation-trigger.sh` forwards this argument as-is to `opportunistic-search.sh`. |
+
+**Matching specification:**
+
+- Extraction: `when=<clauses>` is read from the AC line via `grep -oE 'when=[^ >]+'` (stops at the next space or `-->`), trailing dashes stripped — the same extraction pattern as `keyword=` and `config=`.
+- Clauses are split on `,` and every clause must resolve true for the gate to pass (AND, not OR).
+- Each clause is `<axis>:<value>`. Per axis: `route:<v>` checks `any(.issues[]?; .route == $v)`, `mode:<v>` checks `.mode == $v`, `recovery-tier:<v>` checks `any(.issues[]?; ((.recovery_tiers // []) | map(tostring)) | index($v) != null)` against the resolved run facts JSON.
+- Gate disabled (unconditional match) when: no `when=` attribute on the AC line.
+- Fail-open (unconditional match, with a stderr warning) when: run facts cannot be resolved (`collect-run-facts.sh` fails or the `--facts-file` path is unreadable), the facts JSON is not valid JSON, or the facts JSON carries no run context (`(.issues | length) == 0 and .mode == "unknown"`).
+- A malformed clause (no `:`, or an empty value) or an unknown axis is ignored (fail-open for that clause only, with a stderr warning) rather than excluding the AC — an unrecognized clause never counts as a failed AND term.
+- `when=` presumes `event=auto-run` — the run facts JSON describes an `/auto` execution, so declaring `when=` on an AC tagged with a different `event=` value has no meaningful facts to match against (the gate still evaluates mechanically, but the result is not a meaningful signal).
+- This is a distinct mechanism from `modules/verify-executor.md`'s verify command modifier `--when="shell condition"` (e.g. `<!-- verify: command "..." --when="which bats" -->`). That modifier gates a `verify:` command's execution on a shell condition; `when=<axis>:<value>` here is a `verify-type: observation` tag attribute that gates AC *dispatch* on `/auto` run context. They share a name by coincidence, occupy different positions in the AC comment syntax, and are evaluated by different code paths.
+
+## Conditions That Cannot Be Pre-Excluded
+
+Not every observation condition can be expressed as a `when=` clause, and this is expected rather
+than a gap to keep closing. Some conditions are inherently unobservable in advance:
+
+- **Probabilistic events** — e.g. #1113's jq parse error, which only occurs under specific,
+  non-deterministic input shapes. There is no run-context axis that predicts whether the error
+  will occur on a given run.
+- **Time-series comparisons** — e.g. #1159's condition, which compares behavior across multiple
+  runs over time rather than testing a single run's context.
+- **Recovery kinds not represented in the fact JSON** — e.g. #1009 / #1123, which require knowing
+  *which* recovery path fired, a granularity `collect-run-facts.sh`'s `recovery_tiers` (tier
+  number only) does not capture.
+
+For these, dispatching the AC on every `event=` firing and letting it resolve `SKIPPED` when the
+condition does not hold is the correct, expected behavior — not a defect to fix with a broader
+`when=` axis. Suppressing the resulting comment accumulation is the responsibility of #1099's
+idempotency guard (§ Idempotency guard marker format above), not the condition check gate. The
+gate's job is to filter out AC that are *knowably* inapplicable to a run's context before
+dispatch; conditions in this section are not knowable in advance by construction.
+
 ## Notes
 
 - `opportunistic-search.sh` is the single source of truth for event-name validation (`KNOWN_EVENTS` list)
 - Adding a new event requires: (1) adding to `KNOWN_EVENTS` in `opportunistic-search.sh`, (2) adding a row to the emitter table in `modules/verify-classifier.md`, (3) wiring the emitter call in the relevant skill or script
 - The `fix-cycle` event is defined but has no emitter yet — see child Issue under #650
 - This mechanism only ever matches ACs by **event name** (`verify-type: observation event=<name>`); `manual`-tagged post-merge AC are never dispatched here at all. [`modules/run-fact-matching.md`](run-fact-matching.md) is the complementary mechanism: it reconciles a completed `/auto` run's structured facts against pending post-merge AC of every verify-type (including `manual`), catching conditions this event-name-only path structurally cannot reach
-- Unlike § Condition Check Gate (`keyword=`) and § Condition Check Gate (`config=`) above, the `session=next` attribute (see `modules/verify-classifier.md` § observation Type: Event Values and Syntax) sits at the same tag position but is **not** a dispatch gate — it does not change which Issues `opportunistic-search.sh` matches. It is a declaration consumed downstream by `/issue` Step 4 and `/verify` Step 8c. This is intentional: the conversation session boundary that `session=next` describes cannot be machine-determined (measured on Issue #1157 and recorded in Issue #1168's comment thread — a different `AUTO_SESSION_ID` still runs on stale skill content within the same conversation session), so gating on it would make the AC permanently fail to dispatch instead of eventually resolving
+- Unlike § Condition Check Gate (`keyword=`), § Condition Check Gate (`config=`), and § Condition Check Gate (`when=`) above, the `session=next` attribute (see `modules/verify-classifier.md` § observation Type: Event Values and Syntax) sits at the same tag position but is **not** a dispatch gate — it does not change which Issues `opportunistic-search.sh` matches. It is a declaration consumed downstream by `/issue` Step 4 and `/verify` Step 8c. This is intentional: the conversation session boundary that `session=next` describes cannot be machine-determined (measured on Issue #1157 and recorded in Issue #1168's comment thread — a different `AUTO_SESSION_ID` still runs on stale skill content within the same conversation session), so gating on it would make the AC permanently fail to dispatch instead of eventually resolving

--- a/modules/run-fact-matching.md
+++ b/modules/run-fact-matching.md
@@ -54,6 +54,11 @@ JSON shape). Fields most relevant to Step 3's rubric judgment:
   issue, or `[]` if no recovery event fired. `anomalies.recovery` keeps its existing
   count-only semantics unchanged (additive, backward-compatible).
 
+This same fact JSON (top-level `mode`, per-issue `route` and `recovery_tiers`) is also consumed by
+`scripts/opportunistic-search.sh`'s `when=<axis>:<value>` condition check gate, which matches
+observation AC dispatch against a single run's context rather than reconciling post-merge AC after
+the fact — see `modules/observation-trigger.md` § Condition Check Gate (`when=`).
+
 ## Processing Steps
 
 1. Run `${CLAUDE_PLUGIN_ROOT}/scripts/collect-run-facts.sh` (with `--session

--- a/modules/verify-classifier.md
+++ b/modules/verify-classifier.md
@@ -67,6 +67,21 @@ Gate (`config=`) for the resolution mechanics.
 keys with two or more dots are not supported, and the comparison is boolean-only (`true`/`false`);
 enum-valued keys (e.g. `auto-stop-at`) are out of scope for `config=`.
 
+**`when=<axis>:<value>` for `/auto` run-context-dependent observation conditions**: when the
+observation condition's text depends on the execution context of the `/auto` run that fires the
+event (route / mode / recovery tier), append one or more comma-separated `when=<axis>:<value>`
+clauses (combined with AND) to the tag:
+
+```
+<!-- verify-type: observation event=auto-run when=route:operate -->
+```
+
+If `when=` is omitted for a context-dependent condition, the AC matches unconditionally on every
+`event=` dispatch — including runs whose context does not satisfy the condition, so it resolves
+SKIPPED every time instead of ever reaching a real evaluation. Declarable axes, per-axis fact JSON
+fields, and fail-open semantics are documented in `modules/observation-trigger.md` § Condition
+Check Gate (`when=`).
+
 **`session=next` for skill self-update propagation**: wholework is self-hosted — the harness caches
 skill content per conversation session, not per `/auto` execution. When an Issue changes
 `skills/*/SKILL.md`, a post-merge observation condition that observes the changed skill's own

--- a/scripts/observation-trigger.sh
+++ b/scripts/observation-trigger.sh
@@ -3,11 +3,16 @@
 # Dispatch observation-type ACs when a named event fires.
 #
 # Usage:
-#   scripts/observation-trigger.sh --event <event-name> [--dry-run] [--context-file <path>]
+#   scripts/observation-trigger.sh --event <event-name> [--dry-run] [--context-file <path>] [--facts-file <path>]
 #
 # --context-file is forwarded as-is to opportunistic-search.sh, which gates
 # matches carrying a `keyword=<text>` AC attribute against the file's content
 # (case-insensitive substring match). See modules/observation-trigger.md § Condition Check Gate.
+#
+# --facts-file is forwarded as-is to opportunistic-search.sh, which gates
+# matches carrying a `when=<axis>:<value>` AC attribute against /auto run facts
+# (route / mode / recovery-tier). See modules/observation-trigger.md § Condition
+# Check Gate (when=).
 #
 # For each matched Issue, posts a comment recommending the user re-run /verify,
 # unless a `<!-- wholework-event: type=observation-trigger ... event=<name> -->`
@@ -26,6 +31,7 @@ SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 EVENT_NAME=""
 DRY_RUN=false
 CONTEXT_FILE=""
+FACTS_FILE=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -49,9 +55,17 @@ while [ $# -gt 0 ]; do
             CONTEXT_FILE="$2"
             shift 2
             ;;
+        --facts-file)
+            if [ $# -lt 2 ]; then
+                echo "Error: --facts-file requires an argument" >&2
+                exit 1
+            fi
+            FACTS_FILE="$2"
+            shift 2
+            ;;
         *)
             echo "Error: Unknown argument: $1" >&2
-            echo "Usage: $0 --event <event-name> [--dry-run] [--context-file <path>]" >&2
+            echo "Usage: $0 --event <event-name> [--dry-run] [--context-file <path>] [--facts-file <path>]" >&2
             exit 1
             ;;
     esac
@@ -63,11 +77,14 @@ if [ -z "$EVENT_NAME" ]; then
     exit 1
 fi
 
+SEARCH_ARGS=(--event "$EVENT_NAME")
 if [ -n "$CONTEXT_FILE" ]; then
-    RESULTS=$("${SCRIPT_DIR}/opportunistic-search.sh" --event "$EVENT_NAME" --context-file "$CONTEXT_FILE" 2>/dev/null || true)
-else
-    RESULTS=$("${SCRIPT_DIR}/opportunistic-search.sh" --event "$EVENT_NAME" 2>/dev/null || true)
+    SEARCH_ARGS+=(--context-file "$CONTEXT_FILE")
 fi
+if [ -n "$FACTS_FILE" ]; then
+    SEARCH_ARGS+=(--facts-file "$FACTS_FILE")
+fi
+RESULTS=$("${SCRIPT_DIR}/opportunistic-search.sh" "${SEARCH_ARGS[@]}" 2>/dev/null || true)
 
 if [ -z "$RESULTS" ] || [ "$RESULTS" = "[]" ]; then
     exit 0

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -141,6 +141,41 @@ if [ -n "$FACTS_FILE" ] && [ ! -f "$FACTS_FILE" ]; then
     FACTS_FILE=""
 fi
 
+# resolve_run_facts: lazily resolve run facts JSON, once per process. Called on demand by
+# the first `when=`-tagged AC line encountered in the match loop below. Result is cached in
+# RUN_FACTS_JSON (empty string means the gate is disabled — fail-open).
+RUN_FACTS_RESOLVED=false
+RUN_FACTS_JSON=""
+
+resolve_run_facts() {
+    if [ "$RUN_FACTS_RESOLVED" = true ]; then
+        return
+    fi
+    RUN_FACTS_RESOLVED=true
+
+    local facts
+    if [ -n "$FACTS_FILE" ]; then
+        facts=$(cat "$FACTS_FILE" 2>/dev/null || true)
+    else
+        facts=$("${SCRIPT_DIR}/collect-run-facts.sh" 2>/dev/null || true)
+    fi
+
+    if [ -z "$facts" ]; then
+        echo "Warning: run facts unavailable, disabling when= condition check gate" >&2
+        return
+    fi
+    if ! echo "$facts" | jq -e . >/dev/null 2>&1; then
+        echo "Warning: run facts are not valid JSON, disabling when= condition check gate" >&2
+        return
+    fi
+    if echo "$facts" | jq -e '(.issues | length) == 0 and .mode == "unknown"' >/dev/null 2>&1; then
+        echo "Warning: run facts carry no run context (empty issues, mode=unknown), disabling when= condition check gate" >&2
+        return
+    fi
+
+    RUN_FACTS_JSON="$facts"
+}
+
 # 1. Fetch closed Issues with phase/verify label
 ISSUES_JSON=$(gh issue list --label "phase/verify" --state closed --json number --limit 50)
 ISSUE_NUMBERS=$(echo "$ISSUES_JSON" | jq -r '.[].number')

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -226,6 +226,64 @@ for N in $ISSUE_NUMBERS; do
             fi
         fi
 
+        # when= condition check gate: skip lines whose when=<axis>:<value>[,<axis>:<value>...]
+        # clauses (AND) do not all match the current /auto run facts (route / mode /
+        # recovery-tier). No when= attribute means unconditional match (backward compatible).
+        # Facts unavailable/invalid/contextless (resolve_run_facts fail-open), and unknown axes
+        # or malformed clauses, are ignored rather than excluding the line.
+        WHEN_ATTR=$(echo "$line" | grep -oE 'when=[^ >]+' | sed -e 's/^when=//' -e 's/-*$//' || true)
+        if [ -n "$WHEN_ATTR" ]; then
+            resolve_run_facts
+            if [ -n "$RUN_FACTS_JSON" ]; then
+                WHEN_MATCH=true
+                OLD_IFS="$IFS"
+                IFS=','
+                for CLAUSE in $WHEN_ATTR; do
+                    IFS="$OLD_IFS"
+                    case "$CLAUSE" in
+                        *:*) ;;
+                        *)
+                            echo "Warning: malformed when= clause '${CLAUSE}' (missing ':'), ignoring" >&2
+                            IFS=','
+                            continue
+                            ;;
+                    esac
+                    WHEN_AXIS="${CLAUSE%%:*}"
+                    WHEN_VALUE="${CLAUSE#*:}"
+                    if [ -z "$WHEN_VALUE" ]; then
+                        echo "Warning: malformed when= clause '${CLAUSE}' (empty value), ignoring" >&2
+                        IFS=','
+                        continue
+                    fi
+                    case "$WHEN_AXIS" in
+                        route)
+                            if ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" 'any(.issues[]?; .route == $v)' >/dev/null 2>&1; then
+                                WHEN_MATCH=false
+                            fi
+                            ;;
+                        mode)
+                            if ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" '.mode == $v' >/dev/null 2>&1; then
+                                WHEN_MATCH=false
+                            fi
+                            ;;
+                        recovery-tier)
+                            if ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" 'any(.issues[]?; ((.recovery_tiers // []) | map(tostring)) | index($v) != null)' >/dev/null 2>&1; then
+                                WHEN_MATCH=false
+                            fi
+                            ;;
+                        *)
+                            echo "Warning: unknown when= axis '${WHEN_AXIS}', ignoring clause" >&2
+                            ;;
+                    esac
+                    IFS=','
+                done
+                IFS="$OLD_IFS"
+                if [ "$WHEN_MATCH" = false ]; then
+                    continue
+                fi
+            fi
+        fi
+
         # Extract text with HTML comments and checkbox markup removed
         CONDITION=$(echo "$line" \
             | sed 's/^- \[ \] //' \

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   scripts/opportunistic-search.sh <skill-name> [--dry-run]
-#   scripts/opportunistic-search.sh --event <event-name> [--dry-run] [--context-file <path>]
+#   scripts/opportunistic-search.sh --event <event-name> [--dry-run] [--context-file <path>] [--facts-file <path>]
 #
 # Examples:
 #   scripts/opportunistic-search.sh /issue
@@ -12,6 +12,7 @@
 #   scripts/opportunistic-search.sh --event pr-review-full
 #   scripts/opportunistic-search.sh --event auto-run --dry-run
 #   scripts/opportunistic-search.sh --event pr-review-full --context-file /tmp/spec.md
+#   scripts/opportunistic-search.sh --event auto-run --facts-file .tmp/run-facts-session1.json
 #
 # --context-file gates event-mode matches: when a matched AC line carries a
 # `keyword=<text>` attribute and --context-file is given, the Issue is only
@@ -27,6 +28,17 @@
 # argument is needed — .wholework.yml is read directly from CWD. See
 # modules/observation-trigger.md § Condition Check Gate (config=).
 #
+# `when=<axis>:<value>` gates event-mode matches on /auto run context (route /
+# mode / recovery-tier): when a matched AC line carries a `when=` attribute,
+# the Issue is only included if the run facts JSON (scripts/collect-run-facts.sh
+# output) satisfies every comma-separated clause (AND). --facts-file <path>
+# supplies the facts JSON explicitly; when omitted, the facts are collected
+# lazily (once per process) by calling collect-run-facts.sh with no arguments.
+# Facts that are unavailable, invalid, or contextless resolve the gate to
+# unconditional match (fail-open). ACs without `when=` match unconditionally
+# (backward compatible). See modules/observation-trigger.md § Condition Check
+# Gate (when=).
+#
 # Output: JSON array [{"number": N, "condition": "condition text"}]
 #         Empty array [] when no matches found
 
@@ -39,6 +51,7 @@ SKILL_NAME=""
 EVENT_NAME=""
 DRY_RUN=false
 CONTEXT_FILE=""
+FACTS_FILE=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -60,6 +73,14 @@ while [ $# -gt 0 ]; do
                 exit 1
             fi
             CONTEXT_FILE="$2"
+            shift 2
+            ;;
+        --facts-file)
+            if [ $# -lt 2 ]; then
+                echo "Error: --facts-file requires an argument" >&2
+                exit 1
+            fi
+            FACTS_FILE="$2"
             shift 2
             ;;
         -*)
@@ -111,6 +132,13 @@ fi
 if [ -n "$CONTEXT_FILE" ] && [ ! -f "$CONTEXT_FILE" ]; then
     echo "Warning: --context-file '${CONTEXT_FILE}' not found, disabling condition check gate" >&2
     CONTEXT_FILE=""
+fi
+
+# --facts-file: if the path does not exist, clear it so resolve_run_facts() falls back to
+# lazy collection instead of reading a missing file.
+if [ -n "$FACTS_FILE" ] && [ ! -f "$FACTS_FILE" ]; then
+    echo "Warning: --facts-file '${FACTS_FILE}' not found, falling back to lazy run-facts collection" >&2
+    FACTS_FILE=""
 fi
 
 # 1. Fetch closed Issues with phase/verify label

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -164,8 +164,8 @@ resolve_run_facts() {
         echo "Warning: run facts unavailable, disabling when= condition check gate" >&2
         return
     fi
-    if ! echo "$facts" | jq -e . >/dev/null 2>&1; then
-        echo "Warning: run facts are not valid JSON, disabling when= condition check gate" >&2
+    if ! echo "$facts" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        echo "Warning: run facts are not a valid JSON object, disabling when= condition check gate" >&2
         return
     fi
     if echo "$facts" | jq -e '(.issues | length) == 0 and .mode == "unknown"' >/dev/null 2>&1; then
@@ -231,20 +231,25 @@ for N in $ISSUE_NUMBERS; do
         # recovery-tier). No when= attribute means unconditional match (backward compatible).
         # Facts unavailable/invalid/contextless (resolve_run_facts fail-open), and unknown axes
         # or malformed clauses, are ignored rather than excluding the line.
-        WHEN_ATTR=$(echo "$line" | grep -oE 'when=[^ >]+' | sed -e 's/^when=//' -e 's/-*$//' || true)
+        # Extraction is scoped to the HTML comment tag (not the whole line) and takes only the
+        # last match: the AC's human-readable prose may itself quote "when=..." syntax (e.g. to
+        # describe the attribute), and matching against the whole line would corrupt WHEN_ATTR
+        # with an embedded newline from grep -o's one-match-per-line output.
+        AC_TAG=$(echo "$line" | grep -oE '<!--.*-->' || true)
+        WHEN_ATTR=$(echo "$AC_TAG" | grep -oE 'when=[^ >]+' | tail -n 1 | sed -e 's/^when=//' -e 's/-*$//' || true)
         if [ -n "$WHEN_ATTR" ]; then
             resolve_run_facts
             if [ -n "$RUN_FACTS_JSON" ]; then
                 WHEN_MATCH=true
-                OLD_IFS="$IFS"
-                IFS=','
-                for CLAUSE in $WHEN_ATTR; do
-                    IFS="$OLD_IFS"
+                # IFS=',' read -a splits on commas without word-splitting/globbing the result,
+                # unlike `for CLAUSE in $WHEN_ATTR` which would pathname-expand values
+                # containing *, ?, or [...] against files in the current working directory.
+                IFS=',' read -r -a WHEN_CLAUSES <<< "$WHEN_ATTR"
+                for CLAUSE in "${WHEN_CLAUSES[@]}"; do
                     case "$CLAUSE" in
                         *:*) ;;
                         *)
                             echo "Warning: malformed when= clause '${CLAUSE}' (missing ':'), ignoring" >&2
-                            IFS=','
                             continue
                             ;;
                     esac
@@ -252,22 +257,27 @@ for N in $ISSUE_NUMBERS; do
                     WHEN_VALUE="${CLAUSE#*:}"
                     if [ -z "$WHEN_VALUE" ]; then
                         echo "Warning: malformed when= clause '${CLAUSE}' (empty value), ignoring" >&2
-                        IFS=','
                         continue
                     fi
                     case "$WHEN_AXIS" in
                         route)
-                            if ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" 'any(.issues[]?; .route == $v)' >/dev/null 2>&1; then
+                            if echo "$RUN_FACTS_JSON" | jq -e '(.issues | length) == 0' >/dev/null 2>&1; then
+                                echo "Warning: run facts carry no per-issue context, ignoring when=route clause" >&2
+                            elif ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" 'any(.issues[]?; .route == $v)' >/dev/null 2>&1; then
                                 WHEN_MATCH=false
                             fi
                             ;;
                         mode)
-                            if ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" '.mode == $v' >/dev/null 2>&1; then
+                            if echo "$RUN_FACTS_JSON" | jq -e '.mode == "unknown"' >/dev/null 2>&1; then
+                                echo "Warning: run facts carry no mode context, ignoring when=mode clause" >&2
+                            elif ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" '.mode == $v' >/dev/null 2>&1; then
                                 WHEN_MATCH=false
                             fi
                             ;;
                         recovery-tier)
-                            if ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" 'any(.issues[]?; ((.recovery_tiers // []) | map(tostring)) | index($v) != null)' >/dev/null 2>&1; then
+                            if echo "$RUN_FACTS_JSON" | jq -e '(.issues | length) == 0' >/dev/null 2>&1; then
+                                echo "Warning: run facts carry no per-issue context, ignoring when=recovery-tier clause" >&2
+                            elif ! echo "$RUN_FACTS_JSON" | jq -e --arg v "$WHEN_VALUE" 'any(.issues[]?; ((.recovery_tiers // []) | map(tostring)) | index($v) != null)' >/dev/null 2>&1; then
                                 WHEN_MATCH=false
                             fi
                             ;;
@@ -275,9 +285,7 @@ for N in $ISSUE_NUMBERS; do
                             echo "Warning: unknown when= axis '${WHEN_AXIS}', ignoring clause" >&2
                             ;;
                     esac
-                    IFS=','
                 done
-                IFS="$OLD_IFS"
                 if [ "$WHEN_MATCH" = false ]; then
                     continue
                 fi

--- a/tests/observation-trigger.bats
+++ b/tests/observation-trigger.bats
@@ -127,6 +127,20 @@ teardown() {
     ! grep -q -- "--context-file" "$BATS_TEST_TMPDIR/search-calls.log"
 }
 
+@test "forwarding: --facts-file is forwarded to opportunistic-search.sh" {
+    export MOCK_SEARCH_OUTPUT="[]"
+    run bash "$SCRIPT" --event auto-run --facts-file "$BATS_TEST_TMPDIR/facts.json"
+    [ "$status" -eq 0 ]
+    grep -q -- "--facts-file $BATS_TEST_TMPDIR/facts.json" "$BATS_TEST_TMPDIR/search-calls.log"
+}
+
+@test "forwarding: no --facts-file means opportunistic-search.sh is called without it" {
+    export MOCK_SEARCH_OUTPUT="[]"
+    run bash "$SCRIPT" --event auto-run
+    [ "$status" -eq 0 ]
+    ! grep -q -- "--facts-file" "$BATS_TEST_TMPDIR/search-calls.log"
+}
+
 @test "resilience: opportunistic-search.sh error does not abort trigger" {
     export MOCK_SEARCH_EXIT=1
     export MOCK_SEARCH_OUTPUT=""

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -31,6 +31,13 @@ fi
 exit 0
 MOCK_EOF
     chmod +x "$MOCK_DIR/gh"
+
+    # collect-run-facts.sh mock (used by when gate tests via WHOLEWORK_SCRIPT_DIR)
+    cat > "$MOCK_DIR/collect-run-facts.sh" << 'MOCK_EOF'
+#!/bin/bash
+echo "${MOCK_RUN_FACTS:-}"
+MOCK_EOF
+    chmod +x "$MOCK_DIR/collect-run-facts.sh"
 }
 
 teardown() {
@@ -287,6 +294,94 @@ teardown() {
     [ "$status" -eq 0 ]
     echo "$output" | jq -e 'length == 1' > /dev/null
     echo "$output" | jq -e '.[0].number == 602' > /dev/null
+}
+
+@test "when gate: run facts route matches includes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 700}]'
+    export MOCK_ISSUE_BODY_700='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":700,"route":"operate","recovery_tiers":[]}]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 700' > /dev/null
+}
+
+@test "when gate: run facts route mismatch excludes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 701}]'
+    export MOCK_ISSUE_BODY_701='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":701,"route":"pr","recovery_tiers":[]}]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "when gate: AC without when= matches unconditionally" {
+    export MOCK_ISSUE_LIST='[{"number": 702}]'
+    export MOCK_ISSUE_BODY_702='- [ ] Next /auto auto-checks this condition <!-- verify-type: observation event=auto-run -->'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 702' > /dev/null
+}
+
+@test "when gate: undeterminable run facts fail open with a warning" {
+    export MOCK_ISSUE_LIST='[{"number": 703}]'
+    export MOCK_ISSUE_BODY_703='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    unset MOCK_RUN_FACTS
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run 2>&1
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning:"*"run facts"* ]]
+    echo "$output" | grep -v "^Warning" | jq -e 'length == 1' > /dev/null
+    echo "$output" | grep -v "^Warning" | jq -e '.[0].number == 703' > /dev/null
+}
+
+@test "when gate: unknown axis fails open with a warning" {
+    export MOCK_ISSUE_LIST='[{"number": 704}]'
+    export MOCK_ISSUE_BODY_704='- [ ] pr-state observed <!-- verify-type: observation event=auto-run when=pr-state:open -->'
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":704,"route":"pr","recovery_tiers":[]}]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run 2>&1
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning: unknown when= axis 'pr-state'"* ]]
+    echo "$output" | grep -v "^Warning" | jq -e 'length == 1' > /dev/null
+    echo "$output" | grep -v "^Warning" | jq -e '.[0].number == 704' > /dev/null
+}
+
+@test "when gate: comma-separated AND excludes when one clause fails" {
+    export MOCK_ISSUE_LIST='[{"number": 705}]'
+    export MOCK_ISSUE_BODY_705='- [ ] batch recovery observed <!-- verify-type: observation event=auto-run when=mode:batch,recovery-tier:2 -->'
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"batch","issues":[{"number":705,"route":"pr","recovery_tiers":[1]}]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "when gate: --facts-file explicit designation bypasses collect-run-facts.sh" {
+    export MOCK_ISSUE_LIST='[{"number": 706}]'
+    export MOCK_ISSUE_BODY_706='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    echo '{"session_id":"s1","mode":"single","issues":[{"number":706,"route":"operate","recovery_tiers":[]}]}' > "$BATS_TEST_TMPDIR/facts.json"
+
+    run bash "$SCRIPT" --event auto-run --facts-file "$BATS_TEST_TMPDIR/facts.json"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 706' > /dev/null
 }
 
 @test "session=next declaration does not affect event= dispatch matching" {

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -376,12 +376,62 @@ teardown() {
 @test "when gate: --facts-file explicit designation bypasses collect-run-facts.sh" {
     export MOCK_ISSUE_LIST='[{"number": 706}]'
     export MOCK_ISSUE_BODY_706='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    # MOCK_RUN_FACTS deliberately mismatches route:operate (facts.json below is the only source
+    # that matches). If --facts-file were silently ignored and collect-run-facts.sh's mock
+    # consulted instead, the result would be [] instead of a match on #706 — making this
+    # assertion decisive proof of bypass rather than just "a result was returned".
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":706,"route":"pr","recovery_tiers":[]}]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
     echo '{"session_id":"s1","mode":"single","issues":[{"number":706,"route":"operate","recovery_tiers":[]}]}' > "$BATS_TEST_TMPDIR/facts.json"
 
     run bash "$SCRIPT" --event auto-run --facts-file "$BATS_TEST_TMPDIR/facts.json"
+    unset WHOLEWORK_SCRIPT_DIR
     [ "$status" -eq 0 ]
     echo "$output" | jq -e 'length == 1' > /dev/null
     echo "$output" | jq -e '.[0].number == 706' > /dev/null
+}
+
+@test "when gate: when= appearing in AC prose text (outside the tag) does not corrupt gate matching" {
+    export MOCK_ISSUE_LIST='[{"number": 707}]'
+    export MOCK_ISSUE_BODY_707='- [ ] AC text that quotes when=route:operate as an example <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":707,"route":"operate","recovery_tiers":[]}]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 707' > /dev/null
+}
+
+@test "when gate: glob metacharacters in a when= value are treated as a literal (no pathname expansion)" {
+    export MOCK_ISSUE_LIST='[{"number": 708}]'
+    export MOCK_ISSUE_BODY_708='- [ ] wildcard axis value observed <!-- verify-type: observation event=auto-run when=route:* -->'
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":708,"route":"operate","recovery_tiers":[]}]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run 2>&1
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    # A literal "*" never equals the facts' route value "operate", so the clause fails and the
+    # issue is excluded — it must NOT expand to the CWD's file list (which would emit multiple
+    # "malformed when= clause" warnings, one per matched filename).
+    [ "$(echo "$output" | grep -c "malformed when= clause")" -le 1 ]
+    [ "$(echo "$output" | grep -v "^Warning")" = "[]" ]
+}
+
+@test "when gate: mode resolved with empty issues fails open on the route axis instead of silently excluding" {
+    export MOCK_ISSUE_LIST='[{"number": 709}]'
+    export MOCK_ISSUE_BODY_709='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[]}'
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+
+    run bash "$SCRIPT" --event auto-run 2>&1
+    unset WHOLEWORK_SCRIPT_DIR
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning:"*"no per-issue context"* ]]
+    echo "$output" | grep -v "^Warning" | jq -e 'length == 1' > /dev/null
+    echo "$output" | grep -v "^Warning" | jq -e '.[0].number == 709' > /dev/null
 }
 
 @test "session=next declaration does not affect event= dispatch matching" {


### PR DESCRIPTION
## Summary
`verify-type: observation` の AC は `event=<name>` だけで発火条件を宣言するため、実行文脈 (route / mode / recovery tier) に依存する条件でも無条件にマッチし、必ず SKIPPED に終わっていた (親 Issue #1118 の実測: 12 件中 7 件が実行文脈依存)。本 PR では `opportunistic-search.sh` の gate 段に `when=<axis>:<value>` 属性 (`config=` と同型) を追加し、`scripts/collect-run-facts.sh` の出力 (route / mode / recovery_tiers) を照合に使う。判定不能・未知軸は fail-open (無条件マッチ + 警告)。

- `scripts/opportunistic-search.sh`: `--facts-file <path>` 引数、`resolve_run_facts()` 遅延解決関数、マッチループへの `when=` ゲート追加
- `scripts/observation-trigger.sh`: `--facts-file` の受理と転送
- `modules/observation-trigger.md`: `## Condition Check Gate (when=)` 節、`## Conditions That Cannot Be Pre-Excluded` 節の新設
- `modules/verify-classifier.md` / `modules/run-fact-matching.md`: `when=` 属性の説明・相互参照を追加
- `tests/opportunistic-search.bats` / `tests/observation-trigger.bats`: `when=` ゲートと `--facts-file` 転送のテストを追加
- Issue #995 の post-merge observation AC 1 行に `when=route:operate` を追加 (Post-merge 条件の参照ケース)

## Verification (pre-merge)
- rubric: 実行文脈条件を宣言する仕組みが実装され、方式選定の根拠が記録されている
- rubric: 実行文脈の取得が `collect-run-facts.sh` と重複していない
- rubric: 宣言可能な軸と除外不能条件の扱いがドキュメント化されている
- grep: `observation-trigger.md` が `when=` に言及している
- rubric: 3 経路 (マッチ/除外/無条件マッチ) を検証するテストが追加されている
- `tests/opportunistic-search.bats` が PASS する (ローカル確認済み、全 52 件 PASS)
- `bats tests/` フルスイート 1412 件 PASS (modules/verify-classifier.md への追記が tests/verify-executor.bats からも参照されるため behavioral change 判定によりフルスイートを実行)
- CI: `gh pr checks` で bats テスト全件が PASS すること

## Verification (post-merge)
- pr route の `/auto` 完走後に `scripts/observation-trigger.sh --event auto-run --dry-run` を実行し、operate route を要求する AC (#995) がマッチ集合から除外されていることを確認する

closes #1172
