### PR TITLE
Issue #1163: manual AC 区分 A (34件) を observation event= へ再型付け

### DIFF
--- a/docs/reports/manual-ac-retype-a.md
+++ b/docs/reports/manual-ac-retype-a.md
@@ -1,0 +1,89 @@
+# manual AC 区分 A: observation 再型付けマッピング (#1163)
+
+親 Issue #1158 の分割対応。`phase/verify` に滞留する `verify-type: manual` の post-merge AC のうち、区分 A (「次回 X が発生した際に…を観察する」型) の 34 Issue / 36 AC 行を対象に、`verify-type: observation event=<name>` への再型付けを行った記録。
+
+## 対象・件数内訳
+
+- 対象 Issue: 34 件 (#1045 #869 #861 #859 #856 #852 #822 #807 #806 #804 #778 #770 #769 #765 #762 #761 #760 #759 #758 #755 #737 #736 #732 #731 #724 #719 #708 #707 #704 #700 #520 #501 #500 #479)
+- 対象 AC 行: 36 行 (#719 と #708 が各 2 行を持つため、Issue 単位の 34 件と AC 行単位の 36 行にずれがある)
+- 再型付け: **29 行** (`event=auto-run` 27 行 / `event=fix-cycle` 2 行)
+- 対象外 (`manual` 維持): **7 行**
+
+## `event=` 有効値の制約
+
+`event=` に使用できるのは `modules/verify-classifier.md` § observation Type が定める 5 つの有効値のみ: `pr-review-full` / `pr-review-light` / `auto-run` / `watchdog-kill` / `fix-cycle`。未知の event 名は `observation-trigger.sh` 側で warning を出したうえ `opportunistic` へフォールバックし、実質的に自動評価パイプラインに乗らない。条件文が待つ将来イベントがこの 5 値のいずれにも一致しない場合は、`manual` のまま維持し対象外として理由を記録する (過去の類似判断: #869 条件6 `code_retry_fire`、#704 条件2 `skill-invocation`、#700 条件A1 `verify-retry`)。
+
+## 再型付けマッピング
+
+### `event=auto-run` (27 AC 行)
+
+| Issue | 条件文の要約 | 選定根拠 |
+|---|---|---|
+| #1045 | 次回 external kill 発生時に `wrapper_alive` と kill 時刻の差分から control-flow / subprocess kill を判別 | external kill 検出 (`detect-external-kill.sh`) は `skills/auto/SKILL.md` の phase 完了判定内で実行される |
+| #869 | 次回 silent no-op が観測された session で `code_retry_fire` が記録される | silent no-op 検出と retry 発火は `/auto` の code phase 内 |
+| #861 | 次回並列セッション環境で phase 開始時に他セッション由来 dirty が warning 表示 | phase 開始は `/auto` 実行の内側。「並列セッション」は `when=` の宣言可能軸 (route / mode / recovery-tier) に無く事前排除できない |
+| #859 | 次回並列セッション環境で他セッション作業ファイルと自セッション作業中ファイルを区別して判定 | 同上 |
+| #856 | 次回 merge なし reopen Issue に `/auto $N` 実行時 fix-cycle と誤判定されない | 条件文が `/auto` 実行そのものを待っている |
+| #852 | 次回 reopen 後の Issue に `/auto $N` 実行時 code phase が正しく実行される | 同上 |
+| #822 | 次回 manual recovery 発生時に対象 sub-issue の Spec へ `## Auto Retrospective` が自動追記 | manual recovery は `/auto` orchestration 内で発生する |
+| #807 | 次回 batch session で wrapper レベル自動 retry が試行され recoveries.md に記録 | `/auto --batch` 実行の内側 |
+| #806 | 次回 `run-auto-sub.sh` kill 発生時に `/auto --resume N` で正常完走 | `/auto --resume` 実行の内側 |
+| #804 | 次回 migration/rename/削除 Issue の `/spec` で Changed Files に symbol grep 結果が反映 | `/spec` は `/auto` の spec phase として実行される |
+| #778 | 次回 migration Issue の Spec に SKILL.md + script の対称的 `file_not_contains` AC が含まれる | 同上 |
+| #770 | 2 つの `/auto --batch` 同時起動で各 session の report が他 session の Issue を含まない | `/auto --batch` 実行の内側 |
+| #769 | 次回 batch 実行後の `/audit auto-session --full` で Per-Issue Durations が実処理件数と一致 | batch 完走が観測の前提 |
+| #765 | 次回 PR で正当な記述が commit に含まれた際 Forbidden Expressions check が PASS | 当該 check は `/code` (`forbidden-expressions-check.md`)・`/review` (`skill-dev-recheck.md`)・CI (`test.yml`) で実行され、いずれも `/auto` の内側。`pr-review-full` は `--full` review でのみ発火するため取りこぼす |
+| #762 | 次回 batch/XL session でデータ層レポート末尾に L3 retrospective への See also リンクが出力 | batch/XL 実行の内側 |
+| #761 | 次回 Tier 2 fallback catalog 適用 Issue の Spec の `## Auto Retrospective` に anomaly エントリが含まれる | Tier 2 fallback は `/auto` orchestration 内 |
+| #760 | 次回 batch で Tier 2 リカバリ発生時に report の Improvement Candidates Surfaced に symptom 表示 | 同上 |
+| #759 | 次回 Tier 2/3 自動回復発生 Issue の `/verify` で新基準に従った判断が一意に行われる | `/auto` 実行内の verify phase が観測窓 |
+| #758 | 次回新 SSoT モジュール作成時に checklist が実行され review phase で SSoT 乖離 SHOULD が出ない | checklist は `/code`、SHOULD 指摘は `/review`。SHOULD は `--light`/`--full` 双方で発生しうるため `pr-review-full` 固定では取りこぼす |
+| #755 | 次回新 skill 作成時に `execution-context.md` を参照して context check が標準化 | spec / code phase の内側 |
+| #737 | 次回 `get-sub-issue-progress.sh` 変更 Issue で direct test が regression を検出 | bats regression は CI (`/review` が完了を待機) で顕在化。対象 Issue の Size が読めず review depth が確定しないため `pr-review-full` 固定は不適 |
+| #736 | 次回 `get-auto-session-report.sh` 変更 Issue で direct unit test が regression を検出 | 同上 |
+| #732 | 次回 `phase-handoff.md` 変更 Issue で `bats tests/phase-handoff.bats` が regression を検出 | 同上 |
+| #731 | 次回 `test-runner.md` 変更 Issue で `bats tests/test-runner.bats` が regression を検出 | 同上 |
+| #724 | 次回 git diff ベース比較ロジックの Spec で当該節が参照され code phase の rework がゼロ | spec / code phase の内側 |
+| #520 | `/auto` 実行で skill mis-dispatch 由来の silent no-op が観察されない | 条件文が `/auto` 実行を明示している |
+| #719 条件2 | pre-existing FAILURE 解消後、`pre-merge-check.sh` が baseline=PASS 状態で正常動作 | `bash scripts/check-forbidden-expressions.sh` は 2026-08-06 時点で exit 0 (実測) — 前提は充足済み。`pre-merge-check.sh` は `/code`・`/review` で実行される |
+
+### `event=fix-cycle` (2 AC 行)
+
+| Issue | 条件文の要約 | 選定根拠 |
+|---|---|---|
+| #707 | `/verify N` を FAIL させ機械可読 marker 付き comment が append され grep できる | `skills/verify/SKILL.md` の FAIL → reopen 経路が、marker comment 投稿と `observation-trigger.sh --event fix-cycle` を同一ステップで実行する |
+| #700 | `auto-retry-on-fail.enabled: true` 下で `/verify` FAIL → `/code` 再発火 → PASS または budget 枯渇 | 同じ FAIL → reopen 経路が観測窓。本リポジトリの `.wholework.yml` は `auto-retry-on-fail.enabled: true` |
+
+### 対象外 (`manual` 維持、7 AC 行)
+
+| Issue | 条件文の要約 | 対象外の理由 |
+|---|---|---|
+| #719 条件1 | 別 PR で意図的に Forbidden Expressions FAIL を作り abort を観察 | 故障注入型。人為的に失敗 PR を用意しない限り 5 有効値のどの発火でも観測窓が開かない (`docs/stats/2026-08-05.md` の区分 C 相当) |
+| #708 条件1 | 試験的に `phase/ready` のみ付与・Spec 無しの M Issue で `matches_expected: false` を確認 | 試験的コマンド実行が前提の故障注入型。bats テスト化が本筋 |
+| #708 条件2 | 試験的に XS Issue (Spec 無し) で `matches_expected: true` を確認 | 同上 |
+| #704 | `autonomy: L2` の状態で skill が許可経路のみ実行することを観察 | 本リポジトリは `autonomy: L3` で前提が成立しない。`config=` ゲートは boolean 専用で enum キー (`autonomy`) を表現できない (`modules/observation-trigger.md` § Condition Check Gate (`config=`)) |
+| #501 | downstream プロジェクトで phase 間の文脈喪失が体感的に減ることを観察 | 別リポジトリでの主観評価。upstream から観測不能 (区分 B 相当) |
+| #500 | downstream で mid-run API 障害時に Tier 2 内で自動 reconcile + retry を実行し復旧 | 別リポジトリ + 障害注入の二重前提。upstream から観測不能 |
+| #479 | 次回 vault 領域に触れる `/code` 実行でファイル編集が実装される | vault 領域は downstream 固有でこのリポジトリに存在しない。upstream の `/auto` 実行では観測窓が開かない |
+
+## 検証
+
+`${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event <name> --dry-run` (read-only、コメント投稿なし) を実行し、再型付け後の AC がマッチ対象になることを確認した。
+
+### `--event auto-run`
+
+- 実行結果: マッチ 59 AC 行 (2026-08-06 実測)
+- 再型付け前 baseline (Spec 記載, 2026-08-06 実測): 31 AC 行
+- 本 Issue で再型付けした 27 AC 行 (#1045 #869 #861 #859 #856 #852 #822 #807 #806 #804 #778 #770 #769 #765 #762 #761 #760 #759 #758 #755 #737 #736 #732 #731 #724 #520 #719条件2) は **全件マッチ集合に含まれることを確認済み** (Python で目視突合)
+- baseline 31 との単純差分 (+28) は再型付け 27 行と一致しない。同期間に他 sub-issue (#1164〜#1167 等、親 #1158 の並行対応) や `/auto` 実行由来の新規 `observation event=auto-run` AC が母集団に加わった可能性があり、本 Issue の再型付けだけが変動要因ではない。目視突合で対象 27 行の含有を直接確認しているため、件数差分の厳密一致よりもこちらを正とする
+
+### `--event fix-cycle`
+
+- 実行結果: マッチ 5 AC 行 (#1006 #700 #707 #569 #586)
+- 本 Issue で再型付けした 2 AC 行 (#707 #700) は **マッチ集合に含まれることを確認済み**
+
+### GitHub 上の実状態 (Pre-merge AC4〜AC6 相当)
+
+- `gh issue view 869 --json body`: `verify-type: observation event=auto-run` へ再型付け済みを確認
+- `gh issue view 707 --json body`: `verify-type: observation event=fix-cycle` へ再型付け済みを確認
+- `gh issue view 704 --json body`: `verify-type: manual` のまま維持されていることを確認 (対象外)

--- a/docs/reports/manual-ac-retype-a.md
+++ b/docs/reports/manual-ac-retype-a.md
@@ -11,64 +11,64 @@
 
 ## `event=` 有効値の制約
 
-`event=` に使用できるのは `modules/verify-classifier.md` § observation Type が定める 5 つの有効値のみ: `pr-review-full` / `pr-review-light` / `auto-run` / `watchdog-kill` / `fix-cycle`。未知の event 名は `observation-trigger.sh` 側で warning を出したうえ `opportunistic` へフォールバックし、実質的に自動評価パイプラインに乗らない。条件文が待つ将来イベントがこの 5 値のいずれにも一致しない場合は、`manual` のまま維持し対象外として理由を記録する (過去の類似判断: #869 条件6 `code_retry_fire`、#704 条件2 `skill-invocation`、#700 条件A1 `verify-retry`)。
+`event=` に使用できるのは `modules/verify-classifier.md` § observation Type が定める 5 つの有効値のみ: `pr-review-full` / `pr-review-light` / `auto-run` / `watchdog-kill` / `fix-cycle`。`watchdog-kill` は `scripts/claude-watchdog.sh` の hang-kill handler からのみ発火するため、external kill / process-group kill を待つ条件 (#1045 #806) には対応せず、これらは `auto-run` を採る。未知の event 名を持つ AC 行は 5 種のどの dispatch にもマッチせず、自動評価パイプラインに乗らない (CLI 引数として未知 event を渡した場合は `opportunistic-search.sh` が warning を出し、skill 名なしの `observation-trigger.sh` 経由では exit 1 となる)。条件文が待つ将来イベントがこの 5 値のいずれにも一致しない場合は、`manual` のまま維持し対象外として理由を記録する (過去に無効な event 名が指摘され一旦 `manual` へ差し戻された例: #869 条件6 `code_retry_fire` → 本 Issue で `auto-run` へ、#700 条件A1 `verify-retry` → 本 Issue で `fix-cycle` へ、#704 条件2 `skill-invocation` → 本 Issue でも `manual` 維持)。
 
 ## 再型付けマッピング
 
 ### `event=auto-run` (27 AC 行)
 
-| Issue | 条件文の要約 | 選定根拠 |
-|---|---|---|
-| #1045 | 次回 external kill 発生時に `wrapper_alive` と kill 時刻の差分から control-flow / subprocess kill を判別 | external kill 検出 (`detect-external-kill.sh`) は `skills/auto/SKILL.md` の phase 完了判定内で実行される |
-| #869 | 次回 silent no-op が観測された session で `code_retry_fire` が記録される | silent no-op 検出と retry 発火は `/auto` の code phase 内 |
-| #861 | 次回並列セッション環境で phase 開始時に他セッション由来 dirty が warning 表示 | phase 開始は `/auto` 実行の内側。「並列セッション」は `when=` の宣言可能軸 (route / mode / recovery-tier) に無く事前排除できない |
-| #859 | 次回並列セッション環境で他セッション作業ファイルと自セッション作業中ファイルを区別して判定 | 同上 |
-| #856 | 次回 merge なし reopen Issue に `/auto $N` 実行時 fix-cycle と誤判定されない | 条件文が `/auto` 実行そのものを待っている |
-| #852 | 次回 reopen 後の Issue に `/auto $N` 実行時 code phase が正しく実行される | 同上 |
-| #822 | 次回 manual recovery 発生時に対象 sub-issue の Spec へ `## Auto Retrospective` が自動追記 | manual recovery は `/auto` orchestration 内で発生する |
-| #807 | 次回 batch session で wrapper レベル自動 retry が試行され recoveries.md に記録 | `/auto --batch` 実行の内側 |
-| #806 | 次回 `run-auto-sub.sh` kill 発生時に `/auto --resume N` で正常完走 | `/auto --resume` 実行の内側 |
-| #804 | 次回 migration/rename/削除 Issue の `/spec` で Changed Files に symbol grep 結果が反映 | `/spec` は `/auto` の spec phase として実行される |
-| #778 | 次回 migration Issue の Spec に SKILL.md + script の対称的 `file_not_contains` AC が含まれる | 同上 |
-| #770 | 2 つの `/auto --batch` 同時起動で各 session の report が他 session の Issue を含まない | `/auto --batch` 実行の内側 |
-| #769 | 次回 batch 実行後の `/audit auto-session --full` で Per-Issue Durations が実処理件数と一致 | batch 完走が観測の前提 |
-| #765 | 次回 PR で正当な記述が commit に含まれた際 Forbidden Expressions check が PASS | 当該 check は `/code` (`forbidden-expressions-check.md`)・`/review` (`skill-dev-recheck.md`)・CI (`test.yml`) で実行され、いずれも `/auto` の内側。`pr-review-full` は `--full` review でのみ発火するため取りこぼす |
-| #762 | 次回 batch/XL session でデータ層レポート末尾に L3 retrospective への See also リンクが出力 | batch/XL 実行の内側 |
-| #761 | 次回 Tier 2 fallback catalog 適用 Issue の Spec の `## Auto Retrospective` に anomaly エントリが含まれる | Tier 2 fallback は `/auto` orchestration 内 |
-| #760 | 次回 batch で Tier 2 リカバリ発生時に report の Improvement Candidates Surfaced に symptom 表示 | 同上 |
-| #759 | 次回 Tier 2/3 自動回復発生 Issue の `/verify` で新基準に従った判断が一意に行われる | `/auto` 実行内の verify phase が観測窓 |
-| #758 | 次回新 SSoT モジュール作成時に checklist が実行され review phase で SSoT 乖離 SHOULD が出ない | checklist は `/code`、SHOULD 指摘は `/review`。SHOULD は `--light`/`--full` 双方で発生しうるため `pr-review-full` 固定では取りこぼす |
-| #755 | 次回新 skill 作成時に `execution-context.md` を参照して context check が標準化 | spec / code phase の内側 |
-| #737 | 次回 `get-sub-issue-progress.sh` 変更 Issue で direct test が regression を検出 | bats regression は CI (`/review` が完了を待機) で顕在化。対象 Issue の Size が読めず review depth が確定しないため `pr-review-full` 固定は不適 |
-| #736 | 次回 `get-auto-session-report.sh` 変更 Issue で direct unit test が regression を検出 | 同上 |
-| #732 | 次回 `phase-handoff.md` 変更 Issue で `bats tests/phase-handoff.bats` が regression を検出 | 同上 |
-| #731 | 次回 `test-runner.md` 変更 Issue で `bats tests/test-runner.bats` が regression を検出 | 同上 |
-| #724 | 次回 git diff ベース比較ロジックの Spec で当該節が参照され code phase の rework がゼロ | spec / code phase の内側 |
-| #520 | `/auto` 実行で skill mis-dispatch 由来の silent no-op が観察されない | 条件文が `/auto` 実行を明示している |
-| #719 条件2 | pre-existing FAILURE 解消後、`pre-merge-check.sh` が baseline=PASS 状態で正常動作 | `bash scripts/check-forbidden-expressions.sh` は 2026-08-06 時点で exit 0 (実測) — 前提は充足済み。`pre-merge-check.sh` は `/code`・`/review` で実行される |
+| Issue | event | 条件文の要約 | 選定根拠 |
+|---|---|---|---|
+| #1045 | auto-run | 次回 external kill 発生時に `wrapper_alive` と kill 時刻の差分から control-flow / subprocess kill を判別 | external kill 検出 (`detect-external-kill.sh`) は `skills/auto/SKILL.md` の phase 完了判定内で実行される |
+| #869 | auto-run | 次回 silent no-op が観測された session で `code_retry_fire` が記録される | silent no-op 検出と retry 発火は `/auto` の code phase 内 |
+| #861 | auto-run | 次回並列セッション環境で phase 開始時に他セッション由来 dirty が warning 表示 | phase 開始は `/auto` 実行の内側。「並列セッション」は `when=` の宣言可能軸 (route / mode / recovery-tier) に無く事前排除できない |
+| #859 | auto-run | 次回並列セッション環境で他セッション作業ファイルと自セッション作業中ファイルを区別して判定 | 同上 |
+| #856 | auto-run | 次回 merge なし reopen Issue に `/auto $N` 実行時 fix-cycle と誤判定されない | 条件文が `/auto` 実行そのものを待っている |
+| #852 | auto-run | 次回 reopen 後の Issue に `/auto $N` 実行時 code phase が正しく実行される | 同上 |
+| #822 | auto-run | 次回 manual recovery 発生時に対象 sub-issue の Spec へ `## Auto Retrospective` が自動追記 | manual recovery は `/auto` orchestration 内で発生する |
+| #807 | auto-run | 次回 batch session で wrapper レベル自動 retry が試行され recoveries.md に記録 | `/auto --batch` 実行の内側 |
+| #806 | auto-run | 次回 `run-auto-sub.sh` kill 発生時に `/auto --resume N` で正常完走 | `/auto --resume` 実行の内側 |
+| #804 | auto-run | 次回 migration/rename/削除 Issue の `/spec` で Changed Files に symbol grep 結果が反映 | `/spec` は `/auto` の spec phase として実行される |
+| #778 | auto-run | 次回 migration Issue の Spec に SKILL.md + script の対称的 `file_not_contains` AC が含まれる | 同上 |
+| #770 | auto-run | 2 つの `/auto --batch` 同時起動で各 session の report が他 session の Issue を含まない | `/auto --batch` 実行の内側 |
+| #769 | auto-run | 次回 batch 実行後の `/audit auto-session --full` で Per-Issue Durations が実処理件数と一致 | batch 完走が観測の前提 |
+| #765 | auto-run | 次回 PR で正当な記述が commit に含まれた際 Forbidden Expressions check が PASS | 当該 check は `/code` (`forbidden-expressions-check.md`)・`/review` (`skill-dev-recheck.md`)・CI (`test.yml`) で実行され、いずれも `/auto` の内側。`pr-review-full` は `--full` review でのみ発火するため取りこぼす |
+| #762 | auto-run | 次回 batch/XL session でデータ層レポート末尾に L3 retrospective への See also リンクが出力 | batch/XL 実行の内側 |
+| #761 | auto-run | 次回 Tier 2 fallback catalog 適用 Issue の Spec の `## Auto Retrospective` に anomaly エントリが含まれる | Tier 2 fallback は `/auto` orchestration 内 |
+| #760 | auto-run | 次回 batch で Tier 2 リカバリ発生時に report の Improvement Candidates Surfaced に symptom 表示 | 同上 |
+| #759 | auto-run | 次回 Tier 2/3 自動回復発生 Issue の `/verify` で新基準に従った判断が一意に行われる | `/auto` 実行内の verify phase が観測窓 |
+| #758 | auto-run | 次回新 SSoT モジュール作成時に checklist が実行され review phase で SSoT 乖離 SHOULD が出ない | checklist は `/code`、SHOULD 指摘は `/review`。SHOULD は `--light`/`--full` 双方で発生しうるため `pr-review-full` 固定では取りこぼす |
+| #755 | auto-run | 次回新 skill 作成時に `execution-context.md` を参照して context check が標準化 | spec / code phase の内側 |
+| #737 | auto-run | 次回 `get-sub-issue-progress.sh` 変更 Issue で direct test が regression を検出 | bats regression は CI (`/review` が完了を待機) で顕在化。対象 Issue の Size が読めず review depth が確定しないため `pr-review-full` 固定は不適 |
+| #736 | auto-run | 次回 `get-auto-session-report.sh` 変更 Issue で direct unit test が regression を検出 | 同上 |
+| #732 | auto-run | 次回 `phase-handoff.md` 変更 Issue で `bats tests/phase-handoff.bats` が regression を検出 | 同上 |
+| #731 | auto-run | 次回 `test-runner.md` 変更 Issue で `bats tests/test-runner.bats` が regression を検出 | 同上 |
+| #724 | auto-run | 次回 git diff ベース比較ロジックの Spec で当該節が参照され code phase の rework がゼロ | spec / code phase の内側 |
+| #520 | auto-run | `/auto` 実行で skill mis-dispatch 由来の silent no-op が観察されない | 条件文が `/auto` 実行を明示している |
+| #719 条件2 | auto-run | pre-existing FAILURE 解消後、`pre-merge-check.sh` が baseline=PASS 状態で正常動作 | `bash scripts/check-forbidden-expressions.sh` は 2026-08-06 時点で exit 0 (実測) — 前提は充足済み。`pre-merge-check.sh` は `/code`・`/review` で実行される |
 
 ### `event=fix-cycle` (2 AC 行)
 
-| Issue | 条件文の要約 | 選定根拠 |
-|---|---|---|
-| #707 | `/verify N` を FAIL させ機械可読 marker 付き comment が append され grep できる | `skills/verify/SKILL.md` の FAIL → reopen 経路が、marker comment 投稿と `observation-trigger.sh --event fix-cycle` を同一ステップで実行する |
-| #700 | `auto-retry-on-fail.enabled: true` 下で `/verify` FAIL → `/code` 再発火 → PASS または budget 枯渇 | 同じ FAIL → reopen 経路が観測窓。本リポジトリの `.wholework.yml` は `auto-retry-on-fail.enabled: true` |
+| Issue | event | 条件文の要約 | 選定根拠 |
+|---|---|---|---|
+| #707 | fix-cycle | `/verify N` を FAIL させ機械可読 marker 付き comment が append され grep できる | `skills/verify/SKILL.md` の FAIL → reopen 経路が、marker comment 投稿と `observation-trigger.sh --event fix-cycle` を同一ステップで実行する |
+| #700 | fix-cycle | `auto-retry-on-fail.enabled: true` 下で `/verify` FAIL → `/code` 再発火 → PASS または budget 枯渇 | 同じ FAIL → reopen 経路が観測窓。本リポジトリの `.wholework.yml` は `auto-retry-on-fail.enabled: true` |
 
 ### 対象外 (`manual` 維持、7 AC 行)
 
-| Issue | 条件文の要約 | 対象外の理由 |
-|---|---|---|
-| #719 条件1 | 別 PR で意図的に Forbidden Expressions FAIL を作り abort を観察 | 故障注入型。人為的に失敗 PR を用意しない限り 5 有効値のどの発火でも観測窓が開かない (`docs/stats/2026-08-05.md` の区分 C 相当) |
-| #708 条件1 | 試験的に `phase/ready` のみ付与・Spec 無しの M Issue で `matches_expected: false` を確認 | 試験的コマンド実行が前提の故障注入型。bats テスト化が本筋 |
-| #708 条件2 | 試験的に XS Issue (Spec 無し) で `matches_expected: true` を確認 | 同上 |
-| #704 | `autonomy: L2` の状態で skill が許可経路のみ実行することを観察 | 本リポジトリは `autonomy: L3` で前提が成立しない。`config=` ゲートは boolean 専用で enum キー (`autonomy`) を表現できない (`modules/observation-trigger.md` § Condition Check Gate (`config=`)) |
-| #501 | downstream プロジェクトで phase 間の文脈喪失が体感的に減ることを観察 | 別リポジトリでの主観評価。upstream から観測不能 (区分 B 相当) |
-| #500 | downstream で mid-run API 障害時に Tier 2 内で自動 reconcile + retry を実行し復旧 | 別リポジトリ + 障害注入の二重前提。upstream から観測不能 |
-| #479 | 次回 vault 領域に触れる `/code` 実行でファイル編集が実装される | vault 領域は downstream 固有でこのリポジトリに存在しない。upstream の `/auto` 実行では観測窓が開かない |
+| Issue | event | 条件文の要約 | 対象外の理由 |
+|---|---|---|---|
+| #719 条件1 | 対象外 | 別 PR で意図的に Forbidden Expressions FAIL を作り abort を観察 | 故障注入型。人為的に失敗 PR を用意しない限り 5 有効値のどの発火でも観測窓が開かない (`docs/stats/2026-08-05.md` の区分 C 相当) |
+| #708 条件1 | 対象外 | 試験的に `phase/ready` のみ付与・Spec 無しの M Issue で `matches_expected: false` を確認 | 試験的コマンド実行が前提の故障注入型。bats テスト化が本筋 |
+| #708 条件2 | 対象外 | 試験的に XS Issue (Spec 無し) で `matches_expected: true` を確認 | 同上 |
+| #704 | 対象外 | `autonomy: L2` の状態で skill が許可経路のみ実行することを観察 | 本リポジトリは `autonomy: L3` で前提が成立しない。`config=` ゲートは boolean 専用で enum キー (`autonomy`) を表現できない (`modules/observation-trigger.md` § Condition Check Gate (`config=`)) |
+| #501 | 対象外 | downstream プロジェクトで phase 間の文脈喪失が体感的に減ることを観察 | 別リポジトリでの主観評価。upstream から観測不能 (区分 B 相当) |
+| #500 | 対象外 | downstream で mid-run API 障害時に Tier 2 内で自動 reconcile + retry を実行し復旧 | 別リポジトリ + 障害注入の二重前提。upstream から観測不能 |
+| #479 | 対象外 | 次回 vault 領域に触れる `/code` 実行でファイル編集が実装される | vault 領域は downstream 固有でこのリポジトリに存在しない。upstream の `/auto` 実行では観測窓が開かない |
 
 ## 検証
 
-`${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event <name> --dry-run` (read-only、コメント投稿なし) を実行し、再型付け後の AC がマッチ対象になることを確認した。
+`${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event <name> --dry-run` (opportunistic-search.sh は検索のみでコメント投稿を行わないため read-only。`--dry-run` は observation-trigger.sh とのインターフェース互換のために受理される no-op) を実行し、再型付け後の AC がマッチ対象になることを確認した。
 
 ### `--event auto-run`
 

--- a/docs/spec/issue-1163-manual-ac-retype-a.md
+++ b/docs/spec/issue-1163-manual-ac-retype-a.md
@@ -241,9 +241,10 @@ Issue 本文の `## Auto-Resolved Ambiguity Points` セクションを参照。
 
 ### Deferred Items
 
-- `modules/observation-trigger.md` § Notes の `fix-cycle` emitter 未実装という古い記述の修正 — 本 Issue のスコープ外、別途起票候補 (spec retrospective から引き継ぎ)。
+- `modules/observation-trigger.md` § Notes と `modules/verify-classifier.md` § observation Type Emitter table の両方に残る `fix-cycle` emitter 未実装という古い記述の修正 — 本 Issue のスコープ外、別途起票候補 (spec retrospective から引き継ぎ)。実装は `skills/verify/SKILL.md:584` (`/verify` FAIL → reopen 経路) で既に完了している。
 - 再型付け後の AC への `when=` 条件付与 — #1118 が担当。
-- #708 の 2 条件の bats テスト化 — 区分 C 相当として #1167 の領域。
+- #708 の 2 条件・#719 条件1 の bats テスト化 (故障注入型で 5 有効値のどの発火でも観測窓が開かない対象外行) — 区分 C 相当として #1167 の領域。
+- #501 / #500 / #479 (downstream 依存で upstream から観測不能な対象外行) — `docs/stats/2026-08-05.md` Section 10 が区分 B に対して定める retire または downstream への移管の判断先が未定。担当 Issue 番号は別途決定する。
 - Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認) — merge 後に `/verify` が `observation event=auto-run` 経路で評価する。
 
 ### Notes for Next Phase

--- a/docs/spec/issue-1163-manual-ac-retype-a.md
+++ b/docs/spec/issue-1163-manual-ac-retype-a.md
@@ -216,26 +216,38 @@ Issue 本文の `## Auto-Resolved Ambiguity Points` セクションを参照。
 - **`#719` 条件2 の前提充足**: 「pre-existing FAILURE を別 Issue で解消後」という前提が現在成立しているかを `bash scripts/check-forbidden-expressions.sh` の実行 (exit 0) で確認し、`auto-run` への再型付けが妥当と判断した。前提未充足なら対象外にすべき条件だった。
 - **`#704` の `config=` 表現可能性**: `autonomy` は enum (`L1`/`L2`/`L3`) で、`config=` ゲートは boolean 専用 (`modules/observation-trigger.md` § Condition Check Gate (`config=`))。本リポジトリは `L3` のため条件の前提自体が成立せず、対象外が妥当と確認した。
 
+## Code Retrospective
+
+### Deviations from Design
+
+- Implementation Steps 2〜5 (`.tmp/retype-mapping.json` 作成 → `.tmp/retype-ac.py` 作成 → dry-run 確認 → `--apply` 実行) を実行しなかった。`/code` 開始時点で `reconcile-phase-state.sh --check-precondition code-pr` が `phase/ready` ラベル不在 (label timeline 上、既に `phase/code` へ遷移済み) を報告し、対象 29 AC 行を個別に確認したところ、全件が GitHub Issue 本文側で既に `verify-type: observation event=<name>` へ再型付け済みだった。対象外 7 AC 行も個別確認し誤編集がないことを確認した。前回セッションが label 遷移後・コミット/PR作成前に中断したレジューム状態と判断し、実質的な追加作業は Step 1 (report file 作成) と Step 7〜9 (opportunistic-search.sh による検証・記録・cleanup) のみとした。Spec Implementation Steps は Deviations として本節に記録するのみとし、Step 2〜5 の記述自体は変更しない (次回同種の再型付け Issue で `.tmp/` ヘルパパターンを再利用する際の参照価値を残すため)。
+
+### Design Gaps/Ambiguities
+
+- Step 8 で baseline 比較を行ったところ、`opportunistic-search.sh --event auto-run` のマッチ件数は baseline 31 行 → 実測 59 行で、再型付けした 27 行の単純加算 (31+27=58) と 1 件ずれた。目視突合で対象 27 行の含有は個別確認済みのため AC2 の充足には影響しないが、母集団が本 Issue の作業以外の要因 (他 sub-issue の並行対応や `/auto` 実行由来の新規 AC) でも変動しうることが分かった。件数差分だけで再型付け完了を判定する設計は将来的に誤検知の余地がある — 個別 Issue 番号の含有確認を必須の一次情報とすべき (report ファイルの `## 検証` 節に既に反映済み)。
+
+### Rework
+
+- なし。Spec の「再型付けマッピング」節の設計 (29 行再型付け / 7 行対象外) をそのまま `docs/reports/manual-ac-retype-a.md` へ転記し、想定通り完了した。
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- 対象 34 Issue / 36 AC 行を全件精査し、`auto-run` 27 行・`fix-cycle` 2 行・対象外 7 行に確定した。マッピング表は Spec の「再型付けマッピング」節が SSoT で、`/code` はこれを `docs/reports/manual-ac-retype-a.md` へ転記する。
-- 親 #1158 の operate route 想定を pr route へ変更した (rubric grader が Issue コメントを読めないため)。`/code` は Step 0 の diff-less 判定で `Changed Files` に記録ファイルがあることを確認し、operate route と誤判定しないこと。
-- `event=` 以外のゲート属性 (`when=` / `keyword=` / `config=`) は付与しない。#1118 のスコープ。
-- 一括置換は `.tmp/` に置く使い捨ての python3 ヘルパで行い、dry-run → apply の 2 段階で実行する。`scripts/` には残さない。
+- `.tmp/retype-mapping.json` / `.tmp/retype-ac.py` を作成・実行せず、既に完了していた Issue 本文の再型付け状態を検証してそのまま採用した (上記 Deviations 参照)。再実行や差し戻しは不要。
+- `docs/reports/manual-ac-retype-a.md` を新規作成し、Spec の「再型付けマッピング」3 表と `## 検証` 節 (opportunistic-search.sh 実行結果) を記録した。Pre-merge AC 6 件は全て PASS 判定し Issue のチェックボックスを更新済み。
+- PR #1194 を作成 (`closes #1163`)。テスト `bats tests/` は 1430/1430 PASS、`validate-skill-syntax.py` は 0 error、`check-forbidden-expressions.sh` は exit 0。
 
 ### Deferred Items
 
-- `modules/observation-trigger.md` § Notes の `fix-cycle` emitter 未実装という古い記述の修正 — 本 Issue のスコープ外、別途起票候補。
-- `skills/code/SKILL.md` の `allowed-tools` への `observation-trigger.sh` 追加 — 本 Issue では `opportunistic-search.sh` で代替するため不要。
+- `modules/observation-trigger.md` § Notes の `fix-cycle` emitter 未実装という古い記述の修正 — 本 Issue のスコープ外、別途起票候補 (spec retrospective から引き継ぎ)。
 - 再型付け後の AC への `when=` 条件付与 — #1118 が担当。
 - #708 の 2 条件の bats テスト化 — 区分 C 相当として #1167 の領域。
+- Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認) — merge 後に `/verify` が `observation event=auto-run` 経路で評価する。
 
 ### Notes for Next Phase
 
-- Issue 本文の AC 行を書き換える際は、`match` 文字列で特定した行が **ちょうど 1 行** であることを必ず検証すること。#869 と #704 と #700 は本文の retrospective 表の中にも `verify-type: manual` / `verify-type: observation` を含む行があるため、`- [ ]` で始まる AC 行だけを対象にする必要がある。
-- 対象外 7 AC 行 (#719 条件1 / #708 条件1・2 / #704 / #501 / #500 / #479) は絶対に編集しないこと。Pre-merge AC6 が #704 の `manual` 維持を機械確認する。
-- Step 7 のマッチ確認で対象 Issue が現れない場合、GitHub 検索インデックスの遅延の可能性が高い。本文が正しく置換されていることを `gh issue view` で先に確認し、時間を置いて再実行すること。
-- `opportunistic-search.sh --event auto-run` は母集団 60 Issue に対し `gh issue view` を逐次実行するため 2〜3 分かかる。タイムアウトを長めに取ること。
+- `/review` は Pre-merge AC が全て `rubric` であることを踏まえ、`docs/reports/manual-ac-retype-a.md` の内容と GitHub Issue 本文の実状態 (#869 #707 #704 など代表 Issue) の整合を優先的に確認すること。
+- 対象外 7 AC 行 (#719 条件1 / #708 条件1・2 / #704 / #501 / #500 / #479) が `manual` のまま維持されていることは commit 前に個別確認済み。`/review` でも再確認する場合は report の「対象外」表と突合すること。
+- baseline 比較の件数ずれ (Design Gaps/Ambiguities 参照) は AC2 の充足を妨げないが、`/verify` が post-merge AC を評価する際に母集団件数の単純比較ではなく個別 Issue 番号の含有確認を優先すること。

--- a/docs/spec/issue-1163-manual-ac-retype-a.md
+++ b/docs/spec/issue-1163-manual-ac-retype-a.md
@@ -18,6 +18,14 @@ cutoff: `2026-08-06T04:23:59Z` (`phase/issue` ラベル付与時刻、Issue time
 
 Cross-phase marker (`type=verify-fail` / `type=preview-ac-unverified`) の追加スキャン結果: 該当なし。
 
+### code phase (cutoff: `2026-08-06T04:50:47Z`, `phase/ready` ラベル付与時刻)
+
+`phase/ready` 付与以降の新規コメントなし。Cross-phase marker の追加スキャン結果も該当なし。
+
+## Autonomous Auto-Resolve Log
+
+- **`phase/ready` ラベル不在での続行**: `/code 1163 --pr --non-interactive` 開始時点で Issue のラベルは `phase/code` (label timeline 上、`phase/ready` は 2026-08-06T04:56:03Z に `phase/code` へ既に遷移済み)。`reconcile-phase-state.sh --check-precondition code-pr` も `matches_expected: false` を返した。Spec (`docs/spec/issue-1163-manual-ac-retype-a.md`) は spec retrospective・issue retrospective・Phase Handoff まで完備しており、コーディング未着手のまま前回セッションが label 遷移後に中断したレジューム状態と判断。Spec が存在するため「Spec なしで Issue 本文から要件を読む」対応は不要。warn のうえ Spec を正として続行した — reason: 非対話モードのポリシー (`--warn-only` 相当) は Spec 欠落時の縮退経路であり、本件は Spec 完備のため実質的にブロッカーではない。
+
 ## Changed Files
 
 - `docs/reports/manual-ac-retype-a.md`: 新規作成 — 区分 A 36 AC 行のマッピング表 (Issue 番号 / 条件文要約 / 付与 event または対象外 / 選定根拠)、対象外 7 行の理由、`opportunistic-search.sh` 実行による検証結果

--- a/docs/spec/issue-1163-manual-ac-retype-a.md
+++ b/docs/spec/issue-1163-manual-ac-retype-a.md
@@ -231,13 +231,14 @@ Issue 本文の `## Auto-Resolved Ambiguity Points` セクションを参照。
 - なし。Spec の「再型付けマッピング」節の設計 (29 行再型付け / 7 行対象外) をそのまま `docs/reports/manual-ac-retype-a.md` へ転記し、想定通り完了した。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- `.tmp/retype-mapping.json` / `.tmp/retype-ac.py` を作成・実行せず、既に完了していた Issue 本文の再型付け状態を検証してそのまま採用した (上記 Deviations 参照)。再実行や差し戻しは不要。
-- `docs/reports/manual-ac-retype-a.md` を新規作成し、Spec の「再型付けマッピング」3 表と `## 検証` 節 (opportunistic-search.sh 実行結果) を記録した。Pre-merge AC 6 件は全て PASS 判定し Issue のチェックボックスを更新済み。
-- PR #1194 を作成 (`closes #1163`)。テスト `bats tests/` は 1430/1430 PASS、`validate-skill-syntax.py` は 0 error、`check-forbidden-expressions.sh` は exit 0。
+- Base Branch Conflict Pre-check (`git merge-tree`) は main 側の並行変更 (`.wholework.yml` / 他 Issue の Spec ファイル) を検出したが、いずれも `merged` (クリーンな自動マージ) で `changed in both` はゼロだったため、コンフリクトコンテキストは review-spec/review-bug へ渡していない。
+- fork context (`--non-interactive` あり、再呼出し保証なし) と判定し、`capabilities.workflow: true` が有効でも Workflow path を使わず静的 Task fan-out (review-spec + review-bug×2) を `Agent(run_in_background: false)` で実行した。`skills/review/workflow-guidance.md` の再呼出し保証チェックに従った判断。
+- Pre-merge AC 6 件 (rubric ×3, github_check ×3) を全て PASS 判定 (Issue チェックボックスは既に `[x]` のため更新不要)。CI 9 job 全て SUCCESS。MUST issue はゼロ。
+- review-spec + review-bug×2 の指摘 6 件 (SHOULD 3 / CONSIDER 3、うち review-bug 3 件は 2 段階検証で全て PASS) を全て修正した。低リスクな文書のみの PR で、修正コストが低く、report が今後の関連 Issue (#1164-#1167) の precedent として参照される想定だったため、SHOULD/CONSIDER を含め全件対応する判断とした。
 
 ### Deferred Items
 
@@ -249,6 +250,20 @@ Issue 本文の `## Auto-Resolved Ambiguity Points` セクションを参照。
 
 ### Notes for Next Phase
 
-- `/review` は Pre-merge AC が全て `rubric` であることを踏まえ、`docs/reports/manual-ac-retype-a.md` の内容と GitHub Issue 本文の実状態 (#869 #707 #704 など代表 Issue) の整合を優先的に確認すること。
-- 対象外 7 AC 行 (#719 条件1 / #708 条件1・2 / #704 / #501 / #500 / #479) が `manual` のまま維持されていることは commit 前に個別確認済み。`/review` でも再確認する場合は report の「対象外」表と突合すること。
-- baseline 比較の件数ずれ (Design Gaps/Ambiguities 参照) は AC2 の充足を妨げないが、`/verify` が post-merge AC を評価する際に母集団件数の単純比較ではなく個別 Issue 番号の含有確認を優先すること。
+- `/merge` は pre-merge AC gate が Pre-merge AC 6 件全てチェック済みであることを確認すればよく、追加の手動確認は不要。
+- review で修正した `docs/reports/manual-ac-retype-a.md` の `event` 列追加・fallback メカニズム記述修正は、後続の #1164-#1167 (区分 B/C/D/E 等の他 sub-issue) が同種の report を作成する際の precedent として参照される想定。同種の precedent 引用を書く場合は「引用対象の Issue が同一 PR で書き換えられていないか」の時制チェックを行うこと (review retrospective 参照)。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- report (`docs/reports/manual-ac-retype-a.md`) の 3 表は Spec の「再型付けマッピング」節を転記する設計だったが、Pre-merge AC1 のrubric文言 (「Issue 番号 / 元の条件文の要約 / 付与した event= 名または対象外 / 選定根拠」の 4 項目) に対し、実装は 3 列 + セクション見出しでの event 表現だった。rubric grader は文脈から意味的に PASS 判定したが、review-spec が「4 項目要求 vs 3 列実装」のギャップを CONSIDER として検出し、`event` 列を明示追加する修正を行った。rubric のような自然言語 AC は、意味的に等価な実装でも構造的な字面乖離が生じうる — rubric 文言が列挙形式 (「A / B / C / D」) を使う場合、実装側も同じ列挙構造で表現すると grader・人間読者の両方にとって監査しやすい。
+
+### Recurring issues
+
+- unknown-event fallback のメカニズム記述 (`observation-trigger.sh` 起因と誤記していた点) は、review-spec・review-bug (diff scan)・review-bug (security scan) の 3 エージェントが**独立に同じ根本原因を検出**した。3 系統からの収束検出は指摘の信頼度を裏付ける一方、report 内の同一パラグラフに複数の独立した事実誤認 (emitter 帰属 + precedent 引用の自己矛盾) が同居していたことを示している。次回同種の report 作成時は、「メカニズムを説明する一文」を書く際に実装ファイル (`scripts/*.sh`) を直接参照して裏取りする習慣が有効。
+- precedent 引用 (「過去に #869/#704/#700 で manual 維持と判断された」) が、引用対象の Issue 自身を**同一 PR で書き換えている**ケースでは、引用文が過去形として読めるよう明示的にスコープしないと自己矛盾が生じる。本件同様「このIssueが対象を書き換える」構造を持つ report では、precedent 引用の時制チェックを review チェックリストに加える価値がある。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note — Pre-merge AC 6 件 (rubric ×3, github_check ×3) は全て決定的に PASS 判定でき、UNCERTAIN はゼロだった。


### PR DESCRIPTION
## Summary
- `phase/verify` に滞留する `verify-type: manual` の post-merge AC のうち、区分 A (「次回…観察」型) の 34 Issue / 36 AC 行を精査し、29 AC 行 (`auto-run` 27 / `fix-cycle` 2) を `verify-type: observation event=<name>` へ再型付け (GitHub Issue 本文編集)
- 7 AC 行 (#719条件1 / #708条件1・2 / #704 / #501 / #500 / #479) は 5 有効値 (`pr-review-full`/`pr-review-light`/`auto-run`/`watchdog-kill`/`fix-cycle`) のいずれにも対応付けられないため `manual` を維持
- 再型付けマッピング・対象外理由・`opportunistic-search.sh` による検証結果を `docs/reports/manual-ac-retype-a.md` に記録 (rubric grader が参照可能な成果物として、親 #1158 の operate route 想定から pr route へ切り替え — 理由は Spec Notes 参照)

## Verification (pre-merge)
- `docs/reports/manual-ac-retype-a.md` のマッピング表 (Issue番号/条件文要約/event名または対象外/選定根拠) を目視確認
- `opportunistic-search.sh --event auto-run --dry-run` / `--event fix-cycle --dry-run` (read-only) を実行し、再型付けした 27+2 AC 行が全てマッチ集合に含まれることを確認
- `gh issue view 869/707/704 --json body` で代表 Issue の GitHub 上の実状態 (再型付け済み / manual 維持) を確認
- `bats tests/`: 1430/1430 PASS
- `python3 scripts/validate-skill-syntax.py skills/`: 0 error
- `bash scripts/check-forbidden-expressions.sh`: exit 0

## Verification (post-merge)
- 移行完了後の `/audit stats --retention` で phase/verify の Manual waiting 件数が再型付け行数分減少していることを確認 (対象外行は減少しない)

closes #1163