### PR TITLE
Issue #1058: Consolidate Spec file write destination to the phase's own working branch

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -162,7 +162,7 @@ wholework/
 **Phase banner:**
 - `scripts/phase-banner.sh` — run-*.sh スクリプトで `print_start_banner` / `print_end_banner` 関数を提供する source 可能なヘルパー
 - `scripts/emit-event.sh` — `.tmp/auto-events.jsonl` への構造化 JSONL イベント emission を提供する source 可能なヘルパー。non-wrapper emitter 向けにポインタファイルから `AUTO_SESSION_ID`/`AUTO_EVENTS_LOG` を復元する `restore_auto_session_pointer()` も提供; run-*.sh、claude-watchdog.sh、wait-ci-checks.sh が使用
-- `scripts/append-consumed-comments-section.sh` — post-processor フォールバック: LLM が Step 5 を silent skip した際に Spec へ `## Consumed Comments` を追記; run-spec.sh / run-code.sh (pre/post カウント比較) と verify SKILL.md (明示 bash call) が使用
+- `scripts/append-consumed-comments-section.sh` — フェーズ自身の作業ブランチ上で Spec へ `## Consumed Comments` を追記; `skills/spec/SKILL.md` / `skills/code/SKILL.md` / `skills/verify/SKILL.md` から in-session (必須、`--no-push` 付き) で呼び出される。加えて run-spec.sh / run-code.sh からの post-processor フォールバック (pre/post カウント比較) があるが、`/code` pr route ではゲートオフされる (#1058)
 - `scripts/hook-worktree-path-guard.sh` — PreToolUse hook: worktree session 中に parent-repo absolute path を file_path とする Edit/Write 呼び出しを block する (`modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions` の structural enforcement)
 
 **GitHub API ユーティリティ:**

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -162,7 +162,7 @@ wholework/
 **Phase banner:**
 - `scripts/phase-banner.sh` — run-*.sh スクリプトで `print_start_banner` / `print_end_banner` 関数を提供する source 可能なヘルパー
 - `scripts/emit-event.sh` — `.tmp/auto-events.jsonl` への構造化 JSONL イベント emission を提供する source 可能なヘルパー。non-wrapper emitter 向けにポインタファイルから `AUTO_SESSION_ID`/`AUTO_EVENTS_LOG` を復元する `restore_auto_session_pointer()` も提供; run-*.sh、claude-watchdog.sh、wait-ci-checks.sh が使用
-- `scripts/append-consumed-comments-section.sh` — フェーズ自身の作業ブランチ上で Spec へ `## Consumed Comments` を追記; `skills/spec/SKILL.md` / `skills/code/SKILL.md` / `skills/verify/SKILL.md` から in-session (必須、`--no-push` 付き) で呼び出される。加えて run-spec.sh / run-code.sh からの post-processor フォールバック (pre/post カウント比較) があるが、`/code` pr route ではゲートオフされる (#1058)
+- `scripts/append-consumed-comments-section.sh` — フェーズ自身の作業ブランチ上で Spec へ `## Consumed Comments` を追記; `skills/spec/SKILL.md` / `skills/code/SKILL.md` (いずれも `--no-push` 付き) / `skills/verify/SKILL.md` (`--no-push` 未適用、直接 push — #1058 では対応保留) から in-session (必須) で呼び出される。加えて run-spec.sh / run-code.sh からの post-processor フォールバック (pre/post カウント比較) があるが、`/code` pr route ではゲートオフされる (#1058)
 - `scripts/hook-worktree-path-guard.sh` — PreToolUse hook: worktree session 中に parent-repo absolute path を file_path とする Edit/Write 呼び出しを block する (`modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions` の structural enforcement)
 
 **GitHub API ユーティリティ:**

--- a/docs/spec/issue-1058-spec-write-branch-consistency.md
+++ b/docs/spec/issue-1058-spec-write-branch-consistency.md
@@ -235,26 +235,37 @@ Size は既に `L` (変更なし)。タイトルとの意味的乖離は検出�
 - `worktree-merge-push.sh` の `--base` 既定値が `main` である点は、main tree では HEAD が base ブランチそのものであることを利用し `--base "$(git rev-parse --abbrev-ref HEAD)"` を渡すことで解決した。`append-consumed-comments-section.sh` に `--base` フラグを新設する必要はない。
 - `tests/append-consumed-comments-section.bats` は `WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` を設定済みのため、新たに呼ばれる `worktree-merge-push.sh` のモック追加が必須である点を Implementation Steps 7 に明記した。`$MOCK_DIR/git` モックが `rev-parse --git-dir` と `rev-parse --git-common-dir` に異なる値を返して worktree 内を模擬している (L47-54) ことも確認済み。
 
+## Code Retrospective
+
+### Deviations from Design
+
+- None. Implementation Steps 1–9 were followed as written; no reordering, omission, or consolidation was needed.
+
+### Design Gaps/Ambiguities
+
+- `tests/run-verify.bats` was not listed in Changed Files but broke on first full-suite run: its `git` mock does not implement `rev-parse --git-dir`/`--git-common-dir` (both calls fall through to the default branch and return an empty string), and the new main-tree push-routing check in `append-consumed-comments-section.sh` originally compared `"$_git_dir" == "$_git_common_dir"` without the non-empty guard the adjacent defense-in-depth warning check already had — two empty strings compare equal, so it misclassified this fixture as "main tree" and called the (unmocked) `worktree-merge-push.sh` instead of `git push origin HEAD`. Fixed by adding the same `-n "$_git_dir" && -n "$_git_common_dir"` guard to the routing check (Implementation Step 1). The Spec's own Changed Files list scoped `tests/run-verify.bats` out because #1058 does not modify `/verify`'s call site, but a script-level behavior change still has to satisfy every existing caller's test fixture, not just the ones the Spec enumerates — the Step 9 Behavioral Change Detection full-suite override (triggered because `append-consumed-comments-section.sh` is referenced by more than its direct-counterpart test) is what caught this, confirming that override's value beyond narrow-scope test runs.
+- Executing this Issue's own `/code` run reproduced the sibling defect this Issue's Related section attributes to #1078: `skills/code/SKILL.md`'s Comment Consumption (Step 1) runs before Worktree Entry (Step 2), so writing the code-phase `## Consumed Comments` entry per that step order edited the main repository's Spec copy directly, before `EnterWorktree` was called. That edit never reached the worktree branch and was left as an uncommitted diff in the main repository, requiring manual reconciliation after Worktree Exit. This is out of scope for #1058 (which explicitly handles only the wrapper post-processor path, route (a), and defers the SKILL.md step-order path to #1078) but is recorded here as a concrete, first-hand reproduction for whoever picks up #1078.
+
+### Rework
+
+- The `-n` guard fix above was the only rework cycle: full-suite `bats tests/` surfaced the `tests/run-verify.bats` failure, root-caused to the missing guard, fixed, and the full suite re-run clean (1443/1443).
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- 案 B (Spec はフェーズ自身の作業ブランチで編集し、base へは Exit 経路経由でのみ反映) を採用。`/verify` が #1037 で確立済みの規約への整合であり、新規設計ではない
-- pr route では wrapper post-processor を無効化し、安全網は `skills/code/SKILL.md` Step 12 の in-session mandatory call に一本化する
-- 新規の in-session 呼び出しには `--no-push` を付ける。base への反映は各フェーズの Exit 経路 (`worktree-merge-push.sh` / PR merge) が担保する
-- 書き込み先規約の SSoT は `modules/worktree-lifecycle.md` に置き、`modules/l0-surfaces.md` からは参照させる (重複記述を作らない)
+- Kept the Spec's designed approach (Candidate B, in-session mandatory `--no-push` calls) unchanged — no implementation-time deviation was needed.
+- Added a non-empty guard to the main-tree push-routing check in `append-consumed-comments-section.sh` (matching the existing defense-in-depth warning check's guard) after `tests/run-verify.bats` exposed the gap; this is a defensive-programming fix within Implementation Step 1's scope, not a design change.
 
 ### Deferred Items
 
-- worktree セッション中の main repository 書き込み全般の棚卸しは別 Issue へ切り出す。起票は `/verify` の Improvement Proposal 集約に委ねる
-- `/verify` の `append-consumed-comments-section.sh` 呼び出しへの `--no-push` 適用 (`origin/worktree-verify+issue-*` 16 本の残留解消) は AC の範囲外のため本 Issue では行わない
-- `run-*.sh` の pre/post カウント比較が見出し数ベースで patch route では常に誤発火する件は、冪等かつ無害のため本 Issue では修正しない
+- Same three items as the Spec Phase Handoff (unchanged from spec phase): worktree-session main-repository write audit spun out to a future Issue; `/verify`'s own `--no-push` adoption (residual `origin/worktree-verify+issue-*` branches) out of scope; patch-route pre/post count fallback mis-fire left unfixed (idempotent, harmless).
+- #1078 (SKILL.md step-order path) remains untouched, as scoped. See Design Gaps/Ambiguities above for a first-hand reproduction of the defect it will need to fix.
 
 ### Notes for Next Phase
 
-- `skills/code/SKILL.md` と `skills/spec/SKILL.md` の `allowed-tools` への `${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh:*` 追加を忘れないこと。`scripts/check-allowed-tools.sh` が Step 8 で mismatch を検出して commit を止める
-- `tests/append-consumed-comments-section.bats` の `setup()` に `worktree-merge-push.sh` モックを追加しないと新テストが解決不能になる (`WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"` のため)
-- `modules/worktree-lifecycle.md` に追加する表には `**(exhaustive)**` マーカーが必要 (`modules/skill-dev-checks.md`)
-- `docs/structure.md` を変更するため `docs/ja/structure.md` の同期が必須 (`docs/translation-workflow.md`)
-- 本 Issue は #1078 と対になっており、#1078 が扱う SKILL.md ステップ順序の経路には手を入れない
+- Pre-merge AC 1 and 2 are both checked (rubric PASS, judged in-session per `modules/verify-executor.md` full mode against the worktree's own modified files).
+- Post-merge AC (observation, `event=auto-run when=route:pr session=next`) is unresolved by design — it activates on the next pr-route `/code` run after this PR merges. `/verify` should treat it as SKIPPED (unfired) rather than attempt evaluation now.
+- Full `bats tests/` (1443 tests), `validate-skill-syntax.py`, `check-forbidden-expressions.sh`, and `check-allowed-tools.sh` all passed clean on the final commit.
+- A stray uncommitted edit was left in the main repository's working tree (see Design Gaps/Ambiguities) — reconciled after Worktree Exit; `/review` and `/merge` should see a clean main-repo status caused by this PR's own commits only.

--- a/docs/spec/issue-1058-spec-write-branch-consistency.md
+++ b/docs/spec/issue-1058-spec-write-branch-consistency.md
@@ -18,7 +18,7 @@ Spec ファイル (`docs/spec/issue-N-*.md`) への追記先が、実行主体�
 ## Changed Files
 
 - `scripts/append-consumed-comments-section.sh`: `--no-push` フラグ追加 (フラグ指定時は commit のみ行い push しない)。main tree で実行された場合の `git push origin HEAD` を `worktree-merge-push.sh --base "$(git rev-parse --abbrev-ref HEAD)"` によるロック付き push に置換 — bash 3.2+ 互換 (`mapfile` 等の bash 4+ 構文を導入しない)
-- `scripts/run-code.sh`: post-processor fallback ブロック (L367-374) を `ROUTE_FLAG != "--pr"` の場合のみ実行するようゲート。pr route では Spec の書き込み先が PR ブランチであり main repository からは観測も安全な書き込みもできないため — bash 3.2+ 互換
+- `scripts/run-code.sh`: post-processor fallback ブロック (L367-374) を、`reconcile-phase-state.sh` が観測した実際の open PR 番号 (`_PR_NUM`) が空の場合のみ実行するようゲート (実装時に `ROUTE_FLAG != "--pr"` から変更 — `ROUTE_FLAG` だけでは Size auto-detection 等による auto-detected pr route を判定できないため、review #1201 指摘)。pr route では Spec の書き込み先が PR ブランチであり main repository からは観測も安全な書き込みもできないため — bash 3.2+ 互換
 - `skills/code/SKILL.md`: Step 12 の `git add` 直前に `append-consumed-comments-section.sh $NUMBER code --no-push` の必須 bash 呼び出しを追加。frontmatter `allowed-tools` に `${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh:*` を追加 (現在は未登録)
 - `skills/spec/SKILL.md`: Step 13 の `git add` 直前に `append-consumed-comments-section.sh $NUMBER spec --no-push` の必須 bash 呼び出しを追加。frontmatter `allowed-tools` に同エントリを追加 (現在は未登録)
 - `modules/worktree-lifecycle.md`: Notes に「Spec file write destination」節を新設 — 「Spec ファイルはフェーズ自身の作業ブランチ (worktree ブランチ / PR ブランチ) 上でのみ編集し、base へは既存の Exit 経路 (`worktree-merge-push.sh` または PR merge) 経由でのみ反映する」という規約を明文化する。`## Consumed Comments` との相互作用にも言及する
@@ -31,9 +31,9 @@ Spec ファイル (`docs/spec/issue-N-*.md`) への追記先が、実行主体�
 ## Implementation Steps
 
 1. `scripts/append-consumed-comments-section.sh` に `--no-push` フラグを追加し、main tree 判定 (既存の `_git_dir == _git_common_dir` チェック) が真のときの push を `worktree-merge-push.sh --base "$(git -C "$_repo_root" rev-parse --abbrev-ref HEAD)"` に置き換える。失敗時は既存同様 best-effort 警告のみ (→ acceptance criteria 2)
-2. `scripts/run-code.sh` の post-processor fallback ブロックの条件を `if [[ $EXIT_CODE -eq 0 && "$ROUTE_FLAG" != "--pr" ]]; then` に変更し、pr route では wrapper が Spec を編集しないようにする。スキップ理由を同ブロックのコメントに記載する (→ acceptance criteria 2)
-3. `skills/code/SKILL.md` Step 12 の Steps 6 (`git add $SPEC_PATH/issue-$NUMBER-*.md` を含む commit ブロック) の直前に、`bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER code --no-push` の必須呼び出しを追加する。あわせて frontmatter の `allowed-tools` に該当エントリを追加する (after 1) (→ acceptance criteria 2)
-4. `skills/spec/SKILL.md` Step 13 の Steps 5 (Phase Handoff write) の直後・Steps 6 (commit) の直前に、`bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER spec --no-push` の必須呼び出しを追加する。あわせて frontmatter の `allowed-tools` に該当エントリを追加する (after 1, parallel with 3) (→ acceptance criteria 2)
+2. `scripts/run-code.sh` の post-processor fallback ブロックの条件を、`reconcile-phase-state.sh` が観測した open PR 番号 (`_PR_NUM`) が空かどうかで判定するよう変更し、pr route では wrapper が Spec を編集しないようにする。スキップ理由を同ブロックのコメントに記載する (実装時に判定軸を `ROUTE_FLAG` から `_PR_NUM` に変更 — review #1201 指摘。auto-detected pr route を `ROUTE_FLAG` だけでは判定できないため) (→ acceptance criteria 2)
+3. `skills/code/SKILL.md` Step 12 の retrospective commit ブロックの**直後**に、`bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER code --no-push` の必須呼び出しを追加する。あわせて frontmatter の `allowed-tools` に該当エントリを追加する (after 1) (→ acceptance criteria 2) (実装時に「commit の直前」から「commit の直後」に変更 — 直前に置くと、未コミットの retrospective / Phase Handoff 編集がスクリプト自身の commit に巻き込まれてしまうため)
+4. `skills/spec/SKILL.md` Step 13 の commit ブロックの**直後**に、`bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER spec --no-push` の必須呼び出しを追加する。あわせて frontmatter の `allowed-tools` に該当エントリを追加する (after 1, parallel with 3) (→ acceptance criteria 2) (実装時に「直前」から「直後」に変更 — 理由は 3 と同様)
 5. `modules/worktree-lifecycle.md` の `## Notes` に「Spec file write destination」節 (見出しレベル `###`) を追加し、Spec ファイルの書き込み先規約とフェーズ別の base 反映経路 (`/spec`・`/code` patch/operate・`/verify` は `worktree-merge-push.sh`、`/code` pr は PR merge) を表で明文化する。表には `**(exhaustive)**` マーカーを付す (`modules/skill-dev-checks.md` "Exhaustive/Example Markers") (→ acceptance criteria 1)
 6. `modules/l0-surfaces.md` の「Bash wrapper fallback (Issue #811)」節を、新しい 2 層構成 (in-session mandatory call が第一の安全網、wrapper post-processor は非 pr route の第二の安全網) に書き換え、Step 5 で追加した `worktree-lifecycle.md` の節を参照させる (after 5) (→ acceptance criteria 1)
 7. `tests/append-consumed-comments-section.bats` の `setup()` に `worktree-merge-push.sh` モックを追加し、`--no-push` 指定時に push されないテストと main tree 実行時に `worktree-merge-push.sh` が呼ばれるテストを追加する (after 1)
@@ -244,7 +244,7 @@ Size は既に `L` (変更なし)。タイトルとの意味的乖離は検出�
 
 ### Deviations from Design
 
-- None. Implementation Steps 1–9 were followed as written; no reordering, omission, or consolidation was needed.
+- The `-n` guard fix recorded under Design Gaps/Ambiguities below is the only *code-behavior* deviation from the original plan. Additionally, three *documentation* deviations were identified in `/review` (#1201) and corrected here: (1) Implementation Step 2 / Changed Files described `scripts/run-code.sh`'s post-processor gate as `ROUTE_FLAG != "--pr"`; the actual implementation gates on the observed open-PR number (`_PR_NUM`) instead, since `ROUTE_FLAG` alone cannot distinguish an auto-detected pr route (Size auto-detection, `always-pr: true`) from patch route. (2) Implementation Steps 3/4 described the `skills/code/SKILL.md` / `skills/spec/SKILL.md` safety-net calls as placed *before* the retrospective/handoff commit; the actual implementation places them *after*, to avoid the safety-net script's own commit sweeping up not-yet-committed retrospective/handoff edits. Both Changed Files and Implementation Steps above have been updated to match.
 
 ### Design Gaps/Ambiguities
 

--- a/docs/spec/issue-1058-spec-write-branch-consistency.md
+++ b/docs/spec/issue-1058-spec-write-branch-consistency.md
@@ -255,22 +255,40 @@ Size は既に `L` (変更なし)。タイトルとの意味的乖離は検出�
 
 - The `-n` guard fix above was the only rework cycle: full-suite `bats tests/` surfaced the `tests/run-verify.bats` failure, root-caused to the missing guard, fixed, and the full suite re-run clean (1443/1443).
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- The code phase's own Code Retrospective claimed "Deviations from Design: None" while the implementation actually diverged from the Spec's Implementation Steps in three places (post-processor gate axis `ROUTE_FLAG`→`_PR_NUM`; safety-net call position moved from before to after the commit, ×2 SKILL.md sites). The divergence was real but was categorized as "not a design deviation" because it was framed as an in-scope refinement rather than a plan change — this is exactly the kind of self-assessment gap `skills/code/SKILL.md` Step 12 item 4's "update Spec Implementation Steps to match" rule exists to catch, and it was missed at code-phase time. Recommendation: when future review passes find a Spec/implementation mismatch that the Code Retrospective already claims doesn't exist, treat the Retrospective's own "Deviations: None" as a signal worth double-checking, not as evidence the search is unnecessary.
+- This PR is itself about eliminating a documentation/implementation split (Spec write-destination inconsistency), and `/review` found the PR's own newly-added documentation (the "Spec file write destination" exhaustive table, the "all in-session callers pass --no-push" claim) had internal self-contradictions on the same axis — new prose asserting completeness/consistency that wasn't actually complete/consistent. Worth naming as a category: "exhaustive-marker" tables and absolute claims ("all", "always") are exactly the phrasing that HIGH SIGNAL review should stress-test hardest, since they're falsified by a single missing case.
+
+### Recurring issues
+
+- Two independent review-bug agents (diff-scan and security-scan) both surfaced the `modules/worktree-lifecycle.md` exhaustive-table gap and the `scripts/run-code.sh:345` stale-`ROUTE_FLAG` inconsistency independently, from different angles — confirms the 2-lens review-bug fan-out has real recall value beyond a single pass, at least for this PR's size/shape.
+- `gh-pr-review.sh`'s `HAS_MUST` detection requires each line-comment JSON object to carry an explicit `"severity"` field (documented in the script's own header comment); a line-comments JSON built with severity only embedded in the comment body text (not as a JSON key) silently defaults to `EVENT="COMMENT"` with no error. This is an easy transcription mistake since the severity is *also* human-readable inside the body text, making the omission easy to miss. Separately, and independently of that mistake: the GitHub Pull Request Reviews API rejects `REQUEST_CHANGES` on your own PR (`422 Unprocessable Entity: "Review Can not request changes on your own pull request"`) — a hard platform constraint for any single-maintainer / self-hosted repo where the reviewer and PR author are the same GitHub account. `gh-pr-review.sh` has no handling for this case; a correctly-populated `severity` field would still have hit the same 422 and, per the script's current `|| { echo Error; exit 1; }` handling, aborted the entire review post (comments included) rather than degrading gracefully to `COMMENT`. Both points are worth an improvement proposal for `/verify` to aggregate: (1) `gh-pr-review.sh` should catch the self-review 422 specifically and retry with `event=COMMENT` instead of failing the whole post, and (2) the MUST-issue visibility that `REQUEST_CHANGES` provides needs a non-event-based fallback (e.g. a bolded banner in the review body) for the self-review case, since the event field cannot carry that signal here.
+
+### Acceptance criteria verification difficulty
+
+- Nothing to note. Both Pre-merge conditions used `rubric` verify commands with self-contained, unambiguous text; grading against the worktree's modified files was straightforward and did not surface any UNCERTAIN cases.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- Kept the Spec's designed approach (Candidate B, in-session mandatory `--no-push` calls) unchanged — no implementation-time deviation was needed.
-- Added a non-empty guard to the main-tree push-routing check in `append-consumed-comments-section.sh` (matching the existing defense-in-depth warning check's guard) after `tests/run-verify.bats` exposed the gap; this is a defensive-programming fix within Implementation Step 1's scope, not a design change.
+- Fixed all 10 review findings (1 MUST, 5 SHOULD, 4 CONSIDER) in-cycle rather than deferring SHOULD/CONSIDER items, since all 10 were defects in content this PR itself introduced (not pre-existing debt) and were individually small/low-risk.
+- Split fixes into 7 commits grouped by file/finding-cluster rather than one commit per finding, to keep the `Refs:` traceability rule satisfied without excessive commit churn.
+- Did not attempt to force `event=REQUEST_CHANGES` after discovering GitHub blocks it for self-authored PRs; the MUST issue's visibility relies on the review body text and this response summary instead. See "Recurring issues" above for the proposed tooling fix.
 
 ### Deferred Items
 
-- Same three items as the Spec Phase Handoff (unchanged from spec phase): worktree-session main-repository write audit spun out to a future Issue; `/verify`'s own `--no-push` adoption (residual `origin/worktree-verify+issue-*` branches) out of scope; patch-route pre/post count fallback mis-fire left unfixed (idempotent, harmless).
-- #1078 (SKILL.md step-order path) remains untouched, as scoped. See Design Gaps/Ambiguities above for a first-hand reproduction of the defect it will need to fix.
+- Same items as the code-phase Phase Handoff (now superseded by this rotation, so restated here): worktree-session main-repository write audit spun out to a future Issue; `/verify`'s own `--no-push` adoption (residual `origin/worktree-verify+issue-*` branches) out of scope; patch-route pre/post count fallback mis-fire left unfixed (idempotent, harmless); #1078 (SKILL.md step-order path) untouched, as scoped.
+- `skills/spec/SKILL.md` Step 14's `ENTERED_WORKTREE=false` branch still issues a bare `git push origin main` instead of routing through `worktree-merge-push.sh` — newly documented as a Known gap in `modules/worktree-lifecycle.md` during this review's MUST fix, but not itself fixed (pre-existing, out of #1058's scope).
+- `gh-pr-review.sh`'s missing `severity`-field validation and its lack of self-review-422 handling (see "Recurring issues" above) — not fixed here; flagged for `/verify`'s improvement-proposal aggregation.
 
 ### Notes for Next Phase
 
-- Pre-merge AC 1 and 2 are both checked (rubric PASS, judged in-session per `modules/verify-executor.md` full mode against the worktree's own modified files).
-- Post-merge AC (observation, `event=auto-run when=route:pr session=next`) is unresolved by design — it activates on the next pr-route `/code` run after this PR merges. `/verify` should treat it as SKIPPED (unfired) rather than attempt evaluation now.
-- Full `bats tests/` (1443 tests), `validate-skill-syntax.py`, `check-forbidden-expressions.sh`, and `check-allowed-tools.sh` all passed clean on the final commit.
-- A stray uncommitted edit was left in the main repository's working tree (see Design Gaps/Ambiguities) — reconciled after Worktree Exit; `/review` and `/merge` should see a clean main-repo status caused by this PR's own commits only.
+- Pre-merge AC 1 and 2 remain PASS (re-verified against the fix commits' final state; both rubric conditions still hold).
+- Post-merge AC (observation, `event=auto-run when=route:pr session=next`) is unchanged — still unfired, still SKIPPED by design.
+- Full `bats tests/` (1443 tests), `validate-skill-syntax.py`, `check-forbidden-expressions.sh`, and `check-allowed-tools.sh` all passed clean after the fix commits.
+- `/merge` should see 9/9 CI SUCCESS on the final commit (re-verified after push).

--- a/docs/spec/issue-1058-spec-write-branch-consistency.md
+++ b/docs/spec/issue-1058-spec-write-branch-consistency.md
@@ -75,18 +75,23 @@ Spec ファイル (`docs/spec/issue-N-*.md`) への追記先が、実行主体�
 |---|---|---|
 | `--no-push` 指定あり | commit まで実行し push をスキップ。スキップした旨を stderr に出力しない (通常経路のため) | 0 |
 | `--no-push` なし かつ worktree 内 (`_git_dir != _git_common_dir`) | 従来どおり `git -C "$_repo_root" push origin HEAD` | 0 (push 失敗時も best-effort 警告のみで 0) |
-| `--no-push` なし かつ main tree (`_git_dir == _git_common_dir`) | 既存の defense-in-depth 警告を stderr に出力したうえで、`worktree-merge-push.sh --base "$(git -C "$_repo_root" rev-parse --abbrev-ref HEAD)"` を実行 | 0 (`worktree-merge-push.sh` が非 0 で終了しても best-effort 警告のみで 0) |
+| `--no-push` なし かつ main tree (`_git_dir == _git_common_dir`、いずれも非空) | 既存の defense-in-depth 警告を stderr に出力したうえで、`worktree-merge-push.sh --base "$(git -C "$_repo_root" rev-parse --abbrev-ref HEAD)"` を実行 | 0 (`worktree-merge-push.sh` が非 0 で終了しても best-effort 警告のみで 0) |
+| `--no-push` なし かつ `_git_dir` / `_git_common_dir` のいずれかが空 (git 解決失敗) | 非空ガード (`-n "$_git_dir" && -n "$_git_common_dir"`) が真にならないため main tree 分岐に入らず、従来どおり `git -C "$_repo_root" push origin HEAD` にフォールスルー | 0 (push 失敗時も best-effort 警告のみで 0) |
 | Spec ファイルに差分なし (`git diff --quiet` が真) | commit も push も実行しない | 0 |
+
+上記 4 分岐目 (非空ガード) は `tests/run-verify.bats` の既存 fixture が `rev-parse --git-dir`/`--git-common-dir` 未実装で両者が空文字を返すことで発覚した実装時のギャップ。Code Retrospective の Deviations from Design に記録済み。
 
 スクリプト全体の best-effort 契約 (常に exit 0) は既存どおり維持し、呼び出し側をブロックしない。
 
 **`scripts/run-code.sh` の post-processor 分岐 (exhaustive):**
 
+判定は `ROUTE_FLAG` (CLI フラグ) ではなく `_PR_NUM` (`reconcile-phase-state.sh` が `worktree-code+issue-N` ブランチに対して観測した実際の open PR 番号) を用いる。route は Size auto-detection や `always-pr: true` により in-session で解決されることがあり (`/code N --auto` は M/L Issue に対しフラグ無しで pr route を選ぶ)、`ROUTE_FLAG` だけでは実際に pr route を通ったかを判定できないため (review #1201 指摘、MUST として修正)。
+
 | 分岐条件 | 挙動 |
 |---|---|
 | `EXIT_CODE != 0` | 従来どおり post-processor をスキップ |
-| `EXIT_CODE == 0` かつ `ROUTE_FLAG == "--pr"` | **新規**: post-processor をスキップ。Spec の書き込み先は PR ブランチであり main repository からは観測も安全な書き込みもできないため。安全網は `skills/code/SKILL.md` Step 12 の in-session 呼び出しが担う |
-| `EXIT_CODE == 0` かつ `ROUTE_FLAG != "--pr"` (patch / operate / 未指定) | 従来どおり pre/post カウント比較を行い、増えていなければ `_append_consumed_comments_section` を実行 |
+| `EXIT_CODE == 0` かつ `_PR_NUM` が非空 (open PR が観測された = 実際に pr route を通った) | post-processor をスキップ。Spec の書き込み先は PR ブランチであり main repository からは観測も安全な書き込みもできないため。安全網は `skills/code/SKILL.md` Step 12 の in-session 呼び出しが担う |
+| `EXIT_CODE == 0` かつ `_PR_NUM` が空 (open PR 未観測 = patch / operate route) | 従来どおり pre/post カウント比較を行い、増えていなければ `_append_consumed_comments_section` を実行 |
 
 ### `validate-skill-syntax.py` の制約
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -169,7 +169,7 @@ Key modules:
 **Phase banner:**
 - `scripts/phase-banner.sh` — sourceable helper providing `print_start_banner` / `print_end_banner` functions for run-*.sh scripts
 - `scripts/emit-event.sh` — sourceable helper providing `emit_event()` for structured JSONL event emission to `.tmp/auto-events.jsonl`, plus `restore_auto_session_pointer()` for restoring `AUTO_SESSION_ID`/`AUTO_EVENTS_LOG` from pointer files in non-wrapper emitters; used by run-*.sh, claude-watchdog.sh, wait-ci-checks.sh, and `skills/verify/SKILL.md` (explicit bash call, no wrapper)
-- `scripts/append-consumed-comments-section.sh` — post-processor fallback: appends `## Consumed Comments` to Spec when LLM silently skips Step 5; used by run-spec.sh / run-code.sh (pre/post count comparison) and verify SKILL.md (explicit bash call)
+- `scripts/append-consumed-comments-section.sh` — appends `## Consumed Comments` to Spec on the phase's own working branch; called in-session (mandatory, with `--no-push`) from `skills/spec/SKILL.md` / `skills/code/SKILL.md` / `skills/verify/SKILL.md`, plus a secondary post-processor fallback from run-spec.sh / run-code.sh (pre/post count comparison) that is gated off for `/code` pr route (#1058)
 - `scripts/hook-worktree-path-guard.sh` — PreToolUse hook: blocks Edit/Write calls with parent-repo absolute file_path while inside a worktree session (structural enforcement of `modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions`)
 
 **GitHub API utilities:**

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -169,7 +169,7 @@ Key modules:
 **Phase banner:**
 - `scripts/phase-banner.sh` — sourceable helper providing `print_start_banner` / `print_end_banner` functions for run-*.sh scripts
 - `scripts/emit-event.sh` — sourceable helper providing `emit_event()` for structured JSONL event emission to `.tmp/auto-events.jsonl`, plus `restore_auto_session_pointer()` for restoring `AUTO_SESSION_ID`/`AUTO_EVENTS_LOG` from pointer files in non-wrapper emitters; used by run-*.sh, claude-watchdog.sh, wait-ci-checks.sh, and `skills/verify/SKILL.md` (explicit bash call, no wrapper)
-- `scripts/append-consumed-comments-section.sh` — appends `## Consumed Comments` to Spec on the phase's own working branch; called in-session (mandatory, with `--no-push`) from `skills/spec/SKILL.md` / `skills/code/SKILL.md` / `skills/verify/SKILL.md`, plus a secondary post-processor fallback from run-spec.sh / run-code.sh (pre/post count comparison) that is gated off for `/code` pr route (#1058)
+- `scripts/append-consumed-comments-section.sh` — appends `## Consumed Comments` to Spec on the phase's own working branch; called in-session (mandatory) from `skills/spec/SKILL.md` / `skills/code/SKILL.md` (both with `--no-push`) / `skills/verify/SKILL.md` (still pushes directly — deferred, see #1058), plus a secondary post-processor fallback from run-spec.sh / run-code.sh (pre/post count comparison) that is gated off for `/code` pr route (#1058)
 - `scripts/hook-worktree-path-guard.sh` — PreToolUse hook: blocks Edit/Write calls with parent-repo absolute file_path while inside a worktree session (structural enforcement of `modules/worktree-lifecycle.md § Edit/Write path conventions in worktree sessions`)
 
 **GitHub API utilities:**

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -252,7 +252,7 @@ is written, and both target the same working branch per `modules/worktree-lifecy
 fires where it can safely reach that branch:
 - **Primary (in-session, all phases):** `SKILL.md` for `/spec`, `/code`, and `/verify` each
   contain an explicit `bash` call to `append-consumed-comments-section.sh` (`/spec` Step 13,
-  `/code` Step 12, `/verify` Step in place before #1058) after the LLM's comment consumption
+  `/code` Step 12, `/verify` Step 4) after the LLM's comment consumption
   step, ensuring deterministic writeback regardless of prose execution. `/spec` and `/code`
   pass `--no-push` — the commit lands on the working branch and reaches base only through
   that phase's own Exit path (see the table in `worktree-lifecycle.md`).

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -251,8 +251,9 @@ is written, and both target the same working branch per `modules/worktree-lifecy
 "Spec file write destination" — the primary layer always does, and the secondary layer only
 fires where it can safely reach that branch:
 - **Primary (in-session, all phases):** `SKILL.md` for `/spec`, `/code`, and `/verify` each
-  contain an explicit `bash` call to `append-consumed-comments-section.sh` (`/spec` Step 13,
-  `/code` Step 12, `/verify` Step 4) after the LLM's comment consumption
+  contain an explicit `bash` call to `append-consumed-comments-section.sh` (`/spec` Step 12,
+  unconditionally so it also covers `SPEC_DEPTH=light` runs where Step 13 is skipped; `/code`
+  Step 12; `/verify` Step 4) after the LLM's comment consumption
   step, ensuring deterministic writeback regardless of prose execution. `/spec` and `/code`
   pass `--no-push` — the commit lands on the working branch and reaches base only through
   that phase's own Exit path (see the table in `worktree-lifecycle.md`).

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -245,14 +245,25 @@ consumed comment:
 
 If no comments were consumed: write "No new comments since last phase."
 
-**Bash wrapper fallback (Issue #811):** This step is LLM-driven and may be silently skipped
-under context pressure or on fix-cycle paths. Two safety nets ensure the section is written:
-- `/spec` and `/code` phases (bash-wrapped via `run-spec.sh` / `run-code.sh`): a pre/post
-  `## Consumed Comments` count comparison triggers `append-consumed-comments-section.sh` as a
-  post-processor when the LLM did not write the section.
-- `/verify` phase (in-session): `SKILL.md` contains an explicit `bash` call to
-  `append-consumed-comments-section.sh` after the LLM's comment consumption step, ensuring
-  deterministic writeback regardless of prose execution.
+**Bash wrapper fallback (Issue #811, revised in #1058):** This step is LLM-driven and may be
+silently skipped under context pressure or on fix-cycle paths. Two layers ensure the section
+is written, and both target the same working branch per `modules/worktree-lifecycle.md` §
+"Spec file write destination" — the primary layer always does, and the secondary layer only
+fires where it can safely reach that branch:
+- **Primary (in-session, all phases):** `SKILL.md` for `/spec`, `/code`, and `/verify` each
+  contain an explicit `bash` call to `append-consumed-comments-section.sh` (`/spec` Step 13,
+  `/code` Step 12, `/verify` Step in place before #1058) after the LLM's comment consumption
+  step, ensuring deterministic writeback regardless of prose execution. `/spec` and `/code`
+  pass `--no-push` — the commit lands on the working branch and reaches base only through
+  that phase's own Exit path (see the table in `worktree-lifecycle.md`).
+- **Secondary (bash wrapper post-processor, non-pr routes only):** `run-spec.sh` / `run-code.sh`
+  additionally run a pre/post `## Consumed Comments` count comparison after the `claude`
+  subprocess exits, triggering `append-consumed-comments-section.sh` as a fallback when the
+  primary layer did not write the section. This runs from the main repository (the wrapper's
+  own CWD after the subprocess exits, not the worktree), so it is gated off for `/code` pr
+  route: the Spec there lives on the PR branch, which this post-exit point can neither observe
+  nor safely write to without reintroducing the two-branch divergence #1058 removed. For pr
+  route, the primary layer is the only safety net.
 
 **Step 6 — Emit event (handled by bash wrapper in auto mode; LLM skip):**
 

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -171,21 +171,29 @@ Issue #1058 for the incident this rule generalizes from.
 | Phase | Working branch | Base propagation path |
 |-------|-----------------|------------------------|
 | `/spec` | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
+| `/spec`, worktree skipped (`ENTERED_WORKTREE=false`) | base branch, in the main repository | Should be `worktree-merge-push.sh` (lock+push only, no `--from`), matching the `/code` patch-route row below — see Known gap |
 | `/code` patch / operate route | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
 | `/code` patch route, worktree skipped (`ENTERED_WORKTREE=false`; XS interactive direct-launch only — see `skills/code/SKILL.md` Step 2) | base branch, in the main repository | `worktree-merge-push.sh` (lock+push only, no `--from` — see "When `ENTERED_WORKTREE=false`" above) |
 | `/code` pr route | worktree branch (= PR branch) | PR merge (`/merge`) |
 | `/verify` | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
 
-All in-session callers of `append-consumed-comments-section.sh` (see `modules/l0-surfaces.md`
-§ "Bash wrapper fallback") pass `--no-push`: the commit lands on the working branch shown
-above, and this table's propagation path — not a push issued by the script itself — carries it
-to base. `/code` pr route also passes `--no-push`; it differs only in *how* the commit reaches
-the remote — its own Step 12 pushes the worktree (= PR) branch directly afterward, since the PR
-branch has no `worktree-merge-push.sh` propagation path of its own.
+`/spec`'s and `/code`'s in-session call sites to `append-consumed-comments-section.sh` (see
+`modules/l0-surfaces.md` § "Bash wrapper fallback") pass `--no-push`: the commit lands on the
+working branch shown above, and this table's propagation path — not a push issued by the
+script itself — carries it to base. `/code` pr route also passes `--no-push`; it differs only
+in *how* the commit reaches the remote — its own Step 12 pushes the worktree (= PR) branch
+directly afterward, since the PR branch has no `worktree-merge-push.sh` propagation path of its
+own. `/verify`'s call site does not yet pass `--no-push` — see the Known gap below.
 
-**Known gap (not yet migrated):** `skills/verify/SKILL.md`'s call site still omits `--no-push`
-and pushes the worktree branch itself, which is the source of the residual
-`origin/worktree-verify+issue-*` branches. Out of scope for #1058; tracked as a deferred item.
+**Known gaps (not yet migrated):**
+- `skills/verify/SKILL.md`'s call site still omits `--no-push`
+  and pushes the worktree branch itself, which is the source of the residual
+  `origin/worktree-verify+issue-*` branches. Out of scope for #1058; tracked as a deferred item.
+- `skills/spec/SKILL.md` Step 14's `ENTERED_WORKTREE=false` branch still issues a bare
+  `git push origin main` rather than routing through `worktree-merge-push.sh` (lock+push only),
+  so this table's `/spec`, worktree-skipped row describes the intended propagation path, not the
+  current implementation. Pre-existing (not introduced by #1058) and out of its scope; tracked as
+  a deferred item.
 
 ### `source`-based shell function calls are blocked by the worktree isolation guard
 

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -148,6 +148,39 @@ Steps that operate on version-controlled files do not need this round trip; thos
 
 While executing a Step against the main repository per the round trip above, the auto-mode classifier may reject `mv` targeting a gitignored path in the parent repository — observed both from inside the worktree and from the main repository root immediately after `ExitWorktree`. `cp` performing an in-place overwrite of the same target is not subject to the same rejection. Where a Step's natural implementation is "write to a temp file, then move it into place" (e.g. `jq ... > .new`), prefer `cp .new target` over `mv .new target` as the final write — this avoids the rejection without resorting to `--dangerously-skip-permissions` or other permission bypasses.
 
+### Spec file write destination
+
+All phases that append to a disposable Spec (`docs/spec/issue-N-*.md` — Consumed Comments,
+retrospectives, Phase Handoff) must write **only on that phase's own working branch** — the
+worktree branch it entered via the Entry section above (which is also the PR branch for
+`/code` pr route). Never write the Spec directly against the base branch from a main-repository
+context. Base propagation happens exclusively through this module's own Exit paths: `Exit:
+merge-to-main` (`worktree-merge-push.sh`) or a PR merge — never a standalone `git push` issued
+from outside the worktree.
+
+This rule exists because a Spec file edited from two different branches in the same phase
+window — the phase's own worktree branch and, separately, the base branch via an
+out-of-worktree write — produces a two-sided edit to the same file that conflicts at merge
+time (`mergeStateStatus: DIRTY`), even though the actual implementation diff is untouched. See
+Issue #1058 for the incident this rule generalizes from.
+
+**Base propagation path per phase (exhaustive):**
+
+| Phase | Working branch | Base propagation path |
+|-------|-----------------|------------------------|
+| `/spec` | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
+| `/code` patch / operate route | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
+| `/code` pr route | worktree branch (= PR branch) | PR merge (`/merge`) |
+| `/verify` | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
+
+Callers that append to `## Consumed Comments` (see `modules/l0-surfaces.md` § "Bash wrapper
+fallback") must pass `--no-push` to `append-consumed-comments-section.sh` when calling it
+in-session from inside the worktree: the commit lands on the working branch shown above, and
+this table's propagation path — not a push issued by the script itself — carries it to base.
+The one exception is `/code` pr route, where the phase's own Step 12 explicitly pushes the
+worktree branch afterward (the PR branch has no `worktree-merge-push.sh` propagation path of
+its own).
+
 ### `source`-based shell function calls are blocked by the worktree isolation guard
 
 Shell helpers that must be invoked via `source` because they define a function rather than being directly executable (e.g. `emit-event.sh`'s `emit_event`) cannot run inside a worktree session: the worktree isolation guard cannot verify that a sourced command stays inside the worktree, and blocks it outright. There is no rewrite that avoids `source` for a function call, so this is a hard blocker for the duration of the worktree session.

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -153,10 +153,12 @@ While executing a Step against the main repository per the round trip above, the
 All phases that append to a disposable Spec (`docs/spec/issue-N-*.md` — Consumed Comments,
 retrospectives, Phase Handoff) must write **only on that phase's own working branch** — the
 worktree branch it entered via the Entry section above (which is also the PR branch for
-`/code` pr route). Never write the Spec directly against the base branch from a main-repository
-context. Base propagation happens exclusively through this module's own Exit paths: `Exit:
-merge-to-main` (`worktree-merge-push.sh`) or a PR merge — never a standalone `git push` issued
-from outside the worktree.
+`/code` pr route), or the base branch itself when the phase documented `ENTERED_WORKTREE=false`
+(see the table below). Never write the Spec directly against the base branch from an
+*undocumented* main-repository context, and never issue a standalone `git push` for it from
+outside the worktree — a lock-mediated main-tree write via `worktree-merge-push.sh` (this
+module's own Exit path, or the equivalent main-tree routing inside
+`append-consumed-comments-section.sh`) is the only base-branch write path this rule permits.
 
 This rule exists because a Spec file edited from two different branches in the same phase
 window — the phase's own worktree branch and, separately, the base branch via an
@@ -170,16 +172,20 @@ Issue #1058 for the incident this rule generalizes from.
 |-------|-----------------|------------------------|
 | `/spec` | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
 | `/code` patch / operate route | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
+| `/code` patch route, worktree skipped (`ENTERED_WORKTREE=false`; XS interactive direct-launch only — see `skills/code/SKILL.md` Step 2) | base branch, in the main repository | `worktree-merge-push.sh` (lock+push only, no `--from` — see "When `ENTERED_WORKTREE=false`" above) |
 | `/code` pr route | worktree branch (= PR branch) | PR merge (`/merge`) |
 | `/verify` | worktree branch | `Exit: merge-to-main` → `worktree-merge-push.sh` |
 
-Callers that append to `## Consumed Comments` (see `modules/l0-surfaces.md` § "Bash wrapper
-fallback") must pass `--no-push` to `append-consumed-comments-section.sh` when calling it
-in-session from inside the worktree: the commit lands on the working branch shown above, and
-this table's propagation path — not a push issued by the script itself — carries it to base.
-The one exception is `/code` pr route, where the phase's own Step 12 explicitly pushes the
-worktree branch afterward (the PR branch has no `worktree-merge-push.sh` propagation path of
-its own).
+All in-session callers of `append-consumed-comments-section.sh` (see `modules/l0-surfaces.md`
+§ "Bash wrapper fallback") pass `--no-push`: the commit lands on the working branch shown
+above, and this table's propagation path — not a push issued by the script itself — carries it
+to base. `/code` pr route also passes `--no-push`; it differs only in *how* the commit reaches
+the remote — its own Step 12 pushes the worktree (= PR) branch directly afterward, since the PR
+branch has no `worktree-merge-push.sh` propagation path of its own.
+
+**Known gap (not yet migrated):** `skills/verify/SKILL.md`'s call site still omits `--no-push`
+and pushes the worktree branch itself, which is the source of the residual
+`origin/worktree-verify+issue-*` branches. Out of scope for #1058; tracked as a deferred item.
 
 ### `source`-based shell function calls are blocked by the worktree isolation guard
 

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -18,11 +18,7 @@ if [[ -z "$ISSUE_NUMBER" || -z "$PHASE_NAME" ]]; then
 fi
 
 NO_PUSH=false
-if [[ $# -ge 2 ]]; then
-  shift 2
-elif [[ $# -eq 1 ]]; then
-  shift 1
-fi
+shift 2
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --no-push)

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -201,7 +201,7 @@ if ! git -C "$_repo_root" diff --quiet "$SPEC_REL" 2>/dev/null; then
 Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" 2>/dev/null; then
     if [[ "$NO_PUSH" == "true" ]]; then
       : # commit only, push is the caller's responsibility (in-session mandatory call path)
-    elif [[ "$_git_dir" == "$_git_common_dir" ]]; then
+    elif [[ -n "$_git_dir" && -n "$_git_common_dir" && "$_git_dir" == "$_git_common_dir" ]]; then
       # Main tree: route through the locked merge-push script instead of a bare push.
       _current_branch="$(git -C "$_repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
       "$SCRIPT_DIR/worktree-merge-push.sh" --base "$_current_branch" 2>/dev/null \

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -2,7 +2,11 @@
 # append-consumed-comments-section.sh - Fallback: append ## Consumed Comments to Spec
 # when the LLM phase did not write it (post-processor pattern, Candidate B).
 #
-# Usage: append-consumed-comments-section.sh <ISSUE_NUMBER> <PHASE_NAME>
+# Usage: append-consumed-comments-section.sh <ISSUE_NUMBER> <PHASE_NAME> [--no-push]
+#
+# --no-push: commit only; skip the push/worktree-merge-push.sh step. The caller is
+# responsible for propagating the commit to base via its own Exit path (see
+# modules/worktree-lifecycle.md § "Spec file write destination").
 #
 # Best-effort: always exits 0. Failures are logged to stderr without blocking the caller.
 # Bash 3.2+ compatible.
@@ -199,8 +203,15 @@ Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" 2>/dev/null; then
       : # commit only, push is the caller's responsibility (in-session mandatory call path)
     elif [[ -n "$_git_dir" && -n "$_git_common_dir" && "$_git_dir" == "$_git_common_dir" ]]; then
       # Main tree: route through the locked merge-push script instead of a bare push.
+      # Bound the lock wait (default 300s) to a short timeout: this call site is reached
+      # from the bash-wrapper post-processor fallback (run-code.sh / run-spec.sh, after the
+      # phase's own claude subprocess has already exited), so a long silent stall here has no
+      # watchdog covering it. Let diagnostics (lock-wait / rebase-failure messages) reach the
+      # caller's log instead of suppressing them a second time on top of this script's own
+      # best-effort warning.
       _current_branch="$(git -C "$_repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
-      "$SCRIPT_DIR/worktree-merge-push.sh" --base "$_current_branch" 2>/dev/null \
+      WHOLEWORK_PATCH_LOCK_TIMEOUT="${WHOLEWORK_PATCH_LOCK_TIMEOUT:-30}" \
+        "$SCRIPT_DIR/worktree-merge-push.sh" --base "$_current_branch" \
         || echo "append-consumed-comments-section.sh: WARNING — worktree-merge-push.sh failed (best-effort)" >&2
     else
       git -C "$_repo_root" push origin HEAD 2>/dev/null \

--- a/scripts/append-consumed-comments-section.sh
+++ b/scripts/append-consumed-comments-section.sh
@@ -17,6 +17,24 @@ if [[ -z "$ISSUE_NUMBER" || -z "$PHASE_NAME" ]]; then
   exit 0
 fi
 
+NO_PUSH=false
+if [[ $# -ge 2 ]]; then
+  shift 2
+elif [[ $# -eq 1 ]]; then
+  shift 1
+fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-push)
+      NO_PUSH=true
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
 SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 _repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
@@ -173,16 +191,28 @@ if [[ -n "$_git_dir" && -n "$_git_common_dir" && "$_git_dir" == "$_git_common_di
   echo "append-consumed-comments-section.sh: WARNING — not running inside an isolated worktree (was skills/verify/SKILL.md Step 3 skipped?); commit/push below lands directly on the current branch" >&2
 fi
 
-# Commit and push (best-effort; failures do not block caller)
+# Commit (and push unless --no-push) — best-effort; failures do not block caller
 SPEC_REL="${SPEC_FILE#$_repo_root/}"
 if ! git -C "$_repo_root" diff --quiet "$SPEC_REL" 2>/dev/null; then
-  git -C "$_repo_root" add "$SPEC_REL" 2>/dev/null \
+  if git -C "$_repo_root" add "$SPEC_REL" 2>/dev/null \
     && git -C "$_repo_root" commit -s \
          -m "Add consumed comments fallback for issue #${ISSUE_NUMBER} (${PHASE_NAME} phase)
 
-Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" 2>/dev/null \
-    && git -C "$_repo_root" push origin HEAD 2>/dev/null \
-    || echo "append-consumed-comments-section.sh: WARNING — commit/push failed (best-effort)" >&2
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>" 2>/dev/null; then
+    if [[ "$NO_PUSH" == "true" ]]; then
+      : # commit only, push is the caller's responsibility (in-session mandatory call path)
+    elif [[ "$_git_dir" == "$_git_common_dir" ]]; then
+      # Main tree: route through the locked merge-push script instead of a bare push.
+      _current_branch="$(git -C "$_repo_root" rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)"
+      "$SCRIPT_DIR/worktree-merge-push.sh" --base "$_current_branch" 2>/dev/null \
+        || echo "append-consumed-comments-section.sh: WARNING — worktree-merge-push.sh failed (best-effort)" >&2
+    else
+      git -C "$_repo_root" push origin HEAD 2>/dev/null \
+        || echo "append-consumed-comments-section.sh: WARNING — push failed (best-effort)" >&2
+    fi
+  else
+    echo "append-consumed-comments-section.sh: WARNING — commit failed (best-effort)" >&2
+  fi
 fi
 
 exit 0

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -364,7 +364,10 @@ fi
 
 # Post-processor fallback: if LLM did not append ## Consumed Comments, do it now.
 # Compare post-count with pre-count; trigger fallback when count did not increase.
-if [[ $EXIT_CODE -eq 0 ]]; then
+# Skipped for pr route: the Spec lives on the PR (worktree) branch there, which this
+# main-repository post-exit point cannot observe or safely write to. The pr route's
+# safety net is instead the in-session mandatory call in skills/code/SKILL.md Step 12.
+if [[ $EXIT_CODE -eq 0 && "$ROUTE_FLAG" != "--pr" ]]; then
   _SPEC_FILE_POST=$(ls "${_REPO_ROOT}/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
   _POST_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_POST:-/dev/null}" 2>/dev/null || true)
   _POST_COUNT="${_POST_COUNT:-0}"

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -328,17 +328,27 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
   fi
 fi
 
+# Resolve the actually-taken route from reconcile-phase-state.sh's observed PR
+# existence rather than ROUTE_FLAG: the route is often decided in-session (Size
+# auto-detection for XS/S->patch, M/L->pr; or `always-pr: true` in .wholework.yml)
+# with no --pr flag on the command line, so ROUTE_FLAG alone cannot distinguish an
+# auto-detected pr route from patch route (Issue #1058 review finding).
+_PR_NUM=""
+if [[ $EXIT_CODE -eq 0 ]]; then
+  _PR_NUM=$(echo "${_reconcile_out:-}" | jq -r '.actual.pr_number // empty' 2>/dev/null || true)
+  if ! [[ "$_PR_NUM" =~ ^[0-9]+$ ]]; then
+    _PR_NUM=""
+  fi
+fi
+
 # See modules/orchestration-fallbacks.md#code-base-conflict
-if [[ "$ROUTE_FLAG" == "--pr" && $EXIT_CODE -eq 0 ]]; then
-  _PR_NUM=$(echo "$_reconcile_out" | jq -r '.actual.pr_number // empty' 2>/dev/null || true)
-  if [[ -n "$_PR_NUM" && "$_PR_NUM" =~ ^[0-9]+$ ]]; then
-    _merge_status=$("$SCRIPT_DIR/gh-pr-merge-status.sh" "$_PR_NUM" 2>/dev/null || true)
-    if echo "$_merge_status" | grep -q '"reason"[[:space:]]*:[[:space:]]*"conflicts"'; then
-      echo "Warning: code phase completed but PR #${_PR_NUM} has conflicts with base." >&2
-      echo "This is likely due to a concurrent merge on the base branch during code phase." >&2
-      echo "PR diff (merge-base based) shows only this Issue's changes correctly -- do not mistake this for contamination." >&2
-      echo "Recommended: resolve conflicts before /merge. See modules/orchestration-fallbacks.md#code-base-conflict for the recovery procedure." >&2
-    fi
+if [[ "$ROUTE_FLAG" == "--pr" && $EXIT_CODE -eq 0 && -n "$_PR_NUM" ]]; then
+  _merge_status=$("$SCRIPT_DIR/gh-pr-merge-status.sh" "$_PR_NUM" 2>/dev/null || true)
+  if echo "$_merge_status" | grep -q '"reason"[[:space:]]*:[[:space:]]*"conflicts"'; then
+    echo "Warning: code phase completed but PR #${_PR_NUM} has conflicts with base." >&2
+    echo "This is likely due to a concurrent merge on the base branch during code phase." >&2
+    echo "PR diff (merge-base based) shows only this Issue's changes correctly -- do not mistake this for contamination." >&2
+    echo "Recommended: resolve conflicts before /merge. See modules/orchestration-fallbacks.md#code-base-conflict for the recovery procedure." >&2
   fi
 fi
 
@@ -364,10 +374,13 @@ fi
 
 # Post-processor fallback: if LLM did not append ## Consumed Comments, do it now.
 # Compare post-count with pre-count; trigger fallback when count did not increase.
-# Skipped for pr route: the Spec lives on the PR (worktree) branch there, which this
-# main-repository post-exit point cannot observe or safely write to. The pr route's
-# safety net is instead the in-session mandatory call in skills/code/SKILL.md Step 12.
-if [[ $EXIT_CODE -eq 0 && "$ROUTE_FLAG" != "--pr" ]]; then
+# Skipped for pr route (detected via _PR_NUM above -- an open PR observed for the
+# worktree-code+issue-N branch -- rather than ROUTE_FLAG, since the route is often
+# resolved in-session with no --pr flag on the command line): the Spec lives on the
+# PR (worktree) branch there, which this main-repository post-exit point cannot
+# observe or safely write to. The pr route's safety net is instead the in-session
+# mandatory call in skills/code/SKILL.md Step 12.
+if [[ $EXIT_CODE -eq 0 && -z "$_PR_NUM" ]]; then
   _SPEC_FILE_POST=$(ls "${_REPO_ROOT}/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
   _POST_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_POST:-/dev/null}" 2>/dev/null || true)
   _POST_COUNT="${_POST_COUNT:-0}"

--- a/scripts/run-code.sh
+++ b/scripts/run-code.sh
@@ -342,7 +342,11 @@ if [[ $EXIT_CODE -eq 0 ]]; then
 fi
 
 # See modules/orchestration-fallbacks.md#code-base-conflict
-if [[ "$ROUTE_FLAG" == "--pr" && $EXIT_CODE -eq 0 && -n "$_PR_NUM" ]]; then
+# Keyed on -n "$_PR_NUM" alone (not ROUTE_FLAG): an observed open PR already means pr
+# route was taken, including the auto-detected case (Size auto-detection, `always-pr:
+# true`) that ROUTE_FLAG cannot see. Requiring ROUTE_FLAG == "--pr" here would silently
+# skip this conflict warning for auto-detected pr route (review #1201 finding).
+if [[ $EXIT_CODE -eq 0 && -n "$_PR_NUM" ]]; then
   _merge_status=$("$SCRIPT_DIR/gh-pr-merge-status.sh" "$_PR_NUM" 2>/dev/null || true)
   if echo "$_merge_status" | grep -q '"reason"[[:space:]]*:[[:space:]]*"conflicts"'; then
     echo "Warning: code phase completed but PR #${_PR_NUM} has conflicts with base." >&2
@@ -375,12 +379,18 @@ fi
 # Post-processor fallback: if LLM did not append ## Consumed Comments, do it now.
 # Compare post-count with pre-count; trigger fallback when count did not increase.
 # Skipped for pr route (detected via _PR_NUM above -- an open PR observed for the
-# worktree-code+issue-N branch -- rather than ROUTE_FLAG, since the route is often
+# worktree-code+issue-N branch -- rather than ROUTE_FLAG alone, since the route is often
 # resolved in-session with no --pr flag on the command line): the Spec lives on the
 # PR (worktree) branch there, which this main-repository post-exit point cannot
 # observe or safely write to. The pr route's safety net is instead the in-session
 # mandatory call in skills/code/SKILL.md Step 12.
-if [[ $EXIT_CODE -eq 0 && -z "$_PR_NUM" ]]; then
+# ROUTE_FLAG is kept as an additional (not replacement) suppressor: if
+# reconcile-phase-state.sh returns empty/failed output (e.g. a transient `gh pr list`
+# failure) on an EXPLICIT --pr run, _PR_NUM alone would be empty and this gate would
+# otherwise fire the fallback against the main-repository Spec copy -- reintroducing
+# the exact two-branch divergence #1058 removes. Keeping ROUTE_FLAG here only widens
+# the skip condition; it never narrows it (review #1201 finding).
+if [[ $EXIT_CODE -eq 0 && -z "$_PR_NUM" && "$ROUTE_FLAG" != "--pr" ]]; then
   _SPEC_FILE_POST=$(ls "${_REPO_ROOT}/$_SPEC_DIR/issue-${ISSUE_NUMBER}-"*.md 2>/dev/null | head -1 || true)
   _POST_COUNT=$(grep -c "^## Consumed Comments" "${_SPEC_FILE_POST:-/dev/null}" 2>/dev/null || true)
   _POST_COUNT="${_POST_COUNT:-0}"

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -663,17 +663,7 @@ If there are items under "Deviations from Design" (reordering of implementation 
    Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
    Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=code`.
    The handoff is staged with the Spec in the same `git add` and committed together.
-6. **Consumed Comments safety net (mandatory, before commit)**: run
-   ```bash
-   bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER code --no-push
-   ```
-   This is the in-session safety net for the `## Consumed Comments` section on the worktree
-   branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). `--no-push`
-   is required — the pr route pushes this commit itself in step 7 below, and base propagation
-   for patch/operate route happens via Step 14's `worktree-merge-push.sh`. The bash wrapper
-   fallback (`scripts/run-code.sh`) no longer runs for pr route, so this call is the only
-   safety net on that path.
-7. Commit (push is done in Step 14 Worktree Exit):
+6. Commit (push is done in Step 14 Worktree Exit for patch/operate route; pr route pushes explicitly in item 8 below):
    ```bash
    git add $SPEC_PATH/issue-$NUMBER-*.md
    git commit -s -m "Add code retrospective for issue #$NUMBER
@@ -683,11 +673,24 @@ Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
    ```bash
    git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }
    ```
-   - **For pr route**: also push from within the worktree (emit a progress line first so the watchdog resets its silence counter):
-     ```bash
-     echo "progress: Pushing branch to origin for issue #$NUMBER..."
-     git push origin HEAD
-     ```
+7. **Consumed Comments safety net (mandatory, after the retrospective commit above)**: run
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER code --no-push
+   ```
+   This is the in-session safety net for the `## Consumed Comments` section on the worktree
+   branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). Running it
+   after the retrospective commit — rather than before — avoids the script's own commit (which
+   fires whenever the Spec has an unstaged diff) sweeping the not-yet-committed retrospective
+   and Phase Handoff edits into a commit titled "Add consumed comments fallback ..."; when it
+   does fire here, it lands as its own separate commit instead. `--no-push` is required — the pr
+   route pushes in item 8 below, and base propagation for patch/operate route happens via Step
+   14's `worktree-merge-push.sh`. The bash wrapper fallback (`scripts/run-code.sh`) no longer
+   runs for pr route, so this call is the only safety net on that path.
+8. **For pr route**: also push from within the worktree (emit a progress line first so the watchdog resets its silence counter):
+   ```bash
+   echo "progress: Pushing branch to origin for issue #$NUMBER..."
+   git push origin HEAD
+   ```
 
 ### Step 13: Preview Build Verification (pr route only)
 

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -2,7 +2,7 @@
 name: code
 description: Local implementation (`/code 123`). Size auto-detection routes XS/S→patch (direct commit to main), M/L→branch+PR. Override with `--patch`/`--pr`. Does not update CLAUDE.md, run session retrospectives, or manage memory.
 context: fork
-allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-allowed-tools.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, gh pr checks:*, gh run view:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
+allowed-tools: Bash(gh issue view:*, gh issue edit:*, gh issue list:*, gh issue create:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, git checkout:*, git pull:*, git add:*, git status:*, git diff:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*, gh pr create:*, gh pr comment:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/test-failure-classify.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-allowed-tools.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/wait-ci-checks.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh:*, gh pr checks:*, gh run view:*, python3:*, bats:*), Glob, Grep, Read, Write, Edit, TaskCreate, TaskUpdate, TaskList, TaskGet, EnterWorktree, ExitWorktree, ToolSearch
 ---
 
 # Local Implementation
@@ -663,7 +663,17 @@ If there are items under "Deviations from Design" (reordering of implementation 
    Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
    Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=code`.
    The handoff is staged with the Spec in the same `git add` and committed together.
-6. Commit (push is done in Step 14 Worktree Exit):
+6. **Consumed Comments safety net (mandatory, before commit)**: run
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER code --no-push
+   ```
+   This is the in-session safety net for the `## Consumed Comments` section on the worktree
+   branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). `--no-push`
+   is required — the pr route pushes this commit itself in step 7 below, and base propagation
+   for patch/operate route happens via Step 14's `worktree-merge-push.sh`. The bash wrapper
+   fallback (`scripts/run-code.sh`) no longer runs for pr route, so this call is the only
+   safety net on that path.
+7. Commit (push is done in Step 14 Worktree Exit):
    ```bash
    git add $SPEC_PATH/issue-$NUMBER-*.md
    git commit -s -m "Add code retrospective for issue #$NUMBER

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -763,6 +763,20 @@ git commit -s -m "Add design for issue #$NUMBER"
 git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }
 ```
 
+**Consumed Comments safety net (mandatory, after the commit above, all SPEC_DEPTH values)**: run
+```bash
+bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER spec --no-push
+```
+This is the in-session safety net for the `## Consumed Comments` section on the worktree
+branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). It runs here
+— unconditionally, unlike Step 13 below — so that it also fires for `SPEC_DEPTH=light` runs
+(Step 13 is skipped entirely when `SPEC_DEPTH=light`, so a call placed there would never run
+on that path). Running it after the commit above — rather than before — avoids the script's
+own commit (which fires whenever the Spec has an unstaged diff) sweeping the not-yet-committed
+title-drift edit into a commit titled "Add consumed comments fallback ..."; when it does fire
+here, it lands as its own separate commit instead. `--no-push` is required — base propagation
+happens via Step 14's `worktree-merge-push.sh`.
+
 ### Step 13: Spec Retrospective
 
 **SPEC_DEPTH=full only. Skip if SPEC_DEPTH=light.**
@@ -828,17 +842,9 @@ Reflect on the specification phase and present improvement suggestions to the us
    ```bash
    git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }
    ```
-6. **Consumed Comments safety net (mandatory, after the commit above)**: run
-   ```bash
-   bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER spec --no-push
-   ```
-   This is the in-session safety net for the `## Consumed Comments` section on the worktree
-   branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). Running it
-   after the commit above — rather than before — avoids the script's own commit (which fires
-   whenever the Spec has an unstaged diff) sweeping the not-yet-committed retrospective/handoff
-   edits into a commit titled "Add consumed comments fallback ..."; when it does fire here, it
-   lands as its own separate commit instead. `--no-push` is required — base propagation happens
-   via Step 14's `worktree-merge-push.sh`.
+
+(The Consumed Comments safety net call runs unconditionally in Step 12, not here, so that it
+also covers `SPEC_DEPTH=light` runs where this step is skipped entirely.)
 
 ### Step 14: Worktree Exit (merge-to-main)
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: Issue specification (`/spec 123`). Reads Issue requirements and creates an implementation plan. Automatically adjusts investigation depth (light/full) based on Size (`--light`/`--full` to override).
-allowed-tools: Bash(gh issue view:*, gh issue create:*, gh issue edit:*, gh issue list:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*), Glob, Grep, Read, Write, Edit, WebFetch, WebSearch, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_figma_figma__get_design_context, mcp__plugin_figma_figma__get_variable_defs, mcp__plugin_figma_figma__get_screenshot, mcp__plugin_figma_figma__get_metadata, mcp__plugin_figma_figma__whoami
+allowed-tools: Bash(gh issue view:*, gh issue create:*, gh issue edit:*, gh issue list:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*), Glob, Grep, Read, Write, Edit, WebFetch, WebSearch, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_figma_figma__get_design_context, mcp__plugin_figma_figma__get_variable_defs, mcp__plugin_figma_figma__get_screenshot, mcp__plugin_figma_figma__get_metadata, mcp__plugin_figma_figma__whoami
 ---
 
 # Issue Specification
@@ -820,7 +820,14 @@ Reflect on the specification phase and present improvement suggestions to the us
    Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
    Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=spec`.
    Include the handoff write in the same commit (next step).
-5. Additional commit (push in Step 14 Worktree Exit):
+5. **Consumed Comments safety net (mandatory, before commit)**: run
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER spec --no-push
+   ```
+   This is the in-session safety net for the `## Consumed Comments` section on the worktree
+   branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). `--no-push`
+   is required — base propagation happens via Step 14's `worktree-merge-push.sh`.
+6. Additional commit (push in Step 14 Worktree Exit):
    ```bash
    git add $SPEC_PATH/issue-$NUMBER-short-title.md
    git commit -s -m "Add retrospective notes for issue #$NUMBER"

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -820,14 +820,7 @@ Reflect on the specification phase and present improvement suggestions to the us
    Read `${CLAUDE_PLUGIN_ROOT}/modules/phase-handoff.md` and follow the "Write Procedure" section.
    Parameters: `SPEC_PATH`, `ISSUE_NUMBER=$NUMBER`, `PHASE_NAME=spec`.
    Include the handoff write in the same commit (next step).
-5. **Consumed Comments safety net (mandatory, before commit)**: run
-   ```bash
-   bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER spec --no-push
-   ```
-   This is the in-session safety net for the `## Consumed Comments` section on the worktree
-   branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). `--no-push`
-   is required — base propagation happens via Step 14's `worktree-merge-push.sh`.
-6. Additional commit (push in Step 14 Worktree Exit):
+5. Additional commit (push in Step 14 Worktree Exit):
    ```bash
    git add $SPEC_PATH/issue-$NUMBER-short-title.md
    git commit -s -m "Add retrospective notes for issue #$NUMBER"
@@ -835,6 +828,17 @@ Reflect on the specification phase and present improvement suggestions to the us
    ```bash
    git log -1 --format='%B' | grep -q "^Signed-off-by:" || { echo "ERROR: missing sign-off"; exit 1; }
    ```
+6. **Consumed Comments safety net (mandatory, after the commit above)**: run
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh $NUMBER spec --no-push
+   ```
+   This is the in-session safety net for the `## Consumed Comments` section on the worktree
+   branch (see `modules/worktree-lifecycle.md` § "Spec file write destination"). Running it
+   after the commit above — rather than before — avoids the script's own commit (which fires
+   whenever the Spec has an unstaged diff) sweeping the not-yet-committed retrospective/handoff
+   edits into a commit titled "Add consumed comments fallback ..."; when it does fire here, it
+   lands as its own separate commit instead. `--no-push` is required — base propagation happens
+   via Step 14's `worktree-merge-push.sh`.
 
 ### Step 14: Worktree Exit (merge-to-main)
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -127,7 +127,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Entry
 
 **Worktree naming convention:** `verify/issue-$NUMBER`
 
-This step is always mandatory regardless of the Issue's Size or route (including XS/S patch route) — there is no condition under which it may be skipped. Skipping it causes Step 4's `append-consumed-comments-section.sh` to commit/push directly onto a branch outside the worktree, bypassing `worktree-merge-push.sh`'s locking mechanism and risking a race when multiple `/verify` runs execute concurrently (e.g. under `/auto --batch`) (Issue #1037).
+This step is always mandatory regardless of the Issue's Size or route (including XS/S patch route) — there is no condition under which it may be skipped. Skipping it causes Step 4's `append-consumed-comments-section.sh` to commit/push directly onto a branch outside the worktree — the wrong branch (Issue #1037; see `modules/worktree-lifecycle.md` § "Spec file write destination" for why this specific branch matters). As of #1058, that main-tree push is lock-mediated via `worktree-merge-push.sh`, so a bare-push race against concurrent `/verify` runs (e.g. under `/auto --batch`) is no longer the primary risk; the remaining reason this step is mandatory is branch-destination correctness — writing to the wrong branch still produces the two-sided Spec edit #1058 exists to prevent.
 
 Record the `ENTERED_WORKTREE` variable for use in subsequent steps.
 

--- a/tests/append-consumed-comments-section.bats
+++ b/tests/append-consumed-comments-section.bats
@@ -243,5 +243,5 @@ MOCK
     [ "$status" -eq 0 ]
     grep -q "^## Consumed Comments" "$SPEC_FILE"
     grep -q "CALLED --base main" "$REPO_ROOT/merge-push.log"
-    ! grep -q "^push origin HEAD" "$REPO_ROOT/git.log"
+    ! grep -q "push origin HEAD" "$REPO_ROOT/git.log"
 }

--- a/tests/append-consumed-comments-section.bats
+++ b/tests/append-consumed-comments-section.bats
@@ -38,6 +38,7 @@ MOCK
 
     cat > "$MOCK_DIR/git" <<MOCK
 #!/bin/bash
+echo "\$*" >> "$REPO_ROOT/git.log"
 if [[ " \$* " == *" diff "* ]] && [[ " \$* " == *" --quiet "* ]]; then
     exit 1
 fi
@@ -56,6 +57,13 @@ fi
 exit 0
 MOCK
     chmod +x "$MOCK_DIR/git"
+
+    cat > "$MOCK_DIR/worktree-merge-push.sh" <<MOCK
+#!/bin/bash
+echo "CALLED \$*" >> "$REPO_ROOT/merge-push.log"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/worktree-merge-push.sh"
 }
 
 @test "no spec file: skips stub creation and exits 0" {
@@ -188,4 +196,52 @@ MOCK
     run "$SCRIPT" 42 code
     [[ "$output" == *"WARNING"* ]]
     [[ "$output" == *"worktree"* ]]
+}
+
+@test "--no-push flag: commits but does not push" {
+    SPEC_FILE="$BATS_TEST_TMPDIR/repo/docs/spec/issue-42-some-title.md"
+    printf '# Issue #42: some title\n\n## Overview\nSome content.\n' > "$SPEC_FILE"
+
+    run "$SCRIPT" 42 code --no-push
+    [ "$status" -eq 0 ]
+    grep -q "^## Consumed Comments" "$SPEC_FILE"
+    ! grep -q "push" "$REPO_ROOT/git.log"
+    [ ! -f "$REPO_ROOT/merge-push.log" ]
+}
+
+@test "main tree execution without --no-push: routes push through worktree-merge-push.sh" {
+    SPEC_FILE="$BATS_TEST_TMPDIR/repo/docs/spec/issue-42-some-title.md"
+    printf '# Issue #42: some title\n\n## Overview\nSome content.\n' > "$SPEC_FILE"
+
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$*" >> "$REPO_ROOT/git.log"
+if [[ " \$* " == *" diff "* ]] && [[ " \$* " == *" --quiet "* ]]; then
+    exit 1
+fi
+if [[ "\$*" == *"rev-parse --show-toplevel"* ]]; then
+    echo "$REPO_ROOT"
+    exit 0
+fi
+if [[ "\$*" == *"rev-parse --git-dir"* ]]; then
+    echo "$REPO_ROOT/.git"
+    exit 0
+fi
+if [[ "\$*" == *"rev-parse --git-common-dir"* ]]; then
+    echo "$REPO_ROOT/.git"
+    exit 0
+fi
+if [[ "\$*" == *"rev-parse --abbrev-ref HEAD"* ]]; then
+    echo "main"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run "$SCRIPT" 42 code
+    [ "$status" -eq 0 ]
+    grep -q "^## Consumed Comments" "$SPEC_FILE"
+    grep -q "CALLED --base main" "$REPO_ROOT/merge-push.log"
+    ! grep -q "^push origin HEAD" "$REPO_ROOT/git.log"
 }

--- a/tests/append-consumed-comments-section.bats
+++ b/tests/append-consumed-comments-section.bats
@@ -205,7 +205,9 @@ MOCK
     run "$SCRIPT" 42 code --no-push
     [ "$status" -eq 0 ]
     grep -q "^## Consumed Comments" "$SPEC_FILE"
-    ! grep -q "push" "$REPO_ROOT/git.log"
+    [ -f "$REPO_ROOT/git.log" ]
+    run grep -q "push" "$REPO_ROOT/git.log"
+    [ "$status" -ne 0 ]
     [ ! -f "$REPO_ROOT/merge-push.log" ]
 }
 

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -562,6 +562,9 @@ MOCK
     # section before or after claude), but with --pr: the post-processor must stay
     # gated off regardless of section state, since the Spec lives on the PR branch
     # which this main-repository post-exit point cannot observe or safely write to.
+    # The gate is keyed on an observed open PR (reconcile-phase-state.sh's
+    # actual.pr_number), not on ROUTE_FLAG alone (#1201 review finding), so the
+    # mock below returns a realistic code-pr completion payload with a PR number.
     mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
     printf '%s\n' "# Issue #123: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
 
@@ -574,7 +577,44 @@ _emit_comments_consumed() { :; }
 _append_consumed_comments_section() { echo "CALLED \$*" >> "${FALLBACK_LOG}"; }
 MOCK
 
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"schema_version":"v1","phase":"code-pr","matches_expected":true,"actual":{"pr_state":"OPEN","pr_number":123},"diagnosis":"open PR found"}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
     run bash "$SCRIPT" 123 --pr
+    [ "$status" -eq 0 ]
+    [ ! -f "$FALLBACK_LOG" ]
+}
+
+@test "auto-detected pr route (no --pr flag, Size M/L in-session): _append_consumed_comments_section not called (#1201)" {
+    # Reproduces the MUST-severity gap found in #1201 review: /code N --auto without
+    # --patch invokes run-code.sh with no route flag, and Step 0 resolves pr route
+    # in-session via Size auto-detection. ROUTE_FLAG alone cannot distinguish this
+    # from patch route, so the post-processor must key on the observed open PR
+    # (reconcile-phase-state.sh's actual.pr_number) instead.
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #123: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+
+    FALLBACK_LOG="$BATS_TEST_TMPDIR/fallback.log"
+    export FALLBACK_LOG
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { return 0; }
+_emit_comments_consumed() { :; }
+_append_consumed_comments_section() { echo "CALLED \$*" >> "${FALLBACK_LOG}"; }
+MOCK
+
+    cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'
+#!/bin/bash
+echo '{"schema_version":"v1","phase":"code-pr","matches_expected":true,"actual":{"pr_state":"OPEN","pr_number":123},"diagnosis":"open PR found"}'
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/reconcile-phase-state.sh"
+
+    run bash "$SCRIPT" 123
     [ "$status" -eq 0 ]
     [ ! -f "$FALLBACK_LOG" ]
 }

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -557,6 +557,28 @@ MOCK
     [ ! -f "$FALLBACK_LOG" ]
 }
 
+@test "pr route: _append_consumed_comments_section not called even when section absent (#1058)" {
+    # Same setup as the patch-route fallback test above (no ## Consumed Comments
+    # section before or after claude), but with --pr: the post-processor must stay
+    # gated off regardless of section state, since the Spec lives on the PR branch
+    # which this main-repository post-exit point cannot observe or safely write to.
+    mkdir -p "$BATS_TEST_TMPDIR/docs/spec"
+    printf '%s\n' "# Issue #123: Test" > "$BATS_TEST_TMPDIR/docs/spec/issue-123-test.md"
+
+    FALLBACK_LOG="$BATS_TEST_TMPDIR/fallback.log"
+    export FALLBACK_LOG
+
+    cat > "$MOCK_DIR/emit-event.sh" <<MOCK
+emit_event() { return 0; }
+_emit_comments_consumed() { :; }
+_append_consumed_comments_section() { echo "CALLED \$*" >> "${FALLBACK_LOG}"; }
+MOCK
+
+    run bash "$SCRIPT" 123 --pr
+    [ "$status" -eq 0 ]
+    [ ! -f "$FALLBACK_LOG" ]
+}
+
 @test "AUTO_SESSION_ID resolves from .tmp/auto-session-current when PGID file absent (parent /auto path)" {
     # Issue #791 iteration B: adds .tmp/auto-session-current as a fallback in the
     # AUTO_SESSION_ID resolve chain. Note: as of PR #793 (Issue #770), SKILL.md writes


### PR DESCRIPTION
## Summary

Spec ファイル (`docs/spec/issue-N-*.md`) への `## Consumed Comments` 追記先を、フェーズ自身の作業ブランチ (worktree ブランチ / PR ブランチ) に一本化した。これまで `scripts/run-code.sh` / `scripts/run-spec.sh` のフォールバック post-processor が `claude` subprocess の exit 後 (CWD が main repository に戻った時点) で発火し、main の Spec を直接編集・push していたため、`/code` pr route の Code Retrospective 追記 (PR ブランチ側) と衝突し `## Consumed Comments` 近傍でコンフリクトが発生していた (#1186 / #1163 / downstream 1 件で実測)。

- `scripts/append-consumed-comments-section.sh` に `--no-push` フラグを追加。main tree 判定時の push は `worktree-merge-push.sh` によるロック付き push に置換
- `scripts/run-code.sh` の post-processor fallback を pr route ではゲートオフ (Spec が PR ブランチにあり、main repository から安全に書き込めないため)
- `skills/code/SKILL.md` Step 12 / `skills/spec/SKILL.md` Step 13 に `append-consumed-comments-section.sh --no-push` の in-session 必須呼び出しを追加し、両フェーズの安全網を確定的なものにした
- `modules/worktree-lifecycle.md` に「Spec file write destination」節を新設し、フェーズ横断の書き込み先規約 (exhaustive) を明文化
- `modules/l0-surfaces.md` の Bash wrapper fallback 節を、新しい 2 層構成 (in-session mandatory call が primary、wrapper post-processor は非 pr route のみの secondary) に合わせて書き換え
- `docs/structure.md` / `docs/ja/structure.md` の該当行を更新

## Verification (pre-merge)

- `modules/worktree-lifecycle.md` の新設節と `modules/l0-surfaces.md` の書き換えにより、Spec ファイルの書き込み先規約が全フェーズ横断で明文化されている
- `skills/code/SKILL.md` Step 12 の in-session 呼び出しと `scripts/run-code.sh` の pr route ゲートにより、両者が worktree ブランチ (= PR ブランチ) を対象とする
- `bats tests/` フルスイート 1443 件 PASS (behavioral change 検出により全件実行)
- `validate-skill-syntax.py` / `check-forbidden-expressions.sh` / `check-allowed-tools.sh` いずれも問題なし

## Verification (post-merge)

- pr route の Issue を 1 件通しで実行し、Spec ファイルのコンフリクトが発生しないことを確認する (observation, 次回 pr route 実行時に確認)

closes #1058
