### PR TITLE
Issue #1117: reconcile-phase-state _completion_issue() の success signature を phase/issue 系に修正

### DIFF
--- a/docs/spec/issue-1117-fix-issue-completion-signature.md
+++ b/docs/spec/issue-1117-fix-issue-completion-signature.md
@@ -67,19 +67,31 @@
 - None.
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Fixed `_completion_issue()` exactly per the Spec's prescribed regex (`grep -qE '^phase/(issue|ready|code|review|merge|verify|done)$'`), matching `_completion_spec()`'s existing pattern style for consistency.
-- Ran the full `bats tests/` suite (not just the direct counterpart file) because `modules/phase-state.md` — one of the three changed files — is also referenced by `tests/operate-route.bats`, triggering the Behavioral Change Detection full-suite override. All 1500+ tests passed.
+- Ran `/review 1244 --light --non-interactive` (Size=M, `--light` explicit); Step 10 dispatched a single `review-light` agent covering all 4 aspects (Spec deviation, edge cases, security, documentation consistency) — no issues found.
+- Verified all 3 Pre-merge AC directly from the diff/CI rather than re-running commands: the `rubric` and `section_contains` conditions were confirmed against the PR diff, and the `command "bats tests/reconcile-phase-state.bats"` condition was confirmed via CI reference fallback (the "Run bats tests" CI job, which already SUCCEEDED) since Step 8 runs in safe mode.
+- Posted review as `COMMENT` (no MUST issues); all 9 CI checks were SUCCESS at review time.
 
 ### Deferred Items
-- The Post-merge AC (opportunistic, "confirm on a real triaged-but-not-phase/issue Issue that `matches_expected:false` is now detected") is left unchecked for `/verify` to confirm post-merge.
+- The Post-merge AC (opportunistic, "confirm on a real triaged-but-not-phase/issue Issue that `matches_expected:false` is now detected") remains unchecked, carried forward from the code phase handoff for `/verify` to confirm post-merge.
 
 ### Notes for Next Phase
-- No implementation deviations from the Spec — `/review` should find the diff matches Changed Files / Implementation Steps exactly.
-- This Issue's own label state (`phase/code` present without `phase/ready`) caused the `code-pr` precondition check to report `matches_expected:false` when probed during this `/code` run — this is expected given the Issue's history (see Autonomous Auto-Resolve Log) and not a new bug; no action needed from `/review`.
+- No MUST/SHOULD/CONSIDER issues were raised; `/merge 1244` can proceed once ready.
+- The Post-merge AC verification depends on finding a real triaged-but-not-`phase/issue` Issue in the wild — `/verify` should check whether such a case has occurred naturally rather than fabricating one.
 
 ## Consumed Comments
 
 - saito / MEMBER / first-class / ## Issue Retrospective / https://github.com/saitoco/wholework/issues/1117#issuecomment-5213109567
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+Nothing to note. `review-light` confirmed the diff matches the Spec's Changed Files and Implementation Steps exactly, with no structural divergence.
+
+### Recurring issues
+Nothing to note. This was a narrowly-scoped, single-purpose bugfix (one regex signature change plus matching test/doc updates); no repeated issue patterns observed across the 4 review aspects.
+
+### Acceptance criteria verification difficulty
+Nothing to note. All 3 Pre-merge conditions carried well-formed verify commands (`rubric`, `section_contains`, `command`) and resolved cleanly — no UNCERTAIN classifications. The `command` condition resolved via CI reference fallback without ambiguity, since the CI job name ("Run bats tests") unambiguously corresponded to the target test file.

--- a/docs/spec/issue-1117-fix-issue-completion-signature.md
+++ b/docs/spec/issue-1117-fix-issue-completion-signature.md
@@ -50,6 +50,36 @@
 - スコープ外 (Issue body で明示済み): `skills/auto/SKILL.md` Step 3 への reconcile 呼び出し追加、`run-issue.sh`/`run-spec.sh` の wrapper 機構そのものの新規実装、`skills/issue/SKILL.md` のラベル遷移ステップの位置変更。理由は Issue body 参照。
 - README.md / docs/workflow.md には `_completion_issue()` の具体的なラベル判定に関する記述がないため、Steering Docs sync candidate には該当しない (grep で確認済み)。
 
+## Autonomous Auto-Resolve Log
+
+- **Proceeded with implementation despite `phase/ready` being absent** — reason: `reconcile-phase-state.sh code-pr 1117 --check-precondition` reported `matches_expected:false` because the Issue's current label is `phase/code` (a later phase than `phase/ready`) rather than `phase/ready` itself, and the precondition check only matches the exact `phase/ready` string. The Spec (`docs/spec/issue-1117-fix-issue-completion-signature.md`) already existed and was fully fleshed out, indicating the `/spec` phase had genuinely completed before this run; the missing `phase/ready` label reflects a label-state artifact from a prior `/code` attempt on this Issue (no PR or remote branch existed), not a missing Spec. Proceeded using the existing Spec as authoritative.
+  - Other candidates: hard-abort and request `/spec 1117` be re-run (rejected — Spec content was already complete and directly usable; re-running `/spec` would have been redundant and wasted a session).
+
+## Code Retrospective
+
+### Deviations from Design
+- None. Implementation followed the Spec's Implementation Steps and Changed Files list exactly (`scripts/reconcile-phase-state.sh` `_completion_issue()`, `modules/phase-state.md` Phase Table, `tests/reconcile-phase-state.bats`).
+
+### Design Gaps/Ambiguities
+- The Spec did not anticipate that this Issue's own label state (`phase/code` present, `phase/ready` absent) would trip the `code-pr` precondition check performed by the very script this Issue modifies (`reconcile-phase-state.sh`). Not a defect in the Spec — the precondition check is a separate code path (`_precondition_code_pr()`) from the one being fixed (`_completion_issue()`); noted here only because it was a self-referential surprise worth recording. See Autonomous Auto-Resolve Log above.
+
+### Rework
+- None.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Fixed `_completion_issue()` exactly per the Spec's prescribed regex (`grep -qE '^phase/(issue|ready|code|review|merge|verify|done)$'`), matching `_completion_spec()`'s existing pattern style for consistency.
+- Ran the full `bats tests/` suite (not just the direct counterpart file) because `modules/phase-state.md` — one of the three changed files — is also referenced by `tests/operate-route.bats`, triggering the Behavioral Change Detection full-suite override. All 1500+ tests passed.
+
+### Deferred Items
+- The Post-merge AC (opportunistic, "confirm on a real triaged-but-not-phase/issue Issue that `matches_expected:false` is now detected") is left unchecked for `/verify` to confirm post-merge.
+
+### Notes for Next Phase
+- No implementation deviations from the Spec — `/review` should find the diff matches Changed Files / Implementation Steps exactly.
+- This Issue's own label state (`phase/code` present without `phase/ready`) caused the `code-pr` precondition check to report `matches_expected:false` when probed during this `/code` run — this is expected given the Issue's history (see Autonomous Auto-Resolve Log) and not a new bug; no action needed from `/review`.
+
 ## Consumed Comments
 
 - saito / MEMBER / first-class / ## Issue Retrospective / https://github.com/saitoco/wholework/issues/1117#issuecomment-5213109567

--- a/modules/phase-state.md
+++ b/modules/phase-state.md
@@ -33,7 +33,7 @@ For precondition checks, `reconcile-phase-state.sh` verifies whether the require
 
 | Phase | Precondition | Success Signature (Completion) | Implementation Status |
 |-------|-------------|-------------------------------|----------------------|
-| issue | Issue exists and state != CLOSED | `triaged` label on issue | Implemented |
+| issue | Issue exists and state != CLOSED | `phase/(issue\|ready\|code\|review\|merge\|verify\|done)` label on issue | Implemented |
 | spec | `phase/issue` or `phase/spec` label on issue | `$SPEC_PATH/issue-N-*.md` exists AND `phase/(ready\|code\|review\|merge\|verify\|done)` label | Implemented |
 | code-patch | `phase/ready` label on issue, Spec exists OR Size=XS | `git log origin/main --after=<reopen_ts> --grep="closes #N"` returns ≥1 fresh commit (reopen timestamp obtained via `get-last-reopen`); falls back to `git log origin/main --grep="closes #N"` when reopen timestamp unavailable; OR an operate route completion marker comment is found (see "Operate Route Completion Signature" below); OR an open PR on the `worktree-code+issue-N` branch is found (see "Stray PR Completion Signature" below) | Precondition: `phase/ready` — Implemented; Spec exists OR Size=XS — Implemented (Spec exists OR Size=XS). Completion: Implemented |
 | code-pr | `phase/ready` label on issue, Spec exists OR Size=XS | Open PR on `worktree-code+issue-N` branch (#310 SSoT) | Precondition: `phase/ready` — Implemented; Spec exists OR Size=XS — Implemented (Spec exists OR Size=XS). Completion: Implemented |

--- a/scripts/reconcile-phase-state.sh
+++ b/scripts/reconcile-phase-state.sh
@@ -134,10 +134,10 @@ _completion_issue() {
   labels_json=$(_labels_to_json_array "$labels")
   local actual_json="{\"labels\":${labels_json}}"
 
-  if echo "$labels" | grep -q "^triaged$"; then
-    _emit_result "true" "triaged label found on issue #${ISSUE_NUMBER}" "$actual_json"
+  if echo "$labels" | grep -qE '^phase/(issue|ready|code|review|merge|verify|done)$'; then
+    _emit_result "true" "issue #${ISSUE_NUMBER} has phase/issue or a later phase label" "$actual_json"
   else
-    _handle_mismatch "triaged label not found on issue #${ISSUE_NUMBER}" "$actual_json"
+    _handle_mismatch "issue #${ISSUE_NUMBER} has no phase/issue or later phase label" "$actual_json"
   fi
 }
 

--- a/tests/reconcile-phase-state.bats
+++ b/tests/reconcile-phase-state.bats
@@ -64,10 +64,10 @@ MOCK_EOF
 
 # --- issue completion ---
 
-@test "issue completion: triaged label present -> matches_expected true" {
+@test "issue completion: phase/issue label present -> matches_expected true" {
     cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
 #!/bin/bash
-echo "triaged"
+echo "phase/issue"
 echo "size/S"
 exit 0
 MOCK_EOF
@@ -80,10 +80,25 @@ MOCK_EOF
     [[ "$output" == *'"schema_version":"v1"'* ]]
 }
 
-@test "issue completion: triaged label absent -> mismatch (strict exit 1)" {
+@test "issue completion: no phase/issue or later label -> mismatch (strict exit 1)" {
     cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
 #!/bin/bash
 echo "size/S"
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" issue 42 --check-completion --strict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"matches_expected":false'* ]]
+}
+
+@test "issue completion: triaged only, no phase/issue or later label -> mismatch (issue #1115 repro)" {
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+echo "triaged"
+echo "retro/verify"
 exit 0
 MOCK_EOF
     chmod +x "$MOCK_DIR/gh"


### PR DESCRIPTION
## Summary
- `scripts/reconcile-phase-state.sh` の `_completion_issue()` の成功シグネチャを、`triaged` ラベル単独の判定から `_completion_spec()` と同型のフェーズラベルファミリー判定 (`phase/(issue|ready|code|review|merge|verify|done)`) に変更
- `modules/phase-state.md` の Phase Table `issue` 行の Success Signature 記述を新シグネチャに更新
- `tests/reconcile-phase-state.bats` の既存 issue completion テスト2件を新シグネチャに合わせて更新し、#1115 の再現ケース (`triaged` のみ・`phase/issue` 以降のラベルなし → `matches_expected:false`) を新規追加

## Verification (pre-merge)
- `_completion_issue()` の成功シグネチャが `phase/issue` 以降のラベルを判定するよう修正されている (rubric)
- `modules/phase-state.md` の Phase Table `issue` 行が新シグネチャを記載している (section_contains)
- `bats tests/reconcile-phase-state.bats` が新シグネチャおよび #1115 再現ケースを含めて全て pass する (実行済み: 78 tests, 0 failures)
- 影響範囲確認のためフルスイート `bats tests/` も実行し、全 1500+ tests pass (behavioral change detection: `modules/phase-state.md` は `tests/operate-route.bats` からも参照されているため)

## Verification (post-merge)
- triage 済みだが `phase/issue` 未遷移の実 Issue に対して `reconcile-phase-state.sh issue --check-completion` (または `run-issue.sh` の再実行) を行い、`matches_expected:false` として silent no-op が検出されることを本番相当の環境で確認する

closes #1117
