### PR TITLE
Issue #1206: pr route merge した skill 修正のローカル main 未追従を検出・防止する

### DIFF
--- a/docs/spec/issue-1206-stale-skill-after-pr-merge.md
+++ b/docs/spec/issue-1206-stale-skill-after-pr-merge.md
@@ -145,16 +145,31 @@ Issue 本文「Proposal (Outline)」節に既に記録済みのため、Spec 側
 - `tests/run-merge.bats` の否定側テスト (`git pull --ff-only` が呼ばれないことの確認) で当初 `[ ! -f "$GIT_LOG" ]` を使ったが、`run-merge.sh` が既存の `git worktree list --porcelain` 呼び出しで `git` モックを起動するため常に失敗した。`grep -q "^pull --ff-only$" "$GIT_LOG"` の否定に変更して解消した。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の Implementation Steps 1–4 をそのまま実装 (skills/auto/SKILL.md の origin 比較化、scripts/run-merge.sh の post-merge sync、tests/auto.bats・tests/run-merge.bats へのテスト追加)。方針からの逸脱なし
-- 全 bats テストスイート (1493件) を behavioral change detection の判定に従って実行し、全件 PASS を確認済み
+- Pre-merge rubric AC 4件 (AC1–4) を Issue 本文 + diff のみから再検証し、全て PASS と判定 (Spec は grader 入力に含めない設計方針を踏襲)
+- CI 全9件 SUCCESS、ベースブランチとのコンフリクトなし (`git merge-tree` pre-check) を確認した上で `REVIEW_DEPTH=light` の 1 エージェント統合レビューを実施
+- review-light が指摘した SHOULD (`scripts/run-merge.sh` の `gh pr view --json files` 100件 truncation) は、本 Issue が実装する検出・防止機構そのものの信頼性に直結するため fix 対象と判断し、`gh api pulls/{pr}/files --paginate` に置き換えて修正・回帰テスト追加・push 済み
 
 ### Deferred Items
-- Post-merge observation AC (`session=next`): 次回 skill を修正する Issue を pr route で完走させた後、同一セッション内でその skill を呼ぶ実行で stale な版が使われないか (または警告が出るか) を観察する。本 PR merge 後の別セッションで確認が必要
+- Post-merge observation AC (`session=next`): 次回 skill を修正する Issue を pr route で完走させた後、同一セッション内でその skill を呼ぶ実行で stale な版が使われないか (または警告が出るか) を観察する。本 PR merge 後の別セッションで確認が必要 (Code フェーズからの引き継ぎを維持)
+- `gh pr view --json files` の 100件 truncation パターンは `skills/review/SKILL.md` 等の他呼び出し箇所にも既存 (review retrospective 参照)。今回のスコープでは修正せず、横断監査の要否は次回同種の truncation を踏んだ際に判断する
 
 ### Notes for Next Phase
-- `/review` は Pre-merge rubric AC 4件 (AC1–4) を再検証すること。実装側では A (origin 比較) + C (post-merge sync) の両方が揃っている
-- Spec の「実装確認済みの前提」節にある「`run-merge.sh` は git を直接呼び出していない」という記述は不正確 (`git worktree list --porcelain` の既存呼び出しがある) — Code Retrospective の Design Gaps/Ambiguities に訂正を記録済み
-- 追加した `git pull --ff-only` は warn-only (fail-open) 設計。失敗しても `EXIT_CODE` は変更されないため、CI や `/review` 側で追加のエラーハンドリングは不要
+- `/merge` はブロッキング MUST issue なし (COMMENT event で投稿済み) のため、そのまま進行可能
+- 追加修正コミット (`dac6722b`) は元の実装コミット群と同じ PR 内。`git pull --ff-only` は引き続き warn-only (fail-open) 設計のまま
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note。review-light の Perspective 1 判定通り、Implementation Steps 1–4 は Spec 記述と一致していた。
+
+### Recurring issues
+
+`gh pr view --json files -q '.files[].path'` は GraphQL の `files` connection をページングせず、100件で暗黙に打ち切られる。review-light の指摘によれば同じパターンが `skills/review/SKILL.md` (Step 6 の diff ファイル一覧取得) にも既存で存在する。今回は本 Issue が実装する検出・防止機構そのものの信頼性に直結する箇所 (`scripts/run-merge.sh` の skills/ 変更検出) だったため SHOULD として修正したが、他の呼び出し箇所は影響の性質が異なる (ファイル一覧の表示用途など) ため今回のスコープには含めていない。100件超のPRで `gh pr view --json files` を使っている箇所を横断的に洗い出す価値があるかもしれないが、頻度は低いと見て新規 Issue化は保留する。次に同種の truncation を踏んだ際に横断監査の起票を検討する。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note。Pre-merge AC 4件は全て `rubric` 形式で、Issue 本文と diff のみから明確に PASS 判定できた。UNCERTAIN や verify command の不備は発生しなかった。

--- a/docs/spec/issue-1206-stale-skill-after-pr-merge.md
+++ b/docs/spec/issue-1206-stale-skill-after-pr-merge.md
@@ -127,3 +127,34 @@ Issue 本文「Proposal (Outline)」節に既に記録済みのため、Spec 側
 
 - **Proposal C の実装位置**: `skills/merge/SKILL.md` (LLM 実行、自分の worktree `merge/pr-$NUMBER` 内で完結) ではなく `scripts/run-merge.sh` (bash wrapper) を選んだ。`/merge` 自身は worktree 内で完結するため、親リポジトリの `main` を直接操作するには worktree 分離を越える必要がある。一方 `run-merge.sh` は `claude -p` サブプロセスの外側で `MAIN_REPO_ROOT` に居続けるため、追加の分離越えロジックなしに実装できる。既存の `_pull_ff_only()` (`scripts/run-auto-sub.sh`) も同じく bash wrapper 層に実装されており、パターンとして一貫する
 - **AC4 のテスト方法**: Step 8 のロジックは SKILL.md prose に埋め込まれた bash スニペットであり、直接ユニットテストできる独立スクリプトではない。`tests/pre-merge-check.bats` が使う bare origin + working repo の実 git fixture パターンを踏襲し、Step 1 で導入する 2 つの git コマンド (ローカル HEAD 比較 / origin 比較) が実際に異なる結果を返すことを実 git 操作で検証する形とした。SKILL.md prose のリファクタ (スクリプトへの抽出) は本 Issue のスコープを超えるため行わない
+
+## Autonomous Auto-Resolve Log
+
+- **Step 3 (`phase/ready` label check)**: `/code 1206` 実行時点で Issue ラベルは `phase/code` であり `phase/ready` は不在だった。Issue タイムラインを確認したところ、`phase/ready` は一度付与された後 `phase/code` へ遷移済み (2026-08-06T15:31:55Z) — 本 Issue に対する `/code` の先行実行が Step 4 (ラベル遷移) まで進んだ後、worktree/branch を作成せずに中断していたと判明した (worktree 一覧・リモートブランチのいずれにも `code+issue-1206` 相当の痕跡なし)。Spec (`docs/spec/issue-1206-stale-skill-after-pr-merge.md`) は既に存在し内容も完成しているため、"Continue" を自動選択し Spec を使って実装を継続した。`reconcile-phase-state.sh --check-precondition code-pr 1206` の `matches_expected:false` も同じ `phase/ready` 不在が理由であり、Spec 欠如ではないことを確認した上で warn のみとして続行した。
+
+## Code Retrospective
+
+### Deviations from Design
+- None. Implementation Steps 1–4 を Spec の記述通りに実装した。
+
+### Design Gaps/Ambiguities
+- Spec の「実装確認済みの前提」節は「`scripts/run-merge.sh` は現状 `git` を直接呼び出していない」と記載しているが、実際には起動直後に `git worktree list --porcelain`という読み取り専用の呼び出しが既に存在していた (`MAIN_REPO_ROOT` 解決のため)。今回追加した `git pull --ff-only` は状態を変更する最初の呼び出しである、という主張自体は正しく実装への影響もなかったが、前提の文言はやや不正確だった。次回この Spec を参照する際は「`git` の読み取り専用呼び出しは既存、書き込みを伴う呼び出しは今回が最初」と読み替えること。
+
+### Rework
+- `tests/auto.bats` の新規テストで `git clone` 直後に `skills/x/SKILL.md` へ書き込めず失敗した。原因は bare origin の `HEAD` が `refs/heads/main` を指しておらず (`branch -M main` 後も symbolic-ref 未設定)、`git clone` が空のチェックアウトを作っていたため。`git -C "$origin_dir" symbolic-ref HEAD refs/heads/main` を push 後に追加して解消した。
+- `tests/run-merge.bats` の否定側テスト (`git pull --ff-only` が呼ばれないことの確認) で当初 `[ ! -f "$GIT_LOG" ]` を使ったが、`run-merge.sh` が既存の `git worktree list --porcelain` 呼び出しで `git` モックを起動するため常に失敗した。`grep -q "^pull --ff-only$" "$GIT_LOG"` の否定に変更して解消した。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の Implementation Steps 1–4 をそのまま実装 (skills/auto/SKILL.md の origin 比較化、scripts/run-merge.sh の post-merge sync、tests/auto.bats・tests/run-merge.bats へのテスト追加)。方針からの逸脱なし
+- 全 bats テストスイート (1493件) を behavioral change detection の判定に従って実行し、全件 PASS を確認済み
+
+### Deferred Items
+- Post-merge observation AC (`session=next`): 次回 skill を修正する Issue を pr route で完走させた後、同一セッション内でその skill を呼ぶ実行で stale な版が使われないか (または警告が出るか) を観察する。本 PR merge 後の別セッションで確認が必要
+
+### Notes for Next Phase
+- `/review` は Pre-merge rubric AC 4件 (AC1–4) を再検証すること。実装側では A (origin 比較) + C (post-merge sync) の両方が揃っている
+- Spec の「実装確認済みの前提」節にある「`run-merge.sh` は git を直接呼び出していない」という記述は不正確 (`git worktree list --porcelain` の既存呼び出しがある) — Code Retrospective の Design Gaps/Ambiguities に訂正を記録済み
+- 追加した `git pull --ff-only` は warn-only (fail-open) 設計。失敗しても `EXIT_CODE` は変更されないため、CI や `/review` 側で追加のエラーハンドリングは不要

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -202,7 +202,10 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
 fi
 
 if [[ $EXIT_CODE -eq 0 ]]; then
-  _pr_files=$(gh pr view "$PR_NUMBER" --json files -q '.files[].path' 2>/dev/null || true)
+  # gh pr view --json files truncates at 100 entries (no pagination); use the
+  # paginated REST endpoint (supports up to 3000 files) so skills/ changes in
+  # large PRs are not silently missed.
+  _pr_files=$(gh api "repos/{owner}/{repo}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' 2>/dev/null || true)
   if echo "$_pr_files" | grep -q '^skills/'; then
     echo "Merged PR touched skills/ — syncing local main..." >&2
     if ! git pull --ff-only; then

--- a/scripts/run-merge.sh
+++ b/scripts/run-merge.sh
@@ -201,6 +201,16 @@ if [[ $EXIT_CODE -eq 143 || $EXIT_CODE -eq 0 ]]; then
   fi
 fi
 
+if [[ $EXIT_CODE -eq 0 ]]; then
+  _pr_files=$(gh pr view "$PR_NUMBER" --json files -q '.files[].path' 2>/dev/null || true)
+  if echo "$_pr_files" | grep -q '^skills/'; then
+    echo "Merged PR touched skills/ — syncing local main..." >&2
+    if ! git pull --ff-only; then
+      echo "Warning: git pull --ff-only failed; local main may be stale for subsequent in-session skill calls." >&2
+    fi
+  fi
+fi
+
 # CI test_result emit (pr route, EXIT_CODE=0 + AUTO_EVENTS_LOG set)
 if [[ $EXIT_CODE -eq 0 && -n "${AUTO_EVENTS_LOG:-}" ]]; then
   _branch=$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName' 2>/dev/null || true)

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -875,11 +875,12 @@ Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
      SKILL_VERSIONS=$(jq -r '.skill_versions // empty' ".tmp/auto-session-${AUTO_SESSION_ID}.json" 2>/dev/null)
      ```
      If the file is absent or `jq` fails (empty output), skip this sub-step entirely.
-   - For each of the 8 skills (auto/code/spec/verify/review/merge/issue/audit), compare the saved hash against the current `HEAD` hash:
+   - For each of the 8 skills (auto/code/spec/verify/review/merge/issue/audit), compare the saved hash against the current `origin/${BASE_BRANCH}` hash (`$BASE_BRANCH` is the session-wide variable resolved from `--base` in Step 0, defaulting to `main`):
      ```bash
+     git fetch origin "$BASE_BRANCH" 2>/dev/null || echo "Warning: git fetch origin ${BASE_BRANCH} failed; comparing against a possibly-stale origin ref" >&2
      for skill in auto code spec verify review merge issue audit; do
        START_HASH=$(echo "$SKILL_VERSIONS" | jq -r ".\"skills/${skill}/SKILL.md\" // \"\"" 2>/dev/null || echo "")
-       CURRENT_HASH=$(git log -1 --format=%H -- "skills/${skill}/SKILL.md" 2>/dev/null || echo "")
+       CURRENT_HASH=$(git log -1 --format=%H "origin/${BASE_BRANCH}" -- "skills/${skill}/SKILL.md" 2>/dev/null || echo "")
        if [ -n "$START_HASH" ] && [ -n "$CURRENT_HASH" ] && [ "$START_HASH" != "$CURRENT_HASH" ]; then
          CHANGED_SKILLS="${CHANGED_SKILLS:+$CHANGED_SKILLS }${skill}:${START_HASH}:${CURRENT_HASH}"
        fi
@@ -889,7 +890,7 @@ Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
      ```markdown
      ## Skill Self-Update Propagation Note
 
-     Session 中に以下の skill が更新されました (本 session には未適用、次 session から反映):
+     Session 中に以下の skill が origin 上で更新されました (比較対象: origin/${BASE_BRANCH})。ローカル main が追従できていない場合、本 session 内の以降の実行や次回セッションが更新前の版を使う可能性があります:
      - skills/auto/SKILL.md: <start-hash> → <current-hash>  (or "(no change)" when unchanged)
      - skills/code/SKILL.md: (no change)
      ...

--- a/tests/auto.bats
+++ b/tests/auto.bats
@@ -161,3 +161,56 @@ EOF
     [ "$status" -eq 0 ]
     [ "$output" = '{"recovery_tier2_3":2,"watchdog_kill":2,"concurrent_commit":1,"commit_event":0}' ]
 }
+
+# Tests for Skill Self-Update Propagation check comparing against origin (Issue #1206)
+# Uses a real git fixture (bare origin + working repo), same pattern as tests/pre-merge-check.bats.
+
+@test "origin comparison detects skill hash divergence that local HEAD comparison misses" {
+    local origin_dir="$BATS_TEST_TMPDIR/origin-auto.git"
+    local repo_dir="$BATS_TEST_TMPDIR/repo-auto"
+    local clone_dir="$BATS_TEST_TMPDIR/clone-auto"
+
+    git init --bare "$origin_dir" >/dev/null 2>&1
+
+    git init "$repo_dir" >/dev/null 2>&1
+    git -C "$repo_dir" config user.email "test@example.com"
+    git -C "$repo_dir" config user.name "Test"
+    git -C "$repo_dir" remote add origin "$origin_dir"
+
+    mkdir -p "$repo_dir/skills/x"
+    echo "commit A content" > "$repo_dir/skills/x/SKILL.md"
+    git -C "$repo_dir" add skills/x/SKILL.md
+    git -C "$repo_dir" commit -m "commit A" >/dev/null 2>&1
+    git -C "$repo_dir" branch -M main
+    git -C "$repo_dir" push origin main >/dev/null 2>&1
+    git -C "$origin_dir" symbolic-ref HEAD refs/heads/main
+    local commit_a
+    commit_a=$(git -C "$repo_dir" log -1 --format=%H -- skills/x/SKILL.md)
+
+    # A second clone advances origin with commit B without touching repo_dir's local HEAD —
+    # simulates a PR merged via `gh pr merge` while this working repo's main stays behind.
+    git clone "$origin_dir" "$clone_dir" >/dev/null 2>&1
+    git -C "$clone_dir" config user.email "test@example.com"
+    git -C "$clone_dir" config user.name "Test"
+    echo "commit B content" > "$clone_dir/skills/x/SKILL.md"
+    git -C "$clone_dir" add skills/x/SKILL.md
+    git -C "$clone_dir" commit -m "commit B" >/dev/null 2>&1
+    git -C "$clone_dir" push origin main >/dev/null 2>&1
+    local commit_b
+    commit_b=$(git -C "$clone_dir" log -1 --format=%H -- skills/x/SKILL.md)
+
+    [ "$commit_a" != "$commit_b" ]
+
+    git -C "$repo_dir" fetch origin main >/dev/null 2>&1
+
+    local local_head_hash
+    local_head_hash=$(git -C "$repo_dir" log -1 --format=%H -- skills/x/SKILL.md)
+    local origin_hash
+    origin_hash=$(git -C "$repo_dir" log -1 --format=%H origin/main -- skills/x/SKILL.md)
+
+    # Local HEAD comparison alone always reports commit A — a false "no change".
+    [ "$local_head_hash" = "$commit_a" ]
+    # Origin comparison correctly detects the divergent commit B.
+    [ "$origin_hash" = "$commit_b" ]
+    [ "$local_head_hash" != "$origin_hash" ]
+}

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -265,9 +265,11 @@ if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
     echo "https://github.com/test/repo/pull/88"
   elif [[ "$*" == *"-q"* && "$*" == *".state"* ]]; then
     echo "MERGED"
-  elif [[ "$*" == *"--json files"* ]]; then
-    echo "skills/verify/SKILL.md"
   fi
+  exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"pulls/123/files"* ]]; then
+  echo "skills/verify/SKILL.md"
   exit 0
 fi
 echo ""
@@ -301,9 +303,11 @@ if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
     echo "https://github.com/test/repo/pull/88"
   elif [[ "$*" == *"-q"* && "$*" == *".state"* ]]; then
     echo "MERGED"
-  elif [[ "$*" == *"--json files"* ]]; then
-    echo "docs/tech.md"
   fi
+  exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"pulls/123/files"* ]]; then
+  echo "docs/tech.md"
   exit 0
 fi
 echo ""
@@ -322,6 +326,49 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" != *"syncing local main"* ]]
     ! grep -q "^pull --ff-only$" "$GIT_LOG"
+}
+
+@test "success: local main is synced via the paginated files endpoint when a skills/ path falls past the 100-file gh pr view --json files cap" {
+    GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+    export GIT_LOG
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  elif [[ "$*" == *"-q"* && "$*" == *".state"* ]]; then
+    echo "MERGED"
+  fi
+  exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"pulls/123/files"* ]]; then
+  # Simulate a PR with more than the 100-entry cap of the non-paginated
+  # `gh pr view --json files` call, with the skills/ path past entry #100.
+  for i in $(seq 1 104); do
+    echo "docs/file-${i}.md"
+  done
+  echo "skills/verify/SKILL.md"
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Merged PR touched skills/ — syncing local main..."* ]]
+    grep -q "^pull --ff-only$" "$GIT_LOG"
 }
 
 @test "error: claude command fails with non-zero exit code" {

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -252,6 +252,78 @@ MOCK
     [[ "$output" == *"CI check wait complete for PR #123"* ]]
 }
 
+@test "success: local main is synced with git pull --ff-only when the merged PR touched skills/" {
+    GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+    export GIT_LOG
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  elif [[ "$*" == *"-q"* && "$*" == *".state"* ]]; then
+    echo "MERGED"
+  elif [[ "$*" == *"--json files"* ]]; then
+    echo "skills/verify/SKILL.md"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Merged PR touched skills/ — syncing local main..."* ]]
+    grep -q "^pull --ff-only$" "$GIT_LOG"
+}
+
+@test "success: git pull --ff-only is not called when the merged PR did not touch skills/" {
+    GIT_LOG="$BATS_TEST_TMPDIR/git.log"
+    export GIT_LOG
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"--json"* ]]; then
+  if [[ "$*" == *"-q"* && "$*" == *".title"* ]]; then
+    echo "test PR title"
+  elif [[ "$*" == *"-q"* && "$*" == *".url"* ]]; then
+    echo "https://github.com/test/repo/pull/88"
+  elif [[ "$*" == *"-q"* && "$*" == *".state"* ]]; then
+    echo "MERGED"
+  elif [[ "$*" == *"--json files"* ]]; then
+    echo "docs/tech.md"
+  fi
+  exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    cat > "$MOCK_DIR/git" <<MOCK
+#!/bin/bash
+echo "\$@" >> "$GIT_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/git"
+
+    run bash "$SCRIPT" 123
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"syncing local main"* ]]
+    ! grep -q "^pull --ff-only$" "$GIT_LOG"
+}
+
 @test "error: claude command fails with non-zero exit code" {
     cat > "$MOCK_DIR/claude" <<'MOCK'
 #!/bin/bash


### PR DESCRIPTION
## Summary

pr route で `skills/*/SKILL.md` を修正する Issue を merge した直後、ローカル main が origin に未追従のまま同一セッション内で別 Issue のフェーズがその skill を呼ぶと、修正前の版が実行されうる問題に対して、Issue 本文が推奨する **A + C** の組み合わせを実装した。

- **A (検出)**: `skills/auto/SKILL.md` Step 8 (Skill Self-Update Propagation check) の `CURRENT_HASH` 取得元をローカル HEAD から `origin/${BASE_BRANCH}` に変更 (事前に `git fetch origin "$BASE_BRANCH"` を追加)。`## Skill Self-Update Propagation Note` の文言も、実際に起こりうる状態 (更新済みだがローカル未追従のまま実行される) に合わせて見直した
- **C (防止)**: `scripts/run-merge.sh` に、squash merge 成功後 merge した PR の変更ファイルが `skills/` を含む場合、ローカル main を `git pull --ff-only` で同期する処理を追加 (warn-only、fail-open)
- 不採用とした方針 B (skill 実行前の全面同期) の判断根拠は Issue 本文「Proposal (Outline)」節および Spec `## Notes` に記録済み

## Verification (pre-merge)

- `skills/auto/SKILL.md` Step 8 が origin/main 比較になっていること
- `scripts/run-merge.sh` が skills/ を含む PR の merge 後に `git pull --ff-only` を実行すること
- `tests/auto.bats` にローカル HEAD と origin で skill hash が異なる条件を実 git fixture で検証するテストを追加、PASS
- `tests/run-merge.bats` に skills/ を含む PR merge 後の同期呼び出しを検証するテストを追加、PASS
- 全 bats テストスイート (1493件) PASS

## Verification (post-merge)

- 次回 skill を変更する Issue を pr route で完走させた後、同一セッション内でその skill を呼ぶ実行があった際、stale な版が使われないこと (または警告が出ること) を観察する (observation, session=next)

closes #1206
