### PR TITLE
Issue #1200: blocked-by: 判定の SSoT を Issue body テキストから GraphQL 関係に移す

### DIFF
--- a/.claude/settings.json.template
+++ b/.claude/settings.json.template
@@ -39,6 +39,7 @@
       "Bash(scripts/gh-pr-merge-status.sh *)",
       "Bash(scripts/gh-pr-review.sh *)",
       "Bash(scripts/gh-check-blocking.sh *)",
+      "Bash(scripts/get-blocked-by.sh *)",
       "Bash(scripts/opportunistic-search.sh *)",
       "Bash(scripts/check-file-overlap.sh *)",
       "Bash(scripts/triage-backlog-filter.sh *)",

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -172,6 +172,7 @@ wholework/
 - `scripts/gh-label-transition.sh` — フェーズラベル遷移
 - `scripts/gh-check-blocking.sh` — ブロッキング issue 依存関係チェック
 - `scripts/set-blocked-by.sh` — issue 番号で GitHub blocked-by relationship を設定する薄い wrapper (`add-blocked-by` mutation のラッパー)
+- `scripts/get-blocked-by.sh` — GitHub blocked-by relationship の単一読み取り窓口 (単一 Issue モード、または `--all` で open Issue 全体のグラフ)
 - `scripts/gh-extract-issue-from-pr.sh` — PR からリンク先 issue を抽出
 - `scripts/gh-pr-merge-status.sh` — PR のマージステータス確認
 - `scripts/gh-pr-review.sh` — PR レビュー投稿

--- a/docs/ja/workflow.md
+++ b/docs/ja/workflow.md
@@ -282,7 +282,11 @@ GitHub リポジトリ設定「Auto-close issues with merged linked pull request
 
 ## Blocked-by relationships
 
-GitHub native の blocked-by relationship (`addBlockedBy` mutation で設定) が Issue 依存関係状態の **SSoT** です。`Blocked by #N` という body テキストは人間向け補足に過ぎません。skill は GitHub relationship を正式なシグナルとして扱います。
+GitHub native の blocked-by relationship (`addBlockedBy` mutation で設定) が Issue 依存関係状態の **SSoT** です。`Blocked by #N` という body テキストは **入力ショートカット (書き込みトリガー)** です — 起票時にテキストを書くだけで relationship を設定できる手段ですが、判定 (gate・依存チェック・グラフ構築) は body テキストを直接読むことはなく、skill は常に GraphQL 経由で権威ある状態を解決します。
+
+### 読み取り経路
+
+すべての判定経路 (`/auto --batch` List mode gate、`/triage` Step 9 の単一 Issue 依存チェック、`/triage --backlog dependency` Step 2b のグラフ構築、`/spec` Step 4 のブロッキングチェック) は、GraphQL SSoT への単一の読み取り窓口である `scripts/get-blocked-by.sh` を経由します。`/auto` の batch gate はこれに加えて、読み取り直前に `gh-check-blocking.sh` を実行して body テキストのショートカットを先に GraphQL へ materialize します — これにより、blocker が body テキストにしか書かれていない Issue でも gate は従来以上に厳密であり続けます。`/spec` Step 4 は materialize 呼び出しを行わず読み取り専用のままです。`/spec` に到達する Issue は `/issue` または `/triage` を既に通過しており、いずれも書き込み時に materialize 済みだからです。
 
 ### 自動設定経路
 
@@ -307,6 +311,7 @@ GitHub native の blocked-by relationship (`addBlockedBy` mutation で設定) �
 
 - `scripts/gh-check-blocking.sh` — issue body の `Blocked by #N` パターンを検出して `addBlockedBy` mutation を呼び出す
 - `scripts/set-blocked-by.sh <issue> <blocker>` — 薄い wrapper: `get-issue-id` で node ID 解決後に `add-blocked-by` を呼び出す
+- `scripts/get-blocked-by.sh <issue> | --all` — 単一の読み取り窓口: 単一 Issue モードは `<blocker><TAB><state>` 行を返す (`OPEN` が 1 件でもあれば exit 2)。`--all` モードは `gh-graphql.sh --query get-open-issues-blocked-by` 経由で open Issue 全体の blocked-by グラフを `<issue><TAB><blocker><TAB><state>` の TSV で返す
 - `scripts/gh-graphql.sh --query add-blocked-by` — `addBlockedBy` mutation
 - `scripts/gh-graphql.sh --query remove-blocked-by` — `removeBlockedBy` mutation
 

--- a/docs/ja/workflow.md
+++ b/docs/ja/workflow.md
@@ -286,7 +286,7 @@ GitHub native の blocked-by relationship (`addBlockedBy` mutation で設定) �
 
 ### 読み取り経路
 
-すべての判定経路 (`/auto --batch` List mode gate、`/triage` Step 9 の単一 Issue 依存チェック、`/triage --backlog dependency` Step 2b のグラフ構築、`/spec` Step 4 のブロッキングチェック) は、GraphQL SSoT への単一の読み取り窓口である `scripts/get-blocked-by.sh` を経由します。`/auto` の batch gate はこれに加えて、読み取り直前に `gh-check-blocking.sh` を実行して body テキストのショートカットを先に GraphQL へ materialize します — これにより、blocker が body テキストにしか書かれていない Issue でも gate は従来以上に厳密であり続けます。`/spec` Step 4 は materialize 呼び出しを行わず読み取り専用のままです。`/spec` に到達する Issue は `/issue` または `/triage` を既に通過しており、いずれも書き込み時に materialize 済みだからです。
+すべての判定経路 (`/auto --batch` List mode gate、`/triage` Step 9 の単一 Issue 依存チェック、`/triage --backlog dependency` Step 2b のグラフ構築、`/spec` Step 4 のブロッキングチェック) は、GraphQL SSoT への単一の読み取り窓口である `scripts/get-blocked-by.sh` を経由します。`/auto` の batch gate と `/spec` Step 4 はいずれも、読み取り直前に `gh-check-blocking.sh` を実行して body テキストのショートカットを先に GraphQL へ materialize します — これにより、blocker が body テキストにしか書かれていない Issue (`/triage` がデフォルトの L1 tier では advisory print のみで materialize しないケースを含む) でも gate は従来以上に厳密であり続けます。
 
 ### 自動設定経路
 

--- a/docs/spec/issue-1200-blocked-by-graphql-ssot.md
+++ b/docs/spec/issue-1200-blocked-by-graphql-ssot.md
@@ -204,24 +204,45 @@ Edit / Write ツールは `.claude/` 配下を sensitive file として拒否す
 - `skills/auto/SKILL.md` と `skills/spec/SKILL.md` は複数のテストファイルから参照されているため (behavioral change detection)、`bats tests/get-blocked-by.bats` / `tests/auto-batch.bats` の直接テストに加えてフルスイート (`bats tests/`, 1476 件) を実行し、全件 PASS を確認した
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- Spec 記載のとおり実装ステップ 1〜10 をすべて実施し、設計からの逸脱は発生しなかった
-- rubric AC 3 件は実装エージェント自身ではなく、独立した adversarial grader sub-agent に diff とファイル内容を読ませて判定させた (自己採点バイアスの排除)。3 件とも PASS
-- `skills/auto/SKILL.md` と `skills/spec/SKILL.md` が挙動変更検知の対象になったため、直接テスト (`get-blocked-by.bats` / `auto-batch.bats`) に加えてフルスイート `bats tests/` (1476 件) を実行し全件 PASS を確認
-- `tests/gh-graphql.bats` への `get-open-issues-blocked-by` テスト追加 (Spec で「Steering Docs sync candidate」として保留されていた項目) を実施 — 既存パターンを踏襲するコストが低く、カバレッジの一貫性を優先した
+- 6 件の Pre-merge AC (rubric×3、command×2、file_contains×1) をすべて PASS 判定した。rubric は diff の直接精査、command 2 件は CI job `Run bats tests` の SUCCESS による safe-mode fallback で判定
+- review-spec + review-bug×2 (Opus) の並列レビューと、review-bug 由来指摘 8 件の 2 段階検証 (verification sub-agent) を実施。1 件 (`get-blocked-by.sh` の存在しない Issue 判定) は実 API 検証の結果 false positive と判明し除外
+- MUST 2 件 (exit code 1 未処理) と、検証で確認された SHOULD 3 件 (`/spec` gate 回帰、`/triage` OPEN-only guard 消失、`/triage --limit` scope 不整合) を修正・push 済み。加えて Verification order の欠落ステップも review-spec 指摘に基づき補完
+- 残り SHOULD 4 件 / CONSIDER 4 件 (主にドキュメント完全性・スクリプトの軽微な robustness) は skip — 挙動には影響しないか、現状の呼び出し元では発現しないため
 
 ### Deferred Items
 
-- `docs/ja/structure.md` の `get-sub-issue-progress.sh` 欠落 (既存 drift) は本 Issue では修正しない
-- `/triage` の「解決済み blocked-by」に対する `remove-blocked-by` の自動実行は行わない (report のみ)。tier-aware な自動削除は将来の検討事項
-- `.claude/settings.json.template` に `set-blocked-by.sh` のエントリが無い既存の不整合は本 Issue では補わない (新規の `get-blocked-by.sh` のみ追加した)
+- `docs/workflow.md` / `docs/ja/workflow.md` の "Automatic relationship setting" テーブルへの `/auto --batch` 行追加 (SHOULD、doc-only)
+- `docs/workflow.md` の `### Scripts` 一覧への `get-open-issues-blocked-by` 独立行追加 (SHOULD、doc-only)
+- `skills/triage/SKILL.md:605` 付近の `remove-blocked-by` 手動アクションが node ID 解決を要求する UX gap (SHOULD) — `remove-blocked-by.sh` wrapper の新設が根本対応候補
+- `modules/autonomy-tier.md` の Tier × L0 Write Matrix への `/auto --batch` 無条件書き込みの例外注記 (SHOULD)
+- `scripts/get-blocked-by.sh` の `--limit` ページ境界超過、`scripts/gh-graphql.sh` の `blockedBy(first:50)` vs `first:100` 非対称、issue番号 `0` の受理と `--all`+位置引数の暗黙無視 (いずれも CONSIDER)
 - Post-merge AC (「GraphQL で blocked-by を設定し body にはテキストを書かない Issue を `/auto --batch` に含め、blocker が未完了の間 skip されることを観察する」) は次回 `/auto --batch` 実行時の観察待ち
 
 ### Notes for Next Phase
 
-- `/review` では PR #1211 の diff に加え、adversarial grader による rubric 判定根拠 (ファイル/行の引用) を参照すると二重チェックになる
-- `scripts/get-blocked-by.sh` は実 GraphQL API に対して動作確認済み (#1200 自身: blocker 0 件で空出力・exit 0。`--all`: 既知の `#1167 → #1157 (CLOSED)` 関係を取得)
+- `/merge` 前に、review で修正した 5 箇所 (`skills/auto/SKILL.md:1125`、`skills/triage/SKILL.md:239,241,581`、`skills/spec/SKILL.md:90` + `docs/workflow.md`/`docs/ja/workflow.md` の追随修正) が commit `029bee8e` としてブランチに積まれていることを確認すること
+- self-authored PR への `REQUEST_CHANGES` は GitHub API が拒否するため (`modules/phase-state.md:77`)、本 review は `COMMENTED` として投稿されている。`/merge` の pre-merge gate は `reviewDecision == APPROVED` に依存しない設計になっているはずなので、この状態で merge を妨げないことを前提としてよい
 - `/verify` の post-merge observation AC は `/auto --batch` の次回実行セッションで確認すること (`verify-type: observation event=auto-run session=next`)
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- `skills/triage/SKILL.md` Step 2b の前置き文「Check dependency health for the issue set collected in Step 1」が、グラフ構築を `get-blocked-by.sh --all` (全 open Issue 対象) に切り替えた後も未更新のままだった。Spec の実装ステップはデータソースの変更のみを求めており、スコープの暗黙的な拡大は指示されていなかった (review 時に修正済み)
+- Step 2b の Verification order (1〜4) に、Notes が言及する「missing blocked-by relationships の tier-aware backfill」に対応するステップが無かった。旧実装では graph construction ステップ自体が body テキスト抽出を兼ねていたため気づかれにくい欠落だった (review 時に item 5 として追加)
+- `docs/workflow.md` の新設小節 `### Reading relationships` の挿入位置が、Spec が指定した「`### Automatic relationship setting` の後」ではなく「前」になっていた。挙動には影響しないが、Code Retrospective の「Deviations from Design」に記録されておらず、Spec と実体の乖離が review まで気づかれなかった
+
+### Recurring issues
+
+- Type=Task (「挙動を変えない」リファクタ) と宣言された PR で、review-bug 2 名 + review-spec の 3 エージェントが独立に **exit code 1 (エラー) 分岐の欠落** を検出した。`/auto` の batch gate と `/triage` の依存チェックの両方で同一パターンが再発しており、新しいスクリプトの exit code 契約を追加する際は、既存の全呼び出し元に対して契約の全分岐 (0/1/2) が網羅されているかを機械的にチェックする価値がありそうだ
+- 「`/spec` に到達する Issue は `/issue` または `/triage` を既に通過しており、いずれも materialize 済み」という設計上の安全性の主張が、`/triage` の autonomy tier 分岐 (L1 ではデフォルトで advisory print のみ) を見落としていた。同一 PR 内の別ファイルが持つ tier-aware な分岐を、正当化コメントを書く際に見落とすケースは他の Issue でも起こりうる。设計文書の安全性主張を書く際は、参照先の tier-aware ロジックを実際に読んで確認する習慣が有効
+- 全 3 rubric AC が PASS、bats フルスイート (1476件) も PASS していたにもかかわらず、上記のロジック回帰は AC 検証にも既存テストにも捕捉されなかった。rubric AC は「GraphQL を参照する実装になっているか」という高レベルの設計適合性は検証できるが、exit code の全分岐網羅性や tier 境界条件のような制御フローの端点は、既存のテストが対象外なら見逃される。この種の「配線は正しいが端点が甘い」regression は multi-perspective code review (review-bug の HIGH SIGNAL 検出 + adversarial verification) が最後の防衛線として機能した
+
+### Acceptance criteria verification difficulty
+
+- 特筆すべき困難はなかった。3 件の rubric AC は diff を直接読むことで明確に判定可能だった。2 件の `command "bats ..."` AC は safe mode の CI reference fallback (`Run bats tests` job の SUCCESS) で PASS 判定したが、このリポジトリでは bats 全ファイルが単一の CI job に集約されているため機能した。テストファイル単位で job が分離されている場合、fallback の粒度が粗く誤判定するリスクがある点は留意事項として記録しておく
+- プロセス上のメモ: `gh-pr-review.sh` への line-comments JSON で `severity` フィールドを付け忘れ、`HAS_MUST` 判定が `false` になり event が `COMMENTED` のまま投稿された。ただし self-authored PR に対する `REQUEST_CHANGES` は GitHub API が HTTP 422 で拒否する既知の制約 (`modules/phase-state.md:77`) のため、正しく `severity` を設定していても同じ `COMMENTED` 結果になっていた可能性が高く、実害はなかった。line-comments JSON を組み立てる際は `severity` フィールドを構造化データとして必ず含めること (body 内のテキスト装飾だけでは `HAS_MUST` 判定に反映されない)

--- a/docs/spec/issue-1200-blocked-by-graphql-ssot.md
+++ b/docs/spec/issue-1200-blocked-by-graphql-ssot.md
@@ -183,27 +183,45 @@ Edit / Write ツールは `.claude/` 配下を sensitive file として拒否す
 - `blockedBy` が Issue リスト文脈 (`repository.issues.nodes[]`) でも取得できるかは設計時点で未確認だったため、実際に GraphQL を叩いて検証した (`#1167 → #1157 (CLOSED)` が返ることを確認)。結果として「CLOSED の blocker も `blockedBy` に残る」ことも判明し、これが「解決済み blocked-by」を GraphQL 側だけで検出できる根拠になった
 - `gh api graphql` が未指定の nullable 変数 (`$cursor:String`) を null として送るかは、`-F cursor=` に空文字を渡すと `after:""` になりエラーとなるリスクがあったため、1 ページ目は `-F cursor` を渡さない設計に倒した。実装フェーズで `--all` のページングテストにより確認されること
 
+## Code Retrospective
+
+### Deviations from Design
+
+- 実装ステップの順序どおりに進めたが、Spec の「Steering Docs sync candidate」として保留されていた `tests/gh-graphql.bats` への `get-open-issues-blocked-by` 名前付きクエリのテスト追加は、既存の他名前付きクエリ (`get-blocked-by` 等) と同じテストパターンを踏襲するコストが低かったため実施した。既存 10 件のテストに 1 件追加する形で、既存アサーションへの影響はない
+
+### Design Gaps/Ambiguities
+
+- N/A — Spec の分岐表 (「`scripts/get-blocked-by.sh` の分岐の挙動 (exhaustive)」) がそのままテストケース設計の1次ソースとして機能し、実装中に解釈の揺れは発生しなかった
+
+### Rework
+
+- N/A
+
+### Verification notes
+
+- 3 件の rubric AC は、実装エージェント自身による自己採点ではなく、diff の文脈を持たない独立した adversarial grader sub-agent に判定させた。3 件とも PASS で、根拠として引用されたファイル/行は実装と一致していた
+- `scripts/get-blocked-by.sh` を実際の GraphQL API に対して実行し、単一 Issue モード (#1200 自身、blocker 0 件で空出力・exit 0) と `--all` モード (`#1167 → #1157 (CLOSED)` の既知の関係を取得) の両方を確認した。後者は Spec の Uncertainty resolution に記録されていた実測値と完全に一致し、設計時点の検証が実装フェーズでも再現されることを確認できた
+- `skills/auto/SKILL.md` と `skills/spec/SKILL.md` は複数のテストファイルから参照されているため (behavioral change detection)、`bats tests/get-blocked-by.bats` / `tests/auto-batch.bats` の直接テストに加えてフルスイート (`bats tests/`, 1476 件) を実行し、全件 PASS を確認した
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- Issue 本文の候補 1 を採用 — 読み取りのみ GraphQL へ統一し、body の `Blocked by #N` は書き込みトリガーとして存続させる。`gh-check-blocking.sh` / `set-blocked-by.sh` / `modules/retro-proposals.md` の書き込み経路は一切変更しない
-- 判定側の読み取り窓口を `scripts/get-blocked-by.sh` 1 本に集約し、exit code 契約を `gh-check-blocking.sh` と同一 (0 = OPEN blocker なし / 1 = エラー / 2 = OPEN blocker あり) に揃えた
-- `--all` 一括モードを同スクリプトに持たせ、`/triage --backlog dependency` のグラフ構築を 1 回 (最大でも数回のページング) の GraphQL 呼び出しに抑える。`--all` は成功時つねに exit 0 (exit 2 のシグナルは単一 Issue モード限定)
-- `/auto` List mode gate では判定直前に `gh-check-blocking.sh` (非 `--dry-run`) を実行して body ショートカットを materialize する。これにより gate は現行より厳密になる
-- 孤児依存を「GraphQL グラフの異常」から「body テキストの衛生チェック」へ再定義した (GraphQL 関係は構造的に孤児になりえない)
+- Spec 記載のとおり実装ステップ 1〜10 をすべて実施し、設計からの逸脱は発生しなかった
+- rubric AC 3 件は実装エージェント自身ではなく、独立した adversarial grader sub-agent に diff とファイル内容を読ませて判定させた (自己採点バイアスの排除)。3 件とも PASS
+- `skills/auto/SKILL.md` と `skills/spec/SKILL.md` が挙動変更検知の対象になったため、直接テスト (`get-blocked-by.bats` / `auto-batch.bats`) に加えてフルスイート `bats tests/` (1476 件) を実行し全件 PASS を確認
+- `tests/gh-graphql.bats` への `get-open-issues-blocked-by` テスト追加 (Spec で「Steering Docs sync candidate」として保留されていた項目) を実施 — 既存パターンを踏襲するコストが低く、カバレッジの一貫性を優先した
 
 ### Deferred Items
 
 - `docs/ja/structure.md` の `get-sub-issue-progress.sh` 欠落 (既存 drift) は本 Issue では修正しない
 - `/triage` の「解決済み blocked-by」に対する `remove-blocked-by` の自動実行は行わない (report のみ)。tier-aware な自動削除は将来の検討事項
-- `.claude/settings.json.template` に `set-blocked-by.sh` のエントリが無い既存の不整合は本 Issue では補わない (新規の `get-blocked-by.sh` のみ追加する)
+- `.claude/settings.json.template` に `set-blocked-by.sh` のエントリが無い既存の不整合は本 Issue では補わない (新規の `get-blocked-by.sh` のみ追加した)
+- Post-merge AC (「GraphQL で blocked-by を設定し body にはテキストを書かない Issue を `/auto --batch` に含め、blocker が未完了の間 skip されることを観察する」) は次回 `/auto --batch` 実行時の観察待ち
 
 ### Notes for Next Phase
 
-- `tests/auto-batch.bats` の既存 10 件は List mode 書き換え後も PASS する必要がある。特に `blocked-by check present` (grep `blocked`) と `phase/done gate condition present` (grep `phase/done`) を壊さないこと。新規追加する 2 件は `grep -q 'get-blocked-by.sh'` (exit 0 期待) と `grep -q 'json body'` (exit **非** 0 期待) の形にすると引用符が入れ子にならず安全
-- `.claude/settings.json.template` は Edit / Write ツールが拒否する。`sed` または `python3` で編集すること。`.gitignore` に `!.claude/settings.json.template` の un-ignore があるため `git add -f` は不要
-- `scripts/get-blocked-by.sh` は bash 3.2+ 互換で書くこと (`mapfile` / 連想配列は使わない)。sibling script は `SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"` で解決する
-- `get-open-issues-blocked-by` の 1 ページ目は `-F cursor=` を**渡さない** (空文字を渡すと `after:""` となりエラーになりうる)。2 ページ目以降のみ `endCursor` を渡す
-- `docs/ja/workflow.md` の同期では「入力ショートカット」という日本語表記を必ず含めること (受け入れ条件 6 の `file_contains` パターン)
+- `/review` では PR #1211 の diff に加え、adversarial grader による rubric 判定根拠 (ファイル/行の引用) を参照すると二重チェックになる
+- `scripts/get-blocked-by.sh` は実 GraphQL API に対して動作確認済み (#1200 自身: blocker 0 件で空出力・exit 0。`--all`: 既知の `#1167 → #1157 (CLOSED)` 関係を取得)
+- `/verify` の post-merge observation AC は `/auto --batch` の次回実行セッションで確認すること (`verify-type: observation event=auto-run session=next`)

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -179,6 +179,7 @@ Key modules:
 - `scripts/gh-label-transition.sh` — phase label transitions
 - `scripts/gh-check-blocking.sh` — check blocking issue dependencies
 - `scripts/set-blocked-by.sh` — set GitHub blocked-by relationship by issue number (wrapper for `add-blocked-by` mutation)
+- `scripts/get-blocked-by.sh` — single read window for GitHub blocked-by relationships (single-issue mode, or `--all` for the full open-issue graph)
 - `scripts/gh-extract-issue-from-pr.sh` — extract linked issue from PR
 - `scripts/gh-pr-merge-status.sh` — check PR merge status
 - `scripts/gh-pr-review.sh` — post PR reviews

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -289,7 +289,11 @@ When the GitHub repository setting "Auto-close issues with merged linked pull re
 
 ## Blocked-by relationships
 
-GitHub native blocked-by relationships (set via `addBlockedBy` mutation) are the **SSoT** for Issue dependency state. Body text such as `Blocked by #N` is a human-readable supplement only — skills treat the GitHub relationship as the authoritative signal.
+GitHub native blocked-by relationships (set via `addBlockedBy` mutation) are the **SSoT** for Issue dependency state. Body text such as `Blocked by #N` is an **input shortcut (a write trigger)** — it exists to let humans set a relationship by typing text at issue-creation time, but judgment (gates, dependency checks, graph construction) never reads it directly; skills always resolve the authoritative state through GraphQL.
+
+### Reading relationships
+
+All judgment paths (the `/auto --batch` List mode gate, `/triage` Step 9's single-Issue dependency check, `/triage --backlog dependency`'s Step 2b graph construction, and `/spec` Step 4's blocking check) read through `scripts/get-blocked-by.sh`, the single read window onto the GraphQL SSoT. `/auto`'s batch gate additionally runs `gh-check-blocking.sh` immediately before the read, to materialize any body-text shortcut into GraphQL first — this keeps the gate at least as strict as before, even for Issues where a blocker was only ever written as body text. `/spec` Step 4 stays read-only (no materialize call), since Issues reaching `/spec` have already passed through `/issue` or `/triage`, both of which materialize on write.
 
 ### Automatic relationship setting
 
@@ -314,6 +318,7 @@ The `autonomy:` field in `.wholework.yml` (default `L1`) governs automatic L0 wr
 
 - `scripts/gh-check-blocking.sh` — detects `Blocked by #N` patterns in issue body and calls `addBlockedBy` mutation
 - `scripts/set-blocked-by.sh <issue> <blocker>` — thin wrapper: resolves node IDs via `get-issue-id` and calls `add-blocked-by`
+- `scripts/get-blocked-by.sh <issue> | --all` — single read window: single-Issue mode returns `<blocker><TAB><state>` lines (exit 2 if any `OPEN`); `--all` mode returns the full open-issue blocked-by graph as `<issue><TAB><blocker><TAB><state>` TSV via `gh-graphql.sh --query get-open-issues-blocked-by`
 - `scripts/gh-graphql.sh --query add-blocked-by` — `addBlockedBy` mutation
 - `scripts/gh-graphql.sh --query remove-blocked-by` — `removeBlockedBy` mutation
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -293,7 +293,7 @@ GitHub native blocked-by relationships (set via `addBlockedBy` mutation) are the
 
 ### Reading relationships
 
-All judgment paths (the `/auto --batch` List mode gate, `/triage` Step 9's single-Issue dependency check, `/triage --backlog dependency`'s Step 2b graph construction, and `/spec` Step 4's blocking check) read through `scripts/get-blocked-by.sh`, the single read window onto the GraphQL SSoT. `/auto`'s batch gate additionally runs `gh-check-blocking.sh` immediately before the read, to materialize any body-text shortcut into GraphQL first — this keeps the gate at least as strict as before, even for Issues where a blocker was only ever written as body text. `/spec` Step 4 stays read-only (no materialize call), since Issues reaching `/spec` have already passed through `/issue` or `/triage`, both of which materialize on write.
+All judgment paths (the `/auto --batch` List mode gate, `/triage` Step 9's single-Issue dependency check, `/triage --backlog dependency`'s Step 2b graph construction, and `/spec` Step 4's blocking check) read through `scripts/get-blocked-by.sh`, the single read window onto the GraphQL SSoT. `/auto`'s batch gate and `/spec` Step 4 both run `gh-check-blocking.sh` immediately before the read, to materialize any body-text shortcut into GraphQL first — this keeps the gate at least as strict as before, even for Issues where a blocker was only ever written as body text and `/triage` (at the default L1 autonomy tier) only printed an advisory recommendation rather than materializing it.
 
 ### Automatic relationship setting
 

--- a/modules/l0-surfaces.md
+++ b/modules/l0-surfaces.md
@@ -34,7 +34,7 @@ The table below is **exhaustive** for Wholework's current scope. Add a row here 
 | PR body, review state | view | `/review`, `/merge` | read-mostly | yes |
 | Sub-issue graph | view (`subIssues` GraphQL) | `get-sub-issue-graph.sh` | read-only | yes |
 | `closes #N` magic | parse | `gh-extract-issue-from-pr.sh` | derived | yes |
-| Issue blocked-by relationships | add, remove | `set-blocked-by.sh`, `gh-check-blocking.sh`, `gh-graphql.sh` (`add-blocked-by`, `remove-blocked-by`) | mutable | yes |
+| Issue blocked-by relationships | add, remove, read | `set-blocked-by.sh`, `gh-check-blocking.sh`, `gh-graphql.sh` (`add-blocked-by`, `remove-blocked-by`), `get-blocked-by.sh` (read) | mutable | yes |
 
 Note: label namespace rules and bare-namespace exceptions (e.g., `triaged`) are defined in [`modules/label-conventions.md`](label-conventions.md).
 

--- a/scripts/get-blocked-by.sh
+++ b/scripts/get-blocked-by.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# get-blocked-by.sh
+# Single read window for GitHub native blocked-by relationships (GraphQL SSoT).
+#
+# Usage:
+#   scripts/get-blocked-by.sh <issue-number>
+#   scripts/get-blocked-by.sh --all [--limit N]
+#
+# Output (single issue mode):
+#   <blocker-number><TAB><state>   -- one line per blocker (CLOSED and OPEN both listed)
+#
+# Output (--all mode):
+#   <issue-number><TAB><blocker-number><TAB><blocker-state>   -- one line per relation
+#   (open issues with no blockers produce no line)
+#
+# Exit codes:
+#   0 -- success (single issue: no OPEN blockers; --all: always 0 on success)
+#   1 -- error (bad arguments, API error, etc.)
+#   2 -- single issue mode only: one or more OPEN blockers found
+
+set -euo pipefail
+
+SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+GH_GRAPHQL="$SCRIPT_DIR/gh-graphql.sh"
+
+DEFAULT_LIMIT=100
+
+usage() {
+    echo "Usage: $(basename "$0") <issue-number>"
+    echo "       $(basename "$0") --all [--limit N]"
+    echo ""
+    echo "Read GitHub native blocked-by relationships via GraphQL."
+    echo ""
+    echo "Single issue mode output: <blocker-number><TAB><state> per line"
+    echo "--all mode output: <issue-number><TAB><blocker-number><TAB><blocker-state> per line"
+    echo ""
+    echo "Exit codes:"
+    echo "  0 -- success (single issue: no OPEN blockers; --all: always 0 on success)"
+    echo "  1 -- error"
+    echo "  2 -- single issue mode only: OPEN blocker(s) found"
+}
+
+NUMBER=""
+ALL_MODE=false
+LIMIT="$DEFAULT_LIMIT"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --all)
+            ALL_MODE=true
+            shift
+            ;;
+        --limit)
+            if [ $# -lt 2 ] || ! [[ "$2" =~ ^[0-9]+$ ]] || [ "$2" -le 0 ]; then
+                echo "Error: --limit must be a positive integer: ${2:-}" >&2
+                exit 1
+            fi
+            LIMIT="$2"
+            shift 2
+            ;;
+        -*)
+            echo "Error: unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+                echo "Error: issue-number must be a positive integer: $1" >&2
+                exit 1
+            fi
+            NUMBER="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ "$ALL_MODE" = false ] && [ -z "$NUMBER" ]; then
+    echo "Error: issue number or --all is required" >&2
+    usage >&2
+    exit 1
+fi
+
+if [ "$ALL_MODE" = true ]; then
+    if [ "$LIMIT" -lt 100 ]; then
+        PAGE_SIZE="$LIMIT"
+    else
+        PAGE_SIZE=100
+    fi
+
+    CURSOR=""
+    TOTAL_ISSUES_SEEN=0
+
+    while :; do
+        if [ -z "$CURSOR" ]; then
+            PAGE_JSON=$("$GH_GRAPHQL" --query get-open-issues-blocked-by -F first="$PAGE_SIZE") || {
+                echo "Error: failed to fetch open-issue blocked-by graph" >&2
+                exit 1
+            }
+        else
+            PAGE_JSON=$("$GH_GRAPHQL" --query get-open-issues-blocked-by -F first="$PAGE_SIZE" -F cursor="$CURSOR") || {
+                echo "Error: failed to fetch open-issue blocked-by graph" >&2
+                exit 1
+            }
+        fi
+
+        LINES=$(printf '%s' "$PAGE_JSON" | jq -r '.data.repository.issues.nodes[] | . as $i | ($i.blockedBy.nodes[]? | "\($i.number)\t\(.number)\t\(.state)")') || {
+            echo "Error: failed to fetch open-issue blocked-by graph" >&2
+            exit 1
+        }
+        if [ -n "$LINES" ]; then
+            printf '%s\n' "$LINES"
+        fi
+
+        PAGE_COUNT=$(printf '%s' "$PAGE_JSON" | jq -r '.data.repository.issues.nodes | length')
+        TOTAL_ISSUES_SEEN=$((TOTAL_ISSUES_SEEN + PAGE_COUNT))
+
+        HAS_NEXT=$(printf '%s' "$PAGE_JSON" | jq -r '.data.repository.issues.pageInfo.hasNextPage')
+        if [ "$HAS_NEXT" != "true" ]; then
+            break
+        fi
+        if [ "$TOTAL_ISSUES_SEEN" -ge "$LIMIT" ]; then
+            break
+        fi
+        CURSOR=$(printf '%s' "$PAGE_JSON" | jq -r '.data.repository.issues.pageInfo.endCursor')
+    done
+
+    exit 0
+fi
+
+# Single issue mode
+RAW=$("$GH_GRAPHQL" --query get-blocked-by -F num="$NUMBER" --jq '.data.repository.issue.blockedBy.nodes[]? | "\(.number)\t\(.state)"') || {
+    echo "Error: failed to fetch blocked-by for issue #$NUMBER" >&2
+    exit 1
+}
+
+if [ -z "$RAW" ]; then
+    exit 0
+fi
+
+printf '%s\n' "$RAW"
+
+if printf '%s\n' "$RAW" | cut -f2 | grep -q '^OPEN$'; then
+    exit 2
+fi
+
+exit 0

--- a/scripts/gh-graphql.sh
+++ b/scripts/gh-graphql.sh
@@ -67,6 +67,9 @@ get_named_query() {
         get-blocked-by)
             printf '%s' 'query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){blockedBy(first:100){nodes{number title state}}}}}'
             ;;
+        get-open-issues-blocked-by)
+            printf '%s' 'query($owner:String!,$repo:String!,$first:Int!,$cursor:String){repository(owner:$owner,name:$repo){issues(states:OPEN,first:$first,after:$cursor,orderBy:{field:CREATED_AT,direction:DESC}){pageInfo{hasNextPage endCursor}nodes{number blockedBy(first:50){nodes{number state}}}}}}'
+            ;;
         get-issue-timeline)
             printf '%s' 'query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){number timelineItems(itemTypes:[LABELED_EVENT,UNLABELED_EVENT,REOPENED_EVENT],first:100){nodes{__typename ... on LabeledEvent{label{name}createdAt} ... on UnlabeledEvent{label{name}createdAt} ... on ReopenedEvent{createdAt}}}}}}'
             ;;

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -1123,6 +1123,7 @@ Process each Issue in `BATCH_LIST` in order:
    ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh $NUMBER
    ```
    - Exit 0 (no blockers, or all blockers `CLOSED`): gate released — skip to step 5
+   - Exit 1 (error, e.g. transient GraphQL failure): output a warning and treat as gate released (proceed to step 5) — same fail-open policy as the preceding `gh-check-blocking.sh` call
    - Exit 2 (one or more `OPEN` blockers; each output line is `<BLOCKER><TAB><STATE>`): for each `OPEN` blocker `$BLOCKER`:
      ```
      gh issue view $BLOCKER --json labels -q '[.labels[].name | select(startswith("phase/"))]'

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -3,7 +3,7 @@ name: auto
 description: Autonomous execution (`/auto 123`). Runs spec (when needed)→code→review→merge→verify in sequence. XL Issues use sub-issue dependency graph with parallel execution. Size auto-detection with `--patch`/`--pr` and `--review=light`/`--review=full` overrides. Issues without `phase/*` labels start from issue triage. `--batch N` processes N backlog XS/S Issues; `--batch N1 N2 ...` processes the explicitly listed Issues in order (assigns a BATCH_ID for parallel-safe checkpointing). `--resume N` resumes a single Issue (restores verify counter from checkpoint); `--batch --resume` resumes an interrupted batch using `list_active_batches` to identify the target session.
 loop-paths-used: [A, E]
 loop-paths-fallback: [A]
-allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, gh issue view:*, gh issue list:*, gh issue close:*, gh issue comment:*, gh issue create:*, gh pr list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-sub-issue-graph.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-spec.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-issue.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-wrapper-anomaly.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-external-kill.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/validate-recovery-plan.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/filter-session-verified-issues.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-auto-session-report.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-session-findings-disposition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/collect-run-facts.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/scan-pending-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/apply-run-fact-match.sh:*), Read, Edit, Glob, Grep, Write, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, gh issue view:*, gh issue list:*, gh issue close:*, gh issue comment:*, gh issue create:*, gh pr list:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-code.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-review.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-merge.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-sub-issue-graph.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-auto-sub.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-spec.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/run-issue.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-wrapper-anomaly.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-external-kill.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/reconcile-phase-state.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/validate-recovery-plan.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/observation-trigger.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/filter-session-verified-issues.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-auto-session-report.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/check-session-findings-disposition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/collect-run-facts.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/scan-pending-ac.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/apply-run-fact-match.sh:*), Read, Edit, Glob, Grep, Write, Skill, Task, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Autonomous Execution
@@ -1114,16 +1114,20 @@ Process each Issue in `BATCH_LIST` in order:
 2. **If no `phase/*` labels**: run `${CLAUDE_PLUGIN_ROOT}/scripts/run-issue.sh $NUMBER` (issue triage → Size setting → `phase/ready` assignment)
    - On failure: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
 3. call `${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh $NUMBER`; retain the result as `$ISSUE_SIZE`; if `$ISSUE_SIZE` is XL: output a warning; call `${CLAUDE_PLUGIN_ROOT}/scripts/auto-checkpoint.sh update_batch "$BATCH_ID" $NUMBER fail`; skip to the next Issue (do not abort the entire batch)
-4. **Blocked-by check**: Extract blocker numbers from the Issue body:
+4. **Blocked-by check**: materialize any body-text `Blocked by #N` shortcuts into GraphQL, then read the authoritative blocker list from GraphQL (GraphQL is the SSoT — see `docs/workflow.md` § Blocked-by relationships):
    ```
-   gh issue view $NUMBER --json body -q '.body' | grep -ioE "blocked by #[0-9]+" | grep -oE "[0-9]+"
+   ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh $NUMBER
    ```
-   - If no blockers found: skip to step 5
-   - For each blocker `$BLOCKER`:
+   (exit code 2 here just means an open blocker was detected in body text and materialized — not an error; only treat exit code 1 as an error, output a warning, and continue to the `get-blocked-by.sh` call below.)
+   ```
+   ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh $NUMBER
+   ```
+   - Exit 0 (no blockers, or all blockers `CLOSED`): gate released — skip to step 5
+   - Exit 2 (one or more `OPEN` blockers; each output line is `<BLOCKER><TAB><STATE>`): for each `OPEN` blocker `$BLOCKER`:
      ```
-     gh issue view $BLOCKER --json state,labels -q '{state: .state, phases: [.labels[].name | select(startswith("phase/"))]}'
+     gh issue view $BLOCKER --json labels -q '[.labels[].name | select(startswith("phase/"))]'
      ```
-     - If `state` is `"CLOSED"` or `phases` contains `"phase/done"`: gate released — continue to next blocker
+     - If `phase/done` is present: gate released — continue to next blocker
      - Otherwise: extract `$BLOCKER_PHASE` (first `phase/*` label of blocker, or `"OPEN"` if no `phase/*` label); output warning and skip `$NUMBER` (do NOT call `update_batch` — keeps `$NUMBER` in `remaining` for `/auto --batch --resume`):
        ```
        Warning: #$NUMBER blocked by #$BLOCKER which is $BLOCKER_PHASE (manual post-merge pending). Skipping #$NUMBER. After completing #$BLOCKER manually, resume with /auto --batch --resume.

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: Issue specification (`/spec 123`). Reads Issue requirements and creates an implementation plan. Automatically adjusts investigation depth (light/full) based on Size (`--light`/`--full` to override).
-allowed-tools: Bash(gh issue view:*, gh issue create:*, gh issue edit:*, gh issue list:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*), Glob, Grep, Read, Write, Edit, WebFetch, WebSearch, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_figma_figma__get_design_context, mcp__plugin_figma_figma__get_variable_defs, mcp__plugin_figma_figma__get_screenshot, mcp__plugin_figma_figma__get_metadata, mcp__plugin_figma_figma__whoami
+allowed-tools: Bash(gh issue view:*, gh issue create:*, gh issue edit:*, gh issue list:*, gh api:*, ${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-edit.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-type.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/worktree-merge-push.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/detect-foreign-worktree.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/append-consumed-comments-section.sh:*, git add:*, git commit:*, git push:*, git merge:*, git worktree:*, git branch:*), Glob, Grep, Read, Write, Edit, WebFetch, WebSearch, ToolSearch, EnterWorktree, ExitWorktree, mcp__plugin_figma_figma__get_design_context, mcp__plugin_figma_figma__get_variable_defs, mcp__plugin_figma_figma__get_screenshot, mcp__plugin_figma_figma__get_metadata, mcp__plugin_figma_figma__whoami
 ---
 
 # Issue Specification
@@ -84,10 +84,10 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh $NUMBER spec
 
 ### Step 4: Blocked-by Detection
 
-Check whether the target Issue has unresolved blocked-by relationships:
+Check whether the target Issue has unresolved blocked-by relationships (read-only — GraphQL is the SSoT, see `docs/workflow.md` § Blocked-by relationships):
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh $NUMBER --dry-run
+${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh $NUMBER
 ```
 
 - Exit code 0: no open blockers → `HAS_OPEN_BLOCKING=false`

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -84,7 +84,13 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/gh-label-transition.sh $NUMBER spec
 
 ### Step 4: Blocked-by Detection
 
-Check whether the target Issue has unresolved blocked-by relationships (read-only — GraphQL is the SSoT, see `docs/workflow.md` § Blocked-by relationships):
+Check whether the target Issue has unresolved blocked-by relationships (GraphQL is the SSoT, see `docs/workflow.md` § Blocked-by relationships). Materialize any body-text `Blocked by #N` shortcuts into GraphQL first — Issues reaching `/spec` may have been triaged at autonomy tier L1 (the default), where `/triage` only prints an advisory recommendation and does not call `set-blocked-by.sh`, so a body-text-only blocker would otherwise be invisible to a GraphQL-only read:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/gh-check-blocking.sh $NUMBER
+```
+
+(exit code 2 here just means an open blocker was detected in body text and materialized — not an error; only treat exit code 1 as an error, output a warning, and continue to the `get-blocked-by.sh` call below.)
 
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh $NUMBER

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -2,7 +2,7 @@
 model: sonnet
 name: triage
 description: Issue triage. Automates title normalization, Type/Priority/Size/Value assignment (`/triage 123` for single issue + lightweight analysis, `/triage` for bulk execution, `/triage --backlog` for bulk processing + 4-perspective deep analysis).
-allowed-tools: Bash(gh:*, cat:*, echo:*, grep:*, jq:*, test:*, bash:*, printf:*, wc:*, head:*, tail:*, sed:*, awk:*, mkdir:*, rm:*, sleep:*, ${CLAUDE_PLUGIN_ROOT}/scripts/triage-backlog-filter.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*), Read, Write, Glob, Grep
+allowed-tools: Bash(gh:*, cat:*, echo:*, grep:*, jq:*, test:*, bash:*, printf:*, wc:*, head:*, tail:*, sed:*, awk:*, mkdir:*, rm:*, sleep:*, ${CLAUDE_PLUGIN_ROOT}/scripts/triage-backlog-filter.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/gh-issue-comment.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh:*, ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh:*), Read, Write, Glob, Grep
 ---
 
 # Issue Triage
@@ -230,16 +230,15 @@ If stagnation patterns are detected, include in completion report. If none detec
 
 **Dependency blocked-by check:**
 
-Extract `Blocked by #N` patterns from the issue body and check the status of blocked-by issues:
+The GraphQL blocked-by relationship is the authoritative source for dependency status (see `docs/workflow.md` § Blocked-by relationships); the issue body's `Blocked by #N` text is only consulted to detect relationships that haven't been materialized into GraphQL yet.
 
-1. If no `Blocked by #N` text, skip
-2. If found, use already-retrieved data from Step 2 if the blocked-by issue is included. Otherwise, check status with `gh issue view N --json state,title`
-3. If the blocked-by issue is CLOSED: report as "resolved dependency (#N is CLOSED)"
-4. If the blocked-by issue is OPEN: check whether the GitHub blocked-by relationship is already set:
+1. Fetch the authoritative blocker list from GraphQL:
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query get-blocked-by -F num=$NUMBER --jq '.data.repository.issue.blockedBy.nodes[].number'
+   ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh $NUMBER
    ```
-   If N is not in the returned list, the relationship is missing. Apply tier-aware action:
+   Each output line is `<blocker-number><TAB><state>` (exit 0: no blockers or all `CLOSED`; exit 2: one or more `OPEN`).
+2. For each returned line: if `state` is `CLOSED`, report as "resolved dependency (#N is CLOSED)" (report only — no auto-correction, current behavior retained). If `state` is `OPEN`, report as "open dependency (#N is OPEN)".
+3. Extract `Blocked by #N` patterns from the issue body. For each `N` **not** present in the GraphQL blocker list from step 1, the relationship is missing. Apply tier-aware action:
    - **L1** (default): print `Recommend: set blocked-by relationship: scripts/set-blocked-by.sh $NUMBER $N`
    - **L2 / L3**: call `${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh $NUMBER $N` to set the relationship
 
@@ -575,31 +574,35 @@ Since the practical range of raw scores varies by fallback level, adjust thresho
 
 Execute only when the `dependency` perspective is specified. Check dependency health for the issue set collected in Step 1.
 
-**Build dependency graph:**
+**Build dependency graph (GraphQL-sourced):**
 
-1. Extract `Blocked by #N` patterns (case-insensitive, e.g., `blocked by #123`, `Blocked by #456`) from each issue body using regex
-2. Build a graph with issue numbers as nodes and blocked-by as directed edges (N → M: issue N is blocked by issue M)
-3. Keep extracted dependencies in memory as a dictionary: `{ issue_num: [blocked_by_num, ...], ... }`
+1. Fetch the full open-issue blocked-by graph in one call:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh --all --limit $LIMIT
+   ```
+   Each output line is `<issue><TAB><blocker><TAB><blocker_state>`.
+2. Build a graph with issue numbers as nodes and blocked-by as directed edges (N → M: issue N is blocked by issue M), keyed off this TSV output rather than issue-body text.
+3. Keep the relations in memory as a dictionary: `{ issue_num: [(blocked_by_num, blocked_by_state), ...], ... }`
 
 **Anomaly detection logic (3 types):**
 
 | Anomaly type | Definition | Detection method |
 |-------------|-----------|-----------------|
-| Circular dependency | Cycle in graph (A→B→C→A etc.) | Cycle detection via DFS |
-| Resolved blocked-by | Blocked-by target is CLOSED but dependency text remains | Check status with `gh issue view N --json state` |
-| Orphan dependency | Blocked-by target issue number doesn't exist in repo | `gh issue view N` returns an error |
+| Circular dependency | Cycle in graph (A→B→C→A etc.) | Cycle detection via DFS on the GraphQL-sourced graph (detection logic unchanged — only the input source changed) |
+| Resolved blocked-by | `blocker_state` is `CLOSED` in the GraphQL graph (a stale GraphQL relationship) | Directly readable from the `--all` TSV output — no additional `gh issue view` call needed |
+| Orphan dependency (body-text hygiene check) | Body text has `Blocked by #N` but `gh issue view N` errors (issue doesn't exist) | Since `addBlockedBy` requires an existing issue's node ID, a GraphQL relationship can never be orphaned — this check is redefined as body-text hygiene rather than a GraphQL graph anomaly |
 
 **Verification order:**
 
-1. **Graph construction**: Extract blocked-by relations from all issue bodies and build the graph
-2. **Circular dependency detection**: Run DFS on entire graph to detect cycles (Claude tracks logically)
-3. **Resolved blocked-by detection**: Use already-collected data for blocked-by targets in Step 1; check status with `gh issue view N --json state` for issues not in Step 1 data (closed)
-4. **Orphan dependency detection**: Run `gh issue view N --json state` for blocked-by targets not collected in Step 1; those that return errors (don't exist) are orphan dependencies
+1. **Graph construction**: Fetch the GraphQL graph via `get-blocked-by.sh --all --limit $LIMIT` and build the in-memory dependency dictionary
+2. **Circular dependency detection**: Run DFS on the GraphQL-sourced graph to detect cycles (Claude tracks logically)
+3. **Resolved blocked-by detection**: Filter the `--all` TSV output for lines where `blocker_state` is `CLOSED` — no additional API call needed
+4. **Orphan dependency detection (body-text hygiene)**: Extract `Blocked by #N` patterns from each issue body in the Step 1 set; for each `N`, run `gh issue view N --json state` — those that return an error (issue doesn't exist) are orphan dependencies
 
 **Notes (exhaustive):**
 - Display "no dependency anomalies" if none detected
-- For missing blocked-by relationships (body text present but GitHub native relationship not set): apply tier-aware action — read `.wholework.yml` to determine the autonomy tier (`autonomy:` key, default `L1`). **L1**: advisory print only (`Recommend: set blocked-by relationship: scripts/set-blocked-by.sh $ISSUE $BLOCKER`). **L2 / L3**: call `${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh $ISSUE $BLOCKER` to backfill the relationship.
-- For all other anomaly types (circular, resolved, orphan): output report and manual action guidance only (no auto-correction).
+- For missing blocked-by relationships (body text `Blocked by #N` present but `N` not in the GraphQL graph from step 1): apply tier-aware action — read `.wholework.yml` to determine the autonomy tier (`autonomy:` key, default `L1`). **L1**: advisory print only (`Recommend: set blocked-by relationship: scripts/set-blocked-by.sh $ISSUE $BLOCKER`). **L2 / L3**: call `${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh $ISSUE $BLOCKER` to backfill the relationship.
+- For all other anomaly types (circular, resolved, orphan): output report and manual action guidance only (no auto-correction). Resolved blocked-by's recommended manual action is `${CLAUDE_PLUGIN_ROOT}/scripts/gh-graphql.sh --query remove-blocked-by` (not editing body text, since GraphQL is now the SSoT).
 
 After analysis, output the report in the Step 3 dependency format.
 
@@ -749,11 +752,11 @@ Total: 5 stagnation candidates
 - #123 → #456 → #789 → #123
   Action: Delete one of the blocked-by descriptions or merge the issues
 
-### Resolved Blocked-by (suggest removing dependency text)
+### Resolved Blocked-by (suggest removing stale GraphQL relationship)
 - #101 "issue-A" is blocked by #200 (CLOSED)
-  Action: Remove `Blocked by #200` from #101 body
+  Action: Remove the relationship with `scripts/gh-graphql.sh --query remove-blocked-by`
 
-### Orphan Dependency (suggest removing dependency text)
+### Orphan Dependency (body-text hygiene — suggest removing dependency text)
 - #102 "issue-B" is blocked by #999 (issue does not exist)
   Action: Remove `Blocked by #999` from #102 body
 
@@ -820,7 +823,7 @@ After each perspective's analysis is complete, always run the application flow. 
    - "Post N dependency analysis comments? (circular: X, resolved blocked-by: Y, orphan: Z)"
 2. After approval, post analysis comments to each anomalous issue (no auto-correction):
    - Comment format (circular): `Dependency analysis: circular dependency detected. Cycle: #123 → #456 → #789 → #123. Delete one of the blocked-by descriptions or merge the issues (no auto-correction)`
-   - Comment format (resolved blocked-by): `Dependency analysis: blocked-by target #200 is already CLOSED. Recommend removing Blocked by #200 from body (no auto-correction)`
+   - Comment format (resolved blocked-by): `Dependency analysis: blocked-by target #200 is already CLOSED. Recommend removing the stale GraphQL relationship with scripts/gh-graphql.sh --query remove-blocked-by (no auto-correction)`
    - Comment format (orphan): `Dependency analysis: blocked-by target #999 does not exist. Recommend removing Blocked by #999 from body (no auto-correction)`
    - Run `mkdir -p .tmp` first
    - Write comment body to `.tmp/triage-dependency-comment-$N.md` using the Write tool

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -236,9 +236,9 @@ The GraphQL blocked-by relationship is the authoritative source for dependency s
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh $NUMBER
    ```
-   Each output line is `<blocker-number><TAB><state>` (exit 0: no blockers or all `CLOSED`; exit 2: one or more `OPEN`).
+   Each output line is `<blocker-number><TAB><state>` (exit 0: no blockers or all `CLOSED`; exit 1: error — warn and skip the dependency check; exit 2: one or more `OPEN`).
 2. For each returned line: if `state` is `CLOSED`, report as "resolved dependency (#N is CLOSED)" (report only — no auto-correction, current behavior retained). If `state` is `OPEN`, report as "open dependency (#N is OPEN)".
-3. Extract `Blocked by #N` patterns from the issue body. For each `N` **not** present in the GraphQL blocker list from step 1, the relationship is missing. Apply tier-aware action:
+3. Extract `Blocked by #N` patterns from the issue body. For each `N` **not** present in the GraphQL blocker list from step 1, check `N`'s state (`gh issue view $N --json state`). If `N` is `CLOSED`, report as "resolved dependency (#N is CLOSED)" (no action — do not backfill a relationship pointing at a closed Issue). If `N` is `OPEN`, the relationship is missing; apply tier-aware action:
    - **L1** (default): print `Recommend: set blocked-by relationship: scripts/set-blocked-by.sh $NUMBER $N`
    - **L2 / L3**: call `${CLAUDE_PLUGIN_ROOT}/scripts/set-blocked-by.sh $NUMBER $N` to set the relationship
 
@@ -576,9 +576,9 @@ Execute only when the `dependency` perspective is specified. Check dependency he
 
 **Build dependency graph (GraphQL-sourced):**
 
-1. Fetch the full open-issue blocked-by graph in one call:
+1. Fetch the full open-issue blocked-by graph in one call. Use a **fixed** `--limit 100` here regardless of the user-facing `--limit $LIMIT` value — `triage-backlog-filter.sh` (Step 1) always scans the newest 100 open Issues internally before applying `--limit $LIMIT` as a post-filter `head` cut, so a fixed 100 keeps this graph covering at least the Step 1 issue set; passing `$LIMIT` straight through would under-cover Step 1's set whenever `$LIMIT` < 100 and the newest Issues happen to already be triaged:
    ```bash
-   ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh --all --limit $LIMIT
+   ${CLAUDE_PLUGIN_ROOT}/scripts/get-blocked-by.sh --all --limit 100
    ```
    Each output line is `<issue><TAB><blocker><TAB><blocker_state>`.
 2. Build a graph with issue numbers as nodes and blocked-by as directed edges (N → M: issue N is blocked by issue M), keyed off this TSV output rather than issue-body text.
@@ -594,10 +594,11 @@ Execute only when the `dependency` perspective is specified. Check dependency he
 
 **Verification order:**
 
-1. **Graph construction**: Fetch the GraphQL graph via `get-blocked-by.sh --all --limit $LIMIT` and build the in-memory dependency dictionary
+1. **Graph construction**: Fetch the GraphQL graph via `get-blocked-by.sh --all --limit 100` and build the in-memory dependency dictionary
 2. **Circular dependency detection**: Run DFS on the GraphQL-sourced graph to detect cycles (Claude tracks logically)
 3. **Resolved blocked-by detection**: Filter the `--all` TSV output for lines where `blocker_state` is `CLOSED` — no additional API call needed
 4. **Orphan dependency detection (body-text hygiene)**: Extract `Blocked by #N` patterns from each issue body in the Step 1 set; for each `N`, run `gh issue view N --json state` — those that return an error (issue doesn't exist) are orphan dependencies
+5. **Missing relationship detection**: reuse the body-text `Blocked by #N` extraction from step 4; for each `N` not present as an edge in the GraphQL graph from step 1, apply the tier-aware action from Notes below
 
 **Notes (exhaustive):**
 - Display "no dependency anomalies" if none detected

--- a/tests/auto-batch.bats
+++ b/tests/auto-batch.bats
@@ -36,6 +36,16 @@ count_mode_section() {
     [ "$status" -eq 0 ]
 }
 
+@test "List mode section: get-blocked-by.sh referenced (GraphQL read window)" {
+    run bash -c "awk '/^### List mode/{found=1} /^### / && !/List mode/{found=0} found{print}' '$SKILL_FILE' | grep -q 'get-blocked-by.sh'"
+    [ "$status" -eq 0 ]
+}
+
+@test "List mode section: body grep read path removed" {
+    run bash -c "awk '/^### List mode/{found=1} /^### / && !/List mode/{found=0} found{print}' '$SKILL_FILE' | grep -q 'json body'"
+    [ "$status" -ne 0 ]
+}
+
 @test "List mode section: phase/done gate condition present" {
     run bash -c "awk '/^### List mode/{found=1} /^### / && !/List mode/{found=0} found{print}' '$SKILL_FILE' | grep -q 'phase/done'"
     [ "$status" -eq 0 ]

--- a/tests/get-blocked-by.bats
+++ b/tests/get-blocked-by.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+
+# Tests for get-blocked-by.sh
+# Mock gh-graphql.sh via MOCK_DIR pattern (WHOLEWORK_SCRIPT_DIR), same pattern as set-blocked-by.bats
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$PROJECT_ROOT/scripts/get-blocked-by.sh"
+
+setup() {
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
+    export WHOLEWORK_CONFIG_PATH=/dev/null
+
+    cat > "$MOCK_DIR/gh-graphql.sh" << 'MOCK_EOF'
+#!/bin/bash
+ARGS="$*"
+
+get_num() {
+    local prev=""
+    for a in "$@"; do
+        if [[ "$prev" == "-F" && "$a" == num=* ]]; then
+            echo "${a#num=}"
+            return
+        fi
+        prev="$a"
+    done
+}
+
+if [[ "$ARGS" == "--query get-blocked-by "* ]]; then
+    NUM=$(get_num "$@")
+    case "$NUM" in
+        100) : ;; # no blockers -> empty output
+        200) printf '10\tCLOSED\n20\tCLOSED\n' ;;
+        300) printf '10\tCLOSED\n30\tOPEN\n' ;;
+        *) : ;;
+    esac
+    exit 0
+fi
+
+if [[ "$ARGS" == "--query get-open-issues-blocked-by "* ]]; then
+    if [[ "$ARGS" == *"-F cursor="* ]]; then
+        cat <<'JSON'
+{"data":{"repository":{"issues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"number":50,"blockedBy":{"nodes":[{"number":51,"state":"OPEN"}]}}]}}}}
+JSON
+    else
+        cat <<'JSON'
+{"data":{"repository":{"issues":{"pageInfo":{"hasNextPage":true,"endCursor":"CURSOR1"},"nodes":[{"number":40,"blockedBy":{"nodes":[{"number":41,"state":"CLOSED"}]}},{"number":42,"blockedBy":{"nodes":[]}}]}}}}
+JSON
+    fi
+    exit 0
+fi
+
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh-graphql.sh"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "--help shows usage" {
+    run bash "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "error: no arguments" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"* ]]
+}
+
+@test "error: non-numeric issue number" {
+    run bash "$SCRIPT" abc
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"* ]]
+    [[ "$output" == *"issue-number must be a positive integer"* ]]
+}
+
+@test "error: unknown option" {
+    run bash "$SCRIPT" --bogus
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "error: --limit non-numeric" {
+    run bash "$SCRIPT" --all --limit abc
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--limit must be a positive integer"* ]]
+}
+
+@test "single issue: no blockers -> exit 0, empty output" {
+    run bash "$SCRIPT" 100
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "single issue: all blockers CLOSED -> exit 0, tab-separated output" {
+    run bash "$SCRIPT" 200
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'10\tCLOSED'* ]]
+    [[ "$output" == *$'20\tCLOSED'* ]]
+}
+
+@test "single issue: OPEN blocker present -> exit 2, all blockers listed" {
+    run bash "$SCRIPT" 300
+    [ "$status" -eq 2 ]
+    [[ "$output" == *$'10\tCLOSED'* ]]
+    [[ "$output" == *$'30\tOPEN'* ]]
+}
+
+@test "--all: TSV 3-column output" {
+    run bash "$SCRIPT" --all
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'40\t41\tCLOSED'* ]]
+}
+
+@test "--all: hasNextPage true reads second page" {
+    run bash "$SCRIPT" --all
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'50\t51\tOPEN'* ]]
+}
+
+@test "--all: OPEN blocker present still exits 0" {
+    run bash "$SCRIPT" --all
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OPEN"* ]]
+}

--- a/tests/gh-graphql.bats
+++ b/tests/gh-graphql.bats
@@ -107,6 +107,16 @@ teardown() {
     [[ "$api_call" == *"blockedBy"* ]]
 }
 
+@test "success: --query get-open-issues-blocked-by resolves named query" {
+    run bash "$SCRIPT" --query get-open-issues-blocked-by -F first=100
+    [ "$status" -eq 0 ]
+    grep -q "api graphql" "$GH_CALL_LOG"
+    local api_call
+    api_call=$(grep "api graphql" "$GH_CALL_LOG")
+    [[ "$api_call" == *"blockedBy"* ]]
+    [[ "$api_call" == *"pageInfo"* ]]
+}
+
 @test "success: --query remove-blocked-by resolves named query" {
     run bash "$SCRIPT" --query remove-blocked-by -F issueId=I_abc -F blockingId=I_xyz
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

blocked-by 関係の判定 (gate・依存チェック・依存グラフ構築) の SSoT を、Issue body の `Blocked by #N` テキスト grep から GitHub native の GraphQL `blockedBy` 関係へ移す。body テキストは廃止せず、書き込みトリガー (入力ショートカット) として存続させる。

- `scripts/gh-graphql.sh`: named query `get-open-issues-blocked-by` を追加 (open Issue 一覧 + `blockedBy` + `pageInfo` の 1 クエリ取得)
- `scripts/get-blocked-by.sh`: 新規作成。GraphQL から blocked-by 関係を読み取る単一窓口 (単一 Issue モード / `--all` 一括モード)
- `skills/auto/SKILL.md`: List mode step 4 の blocked-by gate を「`gh-check-blocking.sh` で body ショートカットを materialize → `get-blocked-by.sh` で GraphQL から判定」に変更
- `skills/triage/SKILL.md`: Step 9 の Dependency blocked-by check と Step 2b の依存グラフ構築を GraphQL 基点に変更。孤児依存検出を「body テキストの衛生チェック」として再定義
- `skills/spec/SKILL.md`: Step 4 の `gh-check-blocking.sh --dry-run` を `get-blocked-by.sh` に変更 (exit code 契約は 0/1/2 のまま)
- `modules/l0-surfaces.md`, `docs/workflow.md` (+ `docs/ja/workflow.md`), `docs/structure.md` (+ `docs/ja/structure.md`): ドキュメント更新
- `.claude/settings.json.template`: `permissions.allow` に `get-blocked-by.sh` を追加
- `tests/get-blocked-by.bats`: 新規。`tests/auto-batch.bats` / `tests/gh-graphql.bats`: 関連テストを追加

## Verification (pre-merge)

- 3 件の rubric AC (auto/triage の gate が GraphQL 参照、SSoT のドキュメント明記) を adversarial grader agent で検証し、全て PASS
- `bats tests/get-blocked-by.bats` (11 tests) PASS
- `bats tests/auto-batch.bats` (12 tests) PASS
- `bats tests/gh-graphql.bats` (26 tests) PASS
- フルスイート `bats tests/` (1476 tests) PASS (skills/auto/SKILL.md・skills/spec/SKILL.md・scripts/gh-graphql.sh が複数テストファイルから参照されているため behavioral change として full suite を実行)
- `docs/ja/workflow.md` に「入力ショートカット」の記載を確認 (file_contains AC)
- `scripts/get-blocked-by.sh` を実 GraphQL API に対して動作確認済み (#1200 自身の blocked-by が空であること、`--all` で既知の #1167→#1157 (CLOSED) 関係が取得できることを確認)

## Verification (post-merge)

- GraphQL で blocked-by を設定し body にはテキストを書かない Issue を `/auto --batch` に含め、blocker が未完了の間 skip されることを観察する

closes #1200
