### PR TITLE
Issue #1152: collect-recovery-candidates: 除外判定を entry 単位化し誤検知と再発見落としを同時に解消

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -177,7 +177,7 @@ wholework/
 - `scripts/gh-pr-review.sh` — PR レビュー投稿
 
 **プロジェクトユーティリティ:**
-- `scripts/collect-recovery-candidates.sh` — `docs/reports/orchestration-recoveries.md` を parse し group-key (素の symptom-short、または エントリの Diagnosis 本文に `- cause:` 行がある場合は `symptom-short/cause-slug`) の頻度を集計。起票済みエントリを除外し `--threshold K` フィルタを適用。`<group-key>\t<count>` 形式で候補を出力。`--issues-json PATH` で重複チェック用 open issues JSON を受け取り
+- `scripts/collect-recovery-candidates.sh` — `docs/reports/orchestration-recoveries.md` を parse し group-key (素の symptom-short、または エントリの Diagnosis 本文に `- cause:` 行がある場合は `symptom-short/cause-slug`) の頻度を集計。各 entry を個別に判定し、対応 Issue の `closedAt` と比較して除外 (Issue が open ならその group-key の全 entry を除外、closed なら `closedAt` 以前の entry のみ除外し以降を計数。`--issues-json` に `state`/`closedAt` が無い場合は group 自身の最新 `起票済み #N` entry の日時を代替基準とする)。`--threshold K` フィルタを適用し `<group-key>\t<count>` 形式で候補を出力 (`--with-tracking` で 3 列目に `tracked:#N`/`untracked` を付加)。`--issues-json PATH` で Issue 解決用の全 state issue 一覧 (`state`/`closedAt` 付き) を受け取り
 - `scripts/get-config-value.sh` — `.wholework.yml` から設定値を抽出
 - `scripts/handle-permission-mode-failure.sh` — `permission-mode: auto` 失敗を診断し remediation hint を stderr に出力（heuristic: exit!=0 かつ elapsed<=30s）
 - `scripts/get-verify-permission.sh` — verify コマンドハンドラファイルから permission 値を抽出

--- a/docs/spec/issue-1152-recovery-dedup-entry-unit.md
+++ b/docs/spec/issue-1152-recovery-dedup-entry-unit.md
@@ -147,3 +147,37 @@ Root Cause の 3 行目 (`run-auto-sub.sh:194-204`) は false negative の一因
 - `EXCLUDED_LIST` の group-key 一括抑止: 合成 fixture (`.tmp/recoveries-probe.md`、4 entry) による実行結果
 - `_find_known_recoveries_issue` の closed 解決: `gh issue list --state closed --limit 1000` の全件から `title == "recoveries: manual-recovery-review-rerun"` を完全一致で抽出
 - 現在の `docs/reports/orchestration-recoveries.md`: `未起票` 23 件 / `起票済み` 43 件 (`grep -c`、2026-08-06 時点)
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Spec の `--issues-json が state/closedAt を持たない場合の代替基準` は「ファイル内で最も新しい起票済み entry の日時」とだけ記述しており、file-global か group-key scoped かが曖昧だった。group-key を跨いだ cross-contamination を避けるため **group-key scoped** (その group-key 自身の最新 `起票済み` entry) で実装した。Implementation Steps は更新不要 (Spec の記述自体は誤っていないため) だが、この解釈選択を明記する。
+- Implementation Step 4 が明示した更新対象は既存テスト `exclusion: filed improvement candidate mark` の 1 件のみだったが、同じく `--issues-json` に `state` を含まない旧形式フィクスチャを使っていた 2 件の `duplicate check` テストも新スキーマ (`state`/`closedAt` 前提) の下では意味が変わってしまうため、両方の `issues.json` フィクスチャに `"state": "OPEN"` を追加して意図 (「対応 Issue が存在すれば除外される」) を保った。旧コントラクトが暗黙に "open issues のみのリスト" だったことの明示化であり、テストの検証意図は変えていない。
+
+### Design Gaps/Ambiguities
+
+- 独立サブエージェントによるアドバーサリアルレビューで、AC の対象外の 2 点が見つかった (blocking ではないため据え置き):
+  - **境界の秒精度**: `closedAt` を 16 文字 (分単位) に切り詰めて比較するため、Issue close 直後・同一分内に記録された entry は `<=` 判定で除外側になる (取りこぼす可能性がある)。Spec Notes の「日付比較を文字列比較で行う理由」が明示的に受け入れているトレードオフであり、本 Issue のスコープ外。
+  - **group-key の複数回起票**: 同じ group-key が生涯で 2 回以上 `起票済み #N` された場合、現在の実装は「最後に検出した起票済みマーカーの Issue」のみを解決対象とし、直近の fix の closedAt のみを cutoff に使う。過去の fix ごとの rolling cutoff は考慮しない。Spec もこのケースを明示的に扱っていない (単一 Issue 解決を前提とした設計) ため、実装追随した。将来的に同一 group-key の再起票が頻発するようなら別 Issue で扱う。
+
+### Rework
+
+- なし (実装は Spec の設計通りに 1 パスで完了)
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- 除外判定を group-key 単位から entry 単位に変更し、`起票済み #N` (優先) → `--issues-json` タイトル完全一致の順で対応 Issue を解決、open なら全 entry 除外・closed なら `closedAt` 以前のみ除外という規則で実装した。
+- `--issues-json` に `state`/`closedAt` が無い場合の degrade path は、group-key 自身の最新 `起票済み` entry 日時を代替基準とした (file-global ではなく group-key scoped — Design Gaps 参照)。
+- 出力形式の後方互換性を優先し、`tracked:#N`/`untracked` は `--with-tracking` opt-in の 3 列目とした (Spec Notes の判断を踏襲)。
+- rubric 系 AC 6件は自己判定によるバイアスを避けるため、独立したサブエージェントにアドバーサリアルグレーディングさせて PASS を確認した。
+
+### Deferred Items
+- 境界秒精度 (closedAt 分単位切り詰め) と group-key 複数回起票時の rolling cutoff 非対応は、Design Gaps/Ambiguities に記録の上、本 Issue のスコープ外として据え置いた。再発頻度が高まれば別 Issue で扱う。
+- #1191 (`/audit stats --retention` Section 10) は `--with-tracking` オプションを消費する側の実装であり、本 Issue はフォーマット提供のみ。エンドツーエンドの実消費は #1191 側で検証される。
+
+### Notes for Next Phase
+- Post-merge の observation AC (`/verify` Step 15 出力に close 済み対応 Issue の group-key が再浮上しないこと) は次回 `/auto` セッションでの実行時に観察される。`manual-recovery-review-rerun` / `review-tier3-recovery` が候補から消えているかを確認すること。
+- PR #1198 の CI (`Run bats tests`) 結果が pre-merge AC の最終 1 件。フルスイート 1444 件はローカルで PASS 済みだが CI 環境差異があれば要確認。

--- a/docs/spec/issue-1152-recovery-dedup-entry-unit.md
+++ b/docs/spec/issue-1152-recovery-dedup-entry-unit.md
@@ -165,19 +165,33 @@ Root Cause の 3 行目 (`run-auto-sub.sh:194-204`) は false negative の一因
 
 - なし (実装は Spec の設計通りに 1 パスで完了)
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- 構造的な乖離なし。review-light (Spec Deviation 観点) が Implementation Steps / rubric 文言と実装 (解決順序、OPEN/CLOSED 分岐、degrade path、`--with-tracking`、SKILL.md Step 15) を突き合わせ、すべて一致していることを確認した。Code Retrospective が明記した唯一の解釈選択 (degrade path の group-key scoped 化) も Spec の記述と矛盾しない追加情報として扱った。
+
+### Recurring issues
+
+- review-light が 1 件 SHOULD 指摘 (`scripts/collect-recovery-candidates.sh:104` — `--issues-json` の python→bash 受け渡しに `\t` 区切りを使っており、Issue title にリテラルタブが含まれると欠陥が生じる潜在バグ) を発見し、`\x1f` (unit separator) への変更で即時修正した。今後同種の「python3 出力を tab 区切りで bash に渡す」パターンを新規実装する際は、区切り文字にタイトル文字列と衝突しうる `\t` を避け `\x1f` を既定に据えるとよい (ワークフロー改善候補としては小粒すぎるため Issue 起票はしない)。
+- Base Branch Conflict Pre-check が `docs/spec/issue-1152-*.md` を "changed in both" として検出したが、`git merge-file` による 3-way merge 検証で無害 (重複領域なし) と確認できた。3 引数 `--trivial-merge` 形式が誤検知気味の "changed in both" を出すケースとして記録に値するが、今回は 1 件のみで頻度が低く、個別の改善提案は起票しない。
+
+### Acceptance criteria verification difficulty
+
+- UNCERTAIN 判定はゼロ。9 件の Pre-merge AC のうち rubric 6 件・section_contains 1 件・file_not_contains 1 件はいずれも diff から機械的に確認でき、残る `github_check` 1 件も CI 全 9 checks SUCCESS で PASS 判定できた。Spec Notes が自認する通り AC 数 (9) は light テンプレートの目安 (5) を超えているが、review 側の検証コストとしては rubric の記述が具体的だったため大きな負荷にはならなかった。verify command の過不足や不正確さは見当たらない。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- 除外判定を group-key 単位から entry 単位に変更し、`起票済み #N` (優先) → `--issues-json` タイトル完全一致の順で対応 Issue を解決、open なら全 entry 除外・closed なら `closedAt` 以前のみ除外という規則で実装した。
-- `--issues-json` に `state`/`closedAt` が無い場合の degrade path は、group-key 自身の最新 `起票済み` entry 日時を代替基準とした (file-global ではなく group-key scoped — Design Gaps 参照)。
-- 出力形式の後方互換性を優先し、`tracked:#N`/`untracked` は `--with-tracking` opt-in の 3 列目とした (Spec Notes の判断を踏襲)。
-- rubric 系 AC 6件は自己判定によるバイアスを避けるため、独立したサブエージェントにアドバーサリアルグレーディングさせて PASS を確認した。
+- review-light (1 エージェント統合レビュー、4 観点) を採用し、MUST issue はゼロと確認。SHOULD issue 1 件 (`--issues-json` 区切り文字の tab 依存脆弱性) は即座に修正しコミット・push した。
+- Base Branch Conflict Pre-check で `docs/spec/issue-1152-*.md` の "changed in both" を検出したため、`git merge-file` による 3-way merge 検証を review-light に依頼し、データ損失なしを確認した。
+- 全 9 Pre-merge AC を PASS 判定し、Issue #1152 のチェックボックスを更新した (`github_check` 含む)。Step 13 のポリシー変更検出は該当なし (SHOULD 修正は純粋な堅牢性改善で AC に影響しない)。
 
 ### Deferred Items
-- 境界秒精度 (closedAt 分単位切り詰め) と group-key 複数回起票時の rolling cutoff 非対応は、Design Gaps/Ambiguities に記録の上、本 Issue のスコープ外として据え置いた。再発頻度が高まれば別 Issue で扱う。
-- #1191 (`/audit stats --retention` Section 10) は `--with-tracking` オプションを消費する側の実装であり、本 Issue はフォーマット提供のみ。エンドツーエンドの実消費は #1191 側で検証される。
+- 境界秒精度 (closedAt 分単位切り詰め) と group-key 複数回起票時の rolling cutoff 非対応は、Code Retrospective の Design Gaps/Ambiguities に記録済みで review でも追加の指摘なし。本 Issue のスコープ外として据え置く。
+- #1191 (`/audit stats --retention` Section 10) は `--with-tracking` オプションの実消費側。review では未検証 (#1191 側の責務)。
 
 ### Notes for Next Phase
-- Post-merge の observation AC (`/verify` Step 15 出力に close 済み対応 Issue の group-key が再浮上しないこと) は次回 `/auto` セッションでの実行時に観察される。`manual-recovery-review-rerun` / `review-tier3-recovery` が候補から消えているかを確認すること。
-- PR #1198 の CI (`Run bats tests`) 結果が pre-merge AC の最終 1 件。フルスイート 1444 件はローカルで PASS 済みだが CI 環境差異があれば要確認。
+- `/merge 1198` の前提条件はすべて満たされている (MUST issue ゼロ、CI 全通過、AC 全 PASS)。
+- Post-merge の observation AC (`/verify` Step 15 出力で `manual-recovery-review-rerun` / `review-tier3-recovery` が候補から消えていること) は次回 `/auto` セッションで確認すること。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -184,7 +184,7 @@ Key modules:
 - `scripts/gh-pr-review.sh` — post PR reviews
 
 **Project utilities:**
-- `scripts/collect-recovery-candidates.sh` — parse `docs/reports/orchestration-recoveries.md`; count group-key frequency (group-key is a bare symptom-short, or `symptom-short/cause-slug` when an entry's Diagnosis body has a `- cause:` line); exclude filed entries; apply `--threshold K` filter; output `<group-key>\t<count>` candidates; accepts `--issues-json PATH` for duplicate detection
+- `scripts/collect-recovery-candidates.sh` — parse `docs/reports/orchestration-recoveries.md`; count group-key frequency (group-key is a bare symptom-short, or `symptom-short/cause-slug` when an entry's Diagnosis body has a `- cause:` line); exclude entries individually by comparing each entry's timestamp against its resolved Issue's `closedAt` (open Issue: exclude all entries in the group; closed: exclude entries at or before `closedAt`, count entries after — falls back to the group's own latest `起票済み #N` entry timestamp as cutoff when `--issues-json` lacks `state`/`closedAt`); apply `--threshold K` filter; output `<group-key>\t<count>` candidates (add `--with-tracking` for a 3rd `tracked:#N`/`untracked` column); accepts `--issues-json PATH` (all-state issue list with `state`/`closedAt`) for Issue resolution
 - `scripts/get-config-value.sh` — extract a configuration value from `.wholework.yml`
 - `scripts/handle-permission-mode-failure.sh` — diagnose `permission-mode: auto` failures and print remediation hint to stderr (heuristic: exit!=0 AND elapsed<=30s)
 - `scripts/get-verify-permission.sh` — extract permission value from a verify command handler file

--- a/scripts/collect-recovery-candidates.sh
+++ b/scripts/collect-recovery-candidates.sh
@@ -94,7 +94,10 @@ ISS_TITLE=()
 ISS_STATE=()
 ISS_CLOSEDAT=()
 if [ -n "$ISSUES_JSON" ] && [ -f "$ISSUES_JSON" ]; then
-  while IFS=$'\t' read -r iss_num iss_title iss_state iss_closedat; do
+  # Use \x1f (unit separator) rather than \t as the record delimiter -- an Issue title
+  # could in principle contain a literal tab, which would shift these fields and corrupt
+  # state/closedAt resolution for that Issue (Issue #1198 review finding).
+  while IFS=$'\x1f' read -r iss_num iss_title iss_state iss_closedat; do
     [ -z "$iss_num" ] && continue
     ISS_NUM+=("$iss_num")
     ISS_TITLE+=("$iss_title")
@@ -108,7 +111,7 @@ for item in data:
     title = item.get('title', '')
     state = item.get('state', '') or ''
     closed_at = item.get('closedAt') or ''
-    print(f'{number}\t{title}\t{state}\t{closed_at}')
+    print(f'{number}\x1f{title}\x1f{state}\x1f{closed_at}')
 " "$ISSUES_JSON" 2>/dev/null || true)
 fi
 

--- a/scripts/collect-recovery-candidates.sh
+++ b/scripts/collect-recovery-candidates.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # Parse orchestration-recoveries.md and output frequency-filtered candidate list.
-# Output format: <group-key>\t<count> (tab-separated, one per line)
-# Only entries with count >= threshold and no "起票済み" Improvement Candidate are included.
-# Entries whose group-key matches an open issue title are excluded (duplicate check).
+# Output format: <group-key>\t<count> (tab-separated, one per line).
+# Only entries whose group-key clears --threshold K after entry-unit exclusion are included.
 #
 # group-key (Issue #1123): normally the H2 header's symptom-short (e.g.
 # "manual-recovery-review-rerun"). When an entry's "### Diagnosis" body has a
@@ -11,6 +10,23 @@
 # events with a different root cause are counted (and duplicate-checked) separately
 # rather than merged. Entries without a cause line keep the plain symptom-short key
 # (backward compatible with the existing 4 recoveries-log entries).
+#
+# Exclusion (Issue #1152): judged per entry, not per group-key, so a resolved symptom
+# and a genuine post-fix recurrence of the same group-key can be told apart.
+#   1. Resolve the group-key's corresponding Issue:
+#      - Prefer the "起票済み #N" marker on any entry in the group (latest occurrence wins).
+#      - Otherwise, look up --issues-json for a title exactly equal to "recoveries: <group-key>".
+#   2. If the resolved Issue's state (from --issues-json) is OPEN: exclude every entry in
+#      the group (the symptom is still being worked, so nothing new can be inferred yet).
+#   3. If CLOSED with a closedAt timestamp: exclude entries at or before closedAt; count
+#      entries strictly after closedAt (a real recurrence after the fix).
+#   4. Degrade path -- no resolvable Issue, or --issues-json lacks state/closedAt for the
+#      resolved Issue, or --issues-json was not passed at all: fall back to the group's own
+#      latest "起票済み #N" entry timestamp as the cutoff (same before/after rule as step 3).
+#      If the group has no "起票済み" entry either, there is no basis to exclude anything --
+#      every entry in the group is counted.
+# This keeps the default output format unchanged; pass --with-tracking to append a 3rd
+# column (tracked:#N / untracked) for consumers that need to distinguish the two.
 
 set -euo pipefail
 
@@ -20,6 +36,7 @@ SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$SCRIPT_DIR}"
 THRESHOLD=3
 ISSUES_JSON=""
 RECOVERY_FILE=""
+WITH_TRACKING=0
 
 # Parse arguments
 while [ $# -gt 0 ]; do
@@ -40,6 +57,10 @@ while [ $# -gt 0 ]; do
       ISSUES_JSON="${1#--issues-json=}"
       shift
       ;;
+    --with-tracking)
+      WITH_TRACKING=1
+      shift
+      ;;
     -*)
       echo "Unknown option: $1" >&2
       exit 1
@@ -57,7 +78,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$RECOVERY_FILE" ]; then
-  echo "Usage: $0 <recovery-file> [--threshold K] [--issues-json PATH]" >&2
+  echo "Usage: $0 <recovery-file> [--threshold K] [--issues-json PATH] [--with-tracking]" >&2
   exit 1
 fi
 
@@ -66,44 +87,89 @@ if [ ! -f "$RECOVERY_FILE" ]; then
   exit 1
 fi
 
-# Load open issue titles for duplicate detection
-ISSUE_TITLES=""
+# Load issues for group-key resolution: number, title, state, closedAt (any of the latter
+# two may be empty -- callers on an older contract may pass title-only records).
+ISS_NUM=()
+ISS_TITLE=()
+ISS_STATE=()
+ISS_CLOSEDAT=()
 if [ -n "$ISSUES_JSON" ] && [ -f "$ISSUES_JSON" ]; then
-  # Extract titles from JSON array: [{"number": N, "title": "..."}]
-  ISSUE_TITLES="$(python3 -c "
+  while IFS=$'\t' read -r iss_num iss_title iss_state iss_closedat; do
+    [ -z "$iss_num" ] && continue
+    ISS_NUM+=("$iss_num")
+    ISS_TITLE+=("$iss_title")
+    ISS_STATE+=("$iss_state")
+    ISS_CLOSEDAT+=("$iss_closedat")
+  done < <(python3 -c "
 import json, sys
 data = json.load(open(sys.argv[1]))
 for item in data:
-    print(item.get('title', ''))
-" "$ISSUES_JSON" 2>/dev/null || true)"
+    number = item.get('number', '')
+    title = item.get('title', '')
+    state = item.get('state', '') or ''
+    closed_at = item.get('closedAt') or ''
+    print(f'{number}\t{title}\t{state}\t{closed_at}')
+" "$ISSUES_JSON" 2>/dev/null || true)
 fi
 
-# Parse the recovery file.
-# Track current entry state: group-key (symptom-short, or symptom-short/cause when a
-# "- cause:" line is present) and whether the entry has a "起票済み" candidate.
-# Use associative-array-free approach for bash 3.2 compatibility:
-# - SYMPTOM_LIST: newline-separated list of group-keys (in order, possibly duplicated)
-# - EXCLUDED_LIST: newline-separated list of group-keys that are excluded (起票済み)
+_lookup_issue_by_number() {
+  LOOKUP_FOUND=0
+  LOOKUP_STATE=""
+  LOOKUP_CLOSEDAT=""
+  local target="$1" i
+  for ((i = 0; i < ${#ISS_NUM[@]}; i++)); do
+    if [ "${ISS_NUM[$i]}" = "$target" ]; then
+      LOOKUP_FOUND=1
+      LOOKUP_STATE="${ISS_STATE[$i]}"
+      LOOKUP_CLOSEDAT="${ISS_CLOSEDAT[$i]}"
+      return 0
+    fi
+  done
+}
 
-SYMPTOM_LIST=""
-EXCLUDED_LIST=""
+_lookup_issue_by_title() {
+  LOOKUP_FOUND=0
+  LOOKUP_NUMBER=""
+  LOOKUP_STATE=""
+  LOOKUP_CLOSEDAT=""
+  local target="$1" i
+  for ((i = 0; i < ${#ISS_TITLE[@]}; i++)); do
+    if [ "${ISS_TITLE[$i]}" = "$target" ]; then
+      LOOKUP_FOUND=1
+      LOOKUP_NUMBER="${ISS_NUM[$i]}"
+      LOOKUP_STATE="${ISS_STATE[$i]}"
+      LOOKUP_CLOSEDAT="${ISS_CLOSEDAT[$i]}"
+      return 0
+    fi
+  done
+}
+
+# Parse the recovery file into parallel per-entry arrays (bash 3.2+ compatible: indexed
+# arrays only, no associative arrays):
+# - ENTRY_TS: entry timestamp, normalized to "YYYY-MM-DDTHH:MM" (same width as closedAt
+#   truncated to 16 chars, so lexicographic string comparison matches chronological order)
+# - ENTRY_KEY: group-key (symptom-short, or symptom-short/cause-slug)
+# - ENTRY_FILED: "起票済み #N" issue number for this entry, or "" if absent
+
+ENTRY_TS=()
+ENTRY_KEY=()
+ENTRY_FILED=()
+
 CURRENT_SYMPTOM=""
 CURRENT_CAUSE=""
-CURRENT_EXCLUDED=0
+CURRENT_FILED=""
+CURRENT_TS=""
 HAS_PENDING_ENTRY=0
 
 _flush_entry() {
   [ "$HAS_PENDING_ENTRY" -eq 1 ] || return 0
-  key="$CURRENT_SYMPTOM"
+  local key="$CURRENT_SYMPTOM"
   if [ -n "$CURRENT_CAUSE" ]; then
     key="${CURRENT_SYMPTOM}/${CURRENT_CAUSE}"
   fi
-  SYMPTOM_LIST="${SYMPTOM_LIST}${key}
-"
-  if [ "$CURRENT_EXCLUDED" -eq 1 ]; then
-    EXCLUDED_LIST="${EXCLUDED_LIST}${key}
-"
-  fi
+  ENTRY_TS+=("$CURRENT_TS")
+  ENTRY_KEY+=("$key")
+  ENTRY_FILED+=("$CURRENT_FILED")
 }
 
 while IFS= read -r line; do
@@ -113,15 +179,16 @@ while IFS= read -r line; do
     # Extract symptom-short (everything after "UTC: ")
     CURRENT_SYMPTOM="${line#*UTC: }"
     CURRENT_SYMPTOM="$(echo "$CURRENT_SYMPTOM" | sed 's/ ([^)]*) *$//')"
+    CURRENT_TS="$(echo "$line" | sed -E 's/^## ([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9]{2}:[0-9]{2}) UTC:.*/\1T\2/')"
     CURRENT_CAUSE=""
-    CURRENT_EXCLUDED=0
+    CURRENT_FILED=""
     HAS_PENDING_ENTRY=1
     continue
   fi
   if [ "$HAS_PENDING_ENTRY" -eq 1 ]; then
     # Detect "Improvement Candidate" line with 起票済み
     if echo "$line" | grep -qE '^\- 起票済み #[0-9]+'; then
-      CURRENT_EXCLUDED=1
+      CURRENT_FILED="$(echo "$line" | sed -E 's/^- 起票済み #([0-9]+).*/\1/')"
     fi
     # Detect "### Diagnosis" body's "- cause: <slug>" line (Issue #1123)
     if echo "$line" | grep -qE '^- cause: .+'; then
@@ -131,53 +198,99 @@ while IFS= read -r line; do
 done < "$RECOVERY_FILE"
 _flush_entry
 
-# Count frequency for each unique symptom-short that is not excluded
-# and not a duplicate of an open issue title.
-# Collect unique symptom-shorts first.
-UNIQUE_SYMPTOMS=""
-while IFS= read -r sym; do
-  [ -z "$sym" ] && continue
-  # Skip if already in UNIQUE_SYMPTOMS
-  if ! echo "$UNIQUE_SYMPTOMS" | grep -qxF "$sym"; then
-    UNIQUE_SYMPTOMS="${UNIQUE_SYMPTOMS}${sym}
-"
+# Collect unique group-keys, first-seen order.
+# Note: iterate by index (${#ARR[@]}), not "for x in "${ARR[@]}"" -- under `set -u`,
+# bash 3.2 (macOS system bash) raises "unbound variable" when expanding an empty array
+# with "${ARR[@]}", while ${#ARR[@]} on an empty array safely evaluates to 0.
+UNIQUE_KEYS=()
+for ((ei = 0; ei < ${#ENTRY_KEY[@]}; ei++)); do
+  key="${ENTRY_KEY[$ei]}"
+  is_known=0
+  for ((ui = 0; ui < ${#UNIQUE_KEYS[@]}; ui++)); do
+    if [ "${UNIQUE_KEYS[$ui]}" = "$key" ]; then
+      is_known=1
+      break
+    fi
+  done
+  if [ "$is_known" -eq 0 ]; then
+    UNIQUE_KEYS+=("$key")
   fi
-done <<EOF
-$SYMPTOM_LIST
-EOF
+done
 
-# For each unique symptom, compute count and apply filters
-while IFS= read -r sym; do
-  [ -z "$sym" ] && continue
+for ((ki = 0; ki < ${#UNIQUE_KEYS[@]}; ki++)); do
+  key="${UNIQUE_KEYS[$ki]}"
+  resolved_number=""
+  latest_filed_ts=""
+  # Entries are appended in file order (chronological), so the last filed marker seen
+  # while scanning is both the authoritative resolution and the latest filed timestamp.
+  for ((i = 0; i < ${#ENTRY_KEY[@]}; i++)); do
+    if [ "${ENTRY_KEY[$i]}" = "$key" ] && [ -n "${ENTRY_FILED[$i]}" ]; then
+      resolved_number="${ENTRY_FILED[$i]}"
+      latest_filed_ts="${ENTRY_TS[$i]}"
+    fi
+  done
 
-  # Skip if excluded (起票済み)
-  if echo "$EXCLUDED_LIST" | grep -qxF "$sym"; then
-    continue
-  fi
-
-  # Skip if sym matches an open issue title (duplicate check).
-  # Exact match against "recoveries: <group-key>" -- not substring/"contains" -- so a
-  # bare group-key (e.g. "manual-recovery-review-rerun") is never treated as a duplicate
-  # of a cause-suffixed sibling title (e.g. "recoveries: manual-recovery-review-rerun/dirty-guard")
-  # just because it is a string prefix of it (Issue #1123 review finding).
-  if [ -n "$ISSUE_TITLES" ]; then
-    if echo "$ISSUE_TITLES" | grep -qxF "recoveries: $sym"; then
-      continue
+  resolved_state=""
+  resolved_closedat=""
+  if [ -n "$resolved_number" ]; then
+    _lookup_issue_by_number "$resolved_number"
+    if [ "$LOOKUP_FOUND" -eq 1 ]; then
+      resolved_state="$LOOKUP_STATE"
+      resolved_closedat="$LOOKUP_CLOSEDAT"
+    fi
+  else
+    _lookup_issue_by_title "recoveries: $key"
+    if [ "$LOOKUP_FOUND" -eq 1 ]; then
+      resolved_number="$LOOKUP_NUMBER"
+      resolved_state="$LOOKUP_STATE"
+      resolved_closedat="$LOOKUP_CLOSEDAT"
     fi
   fi
 
-  # Count occurrences in SYMPTOM_LIST
-  count=0
-  while IFS= read -r s; do
-    [ "$s" = "$sym" ] && count=$((count + 1))
-  done <<EOF2
-$SYMPTOM_LIST
-EOF2
-
-  # Apply threshold
-  if [ "$count" -ge "$THRESHOLD" ]; then
-    printf '%s\t%d\n' "$sym" "$count"
+  mode="count_all"
+  cutoff=""
+  if [ "$resolved_state" = "OPEN" ]; then
+    mode="exclude_all"
+  elif [ "$resolved_state" = "CLOSED" ] && [ -n "$resolved_closedat" ]; then
+    mode="cutoff"
+    cutoff="${resolved_closedat:0:16}"
   fi
-done <<EOF3
-$UNIQUE_SYMPTOMS
-EOF3
+
+  # Degrade path: no usable state/closedAt from --issues-json -- fall back to this
+  # group's own latest 起票済み entry timestamp, if any.
+  if [ "$mode" = "count_all" ] && [ -n "$latest_filed_ts" ]; then
+    mode="cutoff"
+    cutoff="$latest_filed_ts"
+  fi
+
+  count=0
+  case "$mode" in
+    exclude_all)
+      count=0
+      ;;
+    cutoff)
+      for ((i = 0; i < ${#ENTRY_KEY[@]}; i++)); do
+        if [ "${ENTRY_KEY[$i]}" = "$key" ] && [[ "${ENTRY_TS[$i]}" > "$cutoff" ]]; then
+          count=$((count + 1))
+        fi
+      done
+      ;;
+    count_all)
+      for ((i = 0; i < ${#ENTRY_KEY[@]}; i++)); do
+        [ "${ENTRY_KEY[$i]}" = "$key" ] && count=$((count + 1))
+      done
+      ;;
+  esac
+
+  if [ "$count" -ge "$THRESHOLD" ]; then
+    if [ "$WITH_TRACKING" -eq 1 ]; then
+      if [ -n "$resolved_number" ]; then
+        printf '%s\t%d\ttracked:#%s\n' "$key" "$count" "$resolved_number"
+      else
+        printf '%s\t%d\tuntracked\n' "$key" "$count"
+      fi
+    else
+      printf '%s\t%d\n' "$key" "$count"
+    fi
+  fi
+done

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -893,11 +893,11 @@ This step implements the `recoveries-auto-fire` feature. Controlled by `.wholewo
 
 Guard: if `docs/reports/orchestration-recoveries.md` does not exist, skip this step entirely.
 
-1. Write open-issues JSON to `.tmp/open-issues-$NUMBER.json` for dedup:
+1. Write all-state issues JSON to `.tmp/open-issues-$NUMBER.json` for entry-unit dedup (Issue #1152 — `collect-recovery-candidates.sh` needs `state` and `closedAt` to tell a resolved symptom from a genuine post-fix recurrence of the same group-key; an open-only list cannot distinguish the two):
    ```bash
-   gh issue list --state open --limit 200 --json number,title
+   gh issue list --state all --limit 1000 --json number,title,state,closedAt
    ```
-   Write the output to `.tmp/open-issues-$NUMBER.json` using the Write tool.
+   Write the output to `.tmp/open-issues-$NUMBER.json` using the Write tool. The filename is kept for backward compatibility even though the content is no longer open-only.
 
 2. Run:
    ```bash

--- a/tests/collect-recovery-candidates.bats
+++ b/tests/collect-recovery-candidates.bats
@@ -33,7 +33,10 @@ FIXTURE_EOF
   [ -z "$output" ]
 }
 
-@test "exclusion: filed improvement candidate mark -> symptom excluded from output" {
+@test "exclusion: filed improvement candidate mark -> only entries after the filed entry are counted" {
+  # No --issues-json is passed, so the degrade path applies: the group's own latest
+  # 起票済み entry timestamp (2026-06-02) becomes the cutoff. Entries at or before it
+  # (06-01, 06-02) are excluded; only the 06-03 entry -- filed after the fix -- is counted.
   cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
 ## 2026-06-01 10:00 UTC: repeated-symptom
 
@@ -52,7 +55,178 @@ FIXTURE_EOF
 
   run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 1
   [ "$status" -eq 0 ]
-  ! echo "$output" | grep -qF "repeated-symptom"
+  echo "$output" | grep -E $'^repeated-symptom\t1$'
+}
+
+@test "entry-unit exclusion: closed issue -- entries after closedAt are counted" {
+  cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
+## 2026-06-01 10:00 UTC: post-close-recurrence
+
+- Cause: occurrence before the fix (excluded)
+
+## 2026-06-05 10:00 UTC: post-close-recurrence
+
+- Cause: first recurrence after the fix
+
+## 2026-06-06 10:00 UTC: post-close-recurrence
+
+- Cause: second recurrence after the fix
+
+## 2026-06-07 10:00 UTC: post-close-recurrence
+
+- Cause: third recurrence after the fix
+
+FIXTURE_EOF
+
+  ISSUES_JSON_FILE="$BATS_TEST_TMPDIR/issues.json"
+  cat > "$ISSUES_JSON_FILE" << 'JSON_EOF'
+[{"number": 500, "title": "recoveries: post-close-recurrence", "state": "CLOSED", "closedAt": "2026-06-03T00:00:00Z"}]
+JSON_EOF
+
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 3 --issues-json "$ISSUES_JSON_FILE"
+  [ "$status" -eq 0 ]
+  # Only the 3 post-closedAt entries count -- the pre-closedAt entry is dropped, so the
+  # group clears the threshold on recurrence alone, not on the original occurrence.
+  echo "$output" | grep -E $'^post-close-recurrence\t3$'
+}
+
+@test "entry-unit exclusion: an entry auto-stamped with the filed marker by run-auto-sub.sh's closed-issue fallback is still counted when it falls after closedAt" {
+  # run-auto-sub.sh's _find_known_recoveries_issue() resolves closed issues too (open ->
+  # closed fallback), so a genuinely new post-fix entry can be auto-stamped 起票済み #N even
+  # though the symptom already recurred. The 起票済み marker must NOT by itself exclude the
+  # entry -- only its timestamp relative to closedAt decides that (Issue #1152 AC #2).
+  cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
+## 2026-06-01 10:00 UTC: stamped-recurrence
+
+- 起票済み #600
+- Cause: occurrence that triggered the original filing (excluded, before closedAt)
+
+## 2026-06-10 10:00 UTC: stamped-recurrence
+
+- 起票済み #600
+- Cause: first recurrence after the fix (auto-stamped by run-auto-sub.sh, but still new)
+
+## 2026-06-11 10:00 UTC: stamped-recurrence
+
+- 起票済み #600
+- Cause: second recurrence after the fix
+
+## 2026-06-12 10:00 UTC: stamped-recurrence
+
+- 起票済み #600
+- Cause: third recurrence after the fix
+
+FIXTURE_EOF
+
+  ISSUES_JSON_FILE="$BATS_TEST_TMPDIR/issues.json"
+  cat > "$ISSUES_JSON_FILE" << 'JSON_EOF'
+[{"number": 600, "title": "recoveries: stamped-recurrence", "state": "CLOSED", "closedAt": "2026-06-03T00:00:00Z"}]
+JSON_EOF
+
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 3 --issues-json "$ISSUES_JSON_FILE"
+  [ "$status" -eq 0 ]
+  # All 4 entries carry 起票済み #600, yet the 3 entries after closedAt are still counted --
+  # proving the cutoff, not the marker, drives exclusion.
+  echo "$output" | grep -E $'^stamped-recurrence\t3$'
+}
+
+@test "entry-unit exclusion: closed issue -- entries at or before closedAt are excluded" {
+  cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
+## 2026-06-01 10:00 UTC: pre-close-only
+
+- Cause: first occurrence
+
+## 2026-06-02 10:00 UTC: pre-close-only
+
+- Cause: second occurrence
+
+## 2026-06-03 10:00 UTC: pre-close-only
+
+- Cause: third occurrence
+
+FIXTURE_EOF
+
+  ISSUES_JSON_FILE="$BATS_TEST_TMPDIR/issues.json"
+  cat > "$ISSUES_JSON_FILE" << 'JSON_EOF'
+[{"number": 501, "title": "recoveries: pre-close-only", "state": "CLOSED", "closedAt": "2026-06-10T00:00:00Z"}]
+JSON_EOF
+
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 1 --issues-json "$ISSUES_JSON_FILE"
+  [ "$status" -eq 0 ]
+  # All 3 entries predate closedAt, so nothing clears even threshold=1 -- the resolved
+  # symptom does not resurface just because its fix Issue exists.
+  [ -z "$output" ]
+}
+
+@test "entry-unit exclusion: open issue -- every entry in the group is excluded" {
+  cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
+## 2026-06-01 10:00 UTC: open-issue-symptom
+
+- Cause: first occurrence
+
+## 2026-06-02 10:00 UTC: open-issue-symptom
+
+- Cause: second occurrence
+
+## 2026-06-03 10:00 UTC: open-issue-symptom
+
+- Cause: third occurrence
+
+FIXTURE_EOF
+
+  ISSUES_JSON_FILE="$BATS_TEST_TMPDIR/issues.json"
+  cat > "$ISSUES_JSON_FILE" << 'JSON_EOF'
+[{"number": 502, "title": "recoveries: open-issue-symptom", "state": "OPEN", "closedAt": ""}]
+JSON_EOF
+
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 1 --issues-json "$ISSUES_JSON_FILE"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "--with-tracking: appends tracked:#N / untracked as a 3rd column; default output is unchanged" {
+  cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
+## 2026-06-01 10:00 UTC: tracked-symptom
+
+- Cause: first
+
+## 2026-06-02 10:00 UTC: tracked-symptom
+
+- Cause: second
+
+## 2026-06-03 10:00 UTC: tracked-symptom
+
+- Cause: third
+
+## 2026-06-01 10:00 UTC: untracked-symptom
+
+- Cause: first
+
+## 2026-06-02 10:00 UTC: untracked-symptom
+
+- Cause: second
+
+## 2026-06-03 10:00 UTC: untracked-symptom
+
+- Cause: third
+
+FIXTURE_EOF
+
+  ISSUES_JSON_FILE="$BATS_TEST_TMPDIR/issues.json"
+  cat > "$ISSUES_JSON_FILE" << 'JSON_EOF'
+[{"number": 503, "title": "recoveries: tracked-symptom", "state": "CLOSED", "closedAt": "2026-05-01T00:00:00Z"}]
+JSON_EOF
+
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 3 --issues-json "$ISSUES_JSON_FILE" --with-tracking
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -E $'^tracked-symptom\t3\ttracked:#503$'
+  echo "$output" | grep -E $'^untracked-symptom\t3\tuntracked$'
+
+  # Default (no --with-tracking): output stays the 2-column <group-key>\t<count> format.
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 3 --issues-json "$ISSUES_JSON_FILE"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -E $'^tracked-symptom\t3$'
+  echo "$output" | grep -E $'^untracked-symptom\t3$'
 }
 
 @test "normal detection: count >= threshold and no exclusion -> appears in output" {
@@ -163,7 +337,7 @@ FIXTURE_EOF
 
   ISSUES_JSON_FILE="$BATS_TEST_TMPDIR/issues.json"
   cat > "$ISSUES_JSON_FILE" << 'JSON_EOF'
-[{"number": 999, "title": "recoveries: manual-recovery-review-rerun/dirty-guard"}]
+[{"number": 999, "title": "recoveries: manual-recovery-review-rerun/dirty-guard", "state": "OPEN", "closedAt": ""}]
 JSON_EOF
 
   run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 3 --issues-json "$ISSUES_JSON_FILE"
@@ -191,7 +365,7 @@ FIXTURE_EOF
 
   ISSUES_JSON_FILE="$BATS_TEST_TMPDIR/issues.json"
   cat > "$ISSUES_JSON_FILE" << 'JSON_EOF'
-[{"number": 999, "title": "recoveries: manual-recovery-review-rerun"}]
+[{"number": 999, "title": "recoveries: manual-recovery-review-rerun", "state": "OPEN", "closedAt": ""}]
 JSON_EOF
 
   run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 3 --issues-json "$ISSUES_JSON_FILE"


### PR DESCRIPTION
## Summary

`scripts/collect-recovery-candidates.sh` の除外判定を group-key 単位から entry 単位に変更した。従来は 1 entry でも `起票済み #N` があるとその group-key の集計が全期間にわたって抑止され、(a) 対応 Issue 起票前の古い entry が毎回閾値超過として再浮上する false positive と、(b) 対応 Issue close 後の真の再発が握り潰される false negative を同時に引き起こしていた。

- 各 entry の対応 Issue を `起票済み #N` (優先) または `recoveries: <group-key>` とのタイトル完全一致から解決
- 対応 Issue が open なら group-key の全 entry を除外、closed なら `closedAt` 以前の entry のみ除外し以降を計数
- `--issues-json` が `state`/`closedAt` を持たない場合は、group 自身の最新 `起票済み` entry 日時を代替基準とする degrade path
- 出力形式は既定で後方互換 (`<group-key>\t<count>`)。`--with-tracking` オプションで 3 列目に `tracked:#N` / `untracked` を追加 (#1191 向け)
- `skills/verify/SKILL.md` Step 15 が渡す `--issues-json` を `--state open` から `--state all` (+ `state`, `closedAt`) に変更
- `docs/structure.md` / `docs/ja/structure.md` の説明を実装後の規則に更新

## Verification (pre-merge)

- bats `tests/collect-recovery-candidates.bats` 14 件全て PASS (新規 5 件追加: closedAt 前後の計数/除外、open issue 全除外、起票済みマーカー付き post-close entry の計数、`--with-tracking`)
- フルスイート `bats tests/` 1444 件全て PASS (`skills/verify/SKILL.md` の変更が `tests/verify.bats` / `tests/verify-dirty-detection.bats` から参照されるため behavioral change 扱いで実行)
- `python3 scripts/validate-skill-syntax.py skills/` — 0 error
- `bash scripts/check-forbidden-expressions.sh` — 0 violation
- Issue #1152 の pre-merge AC 9件中 8件を rubric/機械チェックで自己検証済み (独立サブエージェントによるアドバーサリアルグレーディングで全 6 rubric PASS を確認)。残り 1件 (`github_check "gh pr checks" "Run bats tests"`) はこの PR の CI 結果待ち

## Verification (post-merge)

- `/verify` 実行の Step 15 出力で、close 済みの対応 Issue が存在する group-key (`manual-recovery-review-rerun` / `review-tier3-recovery`) が候補として再浮上しないことを観察 (次回 `/auto` セッションで確認)

closes #1152
