### PR TITLE
Issue #1164: verify: manual AC 区分 D2 (実行シナリオ型 13 件) を observation へ再型付け

### DIFF
--- a/docs/reports/manual-ac-retype-d2.md
+++ b/docs/reports/manual-ac-retype-d2.md
@@ -1,0 +1,60 @@
+# manual AC 区分 D2: observation 再型付けマッピング (#1164)
+
+親 Issue #1158 の分割対応。`phase/verify` に滞留する `verify-type: manual` の post-merge AC のうち、区分 D2 (「実際に X を実行して…を確認する」実行シナリオ型) の 13 Issue / 16 AC 行を対象に、`verify-type: observation event=<name>` への再型付けを行った記録。
+
+## 対象・件数内訳
+
+- 対象 Issue: 13 件 (#1109 #1106 #1101 #1097 #1031 #954 #529 #515 #511 #507 #486 #446 #444)
+- 対象 AC 行: 16 行 (#507 が 3 行、#446 が 2 行を持つため、Issue 単位の 13 件と AC 行単位の 16 行にずれがある)
+- 再型付け: **12 行** (すべて `event=auto-run`)
+- 対象外 (`manual` 維持): **4 行** (#507 が 3 行、#444 が 1 行)
+
+## `event=` 有効値の制約
+
+`event=` に使用できるのは `modules/verify-classifier.md` § observation Type が定める 5 つの有効値のみ: `pr-review-full` / `pr-review-light` / `auto-run` / `watchdog-kill` / `fix-cycle`。区分 D2 の条件文は「実際に X を実行して…を確認する」という実行シナリオ型であり、`/auto` のいずれかのフェーズ (issue / spec / code / review / verify) の内側で発火しうるものが大半のため、`auto-run` (取りこぼさない最も広いイベント) を選定した。5 値のいずれの emitter にも対応しない条件 (#444) は `manual` のまま維持し対象外とした。
+
+## 再型付けマッピング
+
+### `event=auto-run` (12 AC 行)
+
+| Issue | event | 条件文の要約 | 選定根拠 |
+|---|---|---|---|
+| #1109 | auto-run | observation AC を持つ Issue に event 発火後 `/verify` を実行し、条件充足時に checkbox 更新・`phase/done` 遷移を確認 | `/verify` は `/auto` の verify phase として実行される。observation 機構自体を検証する条件であり、`/auto` 完了ごとに再チェックする意義が大きい |
+| #1106 | auto-run | 自己 PR に `/auto` の pr route を実行し、merge precondition の警告が出ずに進行することを確認 | `/auto` 実行そのものが観測窓。**2026-08-04 の `/auto 1150` (PR #1151, 自己 PR・pr route・precondition `matches_expected: true`) で既に充足済み** — Issue コメントで記録済み |
+| #1101 | auto-run | ベースブランチ側と同一行を変更する PR を実際にレビューし、conflict が MUST 指摘として検出されることを確認 | `/review` は `/auto` 実行の内側。`pr-review-full`/`pr-review-light` いずれの深度でも起こりうる指摘であり、深度を限定する狭いイベントだと取りこぼす |
+| #1097 | auto-run | Size L の PR に `run-review.sh --full` を実行し silent no-op 検出が発生せず Response Summary が投稿されることを確認 | `--full` review は `/auto` の review phase 内で実行されうる。**2026-08-04 の `/auto 1150` (PR #1151, Size L・`--full`・exit 0 + Summary 投稿済み) で既に充足済み** — Issue コメントで記録済み |
+| #1031 | auto-run | 実際に `/issue` を XL Issue に対して実行し、Step 12a→12c 完了時点で FleetView/pane に subagent が残らないことを目視確認 | `/issue` は `/auto` 実行の内側。非対話モードでは L/XL sub-agent fan-off が High-Stakes Decision として無条件 skip されるため `/auto` 自身の issue phase がこの条件を満たすことは構造的にないが、対話モードでの直接 `/issue` 実行という別経路が満たしうるため対象外にはせず `auto-run` を付与した |
+| #954 | auto-run | 実際に Size=XL の Issue で `/issue` を実行し、3 エージェントの調査結果が手動介入なしに回収できることを確認 | #1031 と同型の留意点 (非対話モードでの Step 12a 無条件 skip) が適用される。同じ理由で対象外にはせず `auto-run` を付与する |
+| #529 | auto-run | spec phase で Size が変化する Issue に `/auto N` を実行し、変化後の Size に応じた review 深度・route が自動選択されることを実運用で確認 | 条件文が `/auto N` の実行そのものを明示している |
+| #515 | auto-run | 実プロジェクトで `/verify N` を複数回実行し、tool call parse 失敗の発生頻度が改善していることを定性的に確認 | `/verify` は `/auto` 実行の内側で反復実行される。「頻度が改善」は単発の event 発火では判定しづらい定性的・統計的な問いであり、専用の計測基盤は現状存在しないため、`/verify` 再チェック時の LLM 判断 (rubric 相当) に委ねる設計とする |
+| #511 | auto-run | 実機 external connector を使う Issue を `/auto` 非対話モードで実行し、MCP smoke 呼び出しブロック時に SKIPPED が記録され run が中断しないことを確認 | Smoke Test 機構自体は本リポジトリの `/code` (`/auto` の内側) に実装済み (#511 で導入)。当該リポジトリ自身の将来 Issue が `## Smoke Test` + `mcp_call` を持てば発火しうる |
+| #486 | auto-run | 削除系 PR (`file_not_exists`/`file_not_contains` AC を含む) を実際にレビューし FALSE POSITIVE が発生しないことを確認 | `/review` は `/auto` 実行の内側 |
+| #446 条件1 | auto-run | サンプル Issue (新 verify command 提案) で `/issue` 実行し、既存 adapter pattern 確認 step が機能することを確認 | 「サンプル」に限らず、新規 verify command を提案する実 Issue が `/issue`/`/spec` (いずれも `/auto` の内側) で処理されるたびに発火しうる |
+| #446 条件2 | auto-run | 同様に `/spec` 実行で確認 | 条件1と同じ根拠 |
+
+### 対象外 (`manual` 維持、4 AC 行)
+
+| Issue | event | 条件文の要約 | 対象外の理由 |
+|---|---|---|---|
+| #507 条件1 | 対象外 | saito/trading リポジトリで `/audit stats --since 2026-05-01` を実行し First-try 成功率の変化を確認 | 別リポジトリ (`saito/trading`) 依存。Issue 本文自身が「saito/trading リポジトリでの実際の `/audit stats` 実行確認が必要であり、機械的に自動検証できない」と明記済み (downstream から観測不能) |
+| #507 条件2 | 対象外 | Outcome レポートに「対象 N 件 / 除外 M 件」表示が含まれることを確認 | 条件1と同一理由 (同一 Issue 内の並列条件) |
+| #507 条件3 | 対象外 | 既存 trading レポートで Highlights 表示が再計算後に変わることを確認 | 条件1と同一理由 |
+| #444 | 対象外 | `/audit stats` を再実行し、SKILL.md の手順だけで全工程が完走することを確認 | `/audit` は `/auto` のフェーズチェーンに含まれない独立 skill。`modules/verify-classifier.md` の 5 有効値はいずれも `/auto`・`/review`・`claude-watchdog.sh`・fix-cycle のいずれかが emitter であり、`/audit` 単独実行に対応する event が存在しない (機構側の語彙制約による除外) |
+
+## 検証
+
+`${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh --event auto-run --dry-run` (read-only。`--dry-run` は `observation-trigger.sh` とのインターフェース互換のために受理される no-op) を実行し、再型付け後の AC がマッチ対象になることを確認した。
+
+- 実行結果: マッチ 85 AC 行 (2026-08-07 実測)
+- 再型付け前 baseline (Spec 記載, #1163 適用後 2026-08-06 実測): 59 AC 行
+- 本 Issue で再型付けした 12 AC 行 (#1109 #1106 #1101 #1097 #1031 #954 #529 #515 #511 #486 #446×2) は **全件マッチ集合に含まれることを確認済み** (Python で機械的に突合、各 1 回 / #446 のみ 2 回のマッチを確認)
+- baseline 59 との単純差分 (+26) は再型付け 12 行と一致しない。同期間に他 sub-issue (#1165〜#1167 等、親 #1158 の並行対応) や `/auto` 実行由来の新規 `observation event=auto-run` AC が母集団に加わった可能性があり、本 Issue の再型付けだけが変動要因ではない。目視突合で対象 12 行の含有を直接確認しているため、件数差分の厳密一致よりもこちらを正とする
+
+### GitHub 上の実状態
+
+- `gh issue view 1109 --json body`: `verify-type: observation event=auto-run` へ再型付け済みを確認
+- `gh issue view 1106 --json body`: `verify-type: observation event=auto-run` へ再型付け済みを確認 (既充足コメントも投稿済み)
+- `gh issue view 1097 --json body`: `verify-type: observation event=auto-run` へ再型付け済みを確認 (既充足コメントも投稿済み)
+- `gh issue view 446 --json body`: 2 条件とも `verify-type: observation event=auto-run` へ再型付け済みを確認
+- `gh issue view 507 --json body`: 3 条件とも `verify-type: manual` のまま維持されていることを確認 (対象外)
+- `gh issue view 444 --json body`: `verify-type: manual` のまま維持されていることを確認 (対象外)

--- a/docs/spec/issue-1164-manual-ac-retype-d2.md
+++ b/docs/spec/issue-1164-manual-ac-retype-d2.md
@@ -113,3 +113,43 @@
 
 ## Consumed Comments
 No new comments since last phase.
+
+## Autonomous Auto-Resolve Log
+
+- **`phase/ready` ラベル不在での続行**: `/code 1164 --pr --non-interactive` 開始時点で Issue のラベルは `phase/code` (label timeline 上、`phase/ready` は既に `phase/code` へ遷移済み)。`reconcile-phase-state.sh --check-precondition code-pr` も `matches_expected: false` を返した。Spec (本ファイル) は spec retrospective まで完備しており、コーディング未着手のまま前回セッションが label 遷移後に中断したレジューム状態と判断した。Spec が存在するため「Spec なしで Issue 本文から要件を読む」対応は不要 — reason: 非対話モードのポリシー (auto-resolve) は Spec 欠落時の縮退経路であり、本件は Spec 完備のため実質的にブロッカーではない。#1163 の Code Retrospective と同型の判断。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- Implementation Steps 2〜4 (`.tmp/retype-mapping-d2.json` 作成 → `.tmp/retype-ac-d2.py` 作成・dry-run・`--apply` 実行、#1164 自身の「Blocked by #1157」文言更新、#1106/#1097 への既充足コメント投稿) を実行しなかった。`/code` 開始時点で対象 13 Issue 全件の GitHub 上の実状態を個別確認したところ、11 Issue 12 AC 行はすべて `verify-type: observation event=auto-run` へ再型付け済み、対象外の #507 (3 行) / #444 (1 行) は `verify-type: manual` のまま誤編集なく維持されていた。#1106・#1097 への既充足コメントも投稿済み、#1164 自身の「Blocked by #1157」セクションも「解消済み」へ更新済みだった。前回セッションが Issue 本文編集・コメント投稿を完了した後、report file 作成前に中断したレジューム状態と判断し、実質的な追加作業は Implementation Step 1 (report file 作成) と Step 5 (`opportunistic-search.sh` による検証・記録) のみとした。#1163 の Code Retrospective と全く同型の状況が区分 D2 でも再現した — 親 #1158 の分割 sub-issue 群で同種のレジュームパターンが繰り返されている。Spec Implementation Steps の記述自体は変更しない (次回同種の再型付け Issue で `.tmp/` ヘルパパターンを再利用する際の参照価値を残すため)。
+
+### Design Gaps/Ambiguities
+
+- なし。#1163 の precedent (report ファイル構造、`opportunistic-search.sh` 検証手順) をそのまま踏襲でき、設計上の曖昧さは生じなかった。
+
+### Rework
+
+- なし。
+
+### Unrelated pre-existing test failures discovered
+
+- `bats tests/` (1507 件) 実行で `run-code.bats` の `auto-retry: silent no-op + AUTO_RETRY_ENABLED=true fires retry` と `auto-retry: preflight stashes parent-main stray untracked file before retry re-invocation` の 2 件が単独実行でも一貫して FAIL することを発見した。両テストとも `reconcile-phase-state.sh` mock のカウンタが retry ループ内で意図通り増加していない (`auto-retry: max iterations reached (3/3)` に到達) ことが原因と推測される。本 Issue の diff は `docs/reports/manual-ac-retype-d2.md` の新規追加のみで `scripts/run-code.sh` やテスト自体には触れていないため、本 Issue のスコープ外の pre-existing な問題と判断し、follow-up Issue #1231 (`retro/code` ラベル) を起票した。また `post_merge_check.bats` の 1 件 (`gh issue reopen called when FAIL input given`) は `--jobs 8` 並列実行時のみ FAIL し、単独実行では PASS することを確認済み (並列実行時のフレーク、実害なし)。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+
+- レジューム検知: 対象 13 Issue 全件の GitHub 上の実状態を個別確認し、11 Issue 12 AC 行が既に `observation event=auto-run` へ再型付け済み、#507/#444 が `manual` のまま誤編集なく維持されていることを確認した。前回セッションが Issue 本文編集完了後・report file 作成前に中断したレジューム状態と判断し、残作業 (`docs/reports/manual-ac-retype-d2.md` 作成 + `opportunistic-search.sh` 検証) のみを実施した。
+- Pre-merge rubric AC 3 件は report ファイル + 既存の Issue 側編集内容と照合し PASS と判定、Issue #1164 のチェックボックスを更新済み。
+
+### Deferred Items
+
+- Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認) — `/verify` が `observation event=auto-run` 経路で評価する。
+- follow-up Issue #1231 (`run-code.bats` の auto-retry テスト 2 件の FAIL) — 本 Issue のスコープ外、別 Issue で対応。
+
+### Notes for Next Phase
+
+- `bats tests/` フルスイート (`--jobs 8`, 1507 件) で本 PR 由来ではない pre-existing FAIL 3 件 (`run-code.bats` ×2, `post_merge_check.bats` ×1 は並列実行時のみのフレーク) を確認済み。review で CI が同じ FAIL を検出しても、本 PR の diff (`docs/reports/manual-ac-retype-d2.md` の新規追加のみ) に起因するものではないことを踏まえて判断すること。
+- Pre-merge AC 3 件 (rubric ×3) は code phase で PASS 判定・チェック済み。review での再確認は不要 (#1163 と同型)。

--- a/docs/spec/issue-1164-manual-ac-retype-d2.md
+++ b/docs/spec/issue-1164-manual-ac-retype-d2.md
@@ -136,8 +136,37 @@ No new comments since last phase.
 
 - `bats tests/` (1507 件) 実行で `run-code.bats` の `auto-retry: silent no-op + AUTO_RETRY_ENABLED=true fires retry` と `auto-retry: preflight stashes parent-main stray untracked file before retry re-invocation` の 2 件が単独実行でも一貫して FAIL することを発見した。両テストとも `reconcile-phase-state.sh` mock のカウンタが retry ループ内で意図通り増加していない (`auto-retry: max iterations reached (3/3)` に到達) ことが原因と推測される。本 Issue の diff は `docs/reports/manual-ac-retype-d2.md` の新規追加のみで `scripts/run-code.sh` やテスト自体には触れていないため、本 Issue のスコープ外の pre-existing な問題と判断し、follow-up Issue #1231 (`retro/code` ラベル) を起票した。また `post_merge_check.bats` の 1 件 (`gh issue reopen called when FAIL input given`) は `--jobs 8` 並列実行時のみ FAIL し、単独実行では PASS することを確認済み (並列実行時のフレーク、実害なし)。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- なし。本 PR は `docs/reports/manual-ac-retype-d2.md` の新規追加と Spec 側の retrospective/handoff 追記のみで、Spec の Implementation Steps からの逸脱はレジューム判断 (#1163 と同型) 以外になかった。
+
+### Recurring issues
+
+- 親 #1158 の分割 sub-issue 群で、「前回セッションが Issue 本文編集・コメント投稿完了後、report file 作成前に中断」というレジュームパターンが #1163 に続き #1164 でも再現した。同種の再型付け Issue が今後も残っている場合、同じ中断パターンが繰り返される可能性が高い。
+
+### Acceptance criteria verification difficulty
+
+- Pre-merge AC 3 件はすべて `rubric` 形式で、対象 13 Issue の GitHub 実状態を個別に `gh issue view` で照合することで機械的かつ明確に PASS 判定できた。UNCERTAIN や verify command の不備は発生しなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
+
+### Key Decisions
+
+- Pre-merge rubric AC 3 件を、対象 13 Issue の GitHub 実状態 (`gh issue view` による個別照合) および #1106・#1097 の充足コメント、#507/#444 の対象外理由記録と突き合わせ、いずれも PASS と判定した。
+- REVIEW_DEPTH=light (Size M + `--light` 明示) のため review-light エージェント 1 体による全 4 観点統合レビューを実行し、MUST/SHOULD/CONSIDER いずれも検出されなかった。
+
+### Deferred Items
+
+- Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認) — `/verify` が `observation event=auto-run` 経路で評価する。
+- follow-up Issue #1231 (`run-code.bats` の auto-retry テスト 2 件の FAIL) — 本 Issue のスコープ外、別 Issue で対応。
+
+### Notes for Next Phase
+
+- MUST issue が存在しないため `event=COMMENT` でレビュー投稿済み。`/merge 1232` に進んで問題ない。
+- CI 全 9 ジョブ SUCCESS 済み、base branch (`main`) との衝突 (`changed in both`) は検出されなかった。
 
 ### Key Decisions
 


### PR DESCRIPTION
## Summary

- `phase/verify` に滞留する `verify-type: manual` の post-merge AC のうち、区分 D2 (実行シナリオ型) の 13 Issue / 16 AC 行を対象とした再型付け作業の記録。
- 対象 12 AC 行 (11 Issue) は前回セッションで既に `verify-type: observation event=auto-run` へ再型付け済みであり、#1106・#1097 への既充足コメント投稿、#1164 自身の「Blocked by #1157」文言更新も完了していた (レジューム状態)。本 PR では残作業として `docs/reports/manual-ac-retype-d2.md` を新規作成し、マッピング表・対象外理由・`opportunistic-search.sh --event auto-run` による検証結果を記録した。
- 対象外 4 AC 行 (#507 ×3, #444 ×1) は `verify-type: manual` のまま維持し、対象外理由をレポートに記録した。

## Verification (pre-merge)

- `docs/reports/manual-ac-retype-d2.md` に区分 D2 全 16 AC 行 (再型付け 12 行 / 対象外 4 行) のマッピング表と選定根拠を記録
- `opportunistic-search.sh --event auto-run --dry-run` を実行し、再型付けした 12 AC 行 (#1109 #1106 #1101 #1097 #1031 #954 #529 #515 #511 #486 #446×2) が全件マッチ集合に含まれることを確認 (マッチ総数 85 AC 行、2026-08-07 実測)
- #1106・#1097 への既充足コメント投稿を確認 (2026-08-04 `/auto 1150` (PR #1151) 実行で条件充足済みの事実)
- Pre-merge rubric AC 3 件を実装 (report ファイル + Issue 側編集済み内容) と照合し PASS と判定、Issue #1164 のチェックボックスを更新済み
- `bats tests/` (1507 件、`--jobs 8`) を実行し、本 PR の変更 (新規ドキュメント追加のみ) に起因する FAIL がないことを確認。既存 3 件の FAIL (`post_merge_check.bats` 1 件、`run-code.bats` 2 件) は本変更と無関係な pre-existing の問題であることを個別実行で確認済み — follow-up Issue #1231 を起票した
- `scripts/check-forbidden-expressions.sh` PASS

## Verification (post-merge)

- 移行完了後の `/audit stats --retention` で、phase/verify の Manual waiting 件数が移行前 (79 件) から 13 件減少していることを確認する (`verify-type: observation event=auto-run` で評価)

closes #1164
