### PR TITLE
Issue #1167: verify: manual AC 区分 C を bats テスト化し D1 の manual 維持を記録

### DIFF
--- a/docs/reports/manual-ac-retype-c-d1.md
+++ b/docs/reports/manual-ac-retype-c-d1.md
@@ -1,0 +1,34 @@
+# manual AC 区分 C + D1: bats テスト化・manual 維持記録 (#1167)
+
+親 Issue #1158 の分割対応。`docs/stats/2026-08-05.md` Section 10 の分類 6 区分のうち、区分 **C (故障注入、2 件)** と区分 **D1 (UI 目視、5 件)** を対象に、区分 C は bats テスト化して `verify-type: auto` へ再型付け、区分 D1 は `manual` 維持の判断根拠を記録した結果。
+
+## 対象・件数内訳
+
+- 区分 C: 2 件 (#1066 #1060) — bats テスト化 + `verify-type: auto` へ再型付け
+- 区分 D1: 5 件 (#1059 #709 #548 #442 #441) — `manual` のまま維持
+
+## 区分 C: bats テスト化マッピング
+
+| Issue | 条件文要約 | 追加したテスト | 選定根拠 |
+|---|---|---|---|
+| #1066 | 「preview build check の失敗を検出し fix loop に入る」— `skills/code/SKILL.md` Step 13 の fix loop Row 1 (`failed>0` → fix loop へ進む) が依存する、`gh pr checks` が `bucket: "fail"` (かつ `pending` なし) の check を返した際にポーリングループが即座に break し `ci_result:` 行が `failed=1` を報告する決定的シグナル | `tests/wait-ci-checks.bats` に `"failed check with no pending breaks on first poll without sleeping (issue #1167)"` を追加。`gh pr checks` モックが `[{"name":"Deploy preview","state":"FAILURE","bucket":"fail"}]` を返すケースで、(a) `sleep` が一度も呼ばれないこと (`sleep 60` に到達しない)、(b) `ci_result: total=1 passed=0 failed=1 pending=0 cancelled=0 zero_checks=false` を確認する | 条件文の「故障を検出して fix loop に入る」という振る舞いの決定的な核は、`scripts/wait-ci-checks.sh:71-73` の `_pending -eq 0` 早期 break パスにある。実際の preview build 環境そのもの (Amplify/Vercel/Netlify の実デプロイ) は要求しておらず、このシグナルの分岐ロジックを固定 fixture で再現すれば故障注入シナリオの機械的な核を担保できる |
+| #1060 | 「pre-merge AC のうち 1 件だけ未チェックの Issue で merge がブロックされる」— `skills/merge/SKILL.md` Step 1 の pre-merge AC ゲートが依存する、Pre-merge セクションの一部だけが未チェックの場合に正しい `unchecked_count` と 1-based index を返す決定的シグナル | `tests/check-pre-merge-ac.bats` に `"(b2) pre-merge 3 items with exactly 1 unchecked excludes post-merge unchecked (issue #1167)"` を追加。Pre-merge 3 件中ちょうど 1 件未チェック (Post-merge 側の未チェックは含めない) の Issue 本文をモックし、`unchecked_count` が `"1"`、`unchecked_indices` が `"3"` (Post-merge の index 4 を含まない) であることを確認する | 既存テスト (b) は Pre-merge 3 件中 2 件未チェックのケースをカバーしており、「ちょうど 1 件未チェック」という条件文が指す境界ケースは未検証だった。`scripts/check-pre-merge-ac.sh` の Pre-merge/Post-merge 分離ロジックとインデックス採番ロジックを固定 fixture で検証すれば、故障注入シナリオ (一部だけ未チェック → merge ブロック) の機械的な核を担保できる |
+
+## 区分 C 2 件の AC 処理
+
+- `#1066`: post-merge manual AC 行に `<!-- verify: command "bats tests/wait-ci-checks.bats" -->` を付与し `<!-- verify-type: auto -->` へ変更 (Implementation Step 5 で `gh-issue-edit.sh` により実施)
+- `#1060`: post-merge manual AC 行に `<!-- verify: command "bats tests/check-pre-merge-ac.bats" -->` を付与し `<!-- verify-type: auto -->` へ変更 (Implementation Step 5 で `gh-issue-edit.sh` により実施)
+
+いずれも retire (phase/done への直接遷移) ではなく、テストによる担保を根拠に `verify-type: auto` へ再型付けする方式を採用した。今後 `/verify` が該当 AC を通常のコマンド実行として自動判定できるようになる。
+
+## 区分 D1 5 件の manual 維持根拠
+
+| Issue | 条件文要約 | manual 維持の理由 |
+|---|---|---|
+| #1059 | preview 環境で人間が確認する AC を含む Issue を 1 件通しで実行し、AC が pre-merge セクションに配置され merge 前に確認される流れになることを確認する | `/issue`→`/spec`→`/code`→`/review` の複数スキルにまたがる実オーケストレーションと実 preview 環境が前提。単一の決定的スクリプトで模擬しようとすると `/issue` の分類判断・実 preview URL・`/review` の提示挙動を同時にモックする必要があり、統合確認としての意味を失う |
+| #709 | GitHub UI から bug_report テンプレートで Issue を新規起票し、AC セクションが入力欄として表示されることを目視確認 | GitHub の Issue Forms レンダリングは GitHub 側プラットフォームの責務であり、本リポジトリのテスト可能範囲外。ブラウザでの見た目確認が必須 |
+| #548 | koganezawa-com#58 を fullPage で再走し、ページ全体の 3-panel が寸法 throw なく生成される | 実 downstream リポジトリの実 Web ページに対するブラウザ自動化と実スクリーンショット取得が前提。bats はネットワークアクセスを避けるヘルメティックなテストを原則とし、生成された合成画像自体の品質確認 (throw の有無だけでなく見た目) には目視が必要 |
+| #442 | `/spec` を実行したとき、インタラクティブな UI コンポーネントを含む Issue の Spec に `aria-*` 属性の動的更新 AC が含まれることを確認する | 任意の将来 Issue に対する LLM の Spec 生成品質 (ガイドラインの適切な反映) という主観的判断が対象。固定 fixture を用いた bats アサーションでは表現できず、rubric も対象となる将来の Spec ファイルを事前に名指しできないため grader の可視範囲制約に抵触する |
+| #441 | サンプル UI 再現プロジェクトで `visual_diff` を実装し、検出結果が期待通り (差分あり→FAIL、なし→PASS) | D1 区分の典型例。実ブラウザによる実ページのレンダリング・スクリーンショット取得・pixel-diff 判定の一連の流れが前提で、`pixelmatch` の数値計算のみを固定 fixture でテストしても「実環境で正しく検出できるか」という AC の主旨を代替できない |
+
+これら 5 件は `docs/stats/2026-08-05.md` の棚卸し方針表でも「manual のまま維持 (正当)」と分類されており、本記録はその判断根拠を Issue 単位で明文化したものである。Issue 本文の post-merge AC 行自体は変更しないため、`phase/verify` の Manual waiting 集計には引き続き残り続けるのが意図した挙動である。

--- a/docs/spec/issue-1167-manual-ac-retype-c-d1.md
+++ b/docs/spec/issue-1167-manual-ac-retype-c-d1.md
@@ -11,6 +11,14 @@
 
 ## Consumed Comments
 
+### code phase
+
+cutoff: 2026-08-07T03:25:23Z (`phase/code` ラベル付与の timeline イベント)。
+
+新規コメントなし (cutoff 以前の 1 件のみ存在)。Cross-phase marker (`type=verify-fail` / `type=preview-ac-unverified`) の追加スキャン結果も該当なし。
+
+### spec phase
+
 cutoff: 未確定 (`phase/*` ラベル付与の timeline イベントが存在せず、`.tmp/auto-events.jsonl` にも本 Issue の `phase_start` イベントが見つからなかったため、フォールバック B によりベストエフォートで全コメントを対象としたが、該当コメント自体が 0 件だった)。
 
 新規コメントなし (`gh issue view 1167 --json comments` の結果が空)。Cross-phase marker (`type=verify-fail` / `type=preview-ac-unverified`) の追加スキャン結果も該当なし。
@@ -86,3 +94,35 @@ Pre-merge AC1・AC3 は `rubric` タイプであり、`modules/verify-executor.m
 - `#719` 条件1: `pre-merge-check.sh` の新規 FAILURE 判定 (`NEW_FAILURE: base PASS / head FAIL exits 2`) を検証するもので、**`tests/pre-merge-check.bats` に既に同一シナリオのテストが存在する** (`grep -n "NEW_FAILURE" tests/pre-merge-check.bats`で確認済み) — 追加実装なしで AC を `auto` へ retype できる可能性が高い
 
 ただし、この 3 件は #1158 の sub-issue 分割時点の Issue 番号割り当て (#1163 に含まれる 34 件、#1167 に割り当てられた 7 件) のいずれにも本 Issue の Acceptance Criteria として明記されておらず、非対話モード・light depth での conflict detection ポリシー (`skills/spec/SKILL.md` Step 6: 「note in Spec's Notes section only」) に従い、本 Spec の Implementation Steps・Changed Files には含めない。対応が必要な場合は別途 Issue 起票または #1167 の追加スコープとして扱うことを推奨する。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Implementation Steps 1〜5 は Spec 記載どおりに実施した。
+
+### Design Gaps/Ambiguities
+
+- 実行開始時点で本 Issue のラベルが既に `phase/ready` を経由せず `phase/code` になっており、`reconcile-phase-state.sh --check-precondition code-pr` が `phase/ready` 欠如を警告した。GitHub Timeline を確認したところ、Implementation Step 5 の Issue 本文編集 (`#1066` / `#1060` の verify-type 再型付けと `#1167` 自身の post-merge AC 文言修正) は既にリモートへ適用済みだった一方、bats テスト追加・レポートファイル作成・commit/push/PR はまだ行われていない状態だった — 中断された前回試行 (watchdog kill 等) の痕跡と判断し、Issue 編集を再実行せず Implementation Step 1〜4 のみを完了させる形で処理を継続した。GitHub Issue 編集はローカル worktree のコミット状態と独立して永続化されるため、再開時にどこまで完了しているかを個別に確認する必要がある。
+- Worktree 作成時のベース (`origin/main` の session 開始時点スナップショット) が、実装完了時には origin/main から 10 commit 遅れていた (並行セッションによる別 Issue のマージが session 中に進行したため)。`git diff origin/main HEAD` で無関係な削除差分 (他 Issue の Spec/レポートファイル) が大量に出たため、push 前に `git rebase origin/main` を実施して解消した。長時間の non-interactive 実行では、PR 作成直前に origin/main との乖離を確認する一手間が有効。
+
+### Rework
+
+- N/A — 上記のベースドリフトは rebase 1 回で解消し、実装内容 (bats テスト・レポートファイル) への手戻りはなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- 区分 C 2 件は #1163 (区分 A) の前例に倣い、「retire (phase/done 遷移)」ではなく「verify command 付きの `verify-type: auto` へ再型付け」を採用した。post-merge AC の文言 (人間可読テキスト) は変更せず、機械可読 marker のみ追加している
+- #1066 は `scripts/wait-ci-checks.sh` の `_pending -eq 0` 早期 break パス、#1060 は `scripts/check-pre-merge-ac.sh` の Pre-merge/Post-merge 分離ロジックを、それぞれ故障注入シナリオの「決定的な核」として bats テスト化対象に選定した (実 preview 環境や実 merge 実行は要求しない)
+- rubric grader 可視範囲制約 (Spec ファイル非参照) のため、区分 C・D1 の詳細マッピング・根拠を `docs/reports/manual-ac-retype-c-d1.md` に記録し、Pre-merge AC1/AC3 (rubric タイプ) がこのファイルを評価できるようにした
+
+### Deferred Items
+- #708 (条件1・2) と #719 (条件1) の計 3 AC 行は、姉妹 sub-issue #1163 の Phase Handoff が「区分 C 相当」と指摘しているが、本 Issue のスコープ外として対応していない (Spec Notes 「#708 / #719 に残る故障注入型 manual AC」参照)。対応候補: `#708` は `tests/reconcile-phase-state.bats` の既存対象、`#719` 条件1 は `tests/pre-merge-check.bats` に既に同一シナリオのテストが存在するため追加実装なしで retype できる可能性が高い
+- Post-merge AC (`/audit stats --retention` での #1066 / #1060 個別確認) は本 PR merge 後の観測が前提であり、本フェーズでは未実施
+
+### Notes for Next Phase
+- `/review` は Pre-merge AC1〜AC3 (rubric) の判定時、`docs/reports/manual-ac-retype-c-d1.md` の内容を評価対象に含めること — Spec ファイルは grader に渡らないため、この記録ファイルが唯一の詳細根拠
+- `/merge` 実行前に `#1066` / `#1060` の Issue 本文が既に `verify-type: auto` へ変更済みであることを確認済み (本 Issue の code フェーズ開始前、前回試行で適用済みだった) — 再度の Issue 編集は不要
+- `/verify` は post-merge AC の observation event (`event=auto-run`) に従い、次回 `/auto` 実行時の `/audit stats --retention` 結果を待って判定すること

--- a/docs/spec/issue-1167-manual-ac-retype-c-d1.md
+++ b/docs/spec/issue-1167-manual-ac-retype-c-d1.md
@@ -111,18 +111,31 @@ Pre-merge AC1・AC3 は `rubric` タイプであり、`modules/verify-executor.m
 - N/A — 上記のベースドリフトは rebase 1 回で解消し、実装内容 (bats テスト・レポートファイル) への手戻りはなかった。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- 区分 C 2 件は #1163 (区分 A) の前例に倣い、「retire (phase/done 遷移)」ではなく「verify command 付きの `verify-type: auto` へ再型付け」を採用した。post-merge AC の文言 (人間可読テキスト) は変更せず、機械可読 marker のみ追加している
-- #1066 は `scripts/wait-ci-checks.sh` の `_pending -eq 0` 早期 break パス、#1060 は `scripts/check-pre-merge-ac.sh` の Pre-merge/Post-merge 分離ロジックを、それぞれ故障注入シナリオの「決定的な核」として bats テスト化対象に選定した (実 preview 環境や実 merge 実行は要求しない)
-- rubric grader 可視範囲制約 (Spec ファイル非参照) のため、区分 C・D1 の詳細マッピング・根拠を `docs/reports/manual-ac-retype-c-d1.md` に記録し、Pre-merge AC1/AC3 (rubric タイプ) がこのファイルを評価できるようにした
+- REVIEW_DEPTH=light (`--light` 明示指定、Issue Size=M とも整合) のため 10.0 の軽量統合レビュー (review-light 1 agent) を実行し、10.1〜10.3 の fan-out レビューはスキップした
+- 新規 bats テスト2件の論理的健全性 (mock 挙動が実スクリプトの分岐と一致するか、常に真になる無意味なアサーションでないか) を dedicated agent で個別に追加検証し、review-light の指摘なしという結果を補強した
 
 ### Deferred Items
 - #708 (条件1・2) と #719 (条件1) の計 3 AC 行は、姉妹 sub-issue #1163 の Phase Handoff が「区分 C 相当」と指摘しているが、本 Issue のスコープ外として対応していない (Spec Notes 「#708 / #719 に残る故障注入型 manual AC」参照)。対応候補: `#708` は `tests/reconcile-phase-state.bats` の既存対象、`#719` 条件1 は `tests/pre-merge-check.bats` に既に同一シナリオのテストが存在するため追加実装なしで retype できる可能性が高い
 - Post-merge AC (`/audit stats --retention` での #1066 / #1060 個別確認) は本 PR merge 後の観測が前提であり、本フェーズでは未実施
 
 ### Notes for Next Phase
-- `/review` は Pre-merge AC1〜AC3 (rubric) の判定時、`docs/reports/manual-ac-retype-c-d1.md` の内容を評価対象に含めること — Spec ファイルは grader に渡らないため、この記録ファイルが唯一の詳細根拠
 - `/merge` 実行前に `#1066` / `#1060` の Issue 本文が既に `verify-type: auto` へ変更済みであることを確認済み (本 Issue の code フェーズ開始前、前回試行で適用済みだった) — 再度の Issue 編集は不要
+- MUST issue はゼロのため Step 12/13 はスキップ、`event=COMMENT` で review 完了。`/merge 1237` にそのまま進んでよい
 - `/verify` は post-merge AC の observation event (`event=auto-run`) に従い、次回 `/auto` 実行時の `/audit stats --retention` 結果を待って判定すること
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — Implementation Steps 1〜5 と PR diff (bats テスト2件・レポートファイル・Spec 追記) は完全に一致していた。review-light agent (Spec 乖離・エッジケース/堅牢性・セキュリティ・ドキュメント整合性の4観点) が指摘なしで完了。
+
+### Recurring issues
+
+Nothing to note — 同種の問題の再発は見られなかった。
+
+### Acceptance criteria verification difficulty
+
+Pre-merge AC1・AC3 は rubric タイプで `docs/reports/manual-ac-retype-c-d1.md` を根拠資料として評価する構成だったが、Phase Handoff の「Notes for Next Phase」に評価対象ファイルの案内が明記されていたため判定に迷いはなかった。AC4 (`bats tests/`) はローカル実行で exit code 0・最終テスト `ok 1510`・`not ok` なしを確認、CI の `Run bats tests` ジョブ SUCCESS とも整合。PR 本文が「1509件」と記載しているのに対し実際のフルスイートは 1510 件だったが、この差は本 PR が新規に bats テストを2件追加したことによる数値の陳腐化であり、AC 判定への影響はない (verify command は件数を固定しない `bats tests/` のみを要求するため)。

--- a/tests/check-pre-merge-ac.bats
+++ b/tests/check-pre-merge-ac.bats
@@ -91,6 +91,30 @@ BODY
     [[ "$(echo "$result" | jq -r '.unchecked_indices')" != *"4"* ]]
 }
 
+@test "(b2) pre-merge 3 items with exactly 1 unchecked excludes post-merge unchecked (issue #1167)" {
+    make_gh_mock_body <<'BODY'
+## Acceptance Criteria
+
+### Pre-merge (auto-verified)
+
+- [x] pre item one
+- [x] pre item two
+- [ ] pre item three
+
+### Post-merge
+
+- [ ] post item
+BODY
+    run bash "$SCRIPT" "123"
+    [ "$status" -eq 0 ]
+    result="$output"
+    [ "$(echo "$result" | jq -r '.pre_merge_total')" = "3" ]
+    [ "$(echo "$result" | jq -r '.unchecked_count')" = "1" ]
+    [ "$(echo "$result" | jq -r '.unchecked_indices')" = "3" ]
+    # index 4 (post item) must not appear in unchecked_indices
+    [[ "$(echo "$result" | jq -r '.unchecked_indices')" != *"4"* ]]
+}
+
 @test "(c) no Pre-merge heading returns pre_merge_total 0" {
     make_gh_mock_body <<'BODY'
 ## Acceptance Criteria

--- a/tests/wait-ci-checks.bats
+++ b/tests/wait-ci-checks.bats
@@ -402,3 +402,33 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" =~ ^[0-9]+$ ]]
 }
+
+@test "failed check with no pending breaks on first poll without sleeping (issue #1167)" {
+    # A single check with bucket=fail and no pending checks must trip the
+    # _pending -eq 0 early-break path (script:71-73) on the very first poll,
+    # never reaching the sleep 60 fallback at the bottom of the loop.
+    SLEEP_CALL_LOG="$BATS_TEST_TMPDIR/sleep_calls.log"
+    export SLEEP_CALL_LOG
+
+    cat > "$MOCK_DIR/sleep" <<'MOCK'
+#!/bin/bash
+echo "sleep called: $@" >> "$SLEEP_CALL_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/sleep"
+
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+    echo '[{"name":"Deploy preview","state":"FAILURE","bucket":"fail"}]'
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCRIPT" 88
+    [ "$status" -eq 0 ]
+    [ ! -f "$SLEEP_CALL_LOG" ]
+    [[ "$output" == *"ci_result: total=1 passed=0 failed=1 pending=0 cancelled=0 zero_checks=false"* ]]
+}


### PR DESCRIPTION
## Summary

`phase/verify` に滞留する manual AC の再型付け・棚卸し (親 #1158) のうち、区分 C (故障注入、2 件: #1066 #1060) と区分 D1 (UI 目視、5 件: #1059 #709 #548 #442 #441) を担当する sub-issue の対応。

- 区分 C: `#1066` / `#1060` の post-merge manual AC が要求する故障注入シナリオの決定的な核を bats テストとして追加 (`tests/wait-ci-checks.bats`, `tests/check-pre-merge-ac.bats`)。両 Issue の post-merge AC は既に `verify-type: auto` + verify command 付きへ再型付け済み
- 区分 D1: 5 件について `manual` のまま維持する判断根拠を Issue 単位で `docs/reports/manual-ac-retype-c-d1.md` に記録

## Verification (pre-merge)

- 区分 C の 2 件 (#1066 / #1060) の故障注入シナリオを検証する bats テストが tests/ 配下に追加されている
- bats テスト化した 2 件の post-merge AC が verify command 付きの自動判定 AC へ変更されている
- 区分 D1 の 5 件について manual のまま維持する判断根拠が Issue 単位で記録されている
- `bats tests/` テストスイート全件 (1509件) が PASS する

## Verification (post-merge)

- 移行完了後の `/audit stats --retention` で `#1066` `#1060` が Manual waiting の集計対象から外れていることを個別に確認する (D1 の 5 件は意図して manual 維持のため対象外)

closes #1167
