### PR TITLE
Issue #1186: /verify でチェック済み AC の再検証をスキップ

### DIFF
--- a/docs/spec/issue-1186-skip-checked-ac-reverify.md
+++ b/docs/spec/issue-1186-skip-checked-ac-reverify.md
@@ -87,17 +87,28 @@ Issue 本文の「方針確定 (2026-08-06)」注記により対応方針は確�
 ### Rework
 - Nothing to note. Rubric verify command 4 件と `bats tests/` はいずれも初回実装で PASS した。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- `/code` の Notes for Next Phase は「Step 5 の already-checked AC skip rule 文言と Step 8a の追加文が既存の pre-merge-preview AC skip rule と矛盾なく併存しているかを確認すること」を明示的に依頼しており、`/review` (review-light agent) がまさにこの点を検証した結果、実装は機能的には矛盾していない (両ルールとも同じ SKIPPED 結果に収束する) が、Spec の Overview (13行目) に書かれていた「preview 規則を置き換えない設計」という優先関係の説明が SKILL.md 本文には転記されていなかった、という CONSIDER レベルのドキュメント明確性ギャップを検出した。Spec に書いた設計意図が実装ファイル本体まで一貫して伝播しているかを確認する Notes for Next Phase の運用が機能した好例。review 中に一文追記して解消済み
+
+### Recurring issues
+- Base Branch Conflict Pre-check (`git merge-tree`) が、本 Spec ファイル自身に対する base (main) 側との "changed in both" 競合を検出した。原因は、姉妹コミット (`aa416dfe Add consumed comments fallback for issue #1186 (code phase)`) が同一 Issue #1186 の同じ Consumed Comments 段落に、別セッションから低品質な fallback 形式で追記していたこと。本 PR ブランチ側は同じソースコメントをより完全な形式 (見出し付きサブセクション) で既に記録していたため内容欠落はなく MUST 化は不要と判断したが、同一 Issue に対して複数セッション (fallback 投稿スクリプトと通常の `/code` セッション) が並行して Spec の同じ段落へ書き込みうる構造自体は、他 Issue でも再発しうるパターンとして記録しておく
+
+### Acceptance criteria verification difficulty
+- Nothing to note. rubric 4 件・`command "bats tests/"` 1 件のいずれも曖昧さや verify command の不備なく PASS 判定できた。`command "bats tests/"` は safe mode のため CI 参照フォールバック (`Run bats tests` job SUCCESS) で判定した
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の投稿位置指定 (段落文脈) どおりに Step 5 / Step 8a / Step 6 / Step 11(a) / Notes を編集し、追加の設計判断は発生しなかった
-- `docs/workflow.md` / `docs/guide/customization.md` は Spec retrospective の判断 (更新不要) を `/code` 側でも再確認し、grep で "re-verif"/"already checked" 系の記述がないことを確認した上で変更なしとした
-- Pre-merge の 5 条件 (rubric 4 件 + `bats tests/`) は SKILL.md 本文の直接確認とフルスイート実行 (1414 件 PASS) により PASS と判定し、Issue チェックボックスを更新した
+- review-light agent (4観点統合) を実行し、CONSIDER 1件 (Step 5 の already-checked AC skip rule と既存 pre-merge-preview AC skip rule の優先関係が SKILL.md 本文で未明記) を検出・修正した。MUST/SHOULD はゼロ
+- Base Branch Conflict Pre-check で本 Spec ファイル自身の base 側競合を検出したが、内容欠落なしと判断し MUST 化しなかった (詳細は review retrospective 参照)
+- Pre-merge の 5 条件は Issue body で既に `[x]` だったが、`/review` Step 8 は `/code` の判定を独立に再検証し (rubric 4件を SKILL.md 本文の直接確認で、`command "bats tests/"` を CI 参照フォールバックで)、いずれも PASS を確認した
 
 ### Deferred Items
 - Post-merge の observation AC (`event=auto-run session=next`) は本セッション内では評価不能。次回 `/auto` 完了後の `/verify` 実行で SKIPPED 報告を観察する必要がある (未着手のまま持ち越し)
 
 ### Notes for Next Phase
-- `/review` では、Step 5 の already-checked AC skip rule 文言と Step 8a の追加文が既存の pre-merge-preview AC skip rule と矛盾なく併存しているかを確認すること
+- `/merge` では通常の pre-merge AC gate に加え、`docs/spec/issue-1186-skip-checked-ac-reverify.md` の base 側競合 (Consumed Comments 段落の重複) が実際の `git merge`/squash merge で問題を起こさないか (fast-forward 前提が崩れていないか) を確認すること
 - `/verify` の次回実行 (session=next) で、post-merge observation AC が SKIPPED として正しく報告されるかを観察すること

--- a/docs/spec/issue-1186-skip-checked-ac-reverify.md
+++ b/docs/spec/issue-1186-skip-checked-ac-reverify.md
@@ -16,7 +16,9 @@ Issue 本文の「方針確定 (2026-08-06)」注記により対応方針は確�
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / summary: トリアージ自動連鎖の Issue Retrospective。Type=Task・Size=M・Value=3 を確定、post-merge observation AC に `session=next` を追加、タイトルの "pre-merge" 限定表現を除去、ambiguity point 0 件、verify command 5 件を Pattern 1〜6 で監査済み (問題なし) / URL: https://github.com/saitoco/wholework/issues/1186#issuecomment-5199530052
 
-- saito / MEMBER / first-class / ## 追加実測: `/verify 1175` と `/verify 1118` (2026-08-06) / https://github.com/saitoco/wholework/issues/1186#issuecomment-5199747782
+### code フェーズ (cutoff: 2026-08-06T02:22:36Z)
+
+- login: saito / authorAssociation: MEMBER / trust tier: first-class / summary: 方針 A を裏づける追加実測 2 件 (`/verify 1175`: チェック済み 4 件が全て SKIPPED 相当・新規情報ゼロ、`/verify 1118`: チェック済み AC ゼロのため方針 A の影響を受けず未チェック AC の評価は損なわれない) と、フル bats スイート 3 本同時実行時の負荷観測 (load average 倍増) を記録。設計・実装方針への変更要求はなく、既存の Implementation Steps をそのまま実行すればよい / URL: https://github.com/saitoco/wholework/issues/1186#issuecomment-5199747782
 ## Changed Files
 - `skills/verify/SKILL.md`: Step 5 に「already-checked AC skip rule」を追加 (pre-merge)、Step 8a の対象条件を unchecked に限定し同スキップ規則を適用 (post-merge + hint)、Step 6 の「Re-runs」箇条書きを新方針に合わせて書き換え、Step 11(a) の SKIPPED 括弧書きを整合、`## Notes` に Post-merge 重複記載による継続検証運用を追記 — bash 非対象 (Markdown skill 定義ファイル)
 - `tests/verify.bats`: already-checked AC skip rule (pre-merge / post-merge+hint) と unchecked AC が従来どおり検証されることを検証するテストを追加
@@ -74,19 +76,28 @@ Issue 本文の「方針確定 (2026-08-06)」注記により対応方針は確�
 ### Uncertainty resolution
 - Nothing to note
 
+## Code Retrospective
+
+### Deviations from Design
+- Nothing to note. Implementation Steps 1〜4 は Spec に記載した挿入位置・文言のとおりに実装した。
+
+### Design Gaps/Ambiguities
+- Nothing to note. Spec の investigation (Step 5/8a への限定、Step 8b/8c 対象外の確認) がそのまま実装に反映された。
+
+### Rework
+- Nothing to note. Rubric verify command 4 件と `bats tests/` はいずれも初回実装で PASS した。
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
-- スキップ規則の実装箇所を Step 5 (pre-merge) と Step 8a (post-merge+hint) の 2 箇所に限定した。Step 8b/8c は既に unchecked のみを対象にしており変更不要と判断した
-- 一般規則 (already-checked AC skip rule) と既存の `ac-tier: preview` 固有規則は併存させ、preview 規則を置き換えない設計とした (両者は矛盾せず、preview AC が `[x]` の場合は一般規則が適用されるだけ)
-- opt-in 再検証フラグは導入せず、継続検証は Post-merge セクションへの AC 重複記載で表現する方針を Notes に明記した (Issue 本文の確定方針どおり)
+- Spec の投稿位置指定 (段落文脈) どおりに Step 5 / Step 8a / Step 6 / Step 11(a) / Notes を編集し、追加の設計判断は発生しなかった
+- `docs/workflow.md` / `docs/guide/customization.md` は Spec retrospective の判断 (更新不要) を `/code` 側でも再確認し、grep で "re-verif"/"already checked" 系の記述がないことを確認した上で変更なしとした
+- Pre-merge の 5 条件 (rubric 4 件 + `bats tests/`) は SKILL.md 本文の直接確認とフルスイート実行 (1414 件 PASS) により PASS と判定し、Issue チェックボックスを更新した
 
 ### Deferred Items
-- Post-merge の observation AC (`event=auto-run session=next`) は本セッション内では評価不能。次回 `/auto` 完了後の `/verify` 実行で SKIPPED 報告を観察する必要がある
-- `docs/workflow.md` / `docs/guide/customization.md` は更新不要と判断したが、`/code` 実装時に SKILL.md の文言が固まった時点で念のため再確認が望ましい
+- Post-merge の observation AC (`event=auto-run session=next`) は本セッション内では評価不能。次回 `/auto` 完了後の `/verify` 実行で SKIPPED 報告を観察する必要がある (未着手のまま持ち越し)
 
 ### Notes for Next Phase
-- `/code` は Implementation Steps 1〜3 (SKILL.md 編集) と Step 4 (bats テスト追加) を、Spec に記載した挿入位置 (段落の文脈で指定、行番号ではない) に従って実装すること
-- `tests/verify.bats` に `step6_section`/`step8a_section` ヘルパーを追加する際、既存の `step5_section`/`step8c_section` の awk パターンに厳密に合わせること (見出しレベル `###` vs `####` の違いに注意)
-- 新規追加する文言 ("already checked; skipped by default" 等) は Pre-merge verify command (rubric) が期待する語彙と一致させ、SKILL.md 本文とテストで同一の exact phrase を使うこと
+- `/review` では、Step 5 の already-checked AC skip rule 文言と Step 8a の追加文が既存の pre-merge-preview AC skip rule と矛盾なく併存しているかを確認すること
+- `/verify` の次回実行 (session=next) で、post-merge observation AC が SKIPPED として正しく報告されるかを観察すること

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -196,6 +196,10 @@ For each `ac-tier: preview` AC in this Pre-merge section, using its own 1-based 
 
 If the same URL/UX verification is also needed against the production URL regardless of this fallback (e.g., to cover both a preview-time check and a standing production check), duplicate the AC in the `### Post-merge` section without the `<!-- ac-tier: preview -->` tag; `/verify` will then execute it against `PRODUCTION_URL` (resolved via `{{base_url}}` and the `production-url` key in `.wholework.yml`).
 
+**Already-checked AC skip rule (default; applies to every Pre-merge condition):**
+
+Any Pre-merge condition already at `- [x]` is excluded from verification and recorded as SKIPPED with the note "already checked; skipped by default" (its verify command, if any, is not re-executed). This is the default behavior for every re-run, not limited to `ac-tier: preview` conditions. Conditions still at `- [ ]` are processed as usual by the Verification priority steps below. Projects that need continuous re-checking after merge duplicate the AC in the `### Post-merge` section (see `## Notes`) — no opt-in re-verification flag is provided.
+
 **Patch route detection (run before verification):**
 
 If PR_NUMBER (from Step 2) is empty and any acceptance condition contains `github_check "gh pr checks"`, treat those conditions as UNCERTAIN with the following guidance:
@@ -308,7 +312,7 @@ Comma-separated multiple indices are supported. Use `--uncheck` to uncheck.
 - SKIPPED conditions → leave as `- [ ]` (not executed due to unmet environment conditions)
 - Cannot auto-verify → leave as `- [ ]` (deferred to user verification)
 - **Post-merge conditions (all types)** → do not update here; post-merge PASS conditions are updated at the end of Step 8
-- **Re-runs**: re-verify all conditions (idempotent). Re-verify even if already checked; report via comment if result changes
+- **Re-runs**: conditions already at `- [x]` are skipped by default per the already-checked AC skip rule in Step 5 (and, for post-merge + hint conditions, Step 8a) and recorded as SKIPPED — they are not re-verified. Only conditions still at `- [ ]` are (re-)verified on every run
 
 ### Step 7: Post-merge Briefing
 
@@ -337,7 +341,9 @@ Process post-merge ACs in two sub-steps, then flip checkboxes for PASS results.
 
 #### Step 8a: Auto-verify Post-merge Conditions with Hints
 
-For post-merge conditions that have `<!-- verify: ... -->` hints, apply the same verification logic as inner Steps 1–4 of Step 5 (CI failure detection, verify command execution via `verify-executor.md`, AI judgment fallback, cannot-auto-verify deferral). Record each result as PASS, FAIL, UNCERTAIN, or PENDING.
+For post-merge conditions that are still `- [ ]` (unchecked) and have `<!-- verify: ... -->` hints, apply the same verification logic as inner Steps 1–4 of Step 5 (CI failure detection, verify command execution via `verify-executor.md`, AI judgment fallback, cannot-auto-verify deferral). Record each result as PASS, FAIL, UNCERTAIN, or PENDING.
+
+Post-merge + hint conditions already at `- [x]` are subject to the same already-checked AC skip rule defined in Step 5: exclude from verification and record as SKIPPED with the note "already checked; skipped by default".
 
 #### Step 8b: Manual Post-merge Conditions
 
@@ -512,7 +518,7 @@ gh issue view "$NUMBER" --json state --jq '.state'
 
 Apply the following judgment based on the verification results (exhaustive):
 
-**(a) All auto-verification target conditions are PASS or SKIPPED (0 FAIL/UNCERTAIN among auto-verification targets; SKIPPED is ignored as environment conditions were unmet):**
+**(a) All auto-verification target conditions are PASS or SKIPPED (0 FAIL/UNCERTAIN among auto-verification targets; SKIPPED is ignored as environment conditions were unmet or the condition was already checked):**
 
 Emit `phase_complete` (phase=verify; only when `AUTO_EVENTS_LOG` is set; restore the pointer first):
 ```bash
@@ -974,3 +980,4 @@ Then read `${CLAUDE_PLUGIN_ROOT}/modules/next-action-guide.md` and follow the "P
 - Verification commands are read-only in principle (do not modify the environment)
 - Always wrap variables (`$NUMBER`, etc.) in double quotes
 - Always create and write temp files with the Write tool. Creating or writing temp files via Bash `cat`/`echo`/redirect (`>`) is prohibited (causes confirmation prompts)
+- Conditions already at `- [x]` are skipped by default (Step 5, Step 8a) and not re-verified on subsequent runs. Projects that need a condition to be continuously re-checked after merge should duplicate the same AC text as a separate condition in the `### Post-merge` section, rather than relying on re-verification of an already-checked condition

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -198,7 +198,7 @@ If the same URL/UX verification is also needed against the production URL regard
 
 **Already-checked AC skip rule (default; applies to every Pre-merge condition):**
 
-Any Pre-merge condition already at `- [x]` is excluded from verification and recorded as SKIPPED with the note "already checked; skipped by default" (its verify command, if any, is not re-executed). This is the default behavior for every re-run, not limited to `ac-tier: preview` conditions. Conditions still at `- [ ]` are processed as usual by the Verification priority steps below. Projects that need continuous re-checking after merge duplicate the AC in the `### Post-merge` section (see `## Notes`) — no opt-in re-verification flag is provided.
+Any Pre-merge condition already at `- [x]` is excluded from verification and recorded as SKIPPED with the note "already checked; skipped by default" (its verify command, if any, is not re-executed). This is the default behavior for every re-run, not limited to `ac-tier: preview` conditions. Conditions still at `- [ ]` are processed as usual by the Verification priority steps below. Projects that need continuous re-checking after merge duplicate the AC in the `### Post-merge` section (see `## Notes`) — no opt-in re-verification flag is provided. This rule does not replace the pre-merge-preview AC skip rule above: for an `ac-tier: preview` condition already at `- [x]`, that rule's own SKIPPED note ("preview-tier AC; verified/checked at /review against preview URL") takes precedence — the two rules do not conflict, they converge on the same SKIPPED outcome via different notes for different reasons.
 
 **Patch route detection (run before verification):**
 

--- a/tests/verify.bats
+++ b/tests/verify.bats
@@ -25,6 +25,18 @@ step8c_section() {
     awk '/^#### Step 8c: /{found=1} (/^#### / || /^### /) && !/Step 8c: /{found=0} found{print}' "$SKILL_FILE"
 }
 
+# Extract the "### Step 6: Update Pre-merge Checkboxes (Immediate Lock-in)" section from SKILL.md.
+# The section ends at the next level-3 (### Step ) heading.
+step6_section() {
+    awk '/^### Step 6: /{found=1} /^### Step / && !/Step 6: /{found=0} found{print}' "$SKILL_FILE"
+}
+
+# Extract the "#### Step 8a: Auto-verify Post-merge Conditions with Hints" section from SKILL.md.
+# The section ends at the next heading (level-3 or level-4).
+step8a_section() {
+    awk '/^#### Step 8a: /{found=1} (/^#### / || /^### /) && !/Step 8a: /{found=0} found{print}' "$SKILL_FILE"
+}
+
 @test "Step 2 guard: detect-foreign-worktree.sh runs before base branch checkout" {
     guard_line=$(step2_section | grep -n -F "detect-foreign-worktree.sh" | head -1 | cut -d: -f1)
     checkout_line=$(step2_section | grep -n -F 'git checkout "${BASE_BRANCH}"' | head -1 | cut -d: -f1)
@@ -107,4 +119,27 @@ step8c_section() {
 @test "Step 8c: session=next resolves to SKIPPED instead of UNCERTAIN" {
     step8c_section | grep -q -F "session=next"
     step8c_section | grep -q -F "skill self-update not yet propagated (session=next)"
+}
+
+@test "Step 5 already-checked AC skip rule: checked pre-merge AC is excluded and recorded SKIPPED" {
+    step5_section | grep -q -F "Already-checked AC skip rule"
+    step5_section | grep -q -F "already checked; skipped by default"
+}
+
+@test "Step 5 already-checked AC skip rule: unchecked pre-merge AC is still processed as usual" {
+    step5_section | grep -q -F "Conditions still at \`- [ ]\` are processed as usual"
+}
+
+@test "Step 8a already-checked AC skip rule: checked post-merge+hint AC is excluded and recorded SKIPPED" {
+    step8a_section | grep -q -F "already checked; skipped by default"
+}
+
+@test "Step 8a already-checked AC skip rule: only unchecked post-merge+hint AC is auto-verified" {
+    step8a_section | grep -q -F "still \`- [ ]\` (unchecked)"
+}
+
+@test "Step 6 Re-runs description no longer re-verifies already-checked conditions" {
+    ! step6_section | grep -q -F "Re-verify even if already checked"
+    step6_section | grep -q -F "skipped by default"
+    step6_section | grep -q -F "Only conditions still at \`- [ ]\` are (re-)verified"
 }


### PR DESCRIPTION
## Summary
- `skills/verify/SKILL.md` の Step 5 (pre-merge) と Step 8a (post-merge + hint) に already-checked AC skip rule を追加し、既に `- [x]` の条件を再検証せず SKIPPED として記録するよう変更
- Step 6 の Re-runs 記述と Step 11(a) の SKIPPED 括弧書きを新方針に合わせて更新
- `## Notes` に、merge 後も継続検証したい条件は Post-merge セクションへ AC を重複記載する運用を明記 (opt-in 再検証フラグは導入しない)
- `tests/verify.bats` に `step6_section`/`step8a_section` ヘルパーと、チェック済み/未チェック双方の経路を検証するテストを追加

## Verification (pre-merge)
- SKILL.md にチェック済み AC を pre-merge/post-merge 問わずスキップする方針が明記されている
- スキップが SKIPPED として理由付きで報告されることが SKILL.md に定められている
- 重複記載による継続検証の運用が記載され、再検証フラグは導入されていない
- チェック済み/未チェックの双方の経路を検証するテストが追加されている
- `bats tests/` 全 1414 件 PASS

## Verification (post-merge)
- 次回 `/verify` 実行時に、チェック済み AC が再実行されず SKIPPED として報告されることを観察する (session=next)

closes #1186