### PR TITLE
Issue #1108: auto: run-auto-sub.sh の spec dispatch を Size 判定込みで /auto Step 3 と一致させる

### DIFF
--- a/docs/spec/issue-1108-auto-spec-dispatch-xs-gate.md
+++ b/docs/spec/issue-1108-auto-spec-dispatch-xs-gate.md
@@ -87,3 +87,41 @@ Completion Report は同一セッション内で Step 2 / Step 8 の triage auto
 ## Consumed Comments
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / 概要: `/issue` フェーズの Issue Retrospective。Issue 本文への「追加観察 (`/issue` の XS 時ラベル付与の非決定性)」の折り込みが既に完了していること、対応方針 (案 A/B/C) の最終決定は `/spec` に委ねる判断であることを記録。タイトルは変更しないと判断した旨も記載。 / URL: https://github.com/saitoco/wholework/issues/1108#issuecomment-5212311203
+
+### code phase (cutoff: `2026-08-07T04:45:15Z`)
+
+No new comments since last phase.
+
+## Autonomous Auto-Resolve Log
+
+- Step 3 (`phase/ready` label check): label list is `triaged`, `phase/code`, `retro/verify` — `phase/ready` is absent because the Issue already advanced past it (timeline shows `phase/ready` at 04:41:22Z → `phase/code` at 04:45:15Z, no PR/branch/worktree existed prior to this run, indicating a prior `/code` invocation transitioned the label but did not complete implementation). Spec file `docs/spec/issue-1108-auto-spec-dispatch-xs-gate.md` was confirmed present and complete. Auto-resolved: proceed with implementation using the existing Spec.
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — implementation followed the Spec's 4 Implementation Steps as written.
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A
+
+### Smoke Test
+- N/A — Spec has no `## Smoke Test` section.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Adopted the Spec's already-decided 案 A (fix `run-auto-sub.sh` to match `skills/auto/SKILL.md` Step 3) verbatim — no new design decisions were needed at code time.
+- All 4 Implementation Steps were carried out exactly as specified; no reordering, consolidation, or approach change occurred.
+- Judged all 5 pre-merge `rubric` AC as PASS during Step 10 self-verification (diff-based adversarial check against each condition text) and checked the corresponding Issue checkboxes before PR creation.
+
+### Deferred Items
+- Post-merge AC ("`--batch` で XS Issue を処理し、spec 要否が規定どおりになること、および Step 4b が二重転記を起こさないことを確認する", `verify-type: opportunistic`) is deferred to post-merge observation as designed — not actionable pre-merge.
+
+### Notes for Next Phase
+- This `/code` run resumed from a stale `phase/code` label with no prior PR/branch/worktree — the Issue timeline shows `phase/ready` → `phase/code` transitioned 4 minutes apart with nothing committed in between, indicating an earlier `/code` invocation was interrupted before creating a PR. This run treated it as a fresh start using the existing Spec; no residual state needed reconciling.
+- The diff touches `scripts/run-auto-sub.sh`, `skills/auto/SKILL.md`, and `skills/issue/SKILL.md` — all three are referenced by test files beyond their direct bats counterpart, so this triggered the Behavioral Change Detection override: `bats tests/` (full suite, 1508 tests) ran instead of the narrower auto-detected scope, all passing.
+- Spec Notes already established that `docs/workflow.md` and the two SSoT tables in `modules/size-workflow-table.md` need no edit (rule unchanged, only actual behavior corrected to match) — review does not need to re-litigate that scope call.

--- a/docs/spec/issue-1108-auto-spec-dispatch-xs-gate.md
+++ b/docs/spec/issue-1108-auto-spec-dispatch-xs-gate.md
@@ -111,17 +111,32 @@ No new comments since last phase.
 - N/A — Spec has no `## Smoke Test` section.
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Adopted the Spec's already-decided 案 A (fix `run-auto-sub.sh` to match `skills/auto/SKILL.md` Step 3) verbatim — no new design decisions were needed at code time.
-- All 4 Implementation Steps were carried out exactly as specified; no reordering, consolidation, or approach change occurred.
-- Judged all 5 pre-merge `rubric` AC as PASS during Step 10 self-verification (diff-based adversarial check against each condition text) and checked the corresponding Issue checkboxes before PR creation.
+- Ran `/review 1235 --light --non-interactive` (Size=M → `REVIEW_DEPTH=light`, matching the `--light` override). Base branch conflict pre-check (`git merge-tree`, 3-arg form) found 0 `changed in both` blocks — no conflict context passed to the review agent.
+- Re-verified all 5 pre-merge `rubric` AC independently in Step 8 (adversarial re-check, not just trusting the code phase's self-verification) — all 5 confirmed PASS with the same reasoning as the code phase's Phase Handoff.
+- Ran `review-light` (all 4 aspects: spec deviation, edge cases, security, documentation consistency) — found 1 CONSIDER-severity issue (cosmetic log-message ordering in `scripts/run-auto-sub.sh`'s new XS branch when `phase/ready` is also absent-vs-present), 0 MUST/SHOULD. Posted as an inline PR comment; not fixed (Claude's Step 12 judgment: cosmetic only, no functional impact, review agent itself offered "leave as-is" as an acceptable alternative).
+- CI: all 9 checks (DCO, Run bats tests ×2, Validate skill syntax ×2, Forbidden Expressions check ×2, macOS shell compatibility ×2) SUCCESS — no FAIL-blocking entries injected into the review.
 
 ### Deferred Items
-- Post-merge AC ("`--batch` で XS Issue を処理し、spec 要否が規定どおりになること、および Step 4b が二重転記を起こさないことを確認する", `verify-type: opportunistic`) is deferred to post-merge observation as designed — not actionable pre-merge.
+- Post-merge AC ("`--batch` で XS Issue を処理し、spec 要否が規定どおりになること、および Step 4b が二重転記を起こさないことを確認する", `verify-type: opportunistic`) remains deferred to post-merge observation — unchanged from the code phase's handoff, still `- [ ]` in the Issue body (cross-referenced, not stale).
+- The CONSIDER-severity log-message-ordering issue in `scripts/run-auto-sub.sh:840` was left unfixed; if a future change touches this `elif` chain, consider reordering the `phase/ready`-absence check ahead of the `Size == XS` check so the log message always attributes the skip to its most direct cause.
 
 ### Notes for Next Phase
-- This `/code` run resumed from a stale `phase/code` label with no prior PR/branch/worktree — the Issue timeline shows `phase/ready` → `phase/code` transitioned 4 minutes apart with nothing committed in between, indicating an earlier `/code` invocation was interrupted before creating a PR. This run treated it as a fresh start using the existing Spec; no residual state needed reconciling.
-- The diff touches `scripts/run-auto-sub.sh`, `skills/auto/SKILL.md`, and `skills/issue/SKILL.md` — all three are referenced by test files beyond their direct bats counterpart, so this triggered the Behavioral Change Detection override: `bats tests/` (full suite, 1508 tests) ran instead of the narrower auto-detected scope, all passing.
-- Spec Notes already established that `docs/workflow.md` and the two SSoT tables in `modules/size-workflow-table.md` need no edit (rule unchanged, only actual behavior corrected to match) — review does not need to re-litigate that scope call.
+- No MUST issues — review posted as `COMMENT`, not `REQUEST_CHANGES`. `/merge 1235` can proceed directly.
+- No policy changes were made in this review pass (Step 12 made no implementation edits), so Step 13's Issue body / AC update was skipped — the Issue's AC text and verify commands are unchanged from the Spec's Verification section.
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — implementation matched the Spec's 4 Implementation Steps exactly, confirmed both by the code phase's own retrospective (Deviations from Design: N/A) and by this review's independent Step 8/10 re-check.
+
+### Recurring issues
+
+Nothing to note — no issue class repeated within this PR (the single CONSIDER finding was a standalone cosmetic observation, not a pattern across multiple files/branches).
+
+### Acceptance criteria verification difficulty
+
+All 5 pre-merge conditions used `rubric` verify commands exclusively (no mechanical `file_contains`/`grep` supplementary checks). This worked cleanly here because the PR diff is small (5 files, ~76 net lines) and each AC maps to a clearly bounded code/doc change, but it's worth noting for future Issues in this area: AC1 ("XS Issue に対して同じ結論を出す") and AC5 ("`/issue` 側の XS 時ラベル付与の非決定性が解消されている") both describe *behavioral equivalence across two independent code paths* rather than a single-file property — a grader without git history access could plausibly miss that the "before" state (Bug 1 / Bug 2 in the Spec's Root Cause section) is what makes the "after" state meaningful. No actual grading difficulty was observed in this run, but a rubric text that briefly names the specific *prior* broken behavior (not just the desired end state) would make the grader's job more robust for this class of "make two paths agree" AC — no Issue filed for this, recording as an observation only per [[feedback_issue_filing_restraint]].

--- a/scripts/run-auto-sub.sh
+++ b/scripts/run-auto-sub.sh
@@ -829,9 +829,15 @@ emit_event "sub_start" "size=${SIZE}"
 # phase/merge, phase/verify, and phase/done — phase/ready is removed once /code starts
 # and is not restored on this path, so without this check every one of those states
 # would redundantly re-dispatch run-spec.sh on a resumed run (issue #977).
+# Also skip when Size is XS: skills/auto/SKILL.md Step 3 (single-issue route) treats
+# spec as not required for XS, and this batch/XL route must reach the same conclusion
+# for the same Size (issue #1108) — otherwise a `phase/issue` (no `phase/ready`) XS
+# issue would dispatch run-spec.sh here despite the single-issue route skipping it.
 LABELS=$(gh issue view "$SUB_NUMBER" --json labels -q '.labels[].name' 2>/dev/null || true)
 if echo "$LABELS" | grep -qE "phase/(code|review|merge|verify|done)"; then
   echo "${LOG_PREFIX} spec phase: skipping dispatch for issue #${SUB_NUMBER} (phase/code, phase/review, phase/merge, phase/verify, or phase/done label present; spec already completed)"
+elif [[ "$SIZE" == "XS" ]]; then
+  echo "${LOG_PREFIX} spec phase: skipping dispatch for issue #${SUB_NUMBER} (Size XS; spec not required per skills/auto/SKILL.md Step 3)"
 elif ! echo "$LABELS" | grep -q "phase/ready"; then
   echo "${LOG_PREFIX} --- spec phase: issue #${SUB_NUMBER} ---"
   # Bash-side comments_consumed emit for spec phase. (Issue #705)

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -323,7 +323,7 @@ Before running any phase, initialize `VERIFY_ITERATION_COUNT`:
 
 ---
 
-**XL route: sub-issue dependency graph with parallel execution (`run-auto-sub.sh` checks each sub-issue's `phase/ready` and auto-runs spec if not set):**
+**XL route: sub-issue dependency graph with parallel execution (`run-auto-sub.sh` checks each sub-issue's `phase/ready` and Size, auto-running spec only when `phase/ready` is absent and Size is not XS (mirrors Step 3)):**
 
 `run-auto-sub.sh` independently loads `ALWAYS_PR` from `.wholework.yml` (via `get-config-value.sh always-pr false`) and applies the same patch→pr promotion logic as Step 2 above when determining each sub-issue's Size-based route — so `always-pr: true` is honored consistently for both the single-Issue path and the XL sub-issue path.
 

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -811,7 +811,7 @@ When an AC describes a behavioral or semantic outcome rather than specific text,
 
 ## Completion Report
 
-After opportunistic verification, get Size with `get-issue-size.sh $NUMBER`.
+After opportunistic verification, get Size with `get-issue-size.sh --no-cache $NUMBER` (avoids a stale cached read immediately after Step 2/Step 8's triage auto-chain sets Size via GraphQL mutation — see `scripts/get-issue-size.sh`'s own `--no-cache` usage note).
 
 **For XL issues (after sub-issue splitting)**: list sub-issues with unresolved "Needs Refinement" points and recommend running `/issue N` for each. Do not list sub-issues without needs-refinement points.
 

--- a/tests/run-auto-sub.bats
+++ b/tests/run-auto-sub.bats
@@ -454,6 +454,36 @@ MOCK
     [ -f "$RUN_SPEC_LOG" ]
 }
 
+@test "Size XS + phase/ready absent: run-spec.sh is NOT called (issue #1108)" {
+    cat > "$MOCK_DIR/get-issue-size.sh" <<'MOCK'
+#!/bin/bash
+echo "XS"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/get-issue-size.sh"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "view" && "$*" == *"--json labels"* ]]; then
+    echo "triaged"
+    echo "phase/issue"
+    exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo '[{"headRefName":"worktree-code+issue-42","number":99}]'
+    exit 0
+fi
+echo ""
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 42
+    [ "$status" -eq 0 ]
+    [ ! -f "$RUN_SPEC_LOG" ]
+    [[ "$output" == *"skipping dispatch for issue #42 (Size XS; spec not required per skills/auto/SKILL.md Step 3)"* ]]
+}
+
 @test "--base flag propagates to run-code.sh for Size M; verify is NOT called by run-auto-sub.sh (deferred to parent /auto)" {
     run bash "$SCRIPT" 42 --base release/v1
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- `scripts/run-auto-sub.sh`: spec フェーズ dispatch に `Size == XS` 分岐を追加し、`skills/auto/SKILL.md` Step 3 (単一 Issue 経路) の「Size XS は spec 不要」ルールに batch/XL 経路を一致させた
- `skills/auto/SKILL.md`: Step 4 の XL 経路説明文 (「auto-runs spec if not set」) を、Size=XS 除外込みの記述に修正し Step 3 との自己矛盾を解消
- `skills/issue/SKILL.md`: Completion Report の `get-issue-size.sh` 呼び出しに `--no-cache` を追加。GraphQL 応答キャッシュ (TTL 300秒) が triage 直前の陳腐化した応答を返すことで `phase/ready` 遷移が黙って no-op になる非決定性 (#1054 / #1052 の実測) を解消
- `tests/run-auto-sub.bats`: Size=XS + `phase/issue` (`phase/ready` 無し) で `run-spec.sh` が呼ばれないことを検証するリグレッションテストを追加

## Verification (pre-merge)
- 単一 Issue 経路と batch/XL 経路で XS の spec 要否が一致している
- `skills/auto/SKILL.md` Step 4b の前提記述が変更後の実挙動と一致している
- Route-Phase Matrix / Phase-Level Light/Full Mapping の XS 行が実挙動と一致している (編集不要、確認のみ)
- `tests/run-auto-sub.bats` に XS の分岐を保護するテストケースが追加されている (`bats tests/run-auto-sub.bats` PASS、および behavioral change 検出により `bats tests/` フルスイート 1508 件 PASS)
- `/issue` の XS 時ラベル付与の非決定性が `--no-cache` 追加により解消されている

## Verification (post-merge)
- `--batch` で XS Issue を処理し、spec 要否が規定どおりになること、および Step 4b が二重転記を起こさないことを確認する

closes #1108
