### PR TITLE
Issue #1078: Run Comment Consumption Procedure after Worktree Entry in /code, /spec

### DIFF
--- a/docs/spec/issue-1078-comment-consumption-order.md
+++ b/docs/spec/issue-1078-comment-consumption-order.md
@@ -59,3 +59,31 @@
 ## Consumed Comments
 
 - saito / MEMBER / first-class / `/issue 1078` 実行時の Issue Retrospective — スコープを `/spec` にも拡大、AC2 の verify command 強化 (`"Consumed Comments"` → `"Comment Consumption"`)、post-merge チェックボックス書式修正の根拠を記録。現行 main で `/code`・`/spec` 双方が未解消であることも確認済み / https://github.com/saitoco/wholework/issues/1078#issuecomment-5204156551
+
+## Code Retrospective
+
+### Deviations from Design
+- None. Implementation Steps 1–4 were followed as written (paragraph relocation only, no Step number/heading changes; Notes point 1's "move-only, not full swap" rationale held up — the 5 existing Step 1/2 cross-references confirmed unaffected).
+
+### Design Gaps/Ambiguities
+- None found beyond what Notes already documents.
+
+### Rework
+- None.
+
+### Own-session precedent follow-through
+- This `/code 1078` session itself reproduced the same ordering risk the Issue describes: `skills/code/SKILL.md` on `main` (pre-fix) still calls the Comment Consumption Procedure in Step 1, before Worktree Entry. Rather than execute the pre-fix instructions literally (which would have written `## Consumed Comments` against the main working tree before `EnterWorktree`, exactly the bug being fixed), this session delayed its own Comment Consumption Procedure call until after Worktree Entry — mirroring the precedent the `/spec 1078` session recorded in this Spec's Notes ("本セッション自身での実地確認"). No new comments were pending at that point, so no observable behavior difference resulted, but the ordering choice is recorded here in case a future session needs the same judgment call while this fix is in flight on a PR branch.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Applied the "move-only" relocation exactly as Notes prescribed (paragraph relocation, no Step 1/Step 2 heading or numbering changes), confirmed after implementation that the 5 cross-references Notes identified remain accurate as-is.
+- Kept this `/code` session's own Comment Consumption Procedure call after Worktree Entry, not per the pre-fix Step 1 instruction still live on `main`, to avoid reproducing the Issue's bug within this very session (see Code Retrospective "Own-session precedent follow-through").
+
+### Deferred Items
+- Post-merge AC (manual): confirm via a live `/code`/`/spec` run on some future Issue that Comment Consumption content recorded post-Entry actually lands in the PR-branch-committed Spec (not verifiable pre-merge — no comments were pending during this session's own run to exercise the path end-to-end).
+
+### Notes for Next Phase
+- `/review` should confirm the grep/rubric verify commands both still PASS against the PR branch content (not just local worktree state) before merge.
+- No Spec Implementation Steps sync was needed (no deviations) — `/review` does not need to reconcile Spec vs. implementation beyond the standard diff check.

--- a/docs/spec/issue-1078-comment-consumption-order.md
+++ b/docs/spec/issue-1078-comment-consumption-order.md
@@ -75,15 +75,27 @@
 - This `/code 1078` session itself reproduced the same ordering risk the Issue describes: `skills/code/SKILL.md` on `main` (pre-fix) still calls the Comment Consumption Procedure in Step 1, before Worktree Entry. Rather than execute the pre-fix instructions literally (which would have written `## Consumed Comments` against the main working tree before `EnterWorktree`, exactly the bug being fixed), this session delayed its own Comment Consumption Procedure call until after Worktree Entry — mirroring the precedent the `/spec 1078` session recorded in this Spec's Notes ("本セッション自身での実地確認"). No new comments were pending at that point, so no observable behavior difference resulted, but the ordering choice is recorded here in case a future session needs the same judgment call while this fix is in flight on a PR branch.
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Applied the "move-only" relocation exactly as Notes prescribed (paragraph relocation, no Step 1/Step 2 heading or numbering changes), confirmed after implementation that the 5 cross-references Notes identified remain accurate as-is.
-- Kept this `/code` session's own Comment Consumption Procedure call after Worktree Entry, not per the pre-fix Step 1 instruction still live on `main`, to avoid reproducing the Issue's bug within this very session (see Code Retrospective "Own-session precedent follow-through").
+- Confirmed both pre-merge verify commands (rubric on the ordering-conflict resolution; `grep "Comment Consumption" modules/worktree-lifecycle.md`) PASS against the PR branch content, not just local worktree state, per the code phase's handoff note.
+- Ran Step 10 as a 1-agent lightweight integrated review (`REVIEW_DEPTH=light`, `--light` explicitly passed) rather than the 2-group full fan-out; all 4 review-light perspectives (spec deviation, edge cases/robustness, security/safety, documentation consistency) returned no issues.
+- Confirmed exhaustiveness of the fix's scope: `skills/code/SKILL.md`, `skills/spec/SKILL.md`, and `skills/verify/SKILL.md` are the only three callers of the Comment Consumption Procedure repo-wide, and all three now share the same correct ordering (Entry before Consumption).
 
 ### Deferred Items
-- Post-merge AC (manual): confirm via a live `/code`/`/spec` run on some future Issue that Comment Consumption content recorded post-Entry actually lands in the PR-branch-committed Spec (not verifiable pre-merge — no comments were pending during this session's own run to exercise the path end-to-end).
+- Post-merge AC (manual, unchanged from code phase's handoff): confirm via a live `/code`/`/spec` run on some future Issue that Comment Consumption content recorded post-Entry actually lands in the PR-branch-committed Spec. Still unresolved (`- [ ]` in the Issue body) as of this review.
 
 ### Notes for Next Phase
-- `/review` should confirm the grep/rubric verify commands both still PASS against the PR branch content (not just local worktree state) before merge.
-- No Spec Implementation Steps sync was needed (no deviations) — `/review` does not need to reconcile Spec vs. implementation beyond the standard diff check.
+- No MUST/SHOULD/CONSIDER issues were raised; `/merge` can proceed without a fix cycle.
+- The Post-merge AC above needs a live run of `/code` or `/spec` on some future Issue to close out — not something `/merge` itself can verify.
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note. Implementation Steps 1–4 were followed exactly (paragraph relocation only); re-verified independently during Step 8 (both pre-merge verify commands PASS) and by the Step 10 review-light agent (Spec deviation perspective: no issues).
+
+### Recurring issues
+- Nothing to note as an unresolved recurrence. This Issue is the deliberate second half of the two-path breakdown #1058 already documented (bash wrapper post-processor vs. SKILL.md Step ordering) — not a fresh instance of the same defect. Confirmed exhaustiveness: `grep -rl "Comment Consumption Procedure" skills/*/SKILL.md` returns exactly `skills/code/SKILL.md`, `skills/spec/SKILL.md` (both fixed by this PR), and `skills/verify/SKILL.md` (already correctly ordered, used as the precedent). No other skill caller exists, so no follow-up sweep Issue is needed for this specific pattern.
+
+### Acceptance criteria verification difficulty
+- Nothing to note. Both pre-merge conditions (`rubric` and `grep`) resolved deterministically to PASS with no UNCERTAIN — the AC2 verify command strengthening done at Issue creation time (`"Consumed Comments"` → `"Comment Consumption"`, recorded in Consumed Comments above) kept the grep condition meaningful rather than vacuously true.

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -166,6 +166,15 @@ out-of-worktree write — produces a two-sided edit to the same file that confli
 time (`mergeStateStatus: DIRTY`), even though the actual implementation diff is untouched. See
 Issue #1058 for the incident this rule generalizes from.
 
+Because the Comment Consumption Procedure (`modules/l0-surfaces.md`) writes to the Spec's
+`## Consumed Comments` section, any phase that calls it must run this module's Entry section
+first — calling it before Entry would write against whatever branch the main repository
+happened to be on, not the phase's own working branch. `skills/verify/SKILL.md` already
+satisfies this ordering (Entry is Step 3, the Comment Consumption Procedure call is Step 4).
+`skills/code/SKILL.md` and `skills/spec/SKILL.md` were brought into alignment with this
+ordering in #1078, by moving each skill's Comment Consumption Procedure call to the end of its
+own Worktree Entry Step.
+
 **Base propagation path per phase (exhaustive):**
 
 | Phase | Working branch | Base propagation path |

--- a/skills/code/SKILL.md
+++ b/skills/code/SKILL.md
@@ -110,10 +110,6 @@ gh issue view $NUMBER --json title,body
 
 Generate a short description from the title (e.g., "add-implement-skill").
 
-**Consume comments since the last phase (L0 input):**
-
-Read `${CLAUDE_PLUGIN_ROOT}/modules/l0-surfaces.md` and follow the "Comment Consumption Procedure" section with parameters: `ISSUE_NUMBER=$NUMBER`, `COMMENT_SCOPE=issue`, `PHASE_NAME=code`. The cutoff resolves to the most recent `phase/ready` label assignment. For resume runs (PR already exists), use `COMMENT_SCOPE=issue+pr`. Record results in the Spec's `## Consumed Comments` section.
-
 ### Step 2: Worktree Entry
 
 **Worktree skip for XS patch route (interactive direct-launch only):**
@@ -146,6 +142,10 @@ Record the `ENTERED_WORKTREE` variable for use in subsequent steps.
 **Edit/Write path conventions inside worktree (CWD-relative):**
 
 After entering the worktree, CWD switches to the worktree directory. When editing or creating files with Edit/Write tools, **verify CWD first** (check with `pwd`), and **use CWD-relative paths rather than absolute paths** (e.g., `~/.claude/` or `/Users/.../src/...`). Using absolute paths would edit the main repository, causing missed commits and conflicts.
+
+**Consume comments since the last phase (L0 input; run after Worktree Entry above — see `modules/worktree-lifecycle.md` § "Spec file write destination"):**
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/l0-surfaces.md` and follow the "Comment Consumption Procedure" section with parameters: `ISSUE_NUMBER=$NUMBER`, `COMMENT_SCOPE=issue`, `PHASE_NAME=code`. The cutoff resolves to the most recent `phase/ready` label assignment. For resume runs (PR already exists), use `COMMENT_SCOPE=issue+pr`. Record results in the Spec's `## Consumed Comments` section.
 
 ### Step 3: `phase/ready` Label Check
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -64,10 +64,6 @@ Run `${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh $NUMBER` and store the resu
 
 `ISSUE_TYPE` is referenced in Step 10 template selection.
 
-**Consume comments since the last phase (L0 input):**
-
-Read `${CLAUDE_PLUGIN_ROOT}/modules/l0-surfaces.md` and follow the "Comment Consumption Procedure" section with parameters: `ISSUE_NUMBER=$NUMBER`, `COMMENT_SCOPE=issue`, `PHASE_NAME=spec`. The cutoff resolves to the most recent `phase/issue` label assignment. Record results in the Spec's `## Consumed Comments` section.
-
 ### Step 2: Worktree Entry
 
 Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Entry" section.
@@ -75,6 +71,10 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/worktree-lifecycle.md` and follow the "Entry
 **Worktree name convention:** `spec/issue-$NUMBER`
 
 Record `ENTERED_WORKTREE` for later use. The Entry section includes running `.claude/hooks/worktree-init.sh` if it exists.
+
+**Consume comments since the last phase (L0 input; run after Worktree Entry above — see `modules/worktree-lifecycle.md` § "Spec file write destination"):**
+
+Read `${CLAUDE_PLUGIN_ROOT}/modules/l0-surfaces.md` and follow the "Comment Consumption Procedure" section with parameters: `ISSUE_NUMBER=$NUMBER`, `COMMENT_SCOPE=issue`, `PHASE_NAME=spec`. The cutoff resolves to the most recent `phase/issue` label assignment. Record results in the Spec's `## Consumed Comments` section.
 
 ### Step 3: Label Transition (start)
 


### PR DESCRIPTION
## Summary
`/code`・`/spec` の Step 1 にあった Comment Consumption Procedure (`modules/l0-surfaces.md`) 呼び出しを、それぞれ Step 2 (Worktree Entry) の末尾に移動した。Comment Consumption Procedure は Spec の `## Consumed Comments` セクションへの書き込みを伴うため、Worktree Entry (デフォルト `baseRef=fresh`、`origin/<default-branch>` から分岐) より前に実行すると、その書き込みは worktree 未作成のメインリポジトリのワーキングツリーに対して行われ、直後に作成される worktree ブランチへ一切引き継がれない (`skills/verify/SKILL.md` は既に Entry → Comment Consumption の正しい順序を持っており、これに整合させた)。

- `skills/code/SKILL.md`: Step 1 末尾の Comment Consumption 呼び出し段落を Step 2 末尾 (Step 3 の直前) に移動
- `skills/spec/SKILL.md`: 同様に Step 1 → Step 2 末尾に移動
- `modules/worktree-lifecycle.md`: "Spec file write destination" 節に、Comment Consumption Procedure との実行順序の依存関係を明記する新規段落を追加

Step 番号・見出し・他の内容は変更していない (Step 1/Step 2 を参照する既存のクロスリファレンス箇所への影響なし)。

## Verification (pre-merge)
- rubric: skills/code/SKILL.md・skills/spec/SKILL.md 双方で、Comment Consumption と Worktree Entry の実行順序矛盾を解消する対応が含まれている — PASS
- grep "Comment Consumption" modules/worktree-lifecycle.md — PASS
- `python3 scripts/validate-skill-syntax.py skills/` — exit 0 (no errors)
- `bash scripts/check-allowed-tools.sh skills/` — exit 0
- `bash scripts/check-forbidden-expressions.sh` — exit 0
- `bats tests/` (behavioral change detected — full suite) — 1460 tests, all PASS

## Verification (post-merge)
- 実際に `/code` および `/spec` を Issue に対して実行し、Comment Consumption Procedure で記録した Consumed Comments の内容が worktree ブランチ経由でコミットされた Spec に反映されていることを確認する (manual)

closes #1078
