### PR TITLE
Issue #1220: observation-trigger keyword= ゲートのパス様トークン除外

### DIFF
--- a/docs/spec/issue-1220-keyword-gate-path-fp-fix.md
+++ b/docs/spec/issue-1220-keyword-gate-path-fp-fix.md
@@ -47,7 +47,34 @@
 - **UI Design Phase**: 本 Issue はバックエンド/CLI スクリプトの内部マッチングロジック修正であり、インタラクティブ UI コンポーネントを含まないため、`skills/spec/figma-design-phase.md` の Auto-detection Criteria により「UI design not needed」と判定した (UI Design セクションは省略)
 - **`config=` / `when=` ゲートとの関係**: 同スクリプト内の `config=` ゲート (`.wholework.yml` キー解決) と `when=` ゲート (run facts JSON の enum 一致) は元々列挙値に対する構造化マッチであり、本 Issue の対象である自由テキスト部分文字列マッチ (`keyword=`) とは性質が異なる。今回の修正は `keyword=` ゲートのみを対象とし、他二つのゲートには変更を加えない
 
+## Code Retrospective
+
+### Deviations from Design
+- None. Implementation Steps 1-3 were followed as written (`resolve_filtered_context()` helper, `modules/observation-trigger.md` update, 2 new bats cases), with no reordering or omission.
+
+### Design Gaps/Ambiguities
+- None encountered. The Spec's Root Cause / Implementation Steps sections already resolved the word-boundary-match dead end and specified the exact `sed -E` pattern, so no new investigation was needed during implementation.
+
+### Rework
+- None.
+
 ## Consumed Comments
 
 - saito / MEMBER / first-class / `/issue` フェーズの retrospective — 曖昧性検出なし、AC2 の verify command を rubric + 補助チェックパターンへ変更した経緯を記録 — https://github.com/saitoco/wholework/issues/1220#issuecomment-5215669688
 - saito / MEMBER / first-class / AC3 の verify command (`grep -i "keyword" ...`) が既存ドキュメント中に "keyword" が多数出現するため常時 PASS になるという監査指摘。代表語の差し替えまたは補助チェック削除を提案 — 本 Spec で `section_contains` + `token` へ差し替えて対応 (Notes 参照) — https://github.com/saitoco/wholework/issues/1220#issuecomment-5215691447
+- No new comments since last phase.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Adopted path-like token stripping (`sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g'`) as the sole mitigation, per the Spec's Root Cause section — word-boundary match (`grep -qiw`) was already ruled out there (verified: `docs/workflow.md` still satisfies `\bworkflow\b` because `/` and `.` are non-word characters).
+- Followed the existing `resolve_run_facts()` lazy-cache pattern for the new `resolve_filtered_context()` helper, so the filtering cost is paid at most once per process even when multiple `keyword=`-tagged AC lines are evaluated in the same run.
+
+### Deferred Items
+- None — all 3 pre-merge AC (2 rubric + 1 section_contains) verified PASS in this phase; no item was pushed to a later phase.
+
+### Notes for Next Phase
+- The 2 new bats cases (`tests/opportunistic-search.bats`) cover both the negative case (keyword only inside a path-like token → excluded) and the positive/prose case (keyword in ordinary text → still included, guarding against over-stripping). Confirm both are exercised, not just the happy path.
+- AC1/AC2 are `rubric`-graded (semantic judgment); this phase's own PASS assessment is not a substitute for `/review`'s independent grader pass.
+- Post-merge AC is an `opportunistic` observation tied to a future `/review --light` run touching a `docs/workflow.md`-style path listing — no action needed now; it resolves naturally when that PR occurs.

--- a/docs/spec/issue-1220-keyword-gate-path-fp-fix.md
+++ b/docs/spec/issue-1220-keyword-gate-path-fp-fix.md
@@ -65,16 +65,26 @@
 - No new comments since last phase.
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Adopted path-like token stripping (`sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g'`) as the sole mitigation, per the Spec's Root Cause section — word-boundary match (`grep -qiw`) was already ruled out there (verified: `docs/workflow.md` still satisfies `\bworkflow\b` because `/` and `.` are non-word characters).
-- Followed the existing `resolve_run_facts()` lazy-cache pattern for the new `resolve_filtered_context()` helper, so the filtering cost is paid at most once per process even when multiple `keyword=`-tagged AC lines are evaluated in the same run.
+- Fixed a SHOULD-severity robustness gap found by `review-light`: `resolve_filtered_context()`'s `sed -E` command substitution (scripts/opportunistic-search.sh L167) had no `2>/dev/null || true` guard, unlike the sibling `resolve_run_facts()` function. Under `set -euo pipefail`, a `sed` read failure (e.g. TOCTOU between the L134 existence check and the later read) would abort the whole script instead of degrading the `keyword=` gate gracefully. Fixed to match the established sibling pattern.
+- All 3 pre-merge AC (2 rubric + 1 section_contains) independently re-verified PASS by `/review`'s own grader pass (not just carried over from `/code`'s self-assessment), per the code-phase handoff's note to run an independent pass.
 
 ### Deferred Items
-- None — all 3 pre-merge AC (2 rubric + 1 section_contains) verified PASS in this phase; no item was pushed to a later phase.
+- None.
 
 ### Notes for Next Phase
-- The 2 new bats cases (`tests/opportunistic-search.bats`) cover both the negative case (keyword only inside a path-like token → excluded) and the positive/prose case (keyword in ordinary text → still included, guarding against over-stripping). Confirm both are exercised, not just the happy path.
-- AC1/AC2 are `rubric`-graded (semantic judgment); this phase's own PASS assessment is not a substitute for `/review`'s independent grader pass.
-- Post-merge AC is an `opportunistic` observation tied to a future `/review --light` run touching a `docs/workflow.md`-style path listing — no action needed now; it resolves naturally when that PR occurs.
+- Post-merge AC remains an `opportunistic` observation tied to a future `/review --light` run touching a `docs/workflow.md`-style path listing — no action needed now; `/merge` and eventual `/verify` should let it resolve naturally when that PR occurs.
+- No policy change occurred during review (the fix was error-handling robustness only), so Issue AC text and verify commands are unchanged from `/code` phase.
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note. Implementation matched the Spec's Root Cause / Implementation Steps exactly; no structural divergence between Spec and PR diff.
+
+### Recurring issues
+- Nothing to note as a workflow-level recurring pattern. One instance worth flagging for awareness (not a repeat pattern yet): the new `resolve_filtered_context()` helper was explicitly modeled after the sibling `resolve_run_facts()` lazy-cache pattern (per Implementation Steps 1 and the code-phase handoff), but omitted that sibling's `2>/dev/null || true` error guard on the actual read call. When a Spec/Step instructs "follow an existing pattern," the follow-up implementation should copy the *whole* pattern (including its defensive guards), not just its structural shape (lazy-cache flag + function signature).
+
+### Acceptance criteria verification difficulty
+- Nothing to note. All 3 pre-merge AC (2 `rubric`, 1 `section_contains`) resolved cleanly to PASS with no UNCERTAIN and no verify command inaccuracies.

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -186,9 +186,20 @@ The gate adds an optional `keyword=<text>` attribute to the observation AC tag:
 
 When the emitter also passes `--context-file <path>` (e.g., the Spec file for the review that
 just completed), `opportunistic-search.sh`/`observation-trigger.sh` only include Issues whose
-matched AC line carries a `keyword=` value found in that file's content (case-insensitive
-substring match via `grep -qi`). ACs without `keyword=`, or invocations without
-`--context-file`, match unconditionally — the existing behavior is preserved.
+matched AC line carries a `keyword=` value found in that file's content, with path-like tokens
+stripped first (case-insensitive substring match via `grep -qi`). ACs without `keyword=`, or
+invocations without `--context-file`, match unconditionally — the existing behavior is
+preserved.
+
+**Path-like token exclusion (Issue #1220)**: a naive full-content substring match false-positives
+when the keyword happens to appear only as a fragment of an unrelated file path — e.g.
+`keyword=workflow` matched `` `docs/workflow.md` `` in a Spec's file listing even though the Spec
+had nothing to do with GitHub Actions workflows (observed on PR #1218 / Issue #476's
+`event=pr-review-full keyword=workflow` AC). To avoid this, `opportunistic-search.sh` strips
+path-like tokens (a run of `[A-Za-z0-9._-]` characters containing at least one `/`, e.g.
+`docs/workflow.md`, `scripts/opportunistic-search.sh`) from the context file's content before
+matching. A word-boundary match (`grep -qiw`) does not fix this: `/` and `.` are non-word
+characters in regex, so `docs/workflow.md` already satisfies `\bworkflow\b`.
 
 **Arguments table addition (both scripts):**
 
@@ -199,7 +210,8 @@ substring match via `grep -qi`). ACs without `keyword=`, or invocations without
 **Matching specification:**
 
 - Extraction: `keyword=<value>` is read from the AC line via `grep -oE 'keyword=[^ >]+'` (stops at the next space or `-->`).
-- Comparison: case-insensitive substring match of `<value>` against `--context-file`'s full content (`grep -qi -- "$KEYWORD" "$CONTEXT_FILE"`).
+- Path-like token stripping: `--context-file`'s content is filtered once per process (cached) via `sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' "$CONTEXT_FILE"` before comparison.
+- Comparison: case-insensitive substring match of `<value>` against the filtered content (`echo "$FILTERED_CONTEXT" | grep -qi -- "$KEYWORD"`).
 - Gate disabled (unconditional match) when: no `keyword=` attribute on the AC line, no `--context-file` given, or the given path does not exist.
 - No semantic/LLM judgment is performed here — this is a lightweight pre-filter; the actual acceptance decision still belongs to `/verify`.
 

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -16,9 +16,11 @@
 #
 # --context-file gates event-mode matches: when a matched AC line carries a
 # `keyword=<text>` attribute and --context-file is given, the Issue is only
-# included if the context file contains that keyword (case-insensitive). ACs
-# without `keyword=`, or runs without --context-file, match unconditionally
-# (backward compatible). See modules/observation-trigger.md § Condition Check Gate.
+# included if the context file contains that keyword (case-insensitive) after
+# path-like tokens (e.g. docs/workflow.md) are stripped from the context file's
+# content. ACs without `keyword=`, or runs without --context-file, match
+# unconditionally (backward compatible). See modules/observation-trigger.md §
+# Condition Check Gate (keyword=).
 #
 # `config=<key>` gates event-mode matches on .wholework.yml validity: when a
 # matched AC line carries a `config=<key>` attribute, the Issue is only
@@ -147,6 +149,25 @@ fi
 RUN_FACTS_RESOLVED=false
 RUN_FACTS_JSON=""
 
+# resolve_filtered_context: lazily strip path-like tokens (e.g. docs/workflow.md) from
+# CONTEXT_FILE, once per process. Called on demand by the first keyword=-tagged AC line
+# encountered in the match loop below. Result is cached in FILTERED_CONTEXT (empty when
+# CONTEXT_FILE is unset). This prevents a keyword= value from matching only because it
+# appears as a fragment of an unrelated file path (Issue #1220).
+FILTERED_CONTEXT_RESOLVED=false
+FILTERED_CONTEXT=""
+
+resolve_filtered_context() {
+    if [ "$FILTERED_CONTEXT_RESOLVED" = true ]; then
+        return
+    fi
+    FILTERED_CONTEXT_RESOLVED=true
+
+    if [ -n "$CONTEXT_FILE" ]; then
+        FILTERED_CONTEXT=$(sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' "$CONTEXT_FILE")
+    fi
+}
+
 resolve_run_facts() {
     if [ "$RUN_FACTS_RESOLVED" = true ]; then
         return
@@ -232,11 +253,14 @@ for N in $ISSUE_NUMBERS; do
     # Convert each matched line to a JSON entry
     while IFS= read -r line; do
         # Condition check gate: skip lines whose keyword= attribute does not
-        # appear in CONTEXT_FILE. No keyword= attribute or no --context-file
-        # means unconditional match (backward compatible).
+        # appear in CONTEXT_FILE once path-like tokens (e.g. docs/workflow.md) are
+        # stripped out. No keyword= attribute or no --context-file means unconditional
+        # match (backward compatible). See modules/observation-trigger.md § Condition
+        # Check Gate (keyword=) — Path-like token exclusion (Issue #1220).
         KEYWORD=$(echo "$line" | grep -oE 'keyword=[^ >]+' | sed -e 's/^keyword=//' -e 's/-*$//' || true)
         if [ -n "$KEYWORD" ] && [ -n "$CONTEXT_FILE" ]; then
-            if ! grep -qi -- "$KEYWORD" "$CONTEXT_FILE"; then
+            resolve_filtered_context
+            if ! echo "$FILTERED_CONTEXT" | grep -qi -- "$KEYWORD"; then
                 continue
             fi
         fi

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -164,7 +164,7 @@ resolve_filtered_context() {
     FILTERED_CONTEXT_RESOLVED=true
 
     if [ -n "$CONTEXT_FILE" ]; then
-        FILTERED_CONTEXT=$(sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' "$CONTEXT_FILE")
+        FILTERED_CONTEXT=$(sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' "$CONTEXT_FILE" 2>/dev/null || true)
     fi
 }
 

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -282,6 +282,27 @@ teardown() {
     echo "$output" | jq -e '.[0].number == 505' > /dev/null
 }
 
+@test "context gate: keyword found only inside a path-like token excludes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 506}]'
+    export MOCK_ISSUE_BODY_506='- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
+    echo "docs/workflow.md" > "$BATS_TEST_TMPDIR/context-path-only.md"
+
+    run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-path-only.md"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "context gate: keyword found in prose text still includes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 507}]'
+    export MOCK_ISSUE_BODY_507='- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
+    echo "This PR changes the CI workflow configuration." > "$BATS_TEST_TMPDIR/context-prose.md"
+
+    run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-prose.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 507' > /dev/null
+}
+
 @test "config gate: enabled config key includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 600}]'
     export MOCK_ISSUE_BODY_600='- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run config=some-flag -->'


### PR DESCRIPTION
## Summary

`scripts/opportunistic-search.sh` の `keyword=` Condition Check Gate が単純な `grep -qi` 部分文字列マッチのみに依存しており、キーワードがファイルパス文字列の一部として出現した場合 (例: `keyword=workflow` が `docs/workflow.md` に部分一致) に誤発火する問題を修正した。

- `scripts/opportunistic-search.sh`: `resolve_run_facts()` に倣った `resolve_filtered_context()` を新設し、`sed -E` でパス様トークン (`/` を含む `[A-Za-z0-9._-]+` の連続) を除去してから `keyword=` マッチを行うように変更
- `modules/observation-trigger.md`: § Condition Check Gate (`keyword=`) にパス様トークン除外の挙動と Issue #1220 を根拠とする補足段落を追加、Matching specification を実装後のコマンドに合わせて更新
- `tests/opportunistic-search.bats`: パス様トークン内のみにキーワードが出現するケースの除外テストと、地の文にキーワードが出現するケースの過剰除去防止テストを追加

## Verification (pre-merge)
- `bats tests/opportunistic-search.bats` — 41/41 PASS (新規2件含む)
- `python3 scripts/validate-skill-syntax.py skills/` — 0 error(s), 0 warning(s)
- `bash scripts/check-forbidden-expressions.sh` — no output (PASS)
- rubric / section_contains verify commands (Issue AC 1-3) — 全件 PASS、Issue チェックボックス更新済み

## Verification (post-merge)
- 次回 `docs/workflow.md` 等、キーワードを含むが無関係なファイルパスのみを参照する PR の `/review --light` 完了時に、該当 `keyword=` ゲート付き observation AC が誤発火しないことを観察

closes #1220