### PR TITLE
Issue #1119: Add reclaim-stale-worktrees.sh for stale worktree/branch cleanup

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（75 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（76 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -210,6 +210,7 @@ wholework/
 - `scripts/pre-merge-check.sh` — ベースライン diff 分類器: 指定チェックをベースブランチと head ブランチで ephemeral worktree で実行し、結果を NEW_FAILURE (exit 2) / PRE_EXISTING / FIXED / CLEAN (exit 0) / env error (exit 1) に分類
 - `scripts/worktree-merge-push.sh` — 短命な patch lock を取得し、fetch-after-lock・checkout レスの ref-fetch マージ (`git fetch . <from>:<base>`)・is-ancestor による rebase skip・push retry loop (max 3) で並列 session race に対応した merge + push を実行
 - `scripts/detect-foreign-worktree.sh` — CWD が foreign (呼び出し元と異なる owner の) git worktree 内かどうかを判定する。`modules/worktree-lifecycle.md` の Entry section、`skills/verify/SKILL.md` Step 2 (base branch checkout guard)、`skills/review/SKILL.md` の Opportunistic Verification (worktree exit precondition) から使用される
+- `scripts/reclaim-stale-worktrees.sh` — 完了済み (CLOSED/MERGED) の Issue/PR に対応する stale worktree と孤児ブランチを棚卸し・回収する。既定は dry-run、`--apply` で削除を実行。並行セッション除外 (locked かつ HEAD が main と一致)、未コミット変更の保護、squash merge されたブランチの安全な削除 (`git branch -d` が拒否された場合、MERGED PR の `headRefOid` とブランチ tip が一致するときのみ `-D` にフォールバック) を備える
 - `scripts/detect-wrapper-anomaly.sh` — shell wrapper 出力の既知失敗パターンを検出し、Auto Retrospective の markdown 断片を生成
 - `scripts/detect-external-kill.sh` — `external-kill-parent-respawn` シグネチャ（exit code 137 単独、または exit code 143/unknown かつ wrapper ログの `Exit code: ` トレーラーと `auto-events.jsonl` の `wrapper_exit` イベントの両方が issue/phase について欠如）を機械的に判定する。exit 0 = match、exit 1 = no-match（`modules/orchestration-fallbacks.md#external-kill-parent-respawn` 参照）
 - `scripts/test-failure-classify.sh` — テスト失敗出力を回復カテゴリに分類（snapshot/mock/fixture/logic/infra）。exit 0 = 修復可、exit 1 = 修復不可

--- a/docs/spec/issue-1119-reclaim-stale-worktrees.md
+++ b/docs/spec/issue-1119-reclaim-stale-worktrees.md
@@ -109,19 +109,32 @@ No new comments since last phase.
 - Real-data smoke test (dry-run against this repository's own ~43 stale worktree entries) surfaced two additional validations beyond the bats suite: (1) the Spec's `merge+pr-1190` example (directory name suggests PR #1190, but the checked-out branch is actually `worktree-code+issue-1186`) was classified correctly by branch-name-priority logic; (2) the current session's own worktree (`code+issue-1119`, locked, Issue still OPEN) was correctly excluded before ever reaching the locked/HEAD-match guard, since the `not-done` completion check short-circuits first — confirming the primary completion-based filter (not just the concurrent-session guard) protects an in-progress session.
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Implemented all of Steps A–I (including the orphan-branch Step H) exactly as specified in the Spec's single-script design; no split into multiple scripts or wrapper-EXIT-trap alternative was introduced.
-- Used a single generic classify_name regex (`^.+\+(issue|pr)-([0-9]+)$`) instead of the Spec's two separate branch/detached-dir regexes — behaviorally identical, simpler implementation, not a functional deviation.
-- Added an extra `warned (gh lookup failed)` summary category beyond Step I's 7 listed categories, since Step D's own text requires this outcome to be tracked and reported, and folding it into `skipped (unrecognized)` would conflate two different failure modes.
+- Independently re-verified all 4 Pre-merge rubric ACs against the implementation and the bats suite rather than treating `/code`'s self-assessment as authoritative (per its own handoff note); all 4 confirmed PASS.
+- Fixed a SHOULD-severity bug found by `review-light` (Step G's `reclaimed (worktree+branch)` counter was not gated on `delete_branch_safe` success, unlike Step H's equivalent orphan-branch path) directly in `/review` Step 12, since it was small, well-isolated, and fully covered by a new regression bats test — not deferred to a follow-up Issue.
+- Left the `docs/structure.md` / `docs/ja/structure.md` `scripts/` file-count off-by-one (caused by a separately-merged parallel PR, #1211) unfixed: the correct post-merge value (77) cannot be verified from this PR's own branch content, so fixing it here would mean guessing rather than confirming.
 
 ### Deferred Items
-- Post-merge opportunistic AC (running the script for real across several sessions to confirm no re-accumulation) is left as documented — not something `/code` can satisfy pre-merge.
-- No `--apply` run was executed against this repository's real worktree/branch data during implementation (only dry-run smoke testing) — the actual cleanup of the ~71 stale entries observed in the dry-run (32 worktrees + 39 orphan branches) is left for a human or a follow-up `--apply` run, since deleting real branches/worktrees is outside this Issue's implementation scope and was not requested.
-- Two pre-existing, unrelated translation-sync gaps were surfaced by `scripts/check-translation-sync.sh` (`docs/guide/autonomy.md` MISSING_JA, `docs/guide/index.md` OUTDATED) — not touched, since neither file was changed by this Issue.
+- Post-merge opportunistic AC (confirm no re-accumulation of stale worktrees/branches after several sessions of real operation) remains open, unchanged from `/code`'s handoff.
+- `docs/structure.md` / `docs/ja/structure.md` `scripts/` count fast-follow (76 → 77) is deferred to a commit made once both this PR and #1211 have actually landed on `main`.
+- No `--apply` run was executed against this repository's real worktree/branch data during review either (only dry-run + bats); the ~71 real stale entries `/code` observed during its smoke test remain unreclaimed.
 
 ### Notes for Next Phase
-- The `set -e` + bare `[ cond ] && assignment`-as-last-statement pitfall (see Rework above) is worth a broader sweep across other bash 3.2-compatible scripts in this repo if a reviewer wants to proactively rule out latent instances elsewhere — out of scope for this Issue's review, noted here only as a possible follow-up angle.
-- All 4 pre-merge rubric ACs were self-assessed PASS directly against the implementation in Step 10; `/review` should independently confirm the rubric judgments rather than treating this as authoritative.
-- The dry-run smoke test output (32 worktree+branch pairs, 39 orphan branches, 6 uncommitted-changes warnings, 9 unrecognized/skipped) is a useful reference for `/review` to spot-check specific classification edge cases against real repository state without needing to re-run anything destructively.
+- `/merge` should proceed normally — no MUST issues block merge.
+- The `scripts/` count drift pattern (see review retrospective's "Recurring issues") may recur for any future PR pair that adds scripts in parallel; worth watching for in future reviews, not yet filed as its own Issue.
+- The `kind=issue` branch-deletion regression test added in this phase (`tests/reclaim-stale-worktrees.bats`) is a useful reference if a future change touches `delete_branch_safe` or the Step G/H reclaim-count gating again.
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+Nothing to note. The implementation followed the Spec's Steps A–I exactly; the two self-documented Code Retrospective deviations (single generic `classify_name` regex, extra `warned (gh lookup failed)` category) were independently confirmed behaviorally sound during review — the permissive regex still requires the `worktree-` prefix for real branches (per `modules/worktree-lifecycle.md`'s naming convention), so it is not a functional narrowing.
+
+### Recurring issues
+One implementation-level inconsistency was found and fixed: Step G (worktree-entry reclaim path) counted a worktree+branch pair as `reclaimed (worktree+branch)` regardless of whether the subsequent `delete_branch_safe` call actually succeeded, while Step H (orphan-branch path) correctly gated its own reclaim count on `delete_branch_safe`'s return value (`if delete_branch_safe ...; then count_reclaimed_orphan=...`). Two code paths calling the same helper function, only one of which checks its result, is a pattern worth watching for in future scripts with multiple reclaim/cleanup entry points — silently produces a misleading summary rather than a hard failure, so it would not have been caught by the bats suite's existing assertions (all of which used PR-kind branches with a working `-D` fallback) without a dedicated regression case for the `kind=issue` (no-fallback) scenario.
+
+Separately, the Base Branch Conflict Pre-check surfaced that `docs/structure.md` / `docs/ja/structure.md`'s manually-maintained `scripts/` file-count comment will read `76` immediately post-merge even though the true count will be `77`, because a separately-merged parallel PR (#1211) already added `scripts/get-blocked-by.sh` to `origin/main` without bumping the same counter (which is *already* stale there today — `origin/main` has 76 actual scripts but the doc still says 75). This is a structural risk: any two PRs developed in parallel that each add a new script will independently compute the counter from a stale baseline and one bump will get lost at merge time. Recorded here as a single observation, not filed as an Issue — left for `/verify` aggregation to judge whether this recurs often enough to warrant a structural fix (e.g. a CI check that recomputes the count from `find scripts -maxdepth 1 -type f | wc -l` instead of a manually-maintained comment).
+
+### Acceptance criteria verification difficulty
+Nothing to note. All 4 Pre-merge rubric ACs were written at a granularity directly verifiable against the implementation logic and the bats suite; no UNCERTAIN results or verify command inaccuracies were encountered. The `/code` Phase Handoff's self-assessment (all 4 PASS) held up under this independent `/review` re-verification.

--- a/docs/spec/issue-1119-reclaim-stale-worktrees.md
+++ b/docs/spec/issue-1119-reclaim-stale-worktrees.md
@@ -95,3 +95,33 @@
 
 ## Consumed Comments
 No new comments since last phase.
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — implemented Steps A–I and the orphan-branch step (H) exactly as specified. `classify_name()` uses a single generic regex (`^.+\+(issue|pr)-([0-9]+)$`) for both the branch-name and detached-directory-basename forms instead of the Spec's two separate regexes (`^worktree-.+\+(issue|pr)-([0-9]+)$` for branches, unprefixed for detached dirs) — the single pattern matches both forms since a `worktree-`-prefixed branch name still satisfies the more permissive pattern, so behavior is identical; not recorded as a deviation requiring an Implementation Steps update.
+
+### Design Gaps/Ambiguities
+- Step D's "gh コマンドが失敗した場合... 状態不明として扱い... `warned (gh lookup failed)` として削除対象から除外する" wording implies a specific summary category, but Step I's exhaustive category list omits it. Added `warned (gh lookup failed)` as an additional summary category (alongside the 7 Step I lists it) rather than folding it into `skipped (unrecognized)`, since the two failure modes (unparseable name vs. unreachable gh state) have different remediation paths and conflating them would obscure which one occurred.
+
+### Rework
+- Initial implementation of `check_completion()`'s issue-kind branch used the shorthand `[ "$state" = "CLOSED" ] && COMPLETION_STATE="done"` as the last statement inside its `if [ "$kind" = "issue" ]; then ... fi` block. Under `set -euo pipefail`, when the branch name's condition is false, this pattern's exit status (1, from the failed `[ ]` test) becomes the function's own return status — and since the top-level `if [ "$kind" = "issue" ]` construct itself resolves to 0 regardless (bash's documented "if with no branch taken → exit 0" rule), the *function's* last-executed-command is actually the failed `[ ]` test, not the `if`. The caller (`check_completion "$kind" "$num"`, called as a bare top-level statement, not guarded by `if`/`||`) then propagates that non-zero status and `set -e` aborts the whole script silently (no error message, no trap) — reproduced live against this repository's real worktree/branch data (script exited at exactly the point where the first `OPEN` Issue was evaluated, right after `[ "$state" = "CLOSED" ]` returned false). Root cause isolated via a series of minimal `bash -c` repros (see below) rather than guesswork. Fixed by rewriting as an explicit `if [ "$state" = "CLOSED" ]; then COMPLETION_STATE="done"; fi` (an if-statement with no else and a false condition returns exit status 0, unlike the `&&` short-circuit form). Generalizable pitfall for future bash 3.2-compatible scripts under `set -e`: **a bare `[ cond ] && assignment` as the last statement of a function is unsafe** — if `cond` is false, the function's return status becomes 1 and kills the caller's script unless the call site explicitly guards it (`if`, `||`, etc.). Prefer an explicit `if`/`fi` (or append a trailing no-op like `|| true` immediately after, though the explicit `if` is clearer) whenever such a construct could be the last thing a function executes. Audited the rest of the script for the same shape (all other `&&` usages are inside `if`-conditions or `||`-guarded, which are safe) before considering the fix complete.
+- Real-data smoke test (dry-run against this repository's own ~43 stale worktree entries) surfaced two additional validations beyond the bats suite: (1) the Spec's `merge+pr-1190` example (directory name suggests PR #1190, but the checked-out branch is actually `worktree-code+issue-1186`) was classified correctly by branch-name-priority logic; (2) the current session's own worktree (`code+issue-1119`, locked, Issue still OPEN) was correctly excluded before ever reaching the locked/HEAD-match guard, since the `not-done` completion check short-circuits first — confirming the primary completion-based filter (not just the concurrent-session guard) protects an in-progress session.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Implemented all of Steps A–I (including the orphan-branch Step H) exactly as specified in the Spec's single-script design; no split into multiple scripts or wrapper-EXIT-trap alternative was introduced.
+- Used a single generic classify_name regex (`^.+\+(issue|pr)-([0-9]+)$`) instead of the Spec's two separate branch/detached-dir regexes — behaviorally identical, simpler implementation, not a functional deviation.
+- Added an extra `warned (gh lookup failed)` summary category beyond Step I's 7 listed categories, since Step D's own text requires this outcome to be tracked and reported, and folding it into `skipped (unrecognized)` would conflate two different failure modes.
+
+### Deferred Items
+- Post-merge opportunistic AC (running the script for real across several sessions to confirm no re-accumulation) is left as documented — not something `/code` can satisfy pre-merge.
+- No `--apply` run was executed against this repository's real worktree/branch data during implementation (only dry-run smoke testing) — the actual cleanup of the ~71 stale entries observed in the dry-run (32 worktrees + 39 orphan branches) is left for a human or a follow-up `--apply` run, since deleting real branches/worktrees is outside this Issue's implementation scope and was not requested.
+- Two pre-existing, unrelated translation-sync gaps were surfaced by `scripts/check-translation-sync.sh` (`docs/guide/autonomy.md` MISSING_JA, `docs/guide/index.md` OUTDATED) — not touched, since neither file was changed by this Issue.
+
+### Notes for Next Phase
+- The `set -e` + bare `[ cond ] && assignment`-as-last-statement pitfall (see Rework above) is worth a broader sweep across other bash 3.2-compatible scripts in this repo if a reviewer wants to proactively rule out latent instances elsewhere — out of scope for this Issue's review, noted here only as a possible follow-up angle.
+- All 4 pre-merge rubric ACs were self-assessed PASS directly against the implementation in Step 10; `/review` should independently confirm the rubric judgments rather than treating this as authoritative.
+- The dry-run smoke test output (32 worktree+branch pairs, 39 orphan branches, 6 uncommitted-changes warnings, 9 unrecognized/skipped) is a useful reference for `/review` to spot-check specific classification edge cases against real repository state without needing to re-run anything destructively.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (75 files)
+├── scripts/             # Utility scripts used by skills and agents (76 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -218,6 +218,7 @@ Key modules:
 - `scripts/pre-merge-check.sh` — baseline diff classifier: runs a specified check on both base and head branches in ephemeral worktrees; classifies result as NEW_FAILURE (exit 2) / PRE_EXISTING / FIXED / CLEAN (exit 0) / env error (exit 1)
 - `scripts/worktree-merge-push.sh` — acquire short-lived patch lock; fetch-after-lock, checkout-less ref-fetch merge (`git fetch . <from>:<base>`) with is-ancestor rebase-skip, and push-retry loop (max 3) for parallel session race hardening
 - `scripts/detect-foreign-worktree.sh` — detect whether CWD is inside a foreign (different-owner) git worktree; used by `modules/worktree-lifecycle.md` Entry section, `skills/verify/SKILL.md` Step 2 (base branch checkout guard), and `skills/review/SKILL.md` Opportunistic Verification (worktree exit precondition)
+- `scripts/reclaim-stale-worktrees.sh` — inventory and reclaim stale worktrees and orphan branches for Issues/PRs that have already completed (CLOSED/MERGED); dry-run by default, `--apply` to perform deletion; concurrent-session guard (locked + HEAD matches main), uncommitted-changes guard, and safe squash-merge branch deletion (`git branch -d` fallback to `-D` only when the branch tip matches the MERGED PR's `headRefOid`)
 - `scripts/detect-wrapper-anomaly.sh` — detect known failure patterns in shell wrapper output and generate Auto Retrospective markdown fragments
 - `scripts/detect-external-kill.sh` — mechanically detect the `external-kill-parent-respawn` signature (exit code 137 alone, or exit code 143/unknown with both the wrapper log `Exit code: ` trailer and the `auto-events.jsonl` `wrapper_exit` event absent for the issue/phase); exit 0 = match, exit 1 = no-match (see `modules/orchestration-fallbacks.md#external-kill-parent-respawn`)
 - `scripts/test-failure-classify.sh` — classify test failure output into recovery categories (snapshot/mock/fixture/logic/infra); exit 0 = repairable, exit 1 = not repairable

--- a/modules/worktree-lifecycle.md
+++ b/modules/worktree-lifecycle.md
@@ -96,6 +96,17 @@ The calling skill exits the worktree with the following steps after completing p
 
 ## Notes
 
+### Broader stale worktree/branch reclaim (beyond the Entry section's same-name check)
+
+The Entry section's step 2 stale worktree check only looks for a worktree matching the *calling
+phase's own* `WORKTREE_NAME` — it cannot see stale worktrees or orphan branches left behind by a
+different phase/Issue whose session crashed or exited without reaching Worktree Exit. For a
+general inventory and reclaim of worktrees/branches whose corresponding Issue is CLOSED or PR is
+MERGED/CLOSED, use `scripts/reclaim-stale-worktrees.sh` (dry-run by default; `--apply` to perform
+deletion). It applies the same safety guards as this module's own lifecycle (concurrent-session
+exclusion, uncommitted-changes protection) plus safe squash-merge branch deletion. See
+`docs/spec/issue-1119-reclaim-stale-worktrees.md` for the full design.
+
 ### Editing `.claude/` files inside worktrees
 
 Files under `.claude/` are treated as **sensitive files** by Claude Code — Edit and Write tools are automatically rejected for these paths. When implementation requires editing `.claude/` files (e.g., `settings.json.template`, hook scripts), use Bash commands instead:

--- a/scripts/reclaim-stale-worktrees.sh
+++ b/scripts/reclaim-stale-worktrees.sh
@@ -40,6 +40,7 @@ MAIN_HEAD="$(git -C "$MAIN_ROOT" rev-parse HEAD)"
 
 count_pruned=0
 count_reclaimed_wt=0
+count_reclaimed_wt_only=0
 count_reclaimed_orphan=0
 count_excluded=0
 count_warned_uncommitted=0
@@ -49,6 +50,7 @@ count_skipped=0
 
 PRUNED_LIST=""
 RECLAIMED_WT_LIST=""
+RECLAIMED_WT_ONLY_LIST=""
 RECLAIMED_ORPHAN_LIST=""
 EXCLUDED_LIST=""
 WARNED_UNCOMMITTED_LIST=""
@@ -202,11 +204,14 @@ handle_worktree_entry() {
   fi
 
   if git worktree remove --force "$path" 2>/dev/null; then
-    count_reclaimed_wt=$((count_reclaimed_wt + 1))
-    RECLAIMED_WT_LIST="${RECLAIMED_WT_LIST}${path} (${branch:-detached}, ${kind} #${num})
+    if [ -n "$branch" ] && ! delete_branch_safe "$branch" "$kind" "$COMPLETION_HEAD_REF_OID"; then
+      count_reclaimed_wt_only=$((count_reclaimed_wt_only + 1))
+      RECLAIMED_WT_ONLY_LIST="${RECLAIMED_WT_ONLY_LIST}${path} (${branch}, ${kind} #${num}, branch retained)
 "
-    if [ -n "$branch" ]; then
-      delete_branch_safe "$branch" "$kind" "$COMPLETION_HEAD_REF_OID" || true
+    else
+      count_reclaimed_wt=$((count_reclaimed_wt + 1))
+      RECLAIMED_WT_LIST="${RECLAIMED_WT_LIST}${path} (${branch:-detached}, ${kind} #${num})
+"
     fi
   else
     count_skipped=$((count_skipped + 1))
@@ -349,6 +354,7 @@ print_section() {
 echo "=== reclaim-stale-worktrees summary ==="
 print_section "pruned" "$count_pruned" "$PRUNED_LIST"
 print_section "reclaimed (worktree+branch)" "$count_reclaimed_wt" "$RECLAIMED_WT_LIST"
+print_section "reclaimed (worktree only, branch retained)" "$count_reclaimed_wt_only" "$RECLAIMED_WT_ONLY_LIST"
 print_section "reclaimed (orphan branch only)" "$count_reclaimed_orphan" "$RECLAIMED_ORPHAN_LIST"
 print_section "excluded (concurrent-session-guard)" "$count_excluded" "$EXCLUDED_LIST"
 print_section "warned (uncommitted changes)" "$count_warned_uncommitted" "$WARNED_UNCOMMITTED_LIST"

--- a/scripts/reclaim-stale-worktrees.sh
+++ b/scripts/reclaim-stale-worktrees.sh
@@ -1,0 +1,362 @@
+#!/bin/bash
+# reclaim-stale-worktrees.sh - Inventory and reclaim stale worktrees and orphan
+# branches for Issues/PRs that have already completed (CLOSED/MERGED).
+#
+# Usage: reclaim-stale-worktrees.sh [--apply]
+#   (no args)  Dry-run: report only, no deletions performed (default)
+#   --apply    Actually perform worktree/branch removal
+#
+# Safety guards applied before any deletion (see docs/spec/issue-1119-reclaim-stale-worktrees.md):
+#   - concurrent-session guard: a locked worktree whose HEAD matches the current
+#     main HEAD is excluded (may be in use by a live parallel session)
+#   - uncommitted-changes guard: a worktree with non-empty `git status --porcelain`
+#     is left in place with a warning instead of being deleted
+#   - safe branch deletion: `git branch -d` first; if rejected (squash-merged
+#     branch, "not fully merged"), fall back to `-D` only when the branch tip
+#     matches the MERGED PR's headRefOid
+#
+# bash 3.2 compatible (no associative arrays, no mapfile/readarray) so it runs
+# under macOS system bash.
+
+set -euo pipefail
+
+APPLY=false
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply)
+      APPLY=true
+      shift
+      ;;
+    *)
+      echo "Error: Invalid option: $1" >&2
+      echo "Usage: $0 [--apply]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+MAIN_ROOT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+MAIN_HEAD="$(git -C "$MAIN_ROOT" rev-parse HEAD)"
+
+count_pruned=0
+count_reclaimed_wt=0
+count_reclaimed_orphan=0
+count_excluded=0
+count_warned_uncommitted=0
+count_warned_diverge=0
+count_warned_gh=0
+count_skipped=0
+
+PRUNED_LIST=""
+RECLAIMED_WT_LIST=""
+RECLAIMED_ORPHAN_LIST=""
+EXCLUDED_LIST=""
+WARNED_UNCOMMITTED_LIST=""
+WARNED_DIVERGE_LIST=""
+WARNED_GH_LIST=""
+SKIPPED_LIST=""
+
+SEEN_BRANCHES=""
+
+# classify_name: match "<anything>+(issue|pr)-<N>" (covers both the
+# "worktree-{phase}+{issue|pr}-{N}" branch form and the "{phase}+{issue|pr}-{N}"
+# detached-worktree directory basename form). On match, sets CLASSIFY_KIND
+# (issue|pr) and CLASSIFY_NUM; returns 1 on no match.
+classify_name() {
+  local name="$1"
+  if [[ "$name" =~ ^.+\+(issue|pr)-([0-9]+)$ ]]; then
+    CLASSIFY_KIND="${BASH_REMATCH[1]}"
+    CLASSIFY_NUM="${BASH_REMATCH[2]}"
+    return 0
+  fi
+  return 1
+}
+
+# check_completion: sets COMPLETION_STATE (done|not-done|unknown) and, for a
+# MERGED PR, COMPLETION_HEAD_REF_OID (used later for safe -D branch deletion).
+check_completion() {
+  local kind="$1"
+  local num="$2"
+  COMPLETION_STATE="not-done"
+  COMPLETION_HEAD_REF_OID=""
+  if [ "$kind" = "issue" ]; then
+    local state
+    state="$(gh issue view "$num" --json state -q .state 2>/dev/null)" || {
+      COMPLETION_STATE="unknown"
+      return
+    }
+    if [ "$state" = "CLOSED" ]; then
+      COMPLETION_STATE="done"
+    fi
+  else
+    local json
+    json="$(gh pr view "$num" --json state,headRefOid 2>/dev/null)" || {
+      COMPLETION_STATE="unknown"
+      return
+    }
+    local state
+    state="$(echo "$json" | jq -r '.state')"
+    if [ "$state" = "MERGED" ] || [ "$state" = "CLOSED" ]; then
+      COMPLETION_STATE="done"
+    fi
+    if [ "$state" = "MERGED" ]; then
+      COMPLETION_HEAD_REF_OID="$(echo "$json" | jq -r '.headRefOid')"
+    fi
+  fi
+}
+
+# delete_branch_safe: `git branch -d`; on rejection, fall back to `-D` only when
+# kind=pr and the branch tip matches the MERGED PR's headRefOid. Returns 1 (and
+# records a "warned (branch tip diverges)" entry) when neither path applies.
+delete_branch_safe() {
+  local branch="$1"
+  local kind="$2"
+  local head_ref_oid="$3"
+  if git branch -d "$branch" 2>/dev/null; then
+    return 0
+  fi
+  if [ "$kind" = "pr" ] && [ -n "$head_ref_oid" ]; then
+    local branch_tip
+    branch_tip="$(git rev-parse "refs/heads/$branch" 2>/dev/null || true)"
+    if [ -n "$branch_tip" ] && [ "$branch_tip" = "$head_ref_oid" ] && git branch -D "$branch" 2>/dev/null; then
+      return 0
+    fi
+  fi
+  count_warned_diverge=$((count_warned_diverge + 1))
+  WARNED_DIVERGE_LIST="${WARNED_DIVERGE_LIST}${branch} (branch tip diverges from merged PR head, or no merged PR found — left in place)
+"
+  return 1
+}
+
+# handle_worktree_entry: apply Steps C-G to one non-main, non-prunable worktree
+# record parsed from `git worktree list --porcelain`.
+handle_worktree_entry() {
+  local path="$1"
+  local head="$2"
+  local branch="$3"
+  local detached="$4"
+  local locked="$5"
+
+  local basis
+  if [ "$detached" = "true" ]; then
+    basis="$(basename "$path")"
+  else
+    basis="$branch"
+    SEEN_BRANCHES="${SEEN_BRANCHES}${branch}
+"
+  fi
+
+  if ! classify_name "$basis"; then
+    count_skipped=$((count_skipped + 1))
+    SKIPPED_LIST="${SKIPPED_LIST}${path} (${basis}, unrecognized)
+"
+    return
+  fi
+
+  local kind="$CLASSIFY_KIND"
+  local num="$CLASSIFY_NUM"
+
+  check_completion "$kind" "$num"
+
+  if [ "$COMPLETION_STATE" = "unknown" ]; then
+    count_warned_gh=$((count_warned_gh + 1))
+    WARNED_GH_LIST="${WARNED_GH_LIST}${path} (${kind} #${num}, gh lookup failed)
+"
+    return
+  fi
+
+  if [ "$COMPLETION_STATE" != "done" ]; then
+    return
+  fi
+
+  # Step E: concurrent-session guard
+  if [ "$locked" = "true" ] && [ "$head" = "$MAIN_HEAD" ]; then
+    count_excluded=$((count_excluded + 1))
+    EXCLUDED_LIST="${EXCLUDED_LIST}${path} (${kind} #${num}, locked + HEAD matches main)
+"
+    return
+  fi
+
+  # Step F: uncommitted-changes guard
+  local status_out
+  status_out="$(git -C "$path" status --porcelain 2>/dev/null || true)"
+  if [ -n "$status_out" ]; then
+    local nfiles
+    nfiles="$(printf '%s\n' "$status_out" | wc -l | tr -d ' ')"
+    count_warned_uncommitted=$((count_warned_uncommitted + 1))
+    WARNED_UNCOMMITTED_LIST="${WARNED_UNCOMMITTED_LIST}${path} (uncommitted changes: ${nfiles} files)
+"
+    return
+  fi
+
+  # Step G: reclaim
+  if [ "$APPLY" != "true" ]; then
+    count_reclaimed_wt=$((count_reclaimed_wt + 1))
+    RECLAIMED_WT_LIST="${RECLAIMED_WT_LIST}would reclaim: ${path} (${branch:-detached}, ${kind} #${num}, completed)
+"
+    return
+  fi
+
+  if [ "$locked" = "true" ]; then
+    git worktree unlock "$path" 2>/dev/null || true
+  fi
+
+  if git worktree remove --force "$path" 2>/dev/null; then
+    count_reclaimed_wt=$((count_reclaimed_wt + 1))
+    RECLAIMED_WT_LIST="${RECLAIMED_WT_LIST}${path} (${branch:-detached}, ${kind} #${num})
+"
+    if [ -n "$branch" ]; then
+      delete_branch_safe "$branch" "$kind" "$COMPLETION_HEAD_REF_OID" || true
+    fi
+  else
+    count_skipped=$((count_skipped + 1))
+    SKIPPED_LIST="${SKIPPED_LIST}${path} (worktree remove failed)
+"
+  fi
+}
+
+# --- Step A: mechanically prune registry entries whose directory is already gone ---
+prune_output="$(git worktree prune -v 2>&1 || true)"
+if [ -n "$prune_output" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    count_pruned=$((count_pruned + 1))
+    PRUNED_LIST="${PRUNED_LIST}${line}
+"
+  done <<< "$prune_output"
+fi
+
+# --- Step B/C/D/E/F/G: enumerate and classify remaining worktrees ---
+wt_path=""
+wt_head=""
+wt_branch=""
+wt_detached=false
+wt_locked=false
+wt_prunable=false
+first_record=true
+
+flush_record() {
+  if [ -z "$wt_path" ]; then
+    return
+  fi
+  if [ "$first_record" = true ]; then
+    first_record=false
+    return
+  fi
+  if [ "$wt_prunable" = true ]; then
+    # Already handled (or should have been) by `git worktree prune -v` above.
+    return
+  fi
+  handle_worktree_entry "$wt_path" "$wt_head" "$wt_branch" "$wt_detached" "$wt_locked"
+}
+
+reset_record() {
+  wt_path=""
+  wt_head=""
+  wt_branch=""
+  wt_detached=false
+  wt_locked=false
+  wt_prunable=false
+}
+
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*)
+      flush_record
+      reset_record
+      wt_path="${line#worktree }"
+      ;;
+    "HEAD "*)
+      wt_head="${line#HEAD }"
+      ;;
+    "branch "*)
+      wt_branch="${line#branch refs/heads/}"
+      ;;
+    "detached")
+      wt_detached=true
+      ;;
+    "locked"*)
+      wt_locked=true
+      ;;
+    "prunable"*)
+      wt_prunable=true
+      ;;
+    *)
+      : # blank line separator / unrecognized field; ignore
+      ;;
+  esac
+done < <(git worktree list --porcelain)
+flush_record
+
+# --- Step H: orphan branches (worktree directory already gone) ---
+orphan_branches="$(git branch --list 'worktree-*' --format='%(refname:short)' 2>/dev/null || true)"
+if [ -n "$orphan_branches" ]; then
+  while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
+    if printf '%s\n' "$SEEN_BRANCHES" | grep -qxF "$branch"; then
+      continue
+    fi
+
+    if ! classify_name "$branch"; then
+      count_skipped=$((count_skipped + 1))
+      SKIPPED_LIST="${SKIPPED_LIST}${branch} (orphan branch, unrecognized)
+"
+      continue
+    fi
+
+    kind="$CLASSIFY_KIND"
+    num="$CLASSIFY_NUM"
+
+    check_completion "$kind" "$num"
+
+    if [ "$COMPLETION_STATE" = "unknown" ]; then
+      count_warned_gh=$((count_warned_gh + 1))
+      WARNED_GH_LIST="${WARNED_GH_LIST}${branch} (${kind} #${num}, gh lookup failed)
+"
+      continue
+    fi
+
+    if [ "$COMPLETION_STATE" != "done" ]; then
+      continue
+    fi
+
+    if [ "$APPLY" != "true" ]; then
+      count_reclaimed_orphan=$((count_reclaimed_orphan + 1))
+      RECLAIMED_ORPHAN_LIST="${RECLAIMED_ORPHAN_LIST}would reclaim (orphan branch): ${branch} (${kind} #${num}, completed)
+"
+      continue
+    fi
+
+    if delete_branch_safe "$branch" "$kind" "$COMPLETION_HEAD_REF_OID"; then
+      count_reclaimed_orphan=$((count_reclaimed_orphan + 1))
+      RECLAIMED_ORPHAN_LIST="${RECLAIMED_ORPHAN_LIST}${branch} (${kind} #${num})
+"
+    fi
+  done <<< "$orphan_branches"
+fi
+
+# --- Step I: summary ---
+print_section() {
+  local title="$1"
+  local count="$2"
+  local list="$3"
+  echo "${title}: ${count}"
+  if [ -n "$list" ]; then
+    printf '%s' "$list" | sed 's/^/  - /'
+  fi
+}
+
+echo "=== reclaim-stale-worktrees summary ==="
+print_section "pruned" "$count_pruned" "$PRUNED_LIST"
+print_section "reclaimed (worktree+branch)" "$count_reclaimed_wt" "$RECLAIMED_WT_LIST"
+print_section "reclaimed (orphan branch only)" "$count_reclaimed_orphan" "$RECLAIMED_ORPHAN_LIST"
+print_section "excluded (concurrent-session-guard)" "$count_excluded" "$EXCLUDED_LIST"
+print_section "warned (uncommitted changes)" "$count_warned_uncommitted" "$WARNED_UNCOMMITTED_LIST"
+print_section "warned (branch tip diverges)" "$count_warned_diverge" "$WARNED_DIVERGE_LIST"
+print_section "warned (gh lookup failed)" "$count_warned_gh" "$WARNED_GH_LIST"
+print_section "skipped (unrecognized)" "$count_skipped" "$SKIPPED_LIST"
+
+if [ "$APPLY" != "true" ]; then
+  echo ""
+  echo "[dry-run] No changes made. Re-run with --apply to perform reclaim."
+fi

--- a/tests/reclaim-stale-worktrees.bats
+++ b/tests/reclaim-stale-worktrees.bats
@@ -145,6 +145,30 @@ mock_pr() {
     ! git -C "$MAIN_REPO" branch --list 'worktree-code+pr-1149' | grep -q "worktree-code+pr-1149"
 }
 
+@test "worktree removed but branch delete rejected (unmerged, no -D fallback for issue kind) is reported separately, not double-counted as reclaimed (worktree+branch)" {
+    mock_issue 5000 CLOSED
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+issue-5000 "$BATS_TEST_TMPDIR/wt5000"
+    (
+        cd "$BATS_TEST_TMPDIR/wt5000"
+        echo "unmerged change" >> file.txt
+        git add -A
+        git commit -q -m "unmerged commit"
+    )
+
+    # sanity: plain -d must fail (branch not fully merged into main); issue kind has no -D fallback
+    ! git -C "$MAIN_REPO" branch -d worktree-code+issue-5000 2>/dev/null
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reclaimed (worktree only, branch retained): 1"* ]]
+    [[ "$output" == *"warned (branch tip diverges): 1"* ]]
+    [[ "$output" != *"reclaimed (worktree+branch): 1"* ]]
+
+    ! git -C "$MAIN_REPO" worktree list | grep -q "wt5000"
+    git -C "$MAIN_REPO" branch --list 'worktree-code+issue-5000' | grep -q "worktree-code+issue-5000"
+}
+
 @test "orphan branch (no worktree directory) is reclaimed via the same completion check (AC3)" {
     git -C "$MAIN_REPO" branch worktree-code+issue-2000
     mock_issue 2000 CLOSED

--- a/tests/reclaim-stale-worktrees.bats
+++ b/tests/reclaim-stale-worktrees.bats
@@ -1,0 +1,196 @@
+#!/usr/bin/env bats
+
+# Tests for reclaim-stale-worktrees.sh
+# Uses real git worktrees (no git binary mocking); mocks gh via PATH.
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/reclaim-stale-worktrees.sh"
+
+setup() {
+    MAIN_REPO="$BATS_TEST_TMPDIR/main"
+    git init -q "$MAIN_REPO"
+    git -C "$MAIN_REPO" config user.email "test@example.com"
+    git -C "$MAIN_REPO" config user.name "Test"
+    (
+        cd "$MAIN_REPO"
+        echo "init" > file.txt
+        git add -A
+        git commit -q -m init
+    )
+    # Resolve to the real path (e.g. macOS /tmp -> /private/tmp) so it matches
+    # what `git worktree list` reports.
+    MAIN_REPO="$(cd "$MAIN_REPO" && pwd -P)"
+
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+MOCK_STATE_DIR="$(dirname "$0")/gh-state"
+if [ "$1" = "issue" ] && [ "$2" = "view" ]; then
+    num="$3"
+    if [ -f "$MOCK_STATE_DIR/issue-$num-state" ]; then
+        cat "$MOCK_STATE_DIR/issue-$num-state"
+    else
+        echo "OPEN"
+    fi
+    exit 0
+fi
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+    num="$3"
+    state="OPEN"
+    href=""
+    [ -f "$MOCK_STATE_DIR/pr-$num-state" ] && state="$(cat "$MOCK_STATE_DIR/pr-$num-state")"
+    [ -f "$MOCK_STATE_DIR/pr-$num-headrefoid" ] && href="$(cat "$MOCK_STATE_DIR/pr-$num-headrefoid")"
+    printf '{"state":"%s","headRefOid":"%s"}\n' "$state" "$href"
+    exit 0
+fi
+echo "Error: unexpected gh mock invocation: $*" >&2
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+    mkdir -p "$MOCK_DIR/gh-state"
+}
+
+# mock_issue <number> <state>  (e.g. mock_issue 1006 CLOSED)
+mock_issue() {
+    echo "$2" > "$MOCK_DIR/gh-state/issue-$1-state"
+}
+
+# mock_pr <number> <state> [headRefOid]  (e.g. mock_pr 1149 MERGED abcdef)
+mock_pr() {
+    echo "$2" > "$MOCK_DIR/gh-state/pr-$1-state"
+    echo "${3:-}" > "$MOCK_DIR/gh-state/pr-$1-headrefoid"
+}
+
+@test "default (no args) is dry-run: no worktree or branch is removed" {
+    mock_issue 1006 CLOSED
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+issue-1006 "$BATS_TEST_TMPDIR/wt1006"
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[dry-run] No changes made. Re-run with --apply to perform reclaim."* ]]
+    [[ "$output" == *"would reclaim: $BATS_TEST_TMPDIR/wt1006"* ]]
+
+    # nothing was actually removed
+    git -C "$MAIN_REPO" worktree list | grep -q "wt1006"
+    git -C "$MAIN_REPO" branch --list 'worktree-code+issue-1006' | grep -q "worktree-code+issue-1006"
+}
+
+@test "completed Issue (CLOSED) + clean worktree is deleted with --apply" {
+    mock_issue 1006 CLOSED
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+issue-1006 "$BATS_TEST_TMPDIR/wt1006"
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reclaimed (worktree+branch): 1"* ]]
+
+    ! git -C "$MAIN_REPO" worktree list | grep -q "wt1006"
+    ! git -C "$MAIN_REPO" branch --list 'worktree-code+issue-1006' | grep -q "worktree-code+issue-1006"
+}
+
+@test "locked worktree whose HEAD matches main HEAD is excluded even with --apply (AC2)" {
+    mock_issue 1006 CLOSED
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+issue-1006 "$BATS_TEST_TMPDIR/wt1006"
+    git -C "$MAIN_REPO" worktree lock "$BATS_TEST_TMPDIR/wt1006"
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"excluded (concurrent-session-guard): 1"* ]]
+
+    # still present -- excluded from reclaim
+    git -C "$MAIN_REPO" worktree list | grep -q "wt1006"
+    git -C "$MAIN_REPO" branch --list 'worktree-code+issue-1006' | grep -q "worktree-code+issue-1006"
+}
+
+@test "worktree with uncommitted changes is not deleted, reported as warning (AC4)" {
+    mock_issue 1006 CLOSED
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+issue-1006 "$BATS_TEST_TMPDIR/wt1006"
+    echo "dirty" >> "$BATS_TEST_TMPDIR/wt1006/file.txt"
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"warned (uncommitted changes): 1"* ]]
+    [[ "$output" == *"uncommitted changes: 1 files"* ]]
+
+    git -C "$MAIN_REPO" worktree list | grep -q "wt1006"
+    git -C "$MAIN_REPO" branch --list 'worktree-code+issue-1006' | grep -q "worktree-code+issue-1006"
+}
+
+@test "squash-merged branch (git branch -d rejected) is safely -D deleted via matching headRefOid (AC3)" {
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+pr-1149 "$BATS_TEST_TMPDIR/wt1149"
+    (
+        cd "$BATS_TEST_TMPDIR/wt1149"
+        echo "unmerged change" >> file.txt
+        git add -A
+        git commit -q -m "unmerged commit"
+    )
+    tip_sha="$(git -C "$BATS_TEST_TMPDIR/wt1149" rev-parse HEAD)"
+    mock_pr 1149 MERGED "$tip_sha"
+
+    # sanity: plain -d must fail (branch not fully merged into main)
+    ! git -C "$MAIN_REPO" branch -d worktree-code+pr-1149 2>/dev/null
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reclaimed (worktree+branch): 1"* ]]
+    [[ "$output" == *"warned (branch tip diverges): 0"* ]]
+
+    ! git -C "$MAIN_REPO" worktree list | grep -q "wt1149"
+    ! git -C "$MAIN_REPO" branch --list 'worktree-code+pr-1149' | grep -q "worktree-code+pr-1149"
+}
+
+@test "orphan branch (no worktree directory) is reclaimed via the same completion check (AC3)" {
+    git -C "$MAIN_REPO" branch worktree-code+issue-2000
+    mock_issue 2000 CLOSED
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reclaimed (orphan branch only): 1"* ]]
+
+    ! git -C "$MAIN_REPO" branch --list 'worktree-code+issue-2000' | grep -q "worktree-code+issue-2000"
+}
+
+@test "worktree/branch not matching current naming convention is skipped as unrecognized" {
+    mock_issue 56 CLOSED
+    git -C "$MAIN_REPO" worktree add -q -b issue-56-configurable-paths "$BATS_TEST_TMPDIR/wt-old"
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipped (unrecognized): 1"* ]]
+
+    git -C "$MAIN_REPO" worktree list | grep -q "wt-old"
+    git -C "$MAIN_REPO" branch --list 'issue-56-configurable-paths' | grep -q "issue-56-configurable-paths"
+}
+
+@test "prunable entry (worktree directory already gone) is reclaimed via git worktree prune" {
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+issue-3000 "$BATS_TEST_TMPDIR/wt3000"
+    rm -rf "$BATS_TEST_TMPDIR/wt3000"
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pruned: 1"* ]]
+
+    ! git -C "$MAIN_REPO" worktree list --porcelain | grep -q "wt3000"
+}
+
+@test "open Issue worktree is left untouched (not completed, not reported)" {
+    mock_issue 4000 OPEN
+    git -C "$MAIN_REPO" worktree add -q -b worktree-code+issue-4000 "$BATS_TEST_TMPDIR/wt4000"
+
+    cd "$MAIN_REPO"
+    run "$SCRIPT" --apply
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"reclaimed (worktree+branch): 0"* ]]
+
+    git -C "$MAIN_REPO" worktree list | grep -q "wt4000"
+    git -C "$MAIN_REPO" branch --list 'worktree-code+issue-4000' | grep -q "worktree-code+issue-4000"
+}


### PR DESCRIPTION
## Summary

Adds a standalone inventory-and-reclaim script (`scripts/reclaim-stale-worktrees.sh`) for stale worktrees and orphan branches left behind by abnormally-terminated phases (external kill + respawn, silent no-op exit, wrapper crash, etc.). Dry-run by default; `--apply` performs the actual deletion.

- Mechanically prunes registry entries whose directory is already gone (`git worktree prune -v`), then enumerates remaining worktrees via `git worktree list --porcelain`, classifying each by `{phase}+{issue|pr}-{N}` naming (branch name takes priority over directory name; falls back to the detached-worktree directory basename)
- Completion is judged by the corresponding Issue being `CLOSED` or PR being `MERGED`/`CLOSED` (`gh issue view` / `gh pr view`)
- Three safety guards before any deletion: concurrent-session exclusion (`locked` + HEAD matches current main HEAD), uncommitted-changes protection (`git status --porcelain`), and safe branch deletion (`git branch -d`, falling back to `-D` only when the branch tip matches the MERGED PR's `headRefOid`)
- Orphan branches (worktree directory already gone) are reclaimed via the same classification/completion logic
- `docs/structure.md` / `docs/ja/structure.md`: added the new script to Key Files > Scripts > Process management, bumped the `scripts/` file count 75 → 76
- `modules/worktree-lifecycle.md`: Notes now point to the new script for completed-Issue/PR worktree/branch reclaim beyond the Entry section's same-name stale check

## Verification (pre-merge)

- 異常終了経路でも worktree が回収される仕組みが実装されている (rubric)
- 使用中の worktree を巻き込まない除外判定がある (rubric)
- 孤児ブランチも回収対象に含み、squash merge 済みブランチの安全な削除判定がある (rubric)
- 未コミット変更のある worktree を検査し、削除せず警告/退避する (rubric)
- `bash tests/reclaim-stale-worktrees.bats` — 9 cases covering AC1–AC4 (prunable entries, completed-Issue reclaim, concurrent-session exclusion, uncommitted-changes protection, squash-merge safe `-D` deletion, orphan-branch reclaim, unrecognized-naming skip, dry-run default)
- Full `bats tests/` suite (1475 tests) passes with no regressions

## Verification (post-merge)

- 数セッション運用したのち `git worktree list` / `git branch` に完了済み Issue/PR の worktree・ブランチが蓄積していないことを確認 (opportunistic)

closes #1119
