### PR TITLE
Issue #1156: Enforce checkbox format for Pre-merge/Post-merge AC lines

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（69 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（74 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -235,6 +235,7 @@ wholework/
 - `scripts/check-verify-dirty.sh` — /verify Step 1 用 session-aware dirty file 分類スクリプト (self-worktree / other-worktree / other-session / self-spec / own-issue-scope / foreign-session / parent-main (帰属未確定時のフォールバック) の 7 分類; own-issue-scope と foreign-session の判定は自 Issue の Spec `## Changed Files` マニフェストを根拠とする; classify=... を stderr 出力)
 - `scripts/check-session-findings-disposition.sh` — L3 `session.md` の `## Findings` から canonical disposition タグ欠落を検出；`skills/auto/SKILL.md` Step 5 の commit 直前に warn-only で呼び出される
 - `scripts/check-skill-change-observation-ac.sh` — Issue 本文が `skills/*/SKILL.md` に言及する場合に、post-merge の `verify-type: observation` AC から `session=next` 未付与を検出；`skills/issue/SKILL.md` Step 4 から warn-only で呼び出される
+- `scripts/check-ac-checkbox-format.sh` — Issue 本文の `### Pre-merge` / `### Post-merge` セクション配下でチェックボックス形式でない条件行を検出；`skills/issue/SKILL.md` Step 4 から warn-only で呼び出される
 - `scripts/check-translation-sync.sh` — docs/ja/* と docs/* の翻訳同期状況を確認
 - `scripts/check-forbidden-expressions.sh` — docs/product.md § Terms の deprecated terms を検出
 - `scripts/setup-labels.sh` — ワークフロー用 GitHub ラベルを作成

--- a/docs/spec/issue-1156-post-merge-checkbox-format.md
+++ b/docs/spec/issue-1156-post-merge-checkbox-format.md
@@ -136,18 +136,32 @@ Issue 本文の対応方針候補 2 は「`/issue` の AC 監査ステップ、�
 ### Rework
 - N/A
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — PR diff は Spec の Implementation Steps / Changed Files と完全に一致していた。AC1 (規約明記) / AC2 (機械検出) / AC3 (既存3件処理) の 3 条件はいずれも diff 上の対応箇所を直接特定でき、`review-light` エージェントによる Spec Deviation 観点でも issue なしと判定された。
+
+### Recurring issues
+
+`scripts/check-ac-checkbox-format.sh` の awk セクション終端判定 (`^## ` / `^### ` の完全一致のみ) が、深いサブ見出しやフェンスコードブロック内の見出し文字列を区別しない CONSIDER 級の指摘を受けた。これは同型の `check-pre-merge-ac.sh` の awk パターンに既に存在する簡略化であり、本 PR 固有の新規不具合ではない。#1168 (`check-skill-change-observation-ac.sh`) から続く「warn-only チェッカースクリプトを awk セクション追跡で実装する」パターンの共通の弱点として、将来同種スクリプトを追加する際は再確認が必要。
+
+### Acceptance criteria verification difficulty
+
+AC3 (rubric "既存の未解決 3 件 (#734 / #735 / #1006) が処理されている、または修正しない判断とその理由が記録されている") の判定に、`rubric` verify command の grader 入力スコープ (`modules/verify-executor.md` により Issue 本文 + git diff + rubric text で明示的に named されたファイルのみ、Spec は対象外) だけでは根拠が不足していた。本 PR の diff は #734/#735/#1006 を一切変更しておらず、修正不要と判断した理由は Spec の Code Retrospective (grader スコープ外) にのみ記録されている。実際の判定は `/review` 実行者が `gh issue view` で #734/#735/#1006 の Post-merge 行を直接確認し、既にチェックボックス形式であることを確認する形で行った — これは grader の正規スコープを超えた追加調査であり、rubric grader 単体では UNCERTAIN になっていた可能性が高い。「他 Issue の外部状態確認」を要求する rubric 条件は、根拠を Spec ではなく Issue 本文または Issue コメントに明示的に記録するよう Issue 起票時に促すと、grader スコープ内で完結できる。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `scripts/check-ac-checkbox-format.sh` は `check-skill-change-observation-ac.sh` のヘッダコメント形式 (Usage / Exit codes) と `check-pre-merge-ac.sh` の awk セクション追跡パターンをそのまま踏襲し、bash 3.2+ 互換を維持した
-- `/issue` Step 4 への挿入位置は Spec 指定通り「BRE metacharacter detection in verify commands」ブロック直後、Step 5 直前とした
-- Step 7 (Existing Issue Refinement) 側は「Step 4 の手順に従う」という既存の委譲文言がそのまま Step 4 への追加をカバーするため、テキスト変更なし (#1168 と同型)
+- Base Branch Conflict Pre-check (`git merge-tree` 3-引数形式) を実行したが `changed in both` は検出されず (main 側が独立に触った `docs/spec/issue-1175-*.md` は本 PR ブランチ側は無変更のためクリーンマージ) 、conflict context ファイルは作成しなかった
+- REVIEW_DEPTH=light (`--light` 明示指定) のため Step 10.0 の 1 エージェント統合レビューのみ実行し、Workflow path (10.1–10.3 static fan-out や workflow-guidance.md の Workflow tool 経路) は評価対象外とした
+- AC3 の rubric 判定は Spec 記載の根拠だけでなく `gh issue view 734/735/1006` による実地確認を追加で行い PASS と判断した (grader 正規スコープ外の追加検証、詳細は review retrospective 参照)
 
 ### Deferred Items
-- Post-merge の observation AC (`session=next`、次回 `/issue` 実行での挙動観察) は本 Issue が `skills/issue/SKILL.md` を変更対象とするため、次回セッションでの観察が必要 — `/verify` フェーズで評価される想定
-- `docs/guide/index.md` の翻訳 OUTDATED および `docs/guide/autonomy.md` の MISSING_JA は `scripts/check-translation-sync.sh` で検出したが、本 Issue のスコープ外 (未変更ファイル) のため対応していない
+- CONSIDER 指摘 (awk セクション終端判定の簡略化) は対応不要と判断し未修正のまま — 姉妹スクリプト `check-pre-merge-ac.sh` 側の既存の弱点でもあるため、再発した場合は別 Issue で awk パターンの一括見直しを検討
+- Post-merge の observation AC (`session=next`) は今回未発火のため引き続き `/verify` フェーズでの評価待ち
 
 ### Notes for Next Phase
-- `bats tests/` フルスイート (1420+ テスト) は green。`skills/issue/SKILL.md` は `tests/issue.bats` 以外に `tests/xl-decomposition.bats` / `tests/run-issue.bats` からも参照されているため、behavioral change 判定でフルスイート実行が必要だった
-- Pre-merge AC 3 件はすべて rubric 確認済みで Issue 本文のチェックボックスを更新済み (`- [x]`)。post-merge AC (observation) のみ未チェックのまま残している
+- Pre-merge AC 3 件すべて PASS、CI 9 ジョブ SUCCESS、MUST/SHOULD なし (CONSIDER 1件のみ) — `/merge 1189` は追加のブロッカーなしで進行可能
+- Post-merge AC (observation, session=next) が唯一の未チェック項目。`/verify` 実行時に `session=next` の発火判定に従うこと

--- a/docs/spec/issue-1156-post-merge-checkbox-format.md
+++ b/docs/spec/issue-1156-post-merge-checkbox-format.md
@@ -10,6 +10,10 @@ cutoff (最新の `phase/*` ラベル付与時刻) は `2026-08-06T01:33:03Z`。
 
 上記コメントの内容は既に Issue 本文に反映済みであり、本 Spec の設計に対する追加の意思決定は不要だった。
 
+### code フェーズ (cutoff: 2026-08-06T02:06:32Z)
+
+No new comments since last phase.
+
 ## Overview
 
 `/issue` が生成する Post-merge 条件が、チェックボックス形式 (`- [ ]`) ではなくプレーン箇条書き (`- `) で書かれるケースが過去に 10 件発生した (2026-06-19〜07-13)。`verify-type` マーカーは正しく付与されるため条件文としては成立するが、チェックを入れる先のチェックボックス自体が存在しないため、`/verify` が PASS 判定してもその結果を記録できず、Issue は CLOSED のまま `phase/verify` に永久滞留する。`skills/issue/SKILL.md` の AC 生成規約にはチェックボックス形式を明示的に要求する記述がなく、これを機械的に強制するガードも存在しない。
@@ -92,6 +96,10 @@ cutoff (最新の `phase/*` ラベル付与時刻) は `2026-08-06T01:33:03Z`。
 
 - 次回 `/issue` で Post-merge 条件を含む Issue を起票した際、チェックボックス形式で生成されることを観察する <!-- verify-type: observation event=auto-run session=next -->
 
+## Autonomous Auto-Resolve Log
+
+- **`phase/ready` ラベル欠如の扱い**: `/code 1156 --pr --non-interactive` 実行時、Issue のラベルは `triaged` / `phase/code` / `audit/drift` で `phase/ready` が存在しなかった (`reconcile-phase-state.sh code-pr 1156 --check-precondition` は `matches_expected: false` を返した)。調査の結果、前回セッションが既に Step 1 (コメント消化, cutoff `2026-08-06T01:59:41Z`) と Step 4 (ラベル遷移 `phase/ready` → `phase/code`, cutoff `2026-08-06T02:06:32Z`) を実行済みで、その後 worktree を残さずに中断していたと判明した (docs/spec 側に未コミットの Step 1 記録のみが main の作業ツリーに残存)。Spec 自体は `/spec` により完備しているため、"Spec がない" ケース向けの auto-resolve ポリシー (Issue 本文から直接要件を読む) は適用せず、既存の完備した Spec を正として実装を継続した。
+
 ## Notes
 
 ### #1006 は変更不要 (grep/gh issue view で確認済み)
@@ -116,3 +124,30 @@ Issue 本文の対応方針候補 2 は「`/issue` の AC 監査ステップ、�
 ### #1168 との類似性
 
 本 Spec の設計 (新規 warn-only チェッカースクリプト + `/issue` Step 4 への組み込み + `allowed-tools` 更新 + `tests/issue.bats` content-assertion + `docs/structure.md`/`docs/ja/structure.md` 同期) は、直近の #1168 (`check-skill-change-observation-ac.sh` の追加) と同型である。#1168 の Verify Retrospective が指摘した MUST 不具合 (Spec 実行時点で未確定な `## Changed Files` をゲート条件にした、`$NUMBER` 未束縛のファイル名を使った) は本 Spec では該当しない — 新スクリプトの適用条件は Issue 本文テキストそのもの (`### Pre-merge` / `### Post-merge` 見出しの有無) であり Spec 由来の未確定情報に依存せず、ファイル名も既存の "Skill self-update propagation check" サブステップが使う固定ファイル名 `.tmp/issue-body-check.md` をそのまま再利用するため、`$NUMBER` 未束縛の問題も生じない。
+
+## Code Retrospective
+
+### Deviations from Design
+- Implementation Step 5 (#734 / #735 のチェックボックス形式修正) は、`/code` 実行時点で `check-ac-checkbox-format.sh` を両 Issue の本文に対して実行したところ既に exit 0 (チェックボックス形式) だったため、外部 GitHub 操作 (`gh-issue-edit.sh` での本文更新) は実行しなかった。原因は、本セッション開始前に一度中断した `/code 1156` の前回実行が、リポジトリファイル変更 (Step 1-4) に到達する前に Step 5 の外部操作のみを先に完了させていたためと判断した (Autonomous Auto-Resolve Log 参照)。受け入れ条件3 が要求する「修正されている」状態は満たされているため、実装ステップとしては完了扱いとする。
+
+### Design Gaps/Ambiguities
+- N/A — Spec の設計 (#1168 と同型のパターン踏襲) はそのまま実装でき、Root Cause / Changed Files / Implementation Steps に記載された前提と実装時の codebase 実態 (`skills/issue/SKILL.md` の該当挿入位置、`check-pre-merge-ac.sh` の awk セクション追跡方式) に齟齬はなかった。
+
+### Rework
+- N/A
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `scripts/check-ac-checkbox-format.sh` は `check-skill-change-observation-ac.sh` のヘッダコメント形式 (Usage / Exit codes) と `check-pre-merge-ac.sh` の awk セクション追跡パターンをそのまま踏襲し、bash 3.2+ 互換を維持した
+- `/issue` Step 4 への挿入位置は Spec 指定通り「BRE metacharacter detection in verify commands」ブロック直後、Step 5 直前とした
+- Step 7 (Existing Issue Refinement) 側は「Step 4 の手順に従う」という既存の委譲文言がそのまま Step 4 への追加をカバーするため、テキスト変更なし (#1168 と同型)
+
+### Deferred Items
+- Post-merge の observation AC (`session=next`、次回 `/issue` 実行での挙動観察) は本 Issue が `skills/issue/SKILL.md` を変更対象とするため、次回セッションでの観察が必要 — `/verify` フェーズで評価される想定
+- `docs/guide/index.md` の翻訳 OUTDATED および `docs/guide/autonomy.md` の MISSING_JA は `scripts/check-translation-sync.sh` で検出したが、本 Issue のスコープ外 (未変更ファイル) のため対応していない
+
+### Notes for Next Phase
+- `bats tests/` フルスイート (1420+ テスト) は green。`skills/issue/SKILL.md` は `tests/issue.bats` 以外に `tests/xl-decomposition.bats` / `tests/run-issue.bats` からも参照されているため、behavioral change 判定でフルスイート実行が必要だった
+- Pre-merge AC 3 件はすべて rubric 確認済みで Issue 本文のチェックボックスを更新済み (`- [x]`)。post-merge AC (observation) のみ未チェックのまま残している

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (69 files)
+├── scripts/             # Utility scripts used by skills and agents (74 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -243,6 +243,7 @@ Key modules:
 - `scripts/check-verify-dirty.sh` — session-aware dirty file classifier for /verify Step 1 (self-worktree / other-worktree / other-session / self-spec / own-issue-scope / foreign-session / parent-main (attribution-undetermined fallback) 7-way classification; own-issue-scope vs. foreign-session is decided against the Issue's own Spec `## Changed Files` manifest; outputs classify=... to stderr)
 - `scripts/check-session-findings-disposition.sh` — detects `## Findings` bullets in an L3 `session.md` missing a canonical disposition tag; called warn-only from `skills/auto/SKILL.md` Step 5 right before the commit
 - `scripts/check-skill-change-observation-ac.sh` — detects post-merge `verify-type: observation` ACs missing `session=next` when the Issue body references `skills/*/SKILL.md`; called warn-only from `skills/issue/SKILL.md` Step 4
+- `scripts/check-ac-checkbox-format.sh` — detects non-checkbox condition lines under `### Pre-merge` / `### Post-merge` sections of an Issue body; called warn-only from `skills/issue/SKILL.md` Step 4
 - `scripts/check-translation-sync.sh` — check translation sync status of docs/ja/* against docs/*
 - `scripts/check-forbidden-expressions.sh` — detect deprecated terms from docs/product.md § Terms
 - `scripts/setup-labels.sh` — create GitHub labels for workflow

--- a/scripts/check-ac-checkbox-format.sh
+++ b/scripts/check-ac-checkbox-format.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check-ac-checkbox-format.sh - Detect non-checkbox acceptance criteria lines
+# under ### Pre-merge / ### Post-merge sections of an Issue body
+#
+# Plain bullet lines (`- text`) in these sections are unresolvable downstream:
+# /verify has no checkbox to mark PASS on, so the Issue stays in phase/verify
+# forever even after the underlying condition is satisfied. This script
+# detects the format violation regardless of whether a verify-type/verify
+# marker is present on the line.
+#
+# Usage: check-ac-checkbox-format.sh <issue-body-md-path>
+#
+# Exit codes:
+#   0 — no ### Pre-merge / ### Post-merge section in the body, or every
+#       condition line under those sections is already checkbox format
+#   1 — usage error (missing argument or unreadable file)
+#   2 — one or more non-checkbox condition lines detected (printed to
+#       stdout, one per line)
+
+set -euo pipefail
+
+FILE="${1:-}"
+
+if [[ -z "$FILE" ]] || [[ ! -f "$FILE" ]] || [[ ! -r "$FILE" ]]; then
+  echo "Usage: check-ac-checkbox-format.sh <issue-body-md-path>" >&2
+  exit 1
+fi
+
+VIOLATIONS=$(awk '
+  BEGIN { in_section = 0 }
+  /^### Pre-merge/ { in_section = 1; next }
+  /^### Post-merge/ { in_section = 1; next }
+  /^## / || /^### / {
+    in_section = 0
+    next
+  }
+  /^- / {
+    if (in_section && $0 !~ /^- \[[ xX]\]/) {
+      print
+    }
+    next
+  }
+  { next }
+' "$FILE")
+
+if [[ -n "$VIOLATIONS" ]]; then
+  printf '%s\n' "$VIOLATIONS"
+  exit 2
+fi
+
+exit 0

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: issue
 description: Issue creation and refinement (`/issue "title"` or `/issue 123`). Creates new issues or refines/reformats existing ones. Use when creating issues, defining requirements, or standardizing issue content.
-allowed-tools: Bash(gh issue create:*, gh issue view:*, gh issue edit:*, gh issue close:*, gh issue list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-skill-change-observation-ac.sh:*), Glob, Grep, Write, Read, WebFetch, ToolSearch, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
+allowed-tools: Bash(gh issue create:*, gh issue view:*, gh issue edit:*, gh issue close:*, gh issue list:*, gh label create:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-skill-change-observation-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-ac-checkbox-format.sh:*), Glob, Grep, Write, Read, WebFetch, ToolSearch, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Issue Creation and Refinement
@@ -259,6 +259,18 @@ Warning: BRE metacharacter detected in verify command:
 Suggested ERE rewrite: grep "PATTERN_WITH_|" "path/to/file"
 Note: verify-executor uses ripgrep (ERE); \| in BRE means OR but is a literal | in ERE.
 ```
+
+**Checkbox format for Pre-merge / Post-merge condition lines:**
+
+Every condition line under `### Pre-merge (auto-verified)` / `### Post-merge` must start with `- [ ]` (or `- [x]` for an already-checked condition) — never a plain bullet (`- `). This applies to both sections and regardless of whether the line carries a `verify:` or `verify-type:` marker. Downstream processing (`/verify`, `scripts/check-pre-merge-ac.sh`, `/audit stats --retention`'s verify-type breakdown) parses condition lines with the `^- \[[ xX]\]` pattern; a plain-bullet condition is invisible to all of it. Once written to the Issue body in this form, the condition becomes permanently unresolvable — there is no checkbox to mark PASS on, so the Issue stays in `phase/verify` forever even after the underlying condition is satisfied (#1156).
+
+To detect a format violation mechanically, write the current Issue body to `.tmp/issue-body-check.md` (same fixed filename as the "Skill self-update propagation check" sub-step above) and run:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/check-ac-checkbox-format.sh .tmp/issue-body-check.md
+```
+
+Exit code 2 means one or more condition lines under `### Pre-merge` / `### Post-merge` are plain bullets — present the printed lines as a warning, insert `[ ] ` immediately after the bullet marker of each (`- ` → `- [ ] `), and update the Issue body. Exit code 1 is warn-only (usage error) — continue processing regardless. Delete the temp file afterward: `rm -f .tmp/issue-body-check.md`.
 
 ### Step 5: Clarification Questions
 

--- a/tests/check-ac-checkbox-format.bats
+++ b/tests/check-ac-checkbox-format.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+# Tests for check-ac-checkbox-format.sh
+# Verifies checkbox-format detection for ### Pre-merge / ### Post-merge
+# condition lines:
+#   exit 0 — no Pre-merge/Post-merge section, or every condition line is
+#            already checkbox format
+#   exit 1 — usage error (missing argument or unreadable file)
+#   exit 2 — one or more non-checkbox condition lines detected
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+REAL_SCRIPT="$PROJECT_ROOT/scripts/check-ac-checkbox-format.sh"
+
+setup() {
+    FIXTURE_DIR="$BATS_TEST_TMPDIR"
+}
+
+write_fixture() {
+    local path="$1"
+    cat > "$path"
+}
+
+@test "all conditions checkbox format: exit 0 and no output" {
+    write_fixture "$FIXTURE_DIR/issue.md" <<'EOF'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [ ] file exists <!-- verify: file_exists "foo.sh" -->
+
+### Post-merge
+
+- [ ] behavior changes as expected <!-- verify-type: observation event=auto-run -->
+EOF
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/issue.md"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "plain bullet under Post-merge: exit 2 and line printed" {
+    write_fixture "$FIXTURE_DIR/issue.md" <<'EOF'
+## Acceptance Criteria
+
+### Post-merge
+
+- behavior changes as expected <!-- verify-type: observation event=auto-run -->
+EOF
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/issue.md"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"behavior changes as expected"* ]]
+}
+
+@test "plain bullet under Pre-merge: exit 2 and line printed" {
+    write_fixture "$FIXTURE_DIR/issue.md" <<'EOF'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- file exists <!-- verify: file_exists "foo.sh" -->
+EOF
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/issue.md"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"file exists"* ]]
+}
+
+@test "plain bullet with no verify-type marker at all: exit 2" {
+    write_fixture "$FIXTURE_DIR/issue.md" <<'EOF'
+## Acceptance Criteria
+
+### Post-merge
+
+- something happens with no marker at all
+EOF
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/issue.md"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"something happens with no marker at all"* ]]
+}
+
+@test "no Pre-merge/Post-merge section in body: exit 0" {
+    write_fixture "$FIXTURE_DIR/issue.md" <<'EOF'
+## Background
+
+Some plain bullet not under any Pre-merge/Post-merge section.
+
+- this is not a condition line
+EOF
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/issue.md"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "already-checked checkbox is not flagged" {
+    write_fixture "$FIXTURE_DIR/issue.md" <<'EOF'
+## Acceptance Criteria
+
+### Post-merge
+
+- [x] behavior changes as expected <!-- verify-type: observation event=auto-run -->
+EOF
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/issue.md"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "plain bullet outside section boundary (after next heading) is not detected" {
+    write_fixture "$FIXTURE_DIR/issue.md" <<'EOF'
+## Acceptance Criteria
+
+### Post-merge
+
+- [ ] properly formatted condition <!-- verify-type: manual -->
+
+## Related
+
+- this plain bullet is outside Post-merge and must not be flagged
+EOF
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/issue.md"
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "no argument: exit 1 with usage message" {
+    run bash "$REAL_SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "nonexistent path: exit 1 with usage message" {
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR/does-not-exist.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "directory path: exit 1 with usage message, not silent exit 0" {
+    run bash "$REAL_SCRIPT" "$FIXTURE_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}

--- a/tests/issue.bats
+++ b/tests/issue.bats
@@ -32,3 +32,8 @@ setup() {
     grep -q 'check-skill-change-observation-ac.sh' "$PROJECT_ROOT/skills/issue/SKILL.md"
     grep -q 'session=next' "$PROJECT_ROOT/skills/issue/SKILL.md"
 }
+
+@test "issue skill Step 4 documents checkbox format convention and detection script" {
+    grep -q 'check-ac-checkbox-format.sh' "$PROJECT_ROOT/skills/issue/SKILL.md"
+    grep -q 'Checkbox format for Pre-merge / Post-merge condition lines' "$PROJECT_ROOT/skills/issue/SKILL.md"
+}


### PR DESCRIPTION
## Summary
- Post-merge/Pre-merge の受け入れ条件行がチェックボックス形式 (`- [ ]`) で始まらなければならない旨の規約を `skills/issue/SKILL.md` Step 4 に明記
- 新規スクリプト `scripts/check-ac-checkbox-format.sh` で形式違反を機械検出し (`verify-type` マーカーの有無によらず対象)、`/issue` Step 4 に warn-only で組み込み
- `docs/structure.md` / `docs/ja/structure.md` を同期 (Tooling 一覧 + scripts ファイル数 69→74)
- `tests/issue.bats` に content-assertion テストを追加
- 既存の未解決 3 件のうち #734 / #735 は調査時点で既にチェックボックス形式に修正済みと確認 (追加編集不要)。#1006 は Spec Notes に「変更不要」の判断根拠を記録済み

## Verification (pre-merge)
- skills/issue/SKILL.md に規約が明記されている (rubric 確認済み、Issue チェック済み)
- check-ac-checkbox-format.sh による機械検出が実装されている (rubric 確認済み、Issue チェック済み)
- 既存の残存3件が処理されている (rubric 確認済み、Issue チェック済み)
- `bats tests/` フルスイート green

## Verification (post-merge)
- 次回 `/issue` で Post-merge 条件を含む Issue を起票した際、チェックボックス形式で生成されることを観察する (observation, session=next)

closes #1156
