### PR TITLE
Issue #1238: Exclude generic phase-name fact_tokens to improve run-fact AC filtering

### DIFF
--- a/docs/spec/issue-1238-exclude-generic-fact-tokens.md
+++ b/docs/spec/issue-1238-exclude-generic-fact-tokens.md
@@ -60,3 +60,30 @@
 ## Consumed Comments
 
 - saito / MEMBER / first-class / ## Issue Retrospective / https://github.com/saitoco/wholework/issues/1238#issuecomment-5218544266
+
+## Code Retrospective
+
+### Deviations from Design
+- None. Implementation followed the Spec's Implementation Steps 1-5 in order with no reordering, omission, or approach change.
+
+### Design Gaps/Ambiguities
+- None. The Spec's method selection (bare phase-name exclusion over token namespacing) and its rationale were fully specified in Notes, leaving no open design decision during implementation.
+
+### Rework
+- None.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Implemented exactly the bare-phase-name exclusion approach the Spec's Notes section already selected and justified — no new design decision was needed at code time.
+- Reconstructed representative fact_tokens JSON for both measurement routes from the token arrays quoted in the Issue body, since the raw `.tmp/auto-events.jsonl` events for both cited sessions were already rotated out (documented in Spec Notes before code started).
+- Measured old-vocabulary vs new-vocabulary filtering on the *same current* Issue population (422 for scan-pending-ac.sh, 13 for opportunistic-search.sh) rather than only reporting the new count against the stale baseline population, so the improvement is directly attributable to the vocabulary change and not to population drift.
+
+### Deferred Items
+- Post-merge observation AC (index 6, `verify-type: observation event=auto-run session=next`) is unresolved pending the next `/auto` completion — no action needed until then.
+- AC5 (`github_check "gh pr checks" "Run bats tests"`) is unresolved pending PR CI completion (PR #1268 just created) — `/review`/`/merge` will observe it.
+
+### Notes for Next Phase
+- All 4 evaluable pre-merge AC (rubric x3, bats command x1) were self-assessed PASS and checked on the Issue during `/code`; only the CI-dependent `github_check` AC remains open for `/review` to confirm once PR checks complete.
+- `docs/spec/issue-1239-opportunistic-fact-filter.md`'s representative-JSON measurement pattern was reused here — worth keeping as the standard approach whenever `.tmp/auto-events.jsonl` has rotated past a cited session's raw events.

--- a/docs/spec/issue-1238-exclude-generic-fact-tokens.md
+++ b/docs/spec/issue-1238-exclude-generic-fact-tokens.md
@@ -32,6 +32,13 @@
 
 **Effect measurement (baseline)**: scan-pending-ac.sh 経路 418 件 → 186 件 (55.5% 除外, session `3340-1786079730`, 2026-08-07 計測, Issue #1238 本文記載)。opportunistic-search.sh 経路 13 件 → 13 件 (0% 除外, session `83694-1786088052`, 2026-08-07 計測, Issue #1238 本文記載)。Implementation Step 5 の実施後、`/code` はこの行の直下に実装後の件数・facts のソース (実セッション再実行 or 代表 JSON)・計測日を追記すること (AC3 の充足条件)。
 
+**Effect measurement (after implementation, 2026-08-08)**: `.tmp/auto-events.jsonl` に session `3340-1786079730` / `83694-1786088052` の生イベントは現存しない (Notes 記載のとおりローテーション済み) ため、両経路とも Issue 本文引用の fact_tokens 配列を新ロジックで手動再構成した代表 JSON (`--facts` 経由) で再測定した。母集団は測定時点 (2026-08-08) の現在の Issue 集合を使用したため、ベースライン計測時点 (2026-08-07) との間に自然な件数のドリフトがある — そのため同一母集団に対して旧語彙 (bare phase 名を含む、変更前の実装を手動再現) と新語彙 (本実装後の `fact_tokens`) を両方適用し、同一母集団内での差分として効果を確認した。
+
+- **scan-pending-ac.sh 経路**: 現在の母集団 422 件 (`--max-candidates 10000` で truncation なく計測。ベースライン計測時の 418 件から自然増)。session `3340-1786079730` の fact_tokens (`["Size S","issue","run-issue.sh","run-spec.sh","spec"]`) をそのまま (旧語彙として) 適用すると **185 件** (55.9% 除外) — ベースラインの 186 件とほぼ一致し、旧ロジックの再現性を確認。同じ token 配列から bare な `issue`/`spec` を除いた新語彙 (`["Size S","run-issue.sh","run-spec.sh"]`) を適用すると **2 件** (99.5% 除外) まで減少した。
+- **opportunistic-search.sh 経路**: 現在の `/verify` 母集団 13 件 (ベースラインと同数)。session `83694-1786088052` を模した batch route・Size M・issue→spec→code(pr)→review→merge→verify を経た代表的 fact_tokens について、旧語彙 (`["pr route","Size M","issue","spec","code-pr","review","merge","verify","run-issue.sh","run-spec.sh","run-code.sh","run-review.sh","run-merge.sh","batch"]`、bare `verify` を含む) を適用すると **13 件** (0% 除外) — ベースラインの 13→13 を再現。同じ token 配列から bare な phase 名 (`issue`/`spec`/`code-pr`/`review`/`merge`/`verify`) を除いた新語彙 (`["pr route","Size M","run-issue.sh","run-spec.sh","run-code.sh","run-review.sh","run-merge.sh","batch"]`) を適用すると **0 件** (100% 除外) まで減少した。`verify` phase は `wrapper_for()` マッピングを持たないため、新語彙では一切のトークンを生成しない (意図した挙動、Notes 参照)。
+
+両経路とも、同一母集団内の旧語彙比較で絞り込み効果の大幅な改善を確認した (scan-pending-ac.sh: 185→2、opportunistic-search.sh: 13→0)。facts のソース: 実行中の `/auto` セッションが存在しない単発実行環境のため、`collect-run-facts.sh` の出力形式に相当する代表的 JSON (`.tmp/facts-old-1238.json` / `.tmp/facts-new-1238.json` / `.tmp/facts-old-opp-1238.json` / `.tmp/facts-new-opp-1238.json`、いずれも `.tmp/` は gitignore 対象で本コミットには含まれない) を使用した。
+
 ### Post-merge
 
 - 次回以降の `/auto` 完走後の Run-fact AC reconciliation で、絞り込み後の候補件数が変更前より減少していることを観察する <!-- verify-type: observation event=auto-run session=next -->

--- a/docs/spec/issue-1238-exclude-generic-fact-tokens.md
+++ b/docs/spec/issue-1238-exclude-generic-fact-tokens.md
@@ -72,18 +72,26 @@
 ### Rework
 - None.
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- None. `/review` (light mode, `review-light` agent, 4 aspects) found the diff matches the Spec's Implementation Steps 1-5 exactly — no structural divergence.
+
+### Recurring issues
+- None. All 4 evaluable pre-merge AC (rubric x3, bats command x1) verified PASS with no re-check needed; no issue category repeated across this run.
+
+### Acceptance criteria verification difficulty
+- AC5 (`github_check "gh pr checks" "Run bats tests"`) was left unchecked at the end of `/code` because the PR's CI had not yet completed — this is expected/normal for a CI-dependent AC checked immediately after PR creation, not a verify command quality gap. `/review` confirmed all 9 CI jobs SUCCESS and updated the checkbox to `[x]`. No verify command changes needed.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Implemented exactly the bare-phase-name exclusion approach the Spec's Notes section already selected and justified — no new design decision was needed at code time.
-- Reconstructed representative fact_tokens JSON for both measurement routes from the token arrays quoted in the Issue body, since the raw `.tmp/auto-events.jsonl` events for both cited sessions were already rotated out (documented in Spec Notes before code started).
-- Measured old-vocabulary vs new-vocabulary filtering on the *same current* Issue population (422 for scan-pending-ac.sh, 13 for opportunistic-search.sh) rather than only reporting the new count against the stale baseline population, so the improvement is directly attributable to the vocabulary change and not to population drift.
+- Ran `--light` mode (1-agent `review-light` covering all 4 aspects) per ARGUMENTS; no findings surfaced, so no fix cycle was needed.
+- Updated Issue checkbox for AC5 (`github_check`) to `[x]` after confirming all 9 PR CI jobs are SUCCESS — this was the only AC left open by `/code` (deferred pending CI completion, as noted in the code-phase handoff).
 
 ### Deferred Items
-- Post-merge observation AC (index 6, `verify-type: observation event=auto-run session=next`) is unresolved pending the next `/auto` completion — no action needed until then.
-- AC5 (`github_check "gh pr checks" "Run bats tests"`) is unresolved pending PR CI completion (PR #1268 just created) — `/review`/`/merge` will observe it.
+- Post-merge observation AC (index 6, `verify-type: observation event=auto-run session=next`) remains unresolved pending the next `/auto` completion — unchanged from the code-phase handoff, no action needed until then.
 
 ### Notes for Next Phase
-- All 4 evaluable pre-merge AC (rubric x3, bats command x1) were self-assessed PASS and checked on the Issue during `/code`; only the CI-dependent `github_check` AC remains open for `/review` to confirm once PR checks complete.
-- `docs/spec/issue-1239-opportunistic-fact-filter.md`'s representative-JSON measurement pattern was reused here — worth keeping as the standard approach whenever `.tmp/auto-events.jsonl` has rotated past a cited session's raw events.
+- All 5 Pre-merge AC are now PASS/`[x]`; only the Post-merge observation AC remains open. `/merge` can proceed directly.

--- a/modules/run-fact-matching.md
+++ b/modules/run-fact-matching.md
@@ -59,6 +59,57 @@ This same fact JSON (top-level `mode`, per-issue `route` and `recovery_tiers`) i
 observation AC dispatch against a single run's context rather than reconciling post-merge AC after
 the fact — see `modules/observation-trigger.md` § Condition Check Gate (`when=`).
 
+## fact_tokens Vocabulary and Matching Rule
+
+`fact_tokens` (per-issue array, built by `scripts/collect-run-facts.sh`'s `JQ_PASS2`) is the
+pre-filter vocabulary that `scan-pending-ac.sh --facts` and `opportunistic-search.sh --facts`
+match against pending AC condition text before this module's Step 3 rubric judgment runs.
+
+**Included token categories:**
+
+- Route: `"<route> route"` (e.g. `"pr route"`, `"patch route"`, `"operate route"`) — omitted
+  when route is `unknown`
+- Size: `"Size <label>"` (e.g. `"Size S"`, `"Size M"`) — omitted when the Issue's Size could
+  not be resolved
+- Phase-wrapper script name: the `wrapper_for()`-mapped script for each phase this issue's run
+  reached (e.g. `"run-issue.sh"`, `"run-spec.sh"`, `"run-code.sh"`, `"run-review.sh"`,
+  `"run-merge.sh"`) — see the "Excluded" list below for what this replaces
+- PR number: `"#<N>"`
+- Anomaly keys with count ≥ 1: `recovery`, `watchdog_kill`, `manual_intervention`,
+  `concurrent_commit_detected`, `code_retry_fire`
+- Recovery tier: `"tier <N>"` for each tier (`1`/`2`/`3`) seen in `recovery_tiers`
+- Batch mode: `"batch"`, only when the session's top-level `mode` is `batch`
+
+**Deliberately excluded (do not add these back):**
+
+- `"/auto"` — matched 84 of 414 measured pending post-merge AC on its own, making the
+  pre-filter a near no-op (`docs/spec/issue-1157-run-fact-ac-match.md` § population)
+- `"single"` (the non-batch mode value) — same reason, Issue #1171
+- Bare phase names (`issue`, `spec`, `code-pr`, `code-patch`, `review`, `merge`, `verify`) —
+  AC condition text almost always mentions the phase name in prose (e.g. "`/verify` を実行した
+  とき"), so a bare phase-name token matched nearly every candidate. This was measured most
+  starkly on the `opportunistic-search.sh` path, where the skill-name filter already narrows
+  candidates to a single phase before the fact-token gate runs: matching that same phase's bare
+  name token against the already-narrowed set passes 100% of candidates by construction (13→13,
+  session `83694-1786088052`). Removed in Issue #1238; the phase-wrapper script name (e.g.
+  `run-issue.sh`) remains as a strictly more specific replacement. `verify` has no
+  `wrapper_for()` mapping (`/verify` runs in-session, no `run-verify.sh` wrapper — see
+  `docs/tech.md` Fork context table), so a run that only reaches the verify phase contributes no
+  token for it at all after this change; this is intentional, not a gap, since the bare `verify`
+  token was the token responsible for the 13→13 result above.
+
+**Matching rule** (unchanged by Issue #1238): case-insensitive substring match — a candidate AC
+is retained when its condition text contains at least one `fact_tokens` entry as a substring
+(both sides lowercased before comparison; see `scripts/scan-pending-ac.sh`'s
+`FACT_TOKENS_LOWER` construction and `scripts/opportunistic-search.sh`'s equivalent gate).
+
+**Guidance for AC authors:** because matching is substring-based against this vocabulary, write
+post-merge AC condition text in terms of the specific, high-signal facts above (Size, route, PR
+number, a named anomaly, a recovery tier) rather than relying on a bare phase name to make a
+condition matchable — a bare phase name is no longer part of the vocabulary and will not narrow
+the pre-filter. Referencing the phase's wrapper script name (e.g. "`run-code.sh` 実行後") also
+works but is a less natural way to write AC prose than referencing the phase's concrete outcome.
+
 ## Processing Steps
 
 1. Run `${CLAUDE_PLUGIN_ROOT}/scripts/collect-run-facts.sh` (with `--session

--- a/scripts/collect-run-facts.sh
+++ b/scripts/collect-run-facts.sh
@@ -44,6 +44,13 @@
 #                    post-merge AC (docs/spec/issue-1157-run-fact-ac-match.md § population),
 #                    "/auto" alone matched 84 of them and made the pre-filter a no-op. Also
 #                    excludes the generic "single" mode token for the same reason (Issue #1171).
+#                    Also excludes bare phase-name tokens (e.g. "issue", "spec", "code-pr",
+#                    "code-patch", "review", "merge", "verify"): AC condition text almost always
+#                    mentions these phase names in prose, so a bare phase-name token matched
+#                    nearly every candidate and made the pre-filter a near no-op (Issue #1238).
+#                    Only the wrapper_for()-mapped script name (e.g. "run-issue.sh") is kept per
+#                    phase; "verify" has no wrapper script (see modules/run-fact-matching.md) and
+#                    so contributes no token at all after this change.
 #
 # operate route detection: when an issue's route resolves to "patch" (and --no-github is not
 #   set), probe the Issue's comments for a `type=execution-log` or `type=execution-plan`
@@ -209,7 +216,7 @@ def wrapper_for(p):
       (if .route != "unknown" then [(.route + " route")] else [] end)
       + (if .size != "" then [("Size " + .size)] else [] end)
       + ((.phases | map(.name)) as $names
-         | $names + ($names | map(wrapper_for(.)) | map(select(. != null))))
+         | ($names | map(wrapper_for(.)) | map(select(. != null))))
       + (if .pr != null then [("#" + (.pr | tostring))] else [] end)
       + (.anomalies | to_entries | map(select(.value >= 1) | .key))
       + (.recovery_tiers | map("tier " + (. | tostring)))

--- a/tests/run-fact-matching.bats
+++ b/tests/run-fact-matching.bats
@@ -81,6 +81,41 @@ EOF
     [[ "$tokens" != *"/auto"* ]]
 }
 
+@test "collect-run-facts: fact_tokens excludes bare phase names, keeps wrapper script tokens" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":1600,"event":"phase_start","session_id":"sess1","phase":"review"}
+{"ts":"2026-08-05T00:01:00Z","issue":1600,"event":"phase_complete","session_id":"sess1","phase":"review"}
+{"ts":"2026-08-05T00:02:00Z","issue":1600,"event":"phase_start","session_id":"sess1","phase":"code-pr"}
+{"ts":"2026-08-05T00:03:00Z","issue":1600,"event":"phase_complete","session_id":"sess1","phase":"code-pr"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+
+    has_review=$(echo "$output" | jq '[.issues[0].fact_tokens[] | select(. == "review")] | length')
+    [ "$has_review" = "0" ]
+    has_code_pr=$(echo "$output" | jq '[.issues[0].fact_tokens[] | select(. == "code-pr")] | length')
+    [ "$has_code_pr" = "0" ]
+
+    tokens=$(echo "$output" | jq -r '.issues[0].fact_tokens | join(",")')
+    [[ "$tokens" == *"run-review.sh"* ]]
+    [[ "$tokens" == *"run-code.sh"* ]]
+}
+
+@test "collect-run-facts: verify phase contributes no fact_tokens entry (no wrapper script)" {
+    EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
+    cat > "$EVENTS_FILE" <<'EOF'
+{"ts":"2026-08-05T00:00:00Z","issue":1700,"event":"phase_start","session_id":"sess1","phase":"verify"}
+{"ts":"2026-08-05T00:01:00Z","issue":1700,"event":"phase_complete","session_id":"sess1","phase":"verify"}
+EOF
+    export AUTO_EVENTS_LOG="$EVENTS_FILE"
+    run bash "$COLLECT_SCRIPT" --session sess1 --no-github
+    [ "$status" -eq 0 ]
+    tokens=$(echo "$output" | jq -c '.issues[0].fact_tokens')
+    [[ "$tokens" != *"verify"* ]]
+}
+
 @test "collect-run-facts: --issue filters output to a single issue" {
     EVENTS_FILE="$BATS_TEST_TMPDIR/events.jsonl"
     cat > "$EVENTS_FILE" <<'EOF'


### PR DESCRIPTION
## Summary
`scripts/collect-run-facts.sh` が生成する `fact_tokens` から、bare な phase 名 token (`issue`/`spec`/`code-pr`/`code-patch`/`review`/`merge`/`verify`) を除外し、`wrapper_for()` マッピング後のスクリプト名 token (例: `run-issue.sh`) のみを残すよう変更した。AC condition text はほぼ必ず phase 名をプローズで含むため、bare token は `scan-pending-ac.sh --facts` / `opportunistic-search.sh --facts` の絞り込みをほぼ無効化していた (実測: opportunistic-search.sh 経路で 13→13、scan-pending-ac.sh 経路で 418→186 に留まっていた)。

- `scripts/collect-run-facts.sh`: `JQ_PASS2` の `fact_tokens` 構築から bare な `$names` を除外し、`wrapper_for()` マッピング後の値のみを残すよう変更。ヘッダーコメントに変更理由を追記
- `modules/run-fact-matching.md`: `fact_tokens` の語彙 (route/size/phase-wrapper script 名/PR 番号/anomaly キー/recovery tier/batch mode) と、意図的に除外されているカテゴリ (bare phase 名, `/auto`, `single`)、マッチング規則、AC 執筆者向け指針を記述するサブセクションを追加
- `tests/run-fact-matching.bats`: bare phase 名の除外と wrapper script token の保持、`verify` phase が token を一切生成しないことを確認する新規テストを追加
- `docs/spec/issue-1238-exclude-generic-fact-tokens.md`: 実装後の絞り込み効果を代表 JSON で再測定し、Verification セクションに記録 (scan-pending-ac.sh: 同一母集団で 185→2、opportunistic-search.sh: 同一母集団で 13→0)

## Verification (pre-merge)
- rubric: fact_tokens の語彙が誤ヒットを排除する方式に変更されている — PASS (self-assessed)
- rubric: `run-fact-matching.md` に語彙とマッチング規則が記述されている — PASS (self-assessed)
- rubric: 絞り込み効果が両経路について数値で記録されている — PASS (self-assessed)
- `bats tests/run-fact-matching.bats tests/opportunistic-search.bats` — PASS (78/78)
- CI (`Run bats tests` job) — pending PR checks

## Verification (post-merge)
- 次回以降の `/auto` 完走後の Run-fact AC reconciliation で、絞り込み後の候補件数が変更前より減少していることを観察する

closes #1238
