### PR TITLE
Issue #1221: Distinguish CI-wait silence from json-mode-silent-hang in detect-wrapper-anomaly

### DIFF
--- a/docs/spec/issue-1221-ci-wait-silence-timeout.md
+++ b/docs/spec/issue-1221-ci-wait-silence-timeout.md
@@ -76,16 +76,27 @@
 - `bats --jobs 18 tests/` の並列フルスイート実行で `tests/post_merge_check.bats` の `fail: gh issue reopen called when FAIL input given` が単発 FAIL した。同テストを単独実行 (`bats tests/post_merge_check.bats`) すると 10/10 PASS するため、`scripts/test-failure-classify.sh` の分類は `infra` (並列実行下のリソース競合と推定)。`scripts/post_merge_check.sh` / `tests/post_merge_check.bats` はいずれも本 Issue の変更対象外であり、原因調査・修正はスコープ外と判断した。CI (`.github/workflows/test.yml`) も `bats --jobs $(nproc) tests/` で実行するため、同じ並列条件下では低頻度で再現しうる — 再発・パターン化した場合は別 Issue として起票を検討
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `--events` の判定分岐は `detect-external-kill.sh` の chained-grep イディオムをそのまま踏襲し、既存コードとの一貫性を優先した
-- `ci-wait-silence-timeout` カタログエントリの Fallback Steps は `skills/verify/SKILL.md` Step 5 の CI インフラ障害判定表を参照する形にとどめ、判定ロジック自体は複製しなかった (SSoT 分散を避けるため)
+- `review-light` (light mode、4 側面統合) で issue 0 件と判定したため、Step 12 (修正作業) は実施せず Step 13 (方針変更検出) もスキップした
+- Pre-merge AC 7 件すべてを safe mode で PASS 判定 (grep x2 / section_contains x1 / rubric x2 / command x1 / CI フォールバック / github_check x1)。AC7 (`github_check "gh pr checks" "Run bats tests"`) は前フェーズで未チェックだったが、CI 9/9 green を確認しチェックボックスを更新した
 
 ### Deferred Items
-- Post-merge AC (`verify-type: observation event=auto-run session=next`) — 次回 CI 待機由来の watchdog kill が実際に発生した際、`ci-wait-silence-timeout` として診断されることの観察が必要。次回 `/auto` セッションでの発火を待つ
-- `scripts/apply-fallback.sh` 側の `code-patch` フェーズ限定の独自 `json-mode-silent-hang` 判定は、本 Issue のスコープ外として Spec Notes に明記済み (将来 `code-pr` に類似の長時間待機が入った場合は別 Issue で再検討)
+- Post-merge AC (`verify-type: observation event=auto-run session=next`) は未発火のため引き続き未チェック — 次回 CI 待機由来の watchdog kill が実際に発生した際の観察を待つ (code フェーズからの申し送り事項を継続)
 
 ### Notes for Next Phase
-- `tests/post_merge_check.bats` の並列実行下フリークな FAIL (上記 Rework 参照) は再現性が低く本 Issue の変更と無関係。review/verify フェーズで再度 FAIL が観測されても、まず単独再実行で切り分けること
-- AC7 (`github_check "gh pr checks" "Run bats tests"`) は PR 作成前のため未チェックのまま — CI green 確認後に `/review` または `/verify` でチェックされる想定
+- `/merge` フェーズでは MUST issue なし・CI green のため、通常の squash merge で進行できる想定
+- Post-merge AC の観察確定 (`event=auto-run`) は `/verify` フェーズの担当
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — PR #1253 の diff (5 ファイル) は Spec の Implementation Steps 1-5 と厳密に一致していた (`--events` 引数名・挿入位置、`detect-external-kill.sh` の chained-grep イディオム踏襲、カタログエントリの配置、`skills/auto/SKILL.md` の引数順、bats 新規 3 ケース)。`review-light` エージェントが Spec 乖離 / エッジケース堅牢性 / セキュリティ / ドキュメント整合性の 4 側面すべてで issue 0 件と判定
+
+### Recurring issues
+- Nothing to note — 本レビューは MUST/SHOULD/CONSIDER いずれも 0 件
+
+### Acceptance criteria verification difficulty
+- Nothing significant to note。Pre-merge 7 件 (`grep` x2, `section_contains` x1, `rubric` x2, `command` x1, `github_check` x1) すべてが UNCERTAIN なしで PASS に到達した
+- `rubric "json-mode-silent-hang の判定条件が、ci_wait イベントが存在する場合に当該パターンへマッチしないよう絞り込まれている"` は、実装の if/else 分岐構造 (ci_wait 検出時のみ `ci-wait-silence-timeout` へ分岐し、それ以外は既存の `json-mode-silent-hang` にフォールバックする形) を直接言い当てており、コード確認 1 回で判定確定できた。rubric 文言がコード構造を正確に予見していた良い例として記録

--- a/docs/spec/issue-1221-ci-wait-silence-timeout.md
+++ b/docs/spec/issue-1221-ci-wait-silence-timeout.md
@@ -60,3 +60,32 @@
 
 - saito / MEMBER / first-class / `/issue` フェーズの Issue Retrospective — Background の技術的主張をコードベースと照合し正確性を確認、Auto-Resolve Log (`ci-wait-silence-timeout` 命名確定、`--events` 配線 AC 追加) を記録 / https://github.com/saitoco/wholework/issues/1221#issuecomment-5214484722
 - saito / MEMBER / first-class / `/issue` Step 15 (AC Verify Command Integrity Audit) — 自己監査で Step 8/9 追加直後の AC が Pattern 6-1 (heading 引数に `#### ` を含む常時 UNCERTAIN) に該当すると検出し、Issue body を修復済み (現在の AC は修復後の形) / https://github.com/saitoco/wholework/issues/1221#issuecomment-5214534020
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1-5 を Spec 記載順のまま実装。分岐イディオムも `detect-external-kill.sh` line 80-82 と同一のものを流用した
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- 本 Issue は `/auto` の code フェーズが 1 回目の試行でフルテストスイートのバックグラウンド実行によりサイレント no-op し (`code_retry_fire iteration 1`)、2 回目の試行 (本セッション) でリトライされたもの。1 回目の失敗は本 Issue の実装内容自体とは無関係で、直前にランディングした Issue #1213 の修正 (`bats --jobs <N> tests/` をフォアグラウンドで 10 分以内に収める) が本セッションの Step 9 に反映されておりリトライは正常完了した
+
+### Observed pre-existing test flakiness (unrelated to this Issue's scope)
+- `bats --jobs 18 tests/` の並列フルスイート実行で `tests/post_merge_check.bats` の `fail: gh issue reopen called when FAIL input given` が単発 FAIL した。同テストを単独実行 (`bats tests/post_merge_check.bats`) すると 10/10 PASS するため、`scripts/test-failure-classify.sh` の分類は `infra` (並列実行下のリソース競合と推定)。`scripts/post_merge_check.sh` / `tests/post_merge_check.bats` はいずれも本 Issue の変更対象外であり、原因調査・修正はスコープ外と判断した。CI (`.github/workflows/test.yml`) も `bats --jobs $(nproc) tests/` で実行するため、同じ並列条件下では低頻度で再現しうる — 再発・パターン化した場合は別 Issue として起票を検討
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `--events` の判定分岐は `detect-external-kill.sh` の chained-grep イディオムをそのまま踏襲し、既存コードとの一貫性を優先した
+- `ci-wait-silence-timeout` カタログエントリの Fallback Steps は `skills/verify/SKILL.md` Step 5 の CI インフラ障害判定表を参照する形にとどめ、判定ロジック自体は複製しなかった (SSoT 分散を避けるため)
+
+### Deferred Items
+- Post-merge AC (`verify-type: observation event=auto-run session=next`) — 次回 CI 待機由来の watchdog kill が実際に発生した際、`ci-wait-silence-timeout` として診断されることの観察が必要。次回 `/auto` セッションでの発火を待つ
+- `scripts/apply-fallback.sh` 側の `code-patch` フェーズ限定の独自 `json-mode-silent-hang` 判定は、本 Issue のスコープ外として Spec Notes に明記済み (将来 `code-pr` に類似の長時間待機が入った場合は別 Issue で再検討)
+
+### Notes for Next Phase
+- `tests/post_merge_check.bats` の並列実行下フリークな FAIL (上記 Rework 参照) は再現性が低く本 Issue の変更と無関係。review/verify フェーズで再度 FAIL が観測されても、まず単独再実行で切り分けること
+- AC7 (`github_check "gh pr checks" "Run bats tests"`) は PR 作成前のため未チェックのまま — CI green 確認後に `/review` または `/verify` でチェックされる想定

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -376,6 +376,33 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 
 ---
 
+## ci-wait-silence-timeout
+
+### Symptom
+- `run-*.sh` exits with code 143 (watchdog SIGTERM)
+- Wrapper log contains: `watchdog: still waiting (json mode), silent for <N>s`
+- `.tmp/auto-events.jsonl` contains a `ci_wait` event for this issue/phase, recorded before the silence began
+- Typical cause: CI infrastructure is slow or down while the session is legitimately waiting on `wait-ci-checks.sh`, not a session init stall
+
+### Applicable Phases
+- Phases that wait on CI via `run-*.sh` (review, merge)
+
+### Fallback Steps
+1. Check current CI status with `gh pr checks <pr_number>` before retrying anything
+2. If the failure signature matches CI infrastructure outage (`steps: []`, `cancelled` + timeout, runner error, network error — see `skills/verify/SKILL.md` Step 5 "Verification priority" Step 1 for the classification table), re-run CI on the same SHA
+3. Once CI reaches a confirmed (non-pending) state, retry the phase
+
+### Escalation
+- If CI still does not reach a confirmed state after the re-run, or the failure signature does not match a known CI infrastructure outage, escalate to Tier 3
+- Do not retry the phase blindly before confirming CI status — retrying while CI infrastructure is still down re-enters the same `ci_wait` silence and burns another full watchdog window
+
+### Rationale
+- Distinguishes CI-wait-caused silence from `json-mode-silent-hang` above, which the two share an identical wrapper-log symptom (exit 143 + `still waiting (json mode)`) but different root causes and different correct recovery
+- Introduced in Issue #1221; real case in Issue #1214 / PR #1216 (2026-08-06): a GitHub Actions-wide outage held CI pending for the length of `watchdog-timeout-review-seconds` (5400s); the catalog's `json-mode-silent-hang` "retry once" instruction would have re-entered the same `ci_wait` wait and been killed again. The parent session instead confirmed CI status first, re-ran CI on the same SHA once green elsewhere, then retried — completing in 1200s
+- `wait-ci-checks.sh` already emits the `ci_wait` event on CI poll completion (`docs/reports/event-log-schema.md` §5); `detect-wrapper-anomaly.sh --events .tmp/auto-events.jsonl` reads it to separate this pattern from `json-mode-silent-hang`
+
+---
+
 ## baseline-failure
 
 ### Symptom

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -2,7 +2,7 @@
 # detect-wrapper-anomaly.sh - Detect known failure patterns in shell wrapper output
 # and generate Auto Retrospective markdown fragments.
 #
-# Usage: detect-wrapper-anomaly.sh --log <path> --exit-code <N> --issue <N> --phase <name>
+# Usage: detect-wrapper-anomaly.sh --log <path> --exit-code <N> --issue <N> --phase <name> [--events <path>]
 #
 # Outputs markdown fragment to stdout when a known pattern is matched.
 # Outputs nothing (empty) when no pattern matches.
@@ -13,6 +13,7 @@ LOG_FILE=""
 EXIT_CODE=""
 ISSUE_NUMBER=""
 PHASE=""
+EVENTS_FILE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -32,6 +33,10 @@ while [[ $# -gt 0 ]]; do
       PHASE="${2:-}"
       shift 2
       ;;
+    --events)
+      EVENTS_FILE="${2:-}"
+      shift 2
+      ;;
     *)
       echo "Error: unknown argument: $1" >&2
       exit 1
@@ -40,7 +45,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$LOG_FILE" || -z "$EXIT_CODE" || -z "$ISSUE_NUMBER" || -z "$PHASE" ]]; then
-  echo "Usage: detect-wrapper-anomaly.sh --log <path> --exit-code <N> --issue <N> --phase <name>" >&2
+  echo "Usage: detect-wrapper-anomaly.sh --log <path> --exit-code <N> --issue <N> --phase <name> [--events <path>]" >&2
   exit 1
 fi
 
@@ -72,9 +77,17 @@ elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q '"phase":"code-pr
   ANOMALY_DESC="Watchdog killed the process in phase \`$PHASE\` (exit code $EXIT_CODE) after code-pr completed its commits but before PR creation: \`matches_expected:false\` and \`phase:code-pr\` detected in reconcile-phase-state output. The run-code.sh phase exited without creating a PR. Reference: #415."
   IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#code-completed-no-pr\`: checkout the worktree branch, rebase onto latest main, push the branch, and create the PR with \`gh pr create\`, then continue with \`/review\`."
 elif [[ "$EXIT_CODE" == "143" ]] && grep -q "still waiting (json mode)" "$LOG_FILE"; then
-  PATTERN_NAME="json-mode-silent-hang"
-  ANOMALY_DESC="json mode silent hang in phase \`$PHASE\` (exit code $EXIT_CODE): \`watchdog: still waiting (json mode)\` detected in wrapper output. The forked session did not produce any output after launching in json mode, and the watchdog terminated it with SIGTERM."
-  IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#json-mode-silent-hang\`: retry the phase once via the corresponding run-*.sh script. Rationale: transient API delay or session init stall."
+  if [[ -n "$EVENTS_FILE" && -f "$EVENTS_FILE" ]] && grep -E "\"issue\":${ISSUE_NUMBER}[,}]" "$EVENTS_FILE" 2>/dev/null \
+    | grep '"event":"ci_wait"' \
+    | grep -q "\"phase\":\"${PHASE}\""; then
+    PATTERN_NAME="ci-wait-silence-timeout"
+    ANOMALY_DESC="CI wait silence timeout in phase \`$PHASE\` (exit code $EXIT_CODE): \`watchdog: still waiting (json mode)\` detected in wrapper output, and a \`ci_wait\` event for this issue/phase is recorded in the events log. The silence is explained by CI wait, not a session init stall — the forked session was likely still alive and waiting on CI to reach a non-pending state."
+    IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#ci-wait-silence-timeout\`: confirm current CI status with \`gh pr checks\` before retrying. Do not retry blindly — if CI infrastructure is still down, an immediate retry re-enters the same \`ci_wait\` silence."
+  else
+    PATTERN_NAME="json-mode-silent-hang"
+    ANOMALY_DESC="json mode silent hang in phase \`$PHASE\` (exit code $EXIT_CODE): \`watchdog: still waiting (json mode)\` detected in wrapper output. The forked session did not produce any output after launching in json mode, and the watchdog terminated it with SIGTERM."
+    IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#json-mode-silent-hang\`: retry the phase once via the corresponding run-*.sh script. Rationale: transient API delay or session init stall."
+  fi
 elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q "Review Summary" "$LOG_FILE"; then
   PATTERN_NAME="reconciler-header-mismatch"
   ANOMALY_DESC="Reconciler detected header mismatch in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`Review Summary\` pattern detected in wrapper output. The reconciler could not find \`## Review Response Summary\` in the PR comment, indicating a mismatch between the skill output header and the reconciler's expected pattern. Reference: #394."

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -965,7 +965,7 @@ If `matches_expected: false`: proceed to Tier 2.
 Run the anomaly detector:
 
 ```bash
-${CLAUDE_PLUGIN_ROOT}/scripts/detect-wrapper-anomaly.sh --log .tmp/wrapper-out-$NUMBER-$PHASE.log --exit-code $EXIT_CODE --issue $NUMBER --phase $PHASE
+${CLAUDE_PLUGIN_ROOT}/scripts/detect-wrapper-anomaly.sh --log .tmp/wrapper-out-$NUMBER-$PHASE.log --events .tmp/auto-events.jsonl --exit-code $EXIT_CODE --issue $NUMBER --phase $PHASE
 ```
 
 If detector output is non-empty (known pattern matched):

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -421,6 +421,36 @@ MOCK
     [[ "$output" != *"json-mode-silent-hang"* ]]
 }
 
+@test "ci wait silence: detects when ci_wait event matches issue and phase" {
+    echo "watchdog: still waiting (json mode), silent for 1800s (pid=99)" > "$LOG_FILE"
+    EVENTS_FILE="$BATS_TEST_TMPDIR/auto-events.jsonl"
+    printf '{"ts":"2026-08-06T15:35:29Z","issue":684,"event":"ci_wait","session_id":"1","pr":100,"phase":"code","wait_sec":"600"}\n' > "$EVENTS_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --events "$EVENTS_FILE" --exit-code 143 --issue 684 --phase code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ci-wait-silence-timeout"* ]]
+    [[ "$output" != *"json-mode-silent-hang"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+    [[ "$output" == *"### Improvement Proposals"* ]]
+}
+
+@test "ci wait silence: falls back to json-mode-silent-hang when ci_wait event is for a different phase" {
+    echo "watchdog: still waiting (json mode), silent for 1800s (pid=99)" > "$LOG_FILE"
+    EVENTS_FILE="$BATS_TEST_TMPDIR/auto-events.jsonl"
+    printf '{"ts":"2026-08-06T15:35:29Z","issue":684,"event":"ci_wait","session_id":"1","pr":100,"phase":"review","wait_sec":"600"}\n' > "$EVENTS_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --events "$EVENTS_FILE" --exit-code 143 --issue 684 --phase code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"json-mode-silent-hang"* ]]
+    [[ "$output" != *"ci-wait-silence-timeout"* ]]
+}
+
+@test "ci wait silence: falls back to json-mode-silent-hang when --events is omitted" {
+    echo "watchdog: still waiting (json mode), silent for 1800s (pid=99)" > "$LOG_FILE"
+    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 143 --issue 684 --phase code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"json-mode-silent-hang"* ]]
+    [[ "$output" != *"ci-wait-silence-timeout"* ]]
+}
+
 @test "review-completion-false-negative: detects matches_expected false with phase review" {
     printf '"matches_expected":false\n"phase":"review"\n' > "$LOG_FILE"
     run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review


### PR DESCRIPTION
## Summary
- `scripts/detect-wrapper-anomaly.sh` gains a new optional `--events <path>` argument. When the exit-143 + `still waiting (json mode)` branch fires, it now checks the events log for a `ci_wait` event matching the current issue/phase before reporting `json-mode-silent-hang`; if a matching `ci_wait` event is found, it reports the new `ci-wait-silence-timeout` pattern instead.
- `modules/orchestration-fallbacks.md` gains a new `## ci-wait-silence-timeout` catalog entry (Symptom/Applicable Phases/Fallback Steps/Escalation/Rationale), whose recovery procedure checks CI status via `gh pr checks` before retrying, instead of retrying immediately.
- `skills/auto/SKILL.md` Tier 2's `detect-wrapper-anomaly.sh` invocation now passes `--events .tmp/auto-events.jsonl`, matching the existing `detect-external-kill.sh` call's argument pattern.
- `tests/detect-wrapper-anomaly.bats` gains 3 new tests covering detection, phase-mismatch fallback, and `--events`-omitted backward compatibility.

## Verification (pre-merge)
- `grep "events" scripts/detect-wrapper-anomaly.sh` — PASS
- `grep "ci_wait" scripts/detect-wrapper-anomaly.sh` — PASS
- `section_contains skills/auto/SKILL.md "Tier 2 (Known pattern): Anomaly Detector + Fallback Catalog" "--events"` — PASS
- ci-wait-silence-timeout カタログエントリの追加内容 (rubric) — PASS
- json-mode-silent-hang が ci_wait ケースを除外する判定 (rubric) — PASS
- `bats tests/detect-wrapper-anomaly.bats` — PASS (44/44, including the 3 new cases)
- CI `Run bats tests` job — pending (checked automatically after PR checks run)

## Verification (post-merge)
- 次回 CI 待機中に watchdog kill が発生した際、`ci-wait-silence-timeout` として診断されることを次回発生時に観察する

closes #1221
