### PR TITLE
Issue #1165: verify: manual AC 区分 D3 (その他 19 件) を個別判断で再型付けまたは retire

### DIFF
--- a/docs/reports/manual-ac-retype-d3.md
+++ b/docs/reports/manual-ac-retype-d3.md
@@ -74,4 +74,30 @@
 
 ## 検証
 
-（Step 9 実行後に追記）
+`${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event auto-run` / `--event watchdog-kill` / `--event pr-review-full` を実行し、再型付けした Issue が個別に含まれることを確認した (件数差分ではなく個別含有で判定 — #1163 の Code Retrospective で母集団が他要因でも変動することが確認されているため)。
+
+### `--event auto-run`
+
+- 実行結果: マッチ 82 AC 行
+- 再型付け対象 12 Issue (#1135 #1056 #961 #710 #513 #512 #491 #490 #484 #478 #477 #465) のうち、`opportunistic-search.sh` のマッチ集合に含まれたのは 8 件 (#1056 #961 #710 #513 #512 #491 #484 #477)
+- **#1135 / #490 / #478 / #465 の 4 件はマッチ集合に含まれなかった**。理由を切り分けて確認:
+  - #490 / #465 は OPEN Issue のため、`opportunistic-search.sh` の母集団取得 (`gh issue list --label phase/verify --state closed`) が `--state closed` 固定である以上、原理的にマッチしない。Spec Notes 「OPEN 2 件は dispatch 母集団に入らない」のとおりの想定内挙動
+  - #1135 / #478 は CLOSED かつ `phase/verify` ラベルを保持しているにもかかわらずマッチしなかった。`gh issue view N --json body` で本文を直接確認したところ、両者とも `<!-- verify-type: observation event=auto-run when=mode:batch -->` へ正しく置換済みであることをリテラル一致で確認した (`.tmp/verify-retype.py` 実行結果: 12 Issue 全件で `auto-run` タグの存在を確認)。`opportunistic-search.sh` の母集団取得は GitHub 検索インデックス (`gh issue list --search "verify-type: observation in:body"`) に依存する粗い事前フィルタであり、本文編集直後はインデックスが未更新でマッチ集合に現れないことがある (Spec Notes 「GitHub 検索インデックスの遅延」で予告済みの挙動)。実行直後の初回確認と再実行の 2 回とも未反映だったが、`gh issue view` によるリテラル一致確認を一次情報として正とする
+
+### `--event watchdog-kill`
+
+- 実行結果: マッチ 3 AC 行 (#802 #535 #585)
+- 再型付けした #535 は **マッチ集合に含まれることを確認済み**
+
+### `--event pr-review-full`
+
+- 実行結果: マッチ 1 AC 行 (#575)
+- 再型付けした #575 は **マッチ集合に含まれることを確認済み**
+
+### GitHub 上の実状態 (Pre-merge AC4〜AC8 相当)
+
+- `gh issue view 961 --json body`: `verify-type: observation event=auto-run` へ再型付け済みを確認
+- `gh issue view 535 --json body`: `verify-type: observation event=watchdog-kill` へ再型付け済みを確認
+- `gh issue view 575 --json body`: `config=capabilities.workflow` ゲート付与を確認
+- `gh issue view 706 --json body`: `### Retired Post-merge Conditions` 節への退避を確認
+- `gh issue view 706 --json labels`: `phase/done` への遷移を確認 (#587 / #563 / #591 も同様に `phase/done` を確認済み)

--- a/docs/reports/manual-ac-retype-d3.md
+++ b/docs/reports/manual-ac-retype-d3.md
@@ -17,7 +17,7 @@
 
 ## OPEN 2 件 (#490 / #465) は dispatch 母集団に入らない
 
-`scripts/opportunistic-search.sh` と `scripts/scan-pending-ac.sh` はいずれも `gh issue list --label phase/verify --state closed` で母集団を取る。#490 / #465 は一度も close されたことがない OPEN Issue のため、`observation` へ再型付けしても現時点では dispatch されない。両者とも Pre-merge AC は全件チェック済みで実装は着地しており、close されれば自然に母集団へ入る。close 判断は各 Issue 自身の post-merge 充足に依存するため本 Issue のスコープ外とし、事実としてここに明記する。
+`scripts/opportunistic-search.sh` は `gh issue list --label phase/verify --state closed --search "verify-type: observation in:body"` (line 202)、`scripts/scan-pending-ac.sh` は `--search` フィルタなしの `gh issue list --label phase/verify --state closed` (line 106) で母集団を取る。`--search` の有無は異なるが、いずれも `--state closed` 固定である点は共通。#490 / #465 は一度も close されたことがない OPEN Issue のため、`observation` へ再型付けしても現時点では dispatch されない。両者とも Pre-merge AC は全件チェック済みで実装は着地しており、close されれば自然に母集団へ入る。close 判断は各 Issue 自身の post-merge 充足に依存するため本 Issue のスコープ外とし、事実としてここに明記する。
 
 ## 再型付けマッピング (16 AC 行 / 14 Issue)
 
@@ -70,11 +70,11 @@
 | Issue | 行の性質 | 扱い |
 |---|---|---|
 | #591 | `- [x]` (チェック済み) の manual AC 「フル auto-decomposition の follow-up Issue が起票されている」 | **編集しない**。既にチェック済みのため Manual Waiting Count にも `opportunistic-search.sh` にもマッチしない |
-| #491 | `## 提案内容` 節のコードフェンス内サンプル行 `- [ ] Trigger workflow once via ... <!-- verify-type: manual -->` | **AC ではないため再型付けも retire もしない**。ただし `- [ ]` + `verify-type: manual` に機械マッチし `/audit stats` の Manual Waiting Count に計上されるため、2 スペースのインデントを付けて `^- \[ \]` アンカーから外す。テキスト本文と `verify-type` は変更しない |
+| #491 | `## 提案内容` 節のコードフェンス内サンプル行 `- [ ] Trigger workflow once via ... <!-- verify-type: manual -->` | **AC ではないため再型付けも retire もしない**。ただし `- [ ]` + `verify-type: manual` に機械マッチし `/audit stats` の Manual Waiting Count に計上されるため、2 スペースのインデントを付けて `scripts/opportunistic-search.sh` / `scripts/scan-pending-ac.sh` の `^- \[ \]` アンカーから外す。`skills/audit/SKILL.md` の Manual Waiting Count はアンカーなしの LLM プロース走査のため、この対処が同カウントから確実に除外することを保証するものではないが、実運用上は一致して振る舞う想定。テキスト本文と `verify-type` は変更しない |
 
 ## 検証
 
-`${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event auto-run` / `--event watchdog-kill` / `--event pr-review-full` を実行し、再型付けした Issue が個別に含まれることを確認した (件数差分ではなく個別含有で判定 — #1163 の Code Retrospective で母集団が他要因でも変動することが確認されているため)。
+`scripts/opportunistic-search.sh --event auto-run` / `--event watchdog-kill` / `--event pr-review-full` を実行し、再型付けした Issue が個別に含まれることを確認した (件数差分ではなく個別含有で判定 — #1163 の Code Retrospective で母集団が他要因でも変動することが確認されているため)。
 
 ### `--event auto-run`
 
@@ -82,7 +82,7 @@
 - 再型付け対象 12 Issue (#1135 #1056 #961 #710 #513 #512 #491 #490 #484 #478 #477 #465) のうち、`opportunistic-search.sh` のマッチ集合に含まれたのは 8 件 (#1056 #961 #710 #513 #512 #491 #484 #477)
 - **#1135 / #490 / #478 / #465 の 4 件はマッチ集合に含まれなかった**。理由を切り分けて確認:
   - #490 / #465 は OPEN Issue のため、`opportunistic-search.sh` の母集団取得 (`gh issue list --label phase/verify --state closed`) が `--state closed` 固定である以上、原理的にマッチしない。Spec Notes 「OPEN 2 件は dispatch 母集団に入らない」のとおりの想定内挙動
-  - #1135 / #478 は CLOSED かつ `phase/verify` ラベルを保持しているにもかかわらずマッチしなかった。`gh issue view N --json body` で本文を直接確認したところ、両者とも `<!-- verify-type: observation event=auto-run when=mode:batch -->` へ正しく置換済みであることをリテラル一致で確認した (`.tmp/verify-retype.py` 実行結果: 12 Issue 全件で `auto-run` タグの存在を確認)。`opportunistic-search.sh` の母集団取得は GitHub 検索インデックス (`gh issue list --search "verify-type: observation in:body"`) に依存する粗い事前フィルタであり、本文編集直後はインデックスが未更新でマッチ集合に現れないことがある (Spec Notes 「GitHub 検索インデックスの遅延」で予告済みの挙動)。実行直後の初回確認と再実行の 2 回とも未反映だったが、`gh issue view` によるリテラル一致確認を一次情報として正とする
+  - #1135 / #478 は CLOSED かつ `phase/verify` ラベルを保持しているにもかかわらずマッチしなかった。`gh issue view N --json body` で本文を直接確認したところ、両者とも `<!-- verify-type: observation event=auto-run when=mode:batch -->` へ正しく置換済みであることをリテラル一致で確認した (`.tmp/verify-retype.py` 実行結果: 12 Issue 全件で `auto-run` タグの存在を確認)。マッチしなかった原因は検索インデックスの遅延ではなく、`scripts/opportunistic-search.sh` の `when=` 条件ゲート (mode 軸) が `mode=single` のセッションで `when=mode:batch` 付き AC 行を設計どおり除外したこと。マッチしなかった 3 AC 行 (#1135 / #478 条件1 / #478 条件2) はレポート冒頭で `when=mode:batch` ゲート付きと記録した 3 行と完全一致しており、`scripts/collect-run-facts.sh` がこのセッションで `mode: single` を返すことも実測確認した。`mode=batch` の run facts を与えない限り常に除外されるため、`gh issue view` によるリテラル一致確認を一次情報として正とする
 
 ### `--event watchdog-kill`
 

--- a/docs/reports/manual-ac-retype-d3.md
+++ b/docs/reports/manual-ac-retype-d3.md
@@ -1,0 +1,77 @@
+# manual AC 区分 D3: observation 再型付け/retire マッピング (#1165)
+
+親 Issue #1158 の分割対応。`phase/verify` に滞留する `verify-type: manual` の post-merge AC のうち、区分 D3 (キーワード機械分類で A / B / C / D1 / D2 のいずれにも当てはまらなかった残余) の 19 Issue を対象に、1 件ずつ条件文を読んで **observation への再型付け / retire / manual 維持** のいずれかへ振り分けた記録。
+
+## 対象・件数内訳
+
+- 対象 Issue: 19 件 (#1135 #1056 #961 #783 #710 #706 #591 #587 #575 #563 #535 #513 #512 #491 #490 #484 #478 #477 #465)
+- 対象 AC 行: 22 行 (#710 / #484 / #478 が各 2 行を持つため、Issue 単位の 19 件と AC 行単位の 22 行にずれがある。#1163 (区分 A) と同じ単位ずれが再現)
+- 再型付け: **16 行** (`event=auto-run` 14 行 / `event=watchdog-kill` 1 行 / `event=pr-review-full` 1 行)
+- retire: **6 行**
+- `manual` 維持: **0 行**
+- 対象外 (編集しない / 別扱い): **2 行** (#591 の `- [x]` 済み行、#491 のコードフェンス内サンプル行)
+
+## `event=` 有効値の制約
+
+`event=` に使用できるのは `modules/verify-classifier.md` § observation Type が定める 5 つの有効値のみ: `pr-review-full` / `pr-review-light` / `auto-run` / `watchdog-kill` / `fix-cycle`。未知の event 名を持つ AC 行は 5 種のどの dispatch にもマッチせず、自動評価パイプラインに乗らない。条件文が待つ将来イベントがこの 5 値のいずれにも一致しない場合は `manual` のまま維持するのが原則だが、本 Issue では前提が原理的に成立しない条件をすべて retire に倒した (#1163 からの意図的な方針変更。理由は Spec `docs/spec/issue-1165-manual-ac-retype-d3.md` § Notes 「`manual` 維持がゼロである理由」を参照)。
+
+## OPEN 2 件 (#490 / #465) は dispatch 母集団に入らない
+
+`scripts/opportunistic-search.sh` と `scripts/scan-pending-ac.sh` はいずれも `gh issue list --label phase/verify --state closed` で母集団を取る。#490 / #465 は一度も close されたことがない OPEN Issue のため、`observation` へ再型付けしても現時点では dispatch されない。両者とも Pre-merge AC は全件チェック済みで実装は着地しており、close されれば自然に母集団へ入る。close 判断は各 Issue 自身の post-merge 充足に依存するため本 Issue のスコープ外とし、事実としてここに明記する。
+
+## 再型付けマッピング (16 AC 行 / 14 Issue)
+
+### `event=auto-run` (14 AC 行)
+
+| Issue | 条件文の要約 | 付与するタグ | 選定根拠 |
+|---|---|---|---|
+| #1135 | 回避策適用状態の `/auto --batch` で `manual-recovery-respawn` 新規エントリ発生率を適用前と比較・記録 | `event=auto-run when=mode:batch` | 観測窓は `/auto --batch` 完了時。`mode` は `when=` の宣言可能軸にあり事前排除できる |
+| #1056 | `pup` 未インストール環境で `html_check` が UNCERTAIN でなく PASS/FAIL を返す | `event=auto-run` | 前提 (pup 不在) は 2026-08-07 に `command -v pup` で不在を実測済み。発火契機が無いことだけが滞留原因なので `auto-run` で `/verify` を dispatch すれば実際に判定できる |
+| #961 | 並列セッション環境で merge-to-main が他セッションのブランチに影響しない | `event=auto-run` | 「並列セッション環境」は `when=` の宣言可能 3 軸に存在せず事前排除できない |
+| #710 条件1 | `Blocked by #N` 付き試験 Issue を `/issue` で起票し `blockedByIssues` に relationship が設定される | `event=auto-run` | `/issue` phase は `/auto` の内側 |
+| #710 条件2 | body-only `Blocked by #N` の既存 Issue に `/triage N` で relationship が backfill される | `event=auto-run` | `/triage` phase は `/auto` の内側。本リポジトリは `autonomy: L3` のため `/triage` が advisory ではなく `set-blocked-by.sh` を実行する |
+| #513 | 次の同種 Issue で間接反映 AC が post-merge manual または command 型に正しく分類される | `event=auto-run` | `/issue` phase の内側 |
+| #512 | `/spec` フェーズで距離ルールに「A 以上かつ B 以下」表記が使われる | `event=auto-run` | `/spec` phase の内側 |
+| #491 | `/verify` 実行前に `workflow_dispatch` を促す運用が実際のワークフローで機能する | `event=auto-run` | `/verify` phase は `/auto` の内側 |
+| #490 | 実際の Issue AC で cron 依存条件に注記が付くことを 1 件以上のサンプルで確認 | `event=auto-run` | `/issue` phase の内側。**ただし #490 は OPEN のため dispatch 母集団外** |
+| #484 条件1 | 代表的な `/verify` 実行で Improvement Proposals が 3 層に分類され Tier 1 のみ Issue 化される | `event=auto-run` | `/verify` phase の内側 |
+| #478 条件1 | `/auto --batch` 実行中に blocked Issue がスキップされ適切な警告メッセージが出力される | `event=auto-run when=mode:batch` | batch 実行が観測窓。`mode` 軸で事前排除できる |
+| #478 条件2 | スキップされた Issue が checkpoint の `remaining` に保持され `--batch --resume` で再処理できる | `event=auto-run when=mode:batch` | 同上 |
+| #477 | 次の外部 API 統合 Spec で本規約が適用されている | `event=auto-run` | `/spec` phase の内側。「外部 API 統合 Spec」の出現有無は `when=` 3 軸で表現できず事前排除不能 |
+| #465 | `/auto` 実行で silent no-op が自動検出され 3-tier recovery へ流れる | `event=auto-run` | 条件文が `/auto` 実行を明示。**ただし #465 は OPEN のため dispatch 母集団外** |
+
+**ゲートの内訳**: 上表 14 行のうち、`when=mode:batch` ゲート付きが 3 行 (#1135 / #478 条件1 / #478 条件2)、ゲートなしが 11 行。
+
+### `event=watchdog-kill` (1 AC 行)
+
+| Issue | 条件文の要約 | 付与するタグ | 選定根拠 |
+|---|---|---|---|
+| #535 | watchdog-kill-before-PR を再現し Tier 3 が `unsupported op` なく commit→push→PR create で自動復旧する | `event=watchdog-kill` | watchdog kill の発火そのものが観測窓。`scripts/claude-watchdog.sh:138-140` の kill handler が `observation-trigger.sh --event watchdog-kill` を呼ぶ実装済み経路 |
+
+### `event=pr-review-full` (1 AC 行)
+
+| Issue | 条件文の要約 | 付与するタグ | 選定根拠 |
+|---|---|---|---|
+| #575 | `capabilities.workflow: true` のプロジェクトで `/review --full` が Workflow 経路で完走し概算トークン使用量が出力される | `event=pr-review-full config=capabilities.workflow` | 条件文が `--full` review を明示しており `pr-review-full` が正確な観測窓。`capabilities.workflow` は block 形式 1 階層ネストキーで `get-config-value.sh capabilities.workflow false` が `true` を返すことを実測済み |
+
+## retire マッピング (6 AC 行 / 6 Issue)
+
+| Issue | 条件文の要約 | retire 理由 | retire 後の phase |
+|---|---|---|---|
+| #783 | 停止後 `/merge N` で手動 merge できることを確認 | `auto-stop-at` は本リポジトリ未設定 (既定 `verify` = フルパイプライン) で停止自体が起きない。`config=` ゲートは boolean 専用のため enum キー `auto-stop-at` を表現できず、観測窓が原理的に開かない。実装の正しさは Pre-merge AC 10 件 (全チェック済) が担保 | `phase/verify` 維持 (他に未チェックの `opportunistic` AC 2 件が残る) |
+| #706 | `/audit drift` の "label namespace 整合性" チェック (将来拡張) がエラーを出さない | 条件文自身が「(将来拡張)」と明記するとおり当該チェックは未実装 (`skills/audit/SKILL.md` に該当なし)。実装されるまで発火契機が存在しない | `phase/done` へ遷移 (Pre-merge 6 件全チェック済 / 他の post-merge 条件なし) |
+| #591 | 実 XL Issue (Nuxt → Next 移行) の decomposition YAML で 50+ sub-issue を一括起票 | downstream プロジェクト固有の XL Issue が前提で、upstream に該当 Issue が存在しない。区分 B 相当で upstream から観測不能 | `phase/done` へ遷移 (Pre-merge 11 件全チェック済 / 残る post-merge 1 件は既に `- [x]`) |
+| #587 | Fable 5 復帰後にレポート結論が再評価され必要なら follow-up spike が起票されている | Fable 5 は 2026-07-01 に再デプロイ済 (`docs/tech.md` § Watchdog timeout calibration の #939 注記) で前提条件は既に発生済み。しかし比較基準だった「Opus 4.8 親セッション」構成は Sonnet 5 (2026-06-30) / Opus 5 (2026-07-24) のリリースで陳腐化しており、再評価に残存価値がない | `phase/done` へ遷移 (Pre-merge 5 件全チェック済 / 他の post-merge 条件なし) |
+| #563 | (該当時) Fable 5 採用後に security 観点の Opus 4.8 fallback が運用上問題ないこと | `docs/tech.md` line 115 が Fable 5 を opt-in only (never a default model swap) と明記しており「採用後」という前提が成立しない。条件文自身も「(該当時)」と条件付き | `phase/done` へ遷移 (Pre-merge 6 件全チェック済 / 残る post-merge 1 件は既に `- [x]`) |
+| #484 条件2 | downstream プロジェクトで retro/verify Issue の発生量がノイズ削減方向に変化することを観察 | 別リポジトリでの主観評価であり upstream から観測不能。#1163 が #501 / #500 / #479 に適用した downstream 依存の判断と同型 | `phase/verify` 維持 (同 Issue の条件1 が再型付けされ未チェックで残る) |
+
+## 対象外 (編集しない / 別扱い, 2 行)
+
+| Issue | 行の性質 | 扱い |
+|---|---|---|
+| #591 | `- [x]` (チェック済み) の manual AC 「フル auto-decomposition の follow-up Issue が起票されている」 | **編集しない**。既にチェック済みのため Manual Waiting Count にも `opportunistic-search.sh` にもマッチしない |
+| #491 | `## 提案内容` 節のコードフェンス内サンプル行 `- [ ] Trigger workflow once via ... <!-- verify-type: manual -->` | **AC ではないため再型付けも retire もしない**。ただし `- [ ]` + `verify-type: manual` に機械マッチし `/audit stats` の Manual Waiting Count に計上されるため、2 スペースのインデントを付けて `^- \[ \]` アンカーから外す。テキスト本文と `verify-type` は変更しない |
+
+## 検証
+
+（Step 9 実行後に追記）

--- a/docs/spec/issue-1165-manual-ac-retype-d3.md
+++ b/docs/spec/issue-1165-manual-ac-retype-d3.md
@@ -246,13 +246,14 @@ Size L 維持の根拠も #1163 と同じ — リポジトリ内変更は 1 フ�
 - Step 9 の `opportunistic-search.sh --event auto-run` 実行で #1135 / #478 が母集団にマッチしなかった。当初は GitHub 検索インデックスの遅延 (Spec Notes で予告済み) を原因と推測したが、`scripts/collect-run-facts.sh` がこのセッションで `mode: single` を返すこと、および #1135 / #478 の該当 AC 行がいずれも `when=mode:batch` ゲート付きであることを実測確認した結果、真因は `opportunistic-search.sh` の `when=` 条件ゲート (mode 軸) による設計どおりの除外と判明した。再実行 (2 回目) でも解消しなかったのはインデックス遅延ではなく確定的なゲート除外であることの証跡であり、`gh issue view --json body` によるリテラル一致確認を一次情報として採用した判断自体は変更していない。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- GitHub 側の編集 (16 AC 行の再型付け、6 AC 行の retire、4 Issue の `phase/done` 遷移、#491 のインデント無害化) は全件、実行前の `gh issue view` 確認で既に完了済みと判明した。二重適用リスクを避けるため `.tmp/retype-d3.py` などの一括置換ヘルパは新規作成・実行せず、実データの個別確認スクリプト (`.tmp/verify-retype.py`) で置換済み内容をリテラル一致確認する方式に切り替えた。
-- ローカル成果物 (`docs/reports/manual-ac-retype-d3.md`) は本セッションで新規作成し、Spec の「再型付けマッピング」「retire マッピング」「対象外」の各表をそのまま転記、`## 検証` 節に実測結果を追記した。
-- Issue #1165 自身の Pre-merge AC 8 件 (rubric 3 + github_check 5) は全件 PASS と判定し、Issue 本文のチェックボックスを更新した。
+- Step 8 (Pre-merge AC 8 件: rubric 3 + github_check 5) はすべて PASS。CI 9 ジョブもすべて SUCCESS。Base Branch Conflict Pre-check (`git merge-tree`) でも `changed in both` は検出されず、main との競合なし。
+- `capabilities.workflow: true` が有効だが、本セッションは `--non-interactive` (fork context) で再呼び出し保証がないため、`workflow-guidance.md` の指示に従い Workflow パスをスキップし、静的 Task fan-out (review-spec + review-bug×2、foreground Agent 呼び出し) にフォールバックした。
+- review-bug×2 が独立して同一の根本原因誤帰属 (report:85 の「GitHub 検索インデックスの遅延」が実際は `when=mode:batch` ゲートによる設計どおりの除外) を実測検証で発見。2 段階検証 (general-purpose 検証エージェント 5 件) を経て MUST 3 / SHOULD 1 / CONSIDER 4 の計 8 件を line コメントとして投稿し、全件を修正・コミット・プッシュ済み (`c67e431d`)。
+- 修正は `docs/reports/manual-ac-retype-d3.md` と `docs/spec/issue-1165-manual-ac-retype-d3.md` の記述精度訂正のみで、GitHub 上の Issue 再型付け・retire・phase 遷移という Issue #1165 本来の成果物 (Pre-merge AC1-8 が検証する内容) には影響しない。
 
 ### Deferred Items
 
@@ -262,5 +263,20 @@ Size L 維持の根拠も #1163 と同じ — リポジトリ内変更は 1 フ�
 
 ### Notes for Next Phase
 
-- `opportunistic-search.sh --event auto-run` は #1135 / #478 をマッチ集合に含めない。これは検索インデックスの遅延ではなく、3 行とも `when=mode:batch` ゲート付きのため、`--batch` 以外のセッション (`collect-run-facts.sh` が `mode: single` を返す通常の `/code` / `/review` / `/verify` 実行) では `opportunistic-search.sh` の `when=` 条件ゲートが設計どおり除外する結果であり、時間を置いても解消しない。`gh issue view --json body` によるリテラル一致確認は完了しているため、`/review` / `/verify` はこの不一致を待機で解消しようとせず、リテラル一致確認済みの実データを正とすること。dispatch 確認が必要な場合は `--facts-file` に `mode: batch` を含む run facts を与えるか、実際の `/auto --batch` 実行時に確認すること。
-- Issue #1165 自体の Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認) は post-merge のため `/verify` フェーズで扱う。
+- Issue #1165 自体の Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認、`observation event=auto-run`) は post-merge のため `/merge` 後の `/verify` フェーズで扱う。
+- `opportunistic-search.sh --event auto-run` が #1135 / #478 をマッチ集合に含めないのは `when=mode:batch` ゲートによる設計どおりの確定的除外であり、`/verify` はこれを異常や遅延として扱わないこと (report / spec とも修正済み)。dispatch 確認が必要な場合は `--facts-file` に `mode: batch` を含む run facts を与えるか、実際の `/auto --batch` 実行時に確認すること。
+- `/merge 1230` 実行可能 (MUST issue は全件修正済み、CI 全件 SUCCESS、Pre-merge AC 全件 PASS)。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Spec 自身が § Notes で「GitHub 検索インデックスの遅延」という仮説を code フェーズ以前に予告していたため、code フェーズで実際にマッチ不一致が発生した際、この予告済み仮説へパターンマッチして採用し、実際の除外機構 (`opportunistic-search.sh` の `when=mode:batch` 条件ゲート) を検証しないまま Report / Code Retrospective (Rework) / Phase Handoff (Notes for Next Phase) の 3 箇所へ同一の誤診断を転記した。review フェーズで 2 系統の review-bug エージェントが `scripts/collect-run-facts.sh` の実行結果と `when=` ゲートのコード読解によって誤りを検出し、3 箇所すべてを修正した。Spec が事前に用意した仮説は、実際に発生した不一致の原因を検証済みとみなす根拠にはならない、という教訓が得られた。
+
+### Recurring issues
+
+同一の誤診断が 1 箇所ではなく report / spec 内の 2 箇所 (Rework、Notes for Next Phase) に転記され、計 3 箇所で修正が必要になった。「先行文書 (report) の記述をそのまま後続文書 (retrospective, handoff) へ転記する」構成では、誤りが 1 箇所に留まらず伝播することが実例として確認できた。record-then-propagate 型の成果物では、転記元を修正した際に転記先も連動して修正されているか確認する工程が有効と考えられる。
+
+### Acceptance criteria verification difficulty
+
+Issue #1165 の Pre-merge AC 8 件 (rubric 3 + github_check 5) はいずれも Step 8 で PASS と判定され、UNCERTAIN は発生しなかった。rubric によるマッピング表の網羅性・根拠記録の意味論的検証と、github_check による GitHub 実状態の直接確認が明確に役割分担しており、verify command の記述・分類に起因する曖昧さはなかった。

--- a/docs/spec/issue-1165-manual-ac-retype-d3.md
+++ b/docs/spec/issue-1165-manual-ac-retype-d3.md
@@ -230,25 +230,37 @@ Size L 維持の根拠も #1163 と同じ — リポジトリ内変更は 1 フ�
 - **`config=` ゲートの `config=key:value` 拡張** — `modules/observation-trigger.md` § Condition Check Gate (`config=`) 自身が候補として挙げている。#783 はこの拡張があれば retire ではなく再型付けできた。
 - **`opportunistic-search.sh` の本文走査がセクション非依存であること** — コードフェンス内のサンプル AC を実 AC と誤認しうる。#491 が実例。
 
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Implementation Steps 1-10 の実行順序・内容ともにそのまま実施した。
+
+### Design Gaps/Ambiguities
+
+- Step 3 (`phase/ready` ラベルチェック) で、本 Issue は `phase/ready` を経由せず既に `phase/code` だった。原因は先行する非対話セッションが Implementation Steps 1-8 (report ファイル作成前の段階まで含む GitHub 側編集) を完了させた後、ローカルの commit/push/PR 作成前に中断していたため。Spec は完備しており `reconcile-phase-state.sh --check-precondition` の `matches_expected: false` は「ラベルが期待状態と異なる」ことを示すのみで実装の欠落を意味しなかったため、非対話モードの auto-resolve 方針 (warn-only) に従って続行した。
+
+### Rework
+
+- Step 2-3 (mapping JSON + 一括置換 python ヘルパ) と Step 6 (retire の手作業編集) は、実行前に対象 19 Issue 全件の本文・ラベルを `gh issue view` で確認した結果、先行セッションによってすでに完了済みであることが判明したため実行不要だった。二重適用を避けるため、`.tmp/retype-d3-mapping.json` / `.tmp/retype-d3.py` の新規作成・実行はスキップし、代わりに全 16 再型付け行 + 6 retire 行 + 4 ラベル遷移を個別に `gh issue view` でリテラル一致確認する検証スクリプト (`.tmp/verify-retype.py`) を書いて実データを突合した。Spec の Implementation Steps はそのまま (先行実行が失敗した場合の再実行パスとして有効なため変更なし)。
+- Step 9 の `opportunistic-search.sh --event auto-run` 実行で #1135 / #478 が母集団にマッチしなかった。GitHub 検索インデックスの遅延 (Spec Notes で予告済み) が原因と判断し、`gh issue view --json body` によるリテラル一致確認を一次情報として採用した。再実行(2回目)でも解消しなかったため、待機時間を延ばした再々実行は行わず、確認済みの実データを記録に採用した。
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- 成果物は pr route で `docs/reports/manual-ac-retype-d3.md` を 1 本追加する。Pre-merge AC 8 件のうち 3 件が `rubric` で、grader には Issue 本文・git diff・rubric 本文で名指しされたファイルしか渡らないため、operate route (Issue 本文編集のみ) では評価不能になる (#1163 と同じ判断)。
-- 22 AC 行の振り分けは再型付け 16 / retire 6 / manual 維持 0。前提が原理的に成立しない 6 行は `manual` 維持ではなく retire に倒した (#1163 からの意図的な方針変更、根拠は Notes § `manual` 維持がゼロである理由)。
-- retire は AC 行の削除ではなく `### Retired Post-merge Conditions` (h3) への退避で行う。h4 では `check-ac-checkbox-format.sh` の `in_section` が解除されず形式違反になるため、見出しレベルは必須制約。
-- 再型付けはタグ置換のみなので `.tmp/` の python ヘルパで一括実行 (dry-run → apply)、retire は節の移動を伴うため 1 件ずつ手作業。
+- GitHub 側の編集 (16 AC 行の再型付け、6 AC 行の retire、4 Issue の `phase/done` 遷移、#491 のインデント無害化) は全件、実行前の `gh issue view` 確認で既に完了済みと判明した。二重適用リスクを避けるため `.tmp/retype-d3.py` などの一括置換ヘルパは新規作成・実行せず、実データの個別確認スクリプト (`.tmp/verify-retype.py`) で置換済み内容をリテラル一致確認する方式に切り替えた。
+- ローカル成果物 (`docs/reports/manual-ac-retype-d3.md`) は本セッションで新規作成し、Spec の「再型付けマッピング」「retire マッピング」「対象外」の各表をそのまま転記、`## 検証` 節に実測結果を追記した。
+- Issue #1165 自身の Pre-merge AC 8 件 (rubric 3 + github_check 5) は全件 PASS と判定し、Issue 本文のチェックボックスを更新した。
 
 ### Deferred Items
 
-- OPEN 2 件 (#490 / #465) の close 判断 — 各 Issue 自身の post-merge 充足に依存するため本 Issue のスコープ外。再型付けのみ行う。
-- `check-ac-checkbox-format.sh` を `/code` の `allowed-tools` へ追加すること — スコープ外。Step 6 (d) は `python3` 同等判定または目視で代替する。
-- 別途起票候補 3 件 (closed 限定母集団 / `config=key:value` 拡張 / セクション非依存走査) — spec retrospective § 別途起票候補 に記録済み。`/verify` の Improvement Proposals で扱う。
+- OPEN 2 件 (#490 / #465) の close 判断 — 各 Issue 自身の post-merge 充足に依存するため本 Issue のスコープ外 (spec からの引き継ぎ、未変化)。
+- `check-ac-checkbox-format.sh` を `/code` の `allowed-tools` へ追加すること — スコープ外 (spec からの引き継ぎ、未変化)。
+- 別途起票候補 3 件 (closed 限定母集団 / `config=key:value` 拡張 / セクション非依存走査) — spec retrospective § 別途起票候補 に記録済み。`/verify` の Improvement Proposals で扱う (spec からの引き継ぎ、未変化)。
 
 ### Notes for Next Phase
 
-- Step 5 の一括置換で `match` 文字列が 2 行以上にマッチした Issue は必ず skip 警告を出し、`match` を修正して再実行すること。特に #710 と #478 は同一 Issue に 2 行あるため取り違えやすい。
-- Step 9 の検証は**件数差分で判定しないこと**。#1163 の Code Retrospective で母集団が他要因 (並行セッション / 新規 AC) でも変動することが実測されている。再型付けした Issue 番号の個別含有確認を一次情報とする。
-- GitHub 検索インデックスの遅延で、本文編集直後は `opportunistic-search.sh` の母集団に現れないことがある。マッチしない場合はまず `gh issue view N --json body` で本文の置換を確認し、時間を置いて再実行する。
-- #591 の `- [x]` 済み manual AC と #491 のコードフェンス内サンプル行は**性質が異なる** — 前者は編集不要、後者はインデント付与が必要。混同しないこと。
+- `opportunistic-search.sh --event auto-run` は #1135 / #478 をマッチ集合に含めなかった (GitHub 検索インデックスの遅延、Spec Notes で予告済み)。`gh issue view --json body` によるリテラル一致確認は完了しているため、`/review` / `/verify` で再実行しても件数がすぐに一致しなくても異常ではない。
+- Issue #1165 自体の Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認) は post-merge のため `/verify` フェーズで扱う。

--- a/docs/spec/issue-1165-manual-ac-retype-d3.md
+++ b/docs/spec/issue-1165-manual-ac-retype-d3.md
@@ -234,16 +234,16 @@ Size L 維持の根拠も #1163 と同じ — リポジトリ内変更は 1 フ�
 
 ### Deviations from Design
 
-- N/A — Implementation Steps 1-10 の実行順序・内容ともにそのまま実施した。
+- Step 2-6 (mapping JSON + 一括置換ヘルパの作成・実行、retire の手作業編集) は、先行する非対話セッションが GitHub 側編集を完了済みだったため未実行。二重適用を避けるため `.tmp/retype-d3-mapping.json` / `.tmp/retype-d3.py` の新規作成・実行はスキップし、代わりに `gh issue view` によるリテラル一致確認を行う検証スクリプト (`.tmp/verify-retype.py`) に置き換えた。Step 1 (report ファイル作成) および Step 7-10 (検証・コミット・PR 作成) は設計どおり実施した。詳細は下記 § Rework を参照。
 
 ### Design Gaps/Ambiguities
 
-- Step 3 (`phase/ready` ラベルチェック) で、本 Issue は `phase/ready` を経由せず既に `phase/code` だった。原因は先行する非対話セッションが Implementation Steps 1-8 (report ファイル作成前の段階まで含む GitHub 側編集) を完了させた後、ローカルの commit/push/PR 作成前に中断していたため。Spec は完備しており `reconcile-phase-state.sh --check-precondition` の `matches_expected: false` は「ラベルが期待状態と異なる」ことを示すのみで実装の欠落を意味しなかったため、非対話モードの auto-resolve 方針 (warn-only) に従って続行した。
+- `/code` SKILL Step 3 (`phase/ready` ラベルチェック) で、本 Issue は `phase/ready` を経由せず既に `phase/code` だった。原因は先行する非対話セッションが Spec の Implementation Steps 2-8 (report ファイル作成を除く GitHub 側編集) を完了させた後、ローカルの commit/push/PR 作成前に中断していたため。Spec は完備しており `reconcile-phase-state.sh --check-precondition` の `matches_expected: false` は「ラベルが期待状態と異なる」ことを示すのみで実装の欠落を意味しなかったため、非対話モードの auto-resolve 方針 (warn-only) に従って続行した。
 
 ### Rework
 
 - Step 2-3 (mapping JSON + 一括置換 python ヘルパ) と Step 6 (retire の手作業編集) は、実行前に対象 19 Issue 全件の本文・ラベルを `gh issue view` で確認した結果、先行セッションによってすでに完了済みであることが判明したため実行不要だった。二重適用を避けるため、`.tmp/retype-d3-mapping.json` / `.tmp/retype-d3.py` の新規作成・実行はスキップし、代わりに全 16 再型付け行 + 6 retire 行 + 4 ラベル遷移を個別に `gh issue view` でリテラル一致確認する検証スクリプト (`.tmp/verify-retype.py`) を書いて実データを突合した。Spec の Implementation Steps はそのまま (先行実行が失敗した場合の再実行パスとして有効なため変更なし)。
-- Step 9 の `opportunistic-search.sh --event auto-run` 実行で #1135 / #478 が母集団にマッチしなかった。GitHub 検索インデックスの遅延 (Spec Notes で予告済み) が原因と判断し、`gh issue view --json body` によるリテラル一致確認を一次情報として採用した。再実行(2回目)でも解消しなかったため、待機時間を延ばした再々実行は行わず、確認済みの実データを記録に採用した。
+- Step 9 の `opportunistic-search.sh --event auto-run` 実行で #1135 / #478 が母集団にマッチしなかった。当初は GitHub 検索インデックスの遅延 (Spec Notes で予告済み) を原因と推測したが、`scripts/collect-run-facts.sh` がこのセッションで `mode: single` を返すこと、および #1135 / #478 の該当 AC 行がいずれも `when=mode:batch` ゲート付きであることを実測確認した結果、真因は `opportunistic-search.sh` の `when=` 条件ゲート (mode 軸) による設計どおりの除外と判明した。再実行 (2 回目) でも解消しなかったのはインデックス遅延ではなく確定的なゲート除外であることの証跡であり、`gh issue view --json body` によるリテラル一致確認を一次情報として採用した判断自体は変更していない。
 
 ## Phase Handoff
 <!-- phase: code -->
@@ -262,5 +262,5 @@ Size L 維持の根拠も #1163 と同じ — リポジトリ内変更は 1 フ�
 
 ### Notes for Next Phase
 
-- `opportunistic-search.sh --event auto-run` は #1135 / #478 をマッチ集合に含めなかった (GitHub 検索インデックスの遅延、Spec Notes で予告済み)。`gh issue view --json body` によるリテラル一致確認は完了しているため、`/review` / `/verify` で再実行しても件数がすぐに一致しなくても異常ではない。
+- `opportunistic-search.sh --event auto-run` は #1135 / #478 をマッチ集合に含めない。これは検索インデックスの遅延ではなく、3 行とも `when=mode:batch` ゲート付きのため、`--batch` 以外のセッション (`collect-run-facts.sh` が `mode: single` を返す通常の `/code` / `/review` / `/verify` 実行) では `opportunistic-search.sh` の `when=` 条件ゲートが設計どおり除外する結果であり、時間を置いても解消しない。`gh issue view --json body` によるリテラル一致確認は完了しているため、`/review` / `/verify` はこの不一致を待機で解消しようとせず、リテラル一致確認済みの実データを正とすること。dispatch 確認が必要な場合は `--facts-file` に `mode: batch` を含む run facts を与えるか、実際の `/auto --batch` 実行時に確認すること。
 - Issue #1165 自体の Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認) は post-merge のため `/verify` フェーズで扱う。


### PR DESCRIPTION
## Summary

親 Issue #1158 の分割対応。`phase/verify` に滞留する `verify-type: manual` post-merge AC のうち区分 D3 (キーワード機械分類の残余 19 Issue / 22 AC 行) を 1 件ずつ精査し、observation への再型付け (16 行: `auto-run` 14 / `watchdog-kill` 1 / `pr-review-full` 1) / retire (6 行) / manual 維持 (0 行) に振り分けた。振り分けの根拠は `docs/reports/manual-ac-retype-d3.md` に記録。

対象 19 Issue の GitHub 上の状態 (本文の再型付け、`### Retired Post-merge Conditions` への退避、`phase/done` への遷移) は本 PR 提出前に完了済み — 先行して実行した非対話セッションが GitHub 側の編集まで終えた後に中断していたため、本セッションでは実行結果を `gh issue view` で個別確認したうえで、ローカルの記録ファイル作成・検証・コミット・PR 作成を完了させた。

- `docs/reports/manual-ac-retype-d3.md`: 新規作成。22 AC 行の振り分けマッピング表、判断根拠、`opportunistic-search.sh` による検証結果を記録
- 再型付け 16 AC 行 (14 Issue): `<!-- verify-type: manual -->` → `<!-- verify-type: observation event=<name> [gate] -->`
- retire 6 AC 行 (6 Issue): `### Post-merge` から除去し `### Retired Post-merge Conditions` (h3) へ取り消し線付きで退避
- retire 完了により post-merge 未チェック条件が 0 になった #706 / #587 / #563 / #591 を `phase/done` へ遷移
- #491 のコードフェンス内サンプル行 (AC ではないが機械走査にマッチしていた) を 2 スペースインデントで無害化

## Verification (pre-merge)

- rubric: 対象全件 (22 AC 行) が振り分けられ判断根拠が記録されている
- rubric: 再型付け分に `modules/verify-classifier.md` の有効な `event=` と選定根拠が記録されている
- rubric: retire 分の理由と `phase/done` 遷移が記録されている
- github_check: 代表 Issue #961 が `observation event=auto-run` へ再型付け済み
- github_check: 代表 Issue #535 が `observation event=watchdog-kill` へ再型付け済み
- github_check: 代表 Issue #575 に `config=capabilities.workflow` ゲートが付与済み
- github_check: retire した #706 が `### Retired Post-merge Conditions` 節を持つ
- github_check: #706 が `phase/done` へ遷移済み
- `bats tests/` 全 1507 件 PASS
- `scripts/check-forbidden-expressions.sh` PASS
- `python3 scripts/validate-skill-syntax.py skills/` PASS (0 error, 0 warning)

## Verification (post-merge)

- 移行完了後の `/audit stats --retention` で、`phase/verify` の Manual waiting 件数が本 Issue で処理した 19 Issue 分だけ減少していることを確認する

closes #1165
