### PR TITLE
Issue #1158: Add aggregate closeout report for manual AC retype (79 AC across 6 categories)

### DIFF
--- a/docs/reports/manual-ac-retype-summary.md
+++ b/docs/reports/manual-ac-retype-summary.md
@@ -60,6 +60,8 @@ Issue 単位 (79件) と AC 行単位 (87行) の件数は一致しない。`doc
 
 Issue 本文の post-merge AC 行自体は変更しないため、`phase/verify` の Manual waiting 集計には引き続き残るのが意図した挙動である。
 
+### C (bats テスト化 → auto 再型付け)
+
 区分 C (故障注入、2 Issue: #1066 #1060、#1167) は D1 とは異なり、故障注入シナリオの機械的な核 (`wait-ci-checks.sh` の早期 break パス、`check-pre-merge-ac.sh` の境界ケース) を固定 fixture の bats テストで再現できたため、`tests/wait-ci-checks.bats` / `tests/check-pre-merge-ac.bats` へのテスト追加を行い、両 Issue の post-merge AC を `verify-type: auto` (`<!-- verify: command "bats tests/..." -->`) へ再型付けした。retire ではなく、テストによる担保を根拠とした再型付け方式を採用している。
 
 ### D3 および対象外 (再型付けしなかった AC)
@@ -71,17 +73,19 @@ Issue 本文の post-merge AC 行自体は変更しないため、`phase/verify`
 | observation 再型付け | 16 | `event=auto-run` 14 / `event=watchdog-kill` 1 / `event=pr-review-full` 1 |
 | retire | 6 | `auto-stop-at` 未設定で前提不成立 (#783)、将来拡張未実装 (#706)、downstream 固有 XL Issue (#591)、比較基準が陳腐化 (#587)、前提条件自体が不成立 (#563)、downstream 主観評価 (#484条件2) |
 | manual 維持 | 0 | — |
-| 対象外 (編集しない/別扱い) | 2 | #591 の既チェック済み (`- [x]`) 行、#491 のコードフェンス内サンプル行 (AC ではない) |
+| 対象外 (編集しない/別扱い) | 2 (22 行の外数) | #591 の既チェック済み (`- [x]`) 行、#491 のコードフェンス内サンプル行 (AC ではない) |
+
+注: 上表の「対象 AC 行 22 行」は再型付け 16 + retire 6 の内訳であり、対象外 2 行は 22 にも 87 行合計にも含まれない (母集団の外側)。
 
 D3 は #1163 (区分 A) の「未知 event なら manual 維持」という原則から意図的に方針変更し、前提が原理的に成立しない条件をすべて retire に倒した (詳細: `docs/spec/issue-1165-manual-ac-retype-d3.md` Notes)。
 
-**移行対象外とした AC 全体のまとめ (AC5 対応)**: A/D2 由来の manual 維持 11 行 (前掲) と D3 の対象外 2 行 (実 AC ではない編集除外) が「再型付け・retire いずれも行わなかった」項目である。D1 の 5 行は「正当な manual 維持」として別枠 (前掲) で扱う。各項目の個別理由は上表および各 sub-issue の記録ファイル (`docs/reports/manual-ac-retype-a.md` / `manual-ac-retype-d2.md` / `manual-ac-retype-d3.md`) に Issue 単位で記録済み。
+**移行対象外とした AC 全体のまとめ (AC5 対応)**: A/D2 由来の manual 維持 11 行 (前掲) と D3 の対象外 2 行 (#591 は既チェック済みのため編集不要、#491 はコードフェンス内サンプルで AC ではない) が「再型付け・retire いずれも行わなかった」項目である。D1 の 5 行は「正当な manual 維持」として別枠 (前掲) で扱う。各項目の個別理由は上表および各 sub-issue の記録ファイル (`docs/reports/manual-ac-retype-a.md` / `manual-ac-retype-d2.md` / `manual-ac-retype-d3.md`) に Issue 単位で記録済み。
 
 ## 検証
 
-- 6 区分の Issue 数合計 (34+13+19+6+5+2=79) は `docs/stats/2026-08-05.md` Section 10 の分類件数 79 と一致することを確認した (差異なし)。
+- 6 区分の Issue 数合計 (34+13+19+6+5+2=79) は `docs/stats/2026-08-05.md` Section 10 の分類件数 79 と一致することを確認した (差異なし)。この 79 件は同レポート Section 10 が集計した 90 日窓の母集団に基づく。同 Section 11 が指摘するとおり全期間へ広げると対象は増えるため、本クローズアウトは「90 日窓内の 79 件」の完了を意味する。全期間の再棚卸しは別途判断とする。
 - AC 行数合計は 87 行 (Issue 単位の 79 件から、A/D2/D3 での複数行 Issue の存在により +8 のずれ)。
-- A/D2/D3 の再型付け後の AC は、それぞれの sub-issue で `opportunistic-search.sh --event <name> --dry-run` の実行によりマッチ対象になることを個別確認済み (各 `docs/reports/manual-ac-retype-*.md` 参照)。
+- A/D2 は `opportunistic-search.sh --event <name> --dry-run` で再型付け全行の含有を個別確認済み (各 `docs/reports/manual-ac-retype-a.md` / `manual-ac-retype-d2.md` 参照)。D3 は 16 行中 11〜12 行を同様に確認し、残る行はマッチ集合外だった: #1135 / #478 条件1・2 は `when=mode:batch` ゲートが `mode=single` セッションで設計どおり除外、#490 / #465 は OPEN のため `opportunistic-search.sh` が固定する `--state closed` 母集団に構造的に入らず、close されるまで dispatch されない (いずれも `gh issue view` のリテラル一致で再型付け済みを確認。詳細: `docs/reports/manual-ac-retype-d3.md` § 検証)。
 - B の 6 件は `gh issue view` でラベルが `phase/done` へ遷移済みであることを確認済み。
 - C の 2 件は追加した bats テストが実際に該当シナリオを検証することを確認済み。
 - D1 の 5 件は Issue 本文が未変更 (manual 維持) であることを確認済み。
@@ -93,3 +97,5 @@ D3 は #1163 (区分 A) の「未知 event なら manual 維持」という原�
 ## 移行後の効果測定 (Post-merge)
 
 移行完了後の `/audit stats --retention` で、`phase/verify` の Manual waiting 件数が移行前 (79 件) から減少していることを確認する (post-merge AC、`event=auto-run` 発火待ち)。
+
+なお、再型付け済みでも #490 / #465 (OPEN) は `--state closed` 固定の母集団に入らず当面 dispatch されない。また `when=mode:batch` ゲート付き行は batch 実行時のみ発火する。減少幅がこれらの分だけ想定より小さくなるのは想定内である。

--- a/docs/reports/manual-ac-retype-summary.md
+++ b/docs/reports/manual-ac-retype-summary.md
@@ -1,0 +1,95 @@
+# manual AC 79 件 分類別移行 集約クローズアウトレポート (#1158)
+
+`phase/verify` に滞留する `verify-type: manual` の post-merge AC 79 件 (`docs/stats/2026-08-05.md` Section 10) を、区分 A/B/C/D1/D2/D3 の 6 区分に従って observation への再型付け・retire・bats テスト化・manual 維持のいずれかへ移行した取り組みの集約結果。実作業は 5 本の sub-issue (#1163〜#1167) が担い、本レポートはそれらの結果を集約する。
+
+## 対象・件数内訳
+
+| 区分 | Issue 数 (本文記載) | 実 AC 行数 | 担当 sub-issue | 状態 |
+|---|---|---|---|---|
+| A (次回…観察型) | 34 | 36 | #1163 | CLOSED |
+| D2 (実行シナリオ型) | 13 | 16 | #1164 | CLOSED |
+| D3 (その他) | 19 | 22 | #1165 | CLOSED |
+| B (別 repo 依存) | 6 | 6 | #1166 | CLOSED |
+| D1 (UI 目視) | 5 | 5 | #1167 | CLOSED |
+| C (故障注入) | 2 | 2 | #1167 | CLOSED |
+| **合計** | **79** | **87** | — | 全件 CLOSED |
+
+Issue 単位 (79件) と AC 行単位 (87行) の件数は一致しない。`docs/stats/2026-08-05.md` の分類は Issue 単位である一方、`observation-trigger.sh` 等のマッチ対象は AC 行単位のため、1 Issue が複数の対象 AC 行を持つ場合 (例: 区分 A の #719 / #708 が各 2 行) にずれが生じる。この単位ずれは複数の sub-issue (A・D2・D3) で共通して観測された。
+
+## 区分別処理結果
+
+### A + D2 (observation 再型付け)
+
+区分 A (34 Issue / 36 AC行、#1163) と区分 D2 (13 Issue / 16 AC行、#1164) を合わせて 47 Issue / 52 AC行が対象。`event=` に使用できるのは `modules/verify-classifier.md` が定める 5 有効値 (`pr-review-full` / `pr-review-light` / `auto-run` / `watchdog-kill` / `fix-cycle`) のみ。
+
+| sub-issue | 対象 AC行 | 再型付け | 内訳 | 対象外 (manual 維持) |
+|---|---|---|---|---|
+| #1163 (A) | 36 | 29 | `event=auto-run` 27 / `event=fix-cycle` 2 | 7 |
+| #1164 (D2) | 16 | 12 | `event=auto-run` 12 | 4 |
+| **合計** | **52** | **41** | auto-run 39 / fix-cycle 2 | **11** |
+
+再型付け後、`opportunistic-search.sh --event auto-run --dry-run` / `--event fix-cycle --dry-run` の実行で、両 sub-issue とも再型付けした全 AC 行が実際のマッチ集合に含まれることを個別に確認済み (件数の単純差分ではなく個別含有で判定。同時期に他 sub-issue や `/auto` 実行由来の新規 AC が母集団に加わるため、単純な件数差分は一致しない)。
+
+対象外 11 行 (manual 維持) の主な理由:
+- 故障注入型で 5 有効値のどの発火でも観測窓が開かない (#719条件1、#708条件1・2)
+- 前提条件 (`autonomy: L2` 等) が本リポジトリの実設定と矛盾し `config=` ゲートでも表現不能 (#704)
+- downstream プロジェクトでの主観評価または障害注入の二重前提で upstream から観測不能 (#501、#500)
+- vault 等 downstream 固有領域がこのリポジトリに存在しない (#479)
+- 別リポジトリ (`saito/trading`) 依存で upstream から機械検証不能、Issue 本文自身が明記済み (#507 条件1〜3)
+- `/audit` 単独実行に対応する event が機構の語彙 (5 有効値) に存在しない (#444)
+
+### B (retire / 移管)
+
+区分 B の対象 6 Issue (#1061 #1044 #1042 #1041 #962 #508、#1166) はすべて **retire** と判断された。downstream への移管は **0 件**。
+
+判断根拠: 6 件すべてで Pre-merge AC が完全にチェック済み (#1061: 10/10、#1044: 2/2、#1042: 2/2、#1041: 4/4、#962: 6/6、#508: 4/4) であり、実装の正しさは bats テスト・grep 検証・rubric 検証によって既に機械的または設計レベルで担保されている。downstream リポジトリへ確認用 Issue を新規に起票しても、既に担保済みの正しさに対して追加の検証シグナルを得られる見込みが薄く、費用対効果に見合わないと判断した。
+
+実施内容: 6 Issue それぞれに retire 決定コメントを投稿し、`phase/verify` → `phase/done` へのラベル遷移を実施 (6/6 成功)。#1166 は Spec の Changed Files が空でリポジトリ内ファイル変更を伴わないため operate route (`## Execution Log` Issue コメントとして記録) で処理された。
+
+### D1 (manual 維持)
+
+区分 D1 の 5 Issue (#1059 #709 #548 #442 #441、#1167) は `docs/stats/2026-08-05.md` の棚卸し方針表でも「manual のまま維持 (正当)」と分類されており、`manual` タグ・AC 本文は変更せず維持する。判断根拠:
+
+| Issue | manual 維持の理由 |
+|---|---|
+| #1059 | 複数スキルにまたがる実オーケストレーションと実 preview 環境が前提で、単一の決定的スクリプトでの模擬は統合確認としての意味を失う |
+| #709 | GitHub Issue Forms のレンダリングは GitHub 側プラットフォームの責務であり、本リポジトリのテスト可能範囲外 |
+| #548 | 実 downstream リポジトリの実 Web ページに対するブラウザ自動化・実スクリーンショット取得が前提で、生成画像の見た目確認には目視が必要 |
+| #442 | 任意の将来 Issue に対する LLM の Spec 生成品質という主観的判断が対象で、固定 fixture でも rubric でも表現できない (rubric は対象ファイルを事前に名指しできない) |
+| #441 | 実ブラウザによるレンダリング・スクリーンショット取得・pixel-diff 判定の一連の流れが前提で、数値計算のみの固定 fixture テストでは AC の主旨を代替できない |
+
+Issue 本文の post-merge AC 行自体は変更しないため、`phase/verify` の Manual waiting 集計には引き続き残るのが意図した挙動である。
+
+区分 C (故障注入、2 Issue: #1066 #1060、#1167) は D1 とは異なり、故障注入シナリオの機械的な核 (`wait-ci-checks.sh` の早期 break パス、`check-pre-merge-ac.sh` の境界ケース) を固定 fixture の bats テストで再現できたため、`tests/wait-ci-checks.bats` / `tests/check-pre-merge-ac.bats` へのテスト追加を行い、両 Issue の post-merge AC を `verify-type: auto` (`<!-- verify: command "bats tests/..." -->`) へ再型付けした。retire ではなく、テストによる担保を根拠とした再型付け方式を採用している。
+
+### D3 および対象外 (再型付けしなかった AC)
+
+区分 D3 (19 Issue / 22 AC行、#1165) は、A/B/C/D1/D2 のいずれにも当てはまらなかった残余として 1 件ずつ条件文を読んで判断した。
+
+| 処理 | AC行数 | 内訳 |
+|---|---|---|
+| observation 再型付け | 16 | `event=auto-run` 14 / `event=watchdog-kill` 1 / `event=pr-review-full` 1 |
+| retire | 6 | `auto-stop-at` 未設定で前提不成立 (#783)、将来拡張未実装 (#706)、downstream 固有 XL Issue (#591)、比較基準が陳腐化 (#587)、前提条件自体が不成立 (#563)、downstream 主観評価 (#484条件2) |
+| manual 維持 | 0 | — |
+| 対象外 (編集しない/別扱い) | 2 | #591 の既チェック済み (`- [x]`) 行、#491 のコードフェンス内サンプル行 (AC ではない) |
+
+D3 は #1163 (区分 A) の「未知 event なら manual 維持」という原則から意図的に方針変更し、前提が原理的に成立しない条件をすべて retire に倒した (詳細: `docs/spec/issue-1165-manual-ac-retype-d3.md` Notes)。
+
+**移行対象外とした AC 全体のまとめ (AC5 対応)**: A/D2 由来の manual 維持 11 行 (前掲) と D3 の対象外 2 行 (実 AC ではない編集除外) が「再型付け・retire いずれも行わなかった」項目である。D1 の 5 行は「正当な manual 維持」として別枠 (前掲) で扱う。各項目の個別理由は上表および各 sub-issue の記録ファイル (`docs/reports/manual-ac-retype-a.md` / `manual-ac-retype-d2.md` / `manual-ac-retype-d3.md`) に Issue 単位で記録済み。
+
+## 検証
+
+- 6 区分の Issue 数合計 (34+13+19+6+5+2=79) は `docs/stats/2026-08-05.md` Section 10 の分類件数 79 と一致することを確認した (差異なし)。
+- AC 行数合計は 87 行 (Issue 単位の 79 件から、A/D2/D3 での複数行 Issue の存在により +8 のずれ)。
+- A/D2/D3 の再型付け後の AC は、それぞれの sub-issue で `opportunistic-search.sh --event <name> --dry-run` の実行によりマッチ対象になることを個別確認済み (各 `docs/reports/manual-ac-retype-*.md` 参照)。
+- B の 6 件は `gh issue view` でラベルが `phase/done` へ遷移済みであることを確認済み。
+- C の 2 件は追加した bats テストが実際に該当シナリオを検証することを確認済み。
+- D1 の 5 件は Issue 本文が未変更 (manual 維持) であることを確認済み。
+
+## `when=` 属性について
+
+79 件全体を通じて `when=` / `keyword=` / `config=` 相当のゲート付与は最小限 (D3 の `when=mode:batch` 3行、`config=capabilities.workflow` 1行) にとどめ、包括的な実行文脈条件の宣言は #1163 の裁定を踏襲し #1118 に委ねた。
+
+## 移行後の効果測定 (Post-merge)
+
+移行完了後の `/audit stats --retention` で、`phase/verify` の Manual waiting 件数が移行前 (79 件) から減少していることを確認する (post-merge AC、`event=auto-run` 発火待ち)。

--- a/docs/spec/issue-1158-manual-ac-retype-summary.md
+++ b/docs/spec/issue-1158-manual-ac-retype-summary.md
@@ -26,6 +26,10 @@ Cross-phase marker (`type=verify-fail` / `type=preview-ac-unverified`) の追加
 
 コメントが提起した「`when=` を 79 件へ併せて付与するか」という論点は、姉妹 sub-issue #1163 が既に裁定済み (`when=` は付与せず #1118 に委ねる。後述 Notes 参照) であり、他の sub-issue もこの前例を踏襲する想定のため、本 Issue で新たに判断し直す必要はない。
 
+### Code phase (cutoff: `2026-08-07T07:26:00Z`, `phase/code` ラベル付与時刻)
+
+No new comments since last phase. Cross-phase marker (`type=verify-fail` / `type=preview-ac-unverified`) の追加スキャン結果: 該当なし。
+
 ## Autonomous Auto-Resolve Log
 
 (non-interactive mode; Step 6 の Issue 本文 vs 実装状態の conflict detection、および Step 7 の ambiguity resolution)
@@ -128,23 +132,36 @@ Consumed Comments で提示された「79 件へ `when=` を併せて付与す�
 - **Size=XL のまま `/code` を実行した場合に `modules/ambiguity-detector.md` の Hard-error abort 条件 (「Size is XL without sub-issue splitting」) に抵触しないか**: #1158 は GraphQL `subIssues` で 5 件の sub-issue が既に確認できるため、この hard-error 条件 (分割が存在しない場合) には該当しないと判断した。ただし `/code` 自身の実装がこの判定をどう行うかは未確認であり、次回 `/code 1158` 実行時に実際に確認されるべき残存確認事項として記録する
 - **Post-merge AC の文言をそのまま流用してよいか**: #1163/#1164 のように「N 件減少」という定量表現へ調整する必要があるか検討したが、#1158 自身の Post-merge AC は元々「79 件から減少していることを確認する」という定性的表現であり、5 sub-issue 全体の合計減少を指すため調整不要と判断し、Issue 本文のまま転記した
 
+## Code Retrospective
+
+### Deviations from Design
+
+- なし。Spec の Implementation Steps (precondition gate → 集約レポート作成 → 検証) をそのまま実行した。Auto Retrospective 節が示唆する「親セッションが手動挿入した `run-code.sh 1158 --pr`」の想定どおり、`--pr --non-interactive` 引数での実行だった。
+
+### Design Gaps/Ambiguities
+
+- Step 10 (verify command consistency) の rubric AC 5 件はいずれも Issue #1158 本文に特定ファイルを名指ししていないため、grader (本セッション自身) の入力スコープは Issue 本文 + git diff (集約レポート本体) のみだった。AC2 (「A + D2 が observation へ再型付けされている」) の実際の裏付け (Issue 本文の再型付け結果) はこの PR の diff に含まれず、`docs/reports/manual-ac-retype-a.md` / `manual-ac-retype-d2.md` (別 PR で追加済みの既存ファイル) にのみ存在する。rubric の可視範囲制約 (Spec Notes 前掲) は「集約レポートファイルを持たせれば解決する」という設計判断だったが、厳密には「rubric text で当該既存ファイルを名指しする」までは踏み込んでいない。今回は集約レポート自身に十分な要約(event= 内訳・マッチ確認結果の転記)を含めることで PASS 判定としたが、将来同種の親 Issue で rubric AC がより厳密な一次情報を要求する場合、rubric text 側で参照ファイルを明示する設計を検討する価値がある。
+- 区分 B (#1166) は operate route で処理されており、独自の記録ファイル (`docs/reports/manual-ac-retype-*.md`) を持たない。集約レポートでは #1166 の `## Execution Log` Issue コメントの内容を転記したが、他区分 (A/D2/D3/C/D1) が専用ファイルを持つのに対し B だけがコメントベースという非対称性がある。
+
+### Rework
+
+- なし。
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
-- #1158 は 2026-08-05 に対応方針 A (sub-issue 分割) で既に分割済みであり、実体作業は #1163 (CLOSED) / #1164 / #1165 / #1166 / #1167 (いずれも OPEN、phase/issue 未到達) が担う。本 Spec は #1158 自身の残存スコープ (5 sub-issue 完了後の集約クローズアウト) のみを定義する
-- Pre-merge AC 5 件が全て `rubric` であるため、rubric grader の可視範囲 (Issue 本文・git diff・rubric 名指しファイルのみ) を確保する目的で `docs/reports/manual-ac-retype-summary.md` を Changed Files に追加した (#1163 の operate→pr route 転換と同じ論理を親 Issue に適用)
-- Size は XL を維持し、ダウングレードは実行しなかった (`modules/ambiguity-detector.md` の Non-Interactive Mode Handling が「Size downgrade from XL」を High-Stakes Decision として明示的に skip 対象としているため)
+- Precondition gate (#1164/#1165/#1166/#1167 が全件 `phase/done`/CLOSED) を再確認し充足を確認した上で、`docs/reports/manual-ac-retype-summary.md` を作成した (Spec Implementation Steps 1〜4 をそのまま実行)
+- Pre-merge AC 5 件 (すべて `rubric`) は、集約レポートの git diff + Issue 本文を入力として grader (本セッション自身) が評価し、全件 PASS と判定してチェックボックスを更新した
+- 区分別処理結果は各 sub-issue の記録ファイル (`docs/reports/manual-ac-retype-a.md` / `-d2.md` / `-d3.md` / `-c-d1.md`) および #1166 の `## Execution Log` コメントから転記・要約する方式を採用し、単純なリンク集ではなく実数値 (件数・event= 内訳・retire 理由) を集約レポート本体に含めた
 
 ### Deferred Items
-- Implementation Step 1 (precondition gate) — #1164/#1165/#1166/#1167 が全て `phase/done`/CLOSED に到達するまで Step 2 以降は実行不可。次回 `/code 1158` 実行時に gate から再開する
-- カテゴリ B (6件) の retire/downstream 移管判断 — #1166 自身の Acceptance Criteria が所有。本 Issue では判断せず集約レポートへの転記のみ行う
-- `size-workflow-table.md` に「XL 分割後も親が rubric 型集約 AC を持つ」パターンの経路定義が存在しない件 — spec retrospective に記録済み。Issue 起票は `/verify` の改善提案集約フェーズに委ねる
+- Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認、`event=auto-run`) — `/verify` が observation 経路で評価する
+- Code Retrospective に記録した rubric AC の可視範囲制約 (別 PR で追加済みの sub-issue 記録ファイルを rubric text が名指ししていない件) — 将来の改善検討事項として記録のみ、本 Issue のスコープ外
 
 ### Notes for Next Phase
-- `/code 1158` 実行時は Size=XL のままだが、明示的に `--pr` フラグを使うこと (Size ベースの自動ルーティングは XL に対して patch/pr/operate のいずれの列も持たないため)
-- Implementation Step 1 の precondition gate で 1 件でも未完了なら、以降の Step を実行せず「blocked」として終了すること — 空ファイルや部分的な内容でレポートを作成しないこと
-- 集約レポート作成時は #1163 の実例 (`docs/reports/manual-ac-retype-a.md`) を構造の参考にすること (見出し構成: `## 対象・件数内訳` → `## 区分別処理結果` → `## 検証`)
+- 本 PR マージ後、`/review` → `/merge` → `/verify` の通常フローに進む。Post-merge AC は `event=auto-run` の発火を待つ observation 型のため、`/verify` 初回実行時は SKIPPED (waiting for event) となる想定
+- 親 Issue #1158 自身の実装はこれで完了。5 sub-issue + 本集約レポートの全体像は `docs/reports/manual-ac-retype-summary.md` を参照すること
 
 ## Auto Retrospective
 

--- a/docs/spec/issue-1158-manual-ac-retype-summary.md
+++ b/docs/spec/issue-1158-manual-ac-retype-summary.md
@@ -140,6 +140,7 @@ Consumed Comments で提示された「79 件へ `when=` を併せて付与す�
 
 ### Design Gaps/Ambiguities
 
+- spec retrospective の `### Uncertainty resolution` が次フェーズへ引き渡した残存確認事項 (「Size=XL のまま `/code` を実行した場合に `modules/ambiguity-detector.md` の Hard-error abort 条件 (「Size is XL without sub-issue splitting」) に抵触しないか」) は、本セッションで `run-code.sh 1158 --pr --non-interactive` が abort せず完走したことで抵触しないことを実測確認した。#1158 は GraphQL `subIssues` に 5 件の sub-issue (#1163〜#1167) が存在するため「分割なし XL」に該当せず、hard-error 条件の対象外だった。
 - Step 10 (verify command consistency) の rubric AC 5 件はいずれも Issue #1158 本文に特定ファイルを名指ししていないため、grader (本セッション自身) の入力スコープは Issue 本文 + git diff (集約レポート本体) のみだった。AC2 (「A + D2 が observation へ再型付けされている」) の実際の裏付け (Issue 本文の再型付け結果) はこの PR の diff に含まれず、`docs/reports/manual-ac-retype-a.md` / `manual-ac-retype-d2.md` (別 PR で追加済みの既存ファイル) にのみ存在する。rubric の可視範囲制約 (Spec Notes 前掲) は「集約レポートファイルを持たせれば解決する」という設計判断だったが、厳密には「rubric text で当該既存ファイルを名指しする」までは踏み込んでいない。今回は集約レポート自身に十分な要約(event= 内訳・マッチ確認結果の転記)を含めることで PASS 判定としたが、将来同種の親 Issue で rubric AC がより厳密な一次情報を要求する場合、rubric text 側で参照ファイルを明示する設計を検討する価値がある。
 - 区分 B (#1166) は operate route で処理されており、独自の記録ファイル (`docs/reports/manual-ac-retype-*.md`) を持たない。集約レポートでは #1166 の `## Execution Log` Issue コメントの内容を転記したが、他区分 (A/D2/D3/C/D1) が専用ファイルを持つのに対し B だけがコメントベースという非対称性がある。
 

--- a/docs/spec/issue-1158-manual-ac-retype-summary.md
+++ b/docs/spec/issue-1158-manual-ac-retype-summary.md
@@ -149,20 +149,22 @@ Consumed Comments で提示された「79 件へ `when=` を併せて付与す�
 - なし。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Precondition gate (#1164/#1165/#1166/#1167 が全件 `phase/done`/CLOSED) を再確認し充足を確認した上で、`docs/reports/manual-ac-retype-summary.md` を作成した (Spec Implementation Steps 1〜4 をそのまま実行)
-- Pre-merge AC 5 件 (すべて `rubric`) は、集約レポートの git diff + Issue 本文を入力として grader (本セッション自身) が評価し、全件 PASS と判定してチェックボックスを更新した
-- 区分別処理結果は各 sub-issue の記録ファイル (`docs/reports/manual-ac-retype-a.md` / `-d2.md` / `-d3.md` / `-c-d1.md`) および #1166 の `## Execution Log` コメントから転記・要約する方式を採用し、単純なリンク集ではなく実数値 (件数・event= 内訳・retire 理由) を集約レポート本体に含めた
+- Pre-merge AC 5 件 (すべて `rubric`) を独立 grader として再評価し、全件 PASS を確認 (Issue 側は既に `[x]`、更新不要)。AC2 の一次証拠が本 PR の diff に現れない点は Code Retrospective の自己申告どおりで、review でも同じ制約を確認した
+- capabilities.workflow: true だが ARGUMENTS に `--non-interactive` があるため fork context (再起動保証なし) と判定し、Workflow パスではなく static Task fan-out (review-spec + review-bug×2) を `run_in_background: false` の foreground 実行で運用した
+- review-spec + review-bug×2 (3 finder) が独立に発見した指摘を統合・重複排除した結果、MUST 0 件 / SHOULD 3 件 / CONSIDER 4 件。SHOULD 3 件はいずれもドキュメントの記述精度 (一括表現の過大主張、テーブル合計不一致、Spec 申し送り事項の未消化) で、adversarial verify で 3/4 件 CONFIRMED、CLAUDE.md 言語規約の指摘 1 件は前例と整合するため REJECT (false positive) と判定した
+- MUST 0 件のため merge blocking はなし。SHOULD/CONSIDER 計 7 件はすべて低リスクなドキュメント修正であり、この phase 内で修正・コミット・プッシュまで完了させた (次フェーズへ持ち越さない判断)
 
 ### Deferred Items
 - Post-merge AC (`/audit stats --retention` での Manual waiting 件数減少確認、`event=auto-run`) — `/verify` が observation 経路で評価する
-- Code Retrospective に記録した rubric AC の可視範囲制約 (別 PR で追加済みの sub-issue 記録ファイルを rubric text が名指ししていない件) — 将来の改善検討事項として記録のみ、本 Issue のスコープ外
+- rubric AC の可視範囲制約 (rubric text で参照ファイルを明示する設計) — Code Retrospective・review retrospective 双方で記録済みだが、本 Issue のスコープ外として対応せず
+- `run-auto-sub.sh` の operate route 判定欠落 (#1166 の再発防止) — Auto Retrospective に既存の Improvement Proposal あり、Issue 化は `/verify` の改善提案集約フェーズに委ねる
 
 ### Notes for Next Phase
-- 本 PR マージ後、`/review` → `/merge` → `/verify` の通常フローに進む。Post-merge AC は `event=auto-run` の発火を待つ observation 型のため、`/verify` 初回実行時は SKIPPED (waiting for event) となる想定
-- 親 Issue #1158 自身の実装はこれで完了。5 sub-issue + 本集約レポートの全体像は `docs/reports/manual-ac-retype-summary.md` を参照すること
+- 本 PR マージ後、`/merge` → `/verify` の通常フローに進む。Post-merge AC は `event=auto-run` の発火を待つ observation 型のため、`/verify` 初回実行時は SKIPPED (waiting for event) となる想定
+- 親 Issue #1158 自身の実装はこれで完了。5 sub-issue + 本集約レポートの全体像は `docs/reports/manual-ac-retype-summary.md` を参照すること (review phase での修正後、記述精度が向上している)
 
 ## Auto Retrospective
 
@@ -191,3 +193,18 @@ Level 1 のみ (4 件すべて独立、blocked-by #1157 は CLOSED 済み)。並
 
 - **auto/run-auto-sub: sub-issue の route 判定が Spec 由来の operate route を honor しない** — `skills/auto/SKILL.md` の単一 Issue 経路には Step 3a「Operate route demotion」があり、spec 後に Spec の diff-less 判定で `ROUTE=operate` へ降格する。しかし `scripts/run-auto-sub.sh` の post-spec Size 再取得 (`INITIAL_SIZE` → `SIZE` 比較) は Size 軸しか見ておらず、同等の operate 判定を持たない。結果として operate route の sub-issue は必ず `code-pr` で dispatch され、completion check 失敗 → Tier 2/Tier 3 を空振りさせ exit 1 で終わる。本セッションの #1166 が実例 (機能的には成功しているのに wrapper は失敗扱い)。`run-auto-sub.sh` に Step 3a 相当の operate 判定を追加し、成立時は `code-patch` dispatch + `code-patch` completion check へ切り替える。バッチ/XL 経路で operate route Issue を扱う限り再発する構造的欠陥。
 - **size-workflow-table / auto: XL 分割後も親が集約成果物を持つパターンの経路定義が無い** — `modules/size-workflow-table.md` は XL を「sub-issue へ分割し親は追跡のみ」と定義するが、親が rubric 型の横断 AC を持つ場合、rubric grader は Issue コメントや Spec ファイルを参照できないため親自身が成果物ファイルを持たざるを得ない (#1163 が sub-issue レベルで同じ結論に到達し、#1158 の Spec がそれを親へ一段上げて適用した)。`/auto` の XL route はこの「親の実装フェーズ」を持たないため、Spec がそう設計しても自動実行経路から漏れる。XL route に「全 sub-issue 完了後、親 Spec の Changed Files が非空なら親の code フェーズを実行する」ステップを追加するか、`size-workflow-table.md` 側で親が成果物を持つことを禁じて sub-issue へ寄せるかの二択を決める。#1158 の spec retrospective でも Deferred Items として同じ欠落が記録されている。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Code phase の Design Gaps/Ambiguities が既に自己申告していた「rubric AC2 の裏付け (再型付け結果) が本 PR の diff に含まれず、別 PR で追加済みの sub-issue 記録ファイルにのみ存在する」というギャップは、review-spec / review-bug 双方の finder が独立に同じ line 84 の「A/D2/D3 の再型付け後の AC は…個別確認済み」という一括表現を「一次資料 (`manual-ac-retype-d3.md`) の実測 (D3 の 4〜5 行がマッチ集合外) と食い違う」として具体的に指摘する形で顕在化した。Code phase の自己申告は「rubric の可視範囲制約」という抽象レベルの懸念だったが、review phase で「具体的にどの数字が不正確か」まで特定できた。集約クローズアウト PR (親 Issue が sub-issue の作業を要約するだけで実装成果物を持たない、または持っていても一次情報は別 PR にある) では、rubric AC の PASS 判定と実際の記述精度は別問題であることを示す事例。
+
+### Recurring issues
+
+- review-spec と review-bug×2 (計 3 finder) が独立に同じ 2 箇所 (line 84 の一括マッチ確認claim、D3 テーブルの AC行数列 24 vs 22) を指摘した。finder 間の corroboration が強く、adversarial verify で 3/4 件が PASS (confirmed) となったことと整合する。fan-out レビューが同一箇所を複数角度から捕捉できることを示す好例。
+- 「カウント対象の母集団に含まれる行」と「対象外 (母集団の外側)」を同じテーブル列に並べ、除外の理由を注記しないパターンが D3 テーブルで発生した。この一次資料 (`docs/reports/manual-ac-retype-d3.md`) 自体が同じ構造を持っていた (bug-diff agent が指摘: 「Note this same structure exists in the source `manual-ac-retype-d3.md` lines 8-12」)。集約時に単純転記するとテーブル設計上のわかりにくさも一緒に転写される。今後同種の集計テーブルを書く際は、「対象外」行を独立させるか合計行を明示する設計を最初から採用するとよい。
+
+### Acceptance criteria verification difficulty
+
+- Pre-merge AC 5 件はすべて `rubric` 型で、grader (本セッション) の入力スコープは Issue 本文 + 本 PR の git diff (集約レポート本体) のみだった。AC2 (「A + D2 が observation へ再型付けされ…マッチ対象になることが確認できる」) の一次証拠 (Issue 本文の実際の再型付け結果、`opportunistic-search.sh --dry-run` の実行結果) は、operate route による GitHub Issue 編集という性質上、原理的にこの PR の diff には現れない。集約レポート自身が十分な要約 (数値内訳・確認手法の記述) を含めることで rubric grader は PASS と判定できたが、記述の「正確さ」までは rubric の役割を超えるため review phase での finder 発見に依存した。将来同種の XL 親 Issue で rubric AC を書く際は、rubric text 側で「参照する sub-issue 記録ファイルを明示する」設計 (Code Retrospective で既に提案済み) に加え、集約レポート本体には一次資料の例外・境界ケースまで正確に転記する規律が必要である。


### PR DESCRIPTION
## Summary

Issue #1158 (親 XL Issue、manual AC 79 件の分類別移行) の残存スコープである集約クローズアウト作業を実施した。5 本の sub-issue (#1163〜#1167) がすべて CLOSED / `phase/done` に到達したことを precondition gate で確認した上で、`docs/reports/manual-ac-retype-summary.md` を新規作成し、6 区分 (A/B/C/D1/D2/D3、計 79 Issue / 87 AC行) それぞれの処理結果 (再型付け・retire・bats テスト化・manual 維持) を集約記録した。

Pre-merge AC 5 件はすべて `rubric` 型で、rubric grader の可視範囲 (Issue 本文・git diff) を確保する目的でこのレポートファイルを Changed Files に追加している (#1163 が sub-issue レベルで採用した operate→pr route 転換と同じ論理を親 Issue にも適用)。

## Verification (pre-merge)

- 分類結果 (Issue 番号ごとの移行先) が構造化データとして記録され、`docs/stats/2026-08-05.md` の分類 6 区分と対応が取れていることを確認
- A (34件) + D2 (13件) が observation へ再型付けされ、`event=` 属性が付与済み。`opportunistic-search.sh --dry-run` によるマッチ確認結果を転記
- B (6件) がすべて retire され、判断根拠 (Pre-merge AC 完全チェック済み) を記録
- D1 (5件) が manual 維持され、Issue ごとの維持根拠を記録
- 移行対象外とした AC (A/D2 の対象外 11行、D3 の対象外 2行) の理由を Issue 単位で記録

## Verification (post-merge)

- 移行完了後の `/audit stats --retention` で、`phase/verify` の Manual waiting 件数が移行前 (79件) から減少していることを確認する (`verify-type: observation event=auto-run`)

closes #1158
