### PR TITLE
Issue #1242: opportunistic-search/scan-pending-ac 母集団の closed 限定と走査スコープの不一致を解消

### DIFF
--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -199,7 +199,7 @@ wholework/
 - `scripts/opportunistic-search.sh` — opportunistic スキル検索と observation イベントスキャン
 - `scripts/post_merge_check.sh` — 複数 Issue の post-merge 手動 AC（verify-type: manual）を 1 セッションでバンドル実行; AC ごとに P/F/S を対話入力; 全 PASS で phase/done 遷移、FAIL で reopen
 - `scripts/collect-run-facts.sh` — 完走した `/auto` 実行の事実 (diff-less な operate 値を含む route・実行 mode・Size・各 phase の結果・PR 状態・anomaly 件数・recovery tier・fact token) を `.tmp/auto-events.jsonl` から JSON に構造化する。run-fact AC 照合 (`modules/run-fact-matching.md`) の入力
-- `scripts/scan-pending-ac.sh` — `phase/verify` の closed Issue から未チェックの post-merge AC を列挙し、`collect-run-facts.sh` の fact token で事前絞り込みする
+- `scripts/scan-pending-ac.sh` — `phase/verify` の Issue (全 state) から未チェックの post-merge AC を列挙し、`collect-run-facts.sh` の fact token で事前絞り込みする
 - `scripts/apply-run-fact-match.sh` — run-fact AC 照合の verdict (satisfied/not_satisfied/ambiguous) に対する決定的な autonomy tier ゲート: チェックボックスの自動チェック、`Recommend:` 候補提示、または無処理のいずれかを実行
 - `scripts/triage-backlog-filter.sh` — triage 向けバックログフィルタ
 

--- a/docs/spec/issue-1242-verify-population-scope-fix.md
+++ b/docs/spec/issue-1242-verify-population-scope-fix.md
@@ -80,6 +80,7 @@
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / 概要: `/issue` フェーズの Issue Retrospective コメント。AC1/AC2 の verify command を `grep -n` から `file_not_contains` に、AC3 を rubric+file_contains 併記に、AC5 を `command "bats ..."` に修正した経緯と、Background 節の行番号引用 (`:291`, `:311`/`:314`) のドリフト修正を記録。本 Spec の Background/Root Cause の行番号・Implementation Steps はこの修正後の内容と整合させた。 / URL: https://github.com/saitoco/wholework/issues/1242#issuecomment-5225061949
 
+- saito / MEMBER / first-class / ## 申し送り: `modules/observation-trigger.md` の母集団記述 (#1264 統合分) / https://github.com/saitoco/wholework/issues/1242#issuecomment-5225205678
 ## Code Retrospective
 
 ### Deviations from Design

--- a/docs/spec/issue-1242-verify-population-scope-fix.md
+++ b/docs/spec/issue-1242-verify-population-scope-fix.md
@@ -79,3 +79,41 @@
 ## Consumed Comments
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / 概要: `/issue` フェーズの Issue Retrospective コメント。AC1/AC2 の verify command を `grep -n` から `file_not_contains` に、AC3 を rubric+file_contains 併記に、AC5 を `command "bats ..."` に修正した経緯と、Background 節の行番号引用 (`:291`, `:311`/`:314`) のドリフト修正を記録。本 Spec の Background/Root Cause の行番号・Implementation Steps はこの修正後の内容と整合させた。 / URL: https://github.com/saitoco/wholework/issues/1242#issuecomment-5225061949
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Implementation Steps 1-5 を Spec の記載順どおりに実施した。
+
+### Design Gaps/Ambiguities
+
+- `tests/opportunistic-search.bats` の新規テスト「gh issue list is called with --state all」を書く際、既存の `gh-list-args.txt` モックは `printf '%s\n' "$@"` で引数を 1 行 1 要素で書き出す形式であることに気づかず、当初 `grep -q -- "--state all"` (1 行に 2 語) で書いて FAIL した。`tr '\n' ' '` で結合してから部分文字列マッチする形に修正して解消。Spec にはこのモック形式の詳細まで書かれていなかったため、実装時に発見した挙動。
+- 新規追加した「post-merge scope: サンプル行除外」テストの最初のドラフトは、Post-merge セクション内に検証対象と無関係な `- [x]` (チェック済み) 行を置いていたため、Post-merge スコープ化の効果とは無関係に (チェック済みという別の理由で) FAIL を再現できてしまっていた。スコープ化の効果だけを切り出して検証するよう、Post-merge セクション内は非マッチの説明文のみにして再構成した。
+
+### Rework
+
+- 上記 2 点のテスト設計の手戻り以外、大きな手戻りはなし。
+
+### Smoke Test
+
+- Spec に `## Smoke Test` セクションが存在しないため未実施 (`skills/code/SKILL.md` Step 11 の条件どおりスキップ)。
+
+### Full Suite Run (Behavioral Change Detection)
+
+- `scripts/opportunistic-search.sh` は `tests/observation-trigger.bats` / `tests/verify.bats` からも、`scripts/scan-pending-ac.sh` は `tests/run-fact-matching.bats` からも参照されていたため、挙動変化検出により `bats --jobs 18 tests/` (1581 件) を実行した。`tests/post_merge_check.bats` の 1 件 (`fail: gh issue reopen called when FAIL input given`) が並列実行時のみ FAIL したが、単独再実行 (`bats tests/post_merge_check.bats`) では 10/10 PASS しており、本 Issue の変更が触れていない `post_merge_check.sh`/`.bats` に起因する並列実行時の共有リソース競合 (フレーク) と判断した。`tests/run-fact-matching.bats` (scan-pending-ac.sh の Post-merge スコープ・`--facts`・gh 失敗時挙動をカバー) は単独実行で 29/29 PASS、`tests/opportunistic-search.bats`/`tests/scan-pending-ac.bats` (AC6 の対象) は単独実行でそれぞれ 54/54・2/2 PASS。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `--state closed` → `--state all` は両スクリプトとも 1 箇所のみの変更で完結。`opportunistic-search.sh` の Post-merge スコープ化は `scan-pending-ac.sh:125-153` の awk 境界ロジックをそのまま踏襲し、新規スコープ機構は発明しなかった (Spec の判断を踏襲)。
+- `tests/opportunistic-search.bats` の既存 46 件の `MOCK_ISSUE_BODY_*` フィクスチャ全件に `## Post-merge\n` を機械的に前置 (python3 の正規表現置換で一括変換)。Spec は「40 件」と見積もっていたが実数は 46 件だった — フィクスチャ数の見積もりズレは実装に影響しない (全件一律適用の方針は変わらないため)。
+
+### Deferred Items
+- Post-merge の post-merge AC (`次回 /audit stats --retention で #490/#465 が走査対象に含まれ、#491 の偽陽性が消えていることを確認する`, verify-type: observation event=auto-run) は未チェックのまま — 次回 `/audit stats --retention` 実行時に観測で確認する。
+- `tests/post_merge_check.bats` の並列実行時フレーク (`fail: gh issue reopen called when FAIL input given`) は本 Issue のスコープ外 (触れていないファイル) のため未対応。再発頻度が高いようなら別 Issue 化を検討。
+
+### Notes for Next Phase
+- Pre-merge AC 1-6 は全て `/code` フェーズ内で PASS 判定しチェック済み。`/review` は AC の再検証と診断的コードレビューを行う想定。
+- `bats tests/opportunistic-search.bats tests/scan-pending-ac.bats` はどちらも単独実行で全件 PASS 済み (54/54, 2/2)。CI 実行時も同じ結果になるはず。

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -207,7 +207,7 @@ Key modules:
 - `scripts/opportunistic-search.sh` — opportunistic skill search and observation event scan
 - `scripts/post_merge_check.sh` — bundle and run post-merge manual (verify-type: manual) ACs for multiple Issues in one session; prompts P/F/S per AC; transitions to phase/done on all-PASS or reopens on FAIL
 - `scripts/collect-run-facts.sh` — structure a completed `/auto` run's facts (route including the diff-less operate value, run mode, Size, phase outcomes, PR state, anomaly counts, recovery tiers, fact tokens) as JSON from `.tmp/auto-events.jsonl`, for run-fact AC reconciliation (`modules/run-fact-matching.md`)
-- `scripts/scan-pending-ac.sh` — enumerate unchecked post-merge acceptance conditions across closed `phase/verify` Issues, optionally pre-filtered by `collect-run-facts.sh` fact tokens
+- `scripts/scan-pending-ac.sh` — enumerate unchecked post-merge acceptance conditions across `phase/verify` Issues (all states), optionally pre-filtered by `collect-run-facts.sh` fact tokens
 - `scripts/apply-run-fact-match.sh` — deterministic autonomy-tier gate for a run-fact AC match verdict (satisfied/not_satisfied/ambiguous): auto-checks the checkbox, prints an advisory `Recommend:` line, or does nothing
 - `scripts/triage-backlog-filter.sh` — filter backlog for triage
 

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -265,7 +265,9 @@ resolve_run_facts() {
     RUN_FACTS_JSON="$facts"
 }
 
-# 1. Fetch closed Issues with phase/verify label
+# 1. Fetch Issues with phase/verify label (all states — OPEN Issues that stay
+#    in phase/verify are structurally excluded from this pipeline otherwise;
+#    Issue #1242)
 #
 # Previously fetched via a fixed --limit 50 with no pre-filter, silently
 # truncating the population once phase/verify+closed Issues exceeded 50
@@ -288,7 +290,7 @@ if [ -n "$EVENT_NAME" ]; then
 else
     SEARCH_TEXT="verify-type: opportunistic in:body"
 fi
-ISSUES_JSON=$(gh issue list --label "phase/verify" --state closed --search "$SEARCH_TEXT" --json number --limit "$POPULATION_LIMIT")
+ISSUES_JSON=$(gh issue list --label "phase/verify" --state all --search "$SEARCH_TEXT" --json number --limit "$POPULATION_LIMIT")
 ISSUE_COUNT=$(echo "$ISSUES_JSON" | jq 'length')
 if [ "$ISSUE_COUNT" -ge "$POPULATION_LIMIT" ]; then
     echo "Warning: population fetch reached --limit ${POPULATION_LIMIT}; results may be truncated. Consider raising POPULATION_LIMIT in scripts/opportunistic-search.sh or narrowing the --search filter." >&2
@@ -300,18 +302,30 @@ if [ -z "$ISSUE_NUMBERS" ]; then
     exit 0
 fi
 
+# Post-merge section scope: extract only lines between a `### Post-merge` /
+# `## Post-merge` heading and the next `## ` / `### ` heading, mirroring
+# scan-pending-ac.sh's own boundary logic. This keeps sample `- [ ]` lines
+# outside the Post-merge section (e.g. inside a code fence in an unrelated
+# section) from being misread as real acceptance conditions (Issue #1242).
+POST_MERGE_AWK='
+  /^### Post-merge/ || /^## Post-merge/ { in_section = 1; next }
+  /^## / || /^### / { in_section = 0; next }
+  { if (in_section) print }
+'
+
 # 2. Fetch each Issue body and filter
 RESULTS="[]"
 
 for N in $ISSUE_NUMBERS; do
     BODY=$(gh issue view "$N" --json body -q .body)
+    SCOPED_BODY=$(printf '%s\n' "$BODY" | awk "$POST_MERGE_AWK")
 
     if [ -n "$EVENT_NAME" ]; then
         # Event mode: match verify-type: observation with the specified event name
-        MATCHED=$(echo "$BODY" | grep -E '^- \[ \]' | grep "verify-type: observation" | grep "event=${EVENT_NAME}" || true)
+        MATCHED=$(echo "$SCOPED_BODY" | grep -E '^- \[ \]' | grep "verify-type: observation" | grep "event=${EVENT_NAME}" || true)
     else
         # Opportunistic mode: match verify-type: opportunistic with skill name
-        MATCHED=$(echo "$BODY" | grep -E '^- \[ \]' | grep "verify-type: opportunistic" | grep -F "$SKILL_NAME" || true)
+        MATCHED=$(echo "$SCOPED_BODY" | grep -E '^- \[ \]' | grep "verify-type: opportunistic" | grep -F "$SKILL_NAME" || true)
     fi
 
     if [ -z "$MATCHED" ]; then

--- a/scripts/scan-pending-ac.sh
+++ b/scripts/scan-pending-ac.sh
@@ -103,7 +103,7 @@ if [ -n "$FACTS_PATH" ]; then
   }
 fi
 
-ISSUES_JSON=$(gh issue list --label "phase/verify" --state closed --json number,body --limit "$LIMIT" 2>/dev/null) || {
+ISSUES_JSON=$(gh issue list --label "phase/verify" --state all --json number,body --limit "$LIMIT" 2>/dev/null) || {
   echo "[]"
   exit 0
 }

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -66,7 +66,8 @@ teardown() {
 
 @test "dry-run: returns the same non-empty result as without --dry-run" {
     export MOCK_ISSUE_LIST='[{"number": 700}]'
-    export MOCK_ISSUE_BODY_700='- [ ] /issue skill creates Issue after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_700='## Post-merge
+- [ ] /issue skill creates Issue after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /issue
     [ "$status" -eq 0 ]
@@ -83,7 +84,8 @@ teardown() {
 
 @test "dry-run: works with --dry-run before skill name" {
     export MOCK_ISSUE_LIST='[{"number": 701}]'
-    export MOCK_ISSUE_BODY_701='- [ ] /spec skill creates file after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_701='## Post-merge
+- [ ] /spec skill creates file after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" --dry-run /spec
     [ "$status" -eq 0 ]
@@ -121,7 +123,8 @@ teardown() {
 
 @test "success: issue with matching condition is returned" {
     export MOCK_ISSUE_LIST='[{"number": 100}]'
-    export MOCK_ISSUE_BODY_100='- [ ] /issue skill creates Issue after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_100='## Post-merge
+- [ ] /issue skill creates Issue after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /issue
     [ "$status" -eq 0 ]
@@ -133,7 +136,8 @@ teardown() {
 
 @test "filter: checked condition is excluded" {
     export MOCK_ISSUE_LIST='[{"number": 101}]'
-    export MOCK_ISSUE_BODY_101='- [x] /issue skill creates Issue after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_101='## Post-merge
+- [x] /issue skill creates Issue after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /issue
     [ "$status" -eq 0 ]
@@ -142,7 +146,8 @@ teardown() {
 
 @test "filter: skill name mismatch is excluded" {
     export MOCK_ISSUE_LIST='[{"number": 102}]'
-    export MOCK_ISSUE_BODY_102='- [ ] /spec skill creates Spec after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_102='## Post-merge
+- [ ] /spec skill creates Spec after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /issue
     [ "$status" -eq 0 ]
@@ -151,8 +156,10 @@ teardown() {
 
 @test "success: multiple conditions from multiple issues" {
     export MOCK_ISSUE_LIST='[{"number": 200},{"number": 201}]'
-    export MOCK_ISSUE_BODY_200='- [ ] /spec skill creates file after execution <!-- verify-type: opportunistic -->'
-    export MOCK_ISSUE_BODY_201='- [ ] /spec skill creates file after execution <!-- verify-type: opportunistic -->
+    export MOCK_ISSUE_BODY_200='## Post-merge
+- [ ] /spec skill creates file after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_201='## Post-merge
+- [ ] /spec skill creates file after execution <!-- verify-type: opportunistic -->
 - [x] /spec skill updates list after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /spec
@@ -163,7 +170,8 @@ teardown() {
 
 @test "output: condition text strips checkbox markup and HTML comments" {
     export MOCK_ISSUE_LIST='[{"number": 300}]'
-    export MOCK_ISSUE_BODY_300='- [ ] /code skill can be verified after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_300='## Post-merge
+- [ ] /code skill can be verified after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /code
     [ "$status" -eq 0 ]
@@ -175,7 +183,8 @@ teardown() {
 
 @test "event filter: --event matches observation conditions with matching event" {
     export MOCK_ISSUE_LIST='[{"number": 400}]'
-    export MOCK_ISSUE_BODY_400='- [ ] Next /review --full auto-checks this condition <!-- verify-type: observation event=pr-review-full -->'
+    export MOCK_ISSUE_BODY_400='## Post-merge
+- [ ] Next /review --full auto-checks this condition <!-- verify-type: observation event=pr-review-full -->'
 
     run bash "$SCRIPT" --event pr-review-full
     [ "$status" -eq 0 ]
@@ -186,7 +195,8 @@ teardown() {
 
 @test "event filter: --event excludes opportunistic conditions" {
     export MOCK_ISSUE_LIST='[{"number": 401}]'
-    export MOCK_ISSUE_BODY_401='- [ ] /review skill creates review after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_401='## Post-merge
+- [ ] /review skill creates review after execution <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" --event pr-review-full
     [ "$status" -eq 0 ]
@@ -195,7 +205,8 @@ teardown() {
 
 @test "event filter: --event excludes non-matching event name" {
     export MOCK_ISSUE_LIST='[{"number": 402}]'
-    export MOCK_ISSUE_BODY_402='- [ ] Next /auto auto-checks this condition <!-- verify-type: observation event=auto-run -->'
+    export MOCK_ISSUE_BODY_402='## Post-merge
+- [ ] Next /auto auto-checks this condition <!-- verify-type: observation event=auto-run -->'
 
     run bash "$SCRIPT" --event pr-review-full
     [ "$status" -eq 0 ]
@@ -204,7 +215,8 @@ teardown() {
 
 @test "event filter: --event with dry-run returns the same non-empty result as without --dry-run" {
     export MOCK_ISSUE_LIST='[{"number": 702}]'
-    export MOCK_ISSUE_BODY_702='- [ ] Next /review --full auto-checks this condition <!-- verify-type: observation event=pr-review-full -->'
+    export MOCK_ISSUE_BODY_702='## Post-merge
+- [ ] Next /review --full auto-checks this condition <!-- verify-type: observation event=pr-review-full -->'
 
     run bash "$SCRIPT" --event pr-review-full
     [ "$status" -eq 0 ]
@@ -221,7 +233,8 @@ teardown() {
 
 @test "context gate: keyword found in context file includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 500}]'
-    export MOCK_ISSUE_BODY_500='- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
+    export MOCK_ISSUE_BODY_500='## Post-merge
+- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
     echo "This spec defines an enum for status codes." > "$BATS_TEST_TMPDIR/context-has-enum.md"
 
     run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-has-enum.md"
@@ -232,7 +245,8 @@ teardown() {
 
 @test "context gate: keyword absent from context file excludes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 501}]'
-    export MOCK_ISSUE_BODY_501='- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
+    export MOCK_ISSUE_BODY_501='## Post-merge
+- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
     echo "This spec covers formatting only." > "$BATS_TEST_TMPDIR/context-no-enum.md"
 
     run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-no-enum.md"
@@ -242,7 +256,8 @@ teardown() {
 
 @test "context gate: AC without keyword= matches unconditionally even with --context-file" {
     export MOCK_ISSUE_LIST='[{"number": 502}]'
-    export MOCK_ISSUE_BODY_502='- [ ] Next /review --full auto-checks this condition <!-- verify-type: observation event=pr-review-full -->'
+    export MOCK_ISSUE_BODY_502='## Post-merge
+- [ ] Next /review --full auto-checks this condition <!-- verify-type: observation event=pr-review-full -->'
     echo "Irrelevant content." > "$BATS_TEST_TMPDIR/context-any.md"
 
     run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-any.md"
@@ -253,7 +268,8 @@ teardown() {
 
 @test "context gate: keyword= present but no --context-file matches unconditionally" {
     export MOCK_ISSUE_LIST='[{"number": 503}]'
-    export MOCK_ISSUE_BODY_503='- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
+    export MOCK_ISSUE_BODY_503='## Post-merge
+- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
 
     run bash "$SCRIPT" --event pr-review-full
     [ "$status" -eq 0 ]
@@ -263,7 +279,8 @@ teardown() {
 
 @test "context gate: nonexistent --context-file path disables gate with a warning" {
     export MOCK_ISSUE_LIST='[{"number": 504}]'
-    export MOCK_ISSUE_BODY_504='- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
+    export MOCK_ISSUE_BODY_504='## Post-merge
+- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum -->'
 
     run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/does-not-exist.md" 2>&1
     [ "$status" -eq 0 ]
@@ -274,7 +291,8 @@ teardown() {
 
 @test "context gate: keyword= with no space before --> is extracted without trailing dashes" {
     export MOCK_ISSUE_LIST='[{"number": 505}]'
-    export MOCK_ISSUE_BODY_505='- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum--> '
+    export MOCK_ISSUE_BODY_505='## Post-merge
+- [ ] Verify enum coverage <!-- verify-type: observation event=pr-review-full keyword=enum--> '
     echo "This spec defines an enum for status codes." > "$BATS_TEST_TMPDIR/context-has-enum-2.md"
 
     run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-has-enum-2.md"
@@ -285,7 +303,8 @@ teardown() {
 
 @test "context gate: keyword found only inside a path-like token excludes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 506}]'
-    export MOCK_ISSUE_BODY_506='- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
+    export MOCK_ISSUE_BODY_506='## Post-merge
+- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
     echo "docs/workflow.md" > "$BATS_TEST_TMPDIR/context-path-only.md"
 
     run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-path-only.md"
@@ -295,7 +314,8 @@ teardown() {
 
 @test "context gate: keyword found in prose text still includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 507}]'
-    export MOCK_ISSUE_BODY_507='- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
+    export MOCK_ISSUE_BODY_507='## Post-merge
+- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
     echo "This PR changes the CI workflow configuration." > "$BATS_TEST_TMPDIR/context-prose.md"
 
     run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-prose.md"
@@ -306,7 +326,8 @@ teardown() {
 
 @test "config gate: enabled config key includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 600}]'
-    export MOCK_ISSUE_BODY_600='- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run config=some-flag -->'
+    export MOCK_ISSUE_BODY_600='## Post-merge
+- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run config=some-flag -->'
     echo "some-flag: true" > "$BATS_TEST_TMPDIR/config-enabled.yml"
     export WHOLEWORK_CONFIG_PATH="$BATS_TEST_TMPDIR/config-enabled.yml"
 
@@ -319,7 +340,8 @@ teardown() {
 
 @test "config gate: disabled config key excludes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 601}]'
-    export MOCK_ISSUE_BODY_601='- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run config=some-flag -->'
+    export MOCK_ISSUE_BODY_601='## Post-merge
+- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run config=some-flag -->'
     export WHOLEWORK_CONFIG_PATH=/dev/null
 
     run bash "$SCRIPT" --event auto-run
@@ -330,7 +352,8 @@ teardown() {
 
 @test "config gate: AC without config= matches unconditionally" {
     export MOCK_ISSUE_LIST='[{"number": 602}]'
-    export MOCK_ISSUE_BODY_602='- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run -->'
+    export MOCK_ISSUE_BODY_602='## Post-merge
+- [ ] Verify demotion is suppressed <!-- verify-type: observation event=auto-run -->'
     export WHOLEWORK_CONFIG_PATH=/dev/null
 
     run bash "$SCRIPT" --event auto-run
@@ -342,7 +365,8 @@ teardown() {
 
 @test "when gate: run facts route matches includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 700}]'
-    export MOCK_ISSUE_BODY_700='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_700='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":700,"route":"operate","recovery_tiers":[]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -355,7 +379,8 @@ teardown() {
 
 @test "when gate: run facts route mismatch excludes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 701}]'
-    export MOCK_ISSUE_BODY_701='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_701='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":701,"route":"pr","recovery_tiers":[]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -367,7 +392,8 @@ teardown() {
 
 @test "when gate: AC without when= matches unconditionally" {
     export MOCK_ISSUE_LIST='[{"number": 702}]'
-    export MOCK_ISSUE_BODY_702='- [ ] Next /auto auto-checks this condition <!-- verify-type: observation event=auto-run -->'
+    export MOCK_ISSUE_BODY_702='## Post-merge
+- [ ] Next /auto auto-checks this condition <!-- verify-type: observation event=auto-run -->'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
     run bash "$SCRIPT" --event auto-run
@@ -379,7 +405,8 @@ teardown() {
 
 @test "when gate: undeterminable run facts fail open with a warning" {
     export MOCK_ISSUE_LIST='[{"number": 703}]'
-    export MOCK_ISSUE_BODY_703='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_703='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     unset MOCK_RUN_FACTS
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -393,7 +420,8 @@ teardown() {
 
 @test "when gate: unknown axis fails open with a warning" {
     export MOCK_ISSUE_LIST='[{"number": 704}]'
-    export MOCK_ISSUE_BODY_704='- [ ] pr-state observed <!-- verify-type: observation event=auto-run when=pr-state:open -->'
+    export MOCK_ISSUE_BODY_704='## Post-merge
+- [ ] pr-state observed <!-- verify-type: observation event=auto-run when=pr-state:open -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":704,"route":"pr","recovery_tiers":[]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -407,7 +435,8 @@ teardown() {
 
 @test "when gate: comma-separated AND excludes when one clause fails" {
     export MOCK_ISSUE_LIST='[{"number": 705}]'
-    export MOCK_ISSUE_BODY_705='- [ ] batch recovery observed <!-- verify-type: observation event=auto-run when=mode:batch,recovery-tier:2 -->'
+    export MOCK_ISSUE_BODY_705='## Post-merge
+- [ ] batch recovery observed <!-- verify-type: observation event=auto-run when=mode:batch,recovery-tier:2 -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"batch","issues":[{"number":705,"route":"pr","recovery_tiers":[1]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -419,7 +448,8 @@ teardown() {
 
 @test "when gate: --facts-file explicit designation bypasses collect-run-facts.sh" {
     export MOCK_ISSUE_LIST='[{"number": 706}]'
-    export MOCK_ISSUE_BODY_706='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_706='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     # MOCK_RUN_FACTS deliberately mismatches route:operate (facts.json below is the only source
     # that matches). If --facts-file were silently ignored and collect-run-facts.sh's mock
     # consulted instead, the result would be [] instead of a match on #706 — making this
@@ -437,7 +467,8 @@ teardown() {
 
 @test "when gate: --session is forwarded to collect-run-facts.sh --session" {
     export MOCK_ISSUE_LIST='[{"number": 710}]'
-    export MOCK_ISSUE_BODY_710='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_710='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":710,"route":"operate","recovery_tiers":[]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -452,7 +483,8 @@ teardown() {
 
 @test "when gate: --facts-file takes priority over --session when both are given" {
     export MOCK_ISSUE_LIST='[{"number": 711}]'
-    export MOCK_ISSUE_BODY_711='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_711='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     # MOCK_RUN_FACTS deliberately mismatches route:operate — if --session were consulted
     # instead of --facts-file, the result would be [] instead of a match on #711.
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":711,"route":"pr","recovery_tiers":[]}]}'
@@ -469,7 +501,8 @@ teardown() {
 
 @test "when gate: no --session and no --facts-file calls collect-run-facts.sh with no arguments" {
     export MOCK_ISSUE_LIST='[{"number": 712}]'
-    export MOCK_ISSUE_BODY_712='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_712='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":712,"route":"operate","recovery_tiers":[]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -484,7 +517,8 @@ teardown() {
 
 @test "when gate: when= appearing in AC prose text (outside the tag) does not corrupt gate matching" {
     export MOCK_ISSUE_LIST='[{"number": 707}]'
-    export MOCK_ISSUE_BODY_707='- [ ] AC text that quotes when=route:operate as an example <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_707='## Post-merge
+- [ ] AC text that quotes when=route:operate as an example <!-- verify-type: observation event=auto-run when=route:operate -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":707,"route":"operate","recovery_tiers":[]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -497,7 +531,8 @@ teardown() {
 
 @test "when gate: glob metacharacters in a when= value are treated as a literal (no pathname expansion)" {
     export MOCK_ISSUE_LIST='[{"number": 708}]'
-    export MOCK_ISSUE_BODY_708='- [ ] wildcard axis value observed <!-- verify-type: observation event=auto-run when=route:* -->'
+    export MOCK_ISSUE_BODY_708='## Post-merge
+- [ ] wildcard axis value observed <!-- verify-type: observation event=auto-run when=route:* -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[{"number":708,"route":"operate","recovery_tiers":[]}]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -513,7 +548,8 @@ teardown() {
 
 @test "when gate: mode resolved with empty issues fails open on the route axis instead of silently excluding" {
     export MOCK_ISSUE_LIST='[{"number": 709}]'
-    export MOCK_ISSUE_BODY_709='- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
+    export MOCK_ISSUE_BODY_709='## Post-merge
+- [ ] operate route observed <!-- verify-type: observation event=auto-run when=route:operate -->'
     export MOCK_RUN_FACTS='{"session_id":"s1","mode":"single","issues":[]}'
     export WHOLEWORK_SCRIPT_DIR="$MOCK_DIR"
 
@@ -527,7 +563,8 @@ teardown() {
 
 @test "when gate: execution-context matches includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 710}]'
-    export MOCK_ISSUE_BODY_710='- [ ] main context observed <!-- verify-type: observation event=pr-review-full when=execution-context:main -->'
+    export MOCK_ISSUE_BODY_710='## Post-merge
+- [ ] main context observed <!-- verify-type: observation event=pr-review-full when=execution-context:main -->'
 
     run bash "$SCRIPT" --event pr-review-full --execution-context main
     [ "$status" -eq 0 ]
@@ -537,7 +574,8 @@ teardown() {
 
 @test "when gate: execution-context mismatch excludes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 711}]'
-    export MOCK_ISSUE_BODY_711='- [ ] main context observed <!-- verify-type: observation event=pr-review-full when=execution-context:main -->'
+    export MOCK_ISSUE_BODY_711='## Post-merge
+- [ ] main context observed <!-- verify-type: observation event=pr-review-full when=execution-context:main -->'
 
     run bash "$SCRIPT" --event pr-review-full --execution-context fork
     [ "$status" -eq 0 ]
@@ -546,7 +584,8 @@ teardown() {
 
 @test "when gate: execution-context clause without --execution-context flag fails open with a warning" {
     export MOCK_ISSUE_LIST='[{"number": 712}]'
-    export MOCK_ISSUE_BODY_712='- [ ] main context observed <!-- verify-type: observation event=pr-review-full when=execution-context:main -->'
+    export MOCK_ISSUE_BODY_712='## Post-merge
+- [ ] main context observed <!-- verify-type: observation event=pr-review-full when=execution-context:main -->'
 
     run bash "$SCRIPT" --event pr-review-full 2>&1
     [ "$status" -eq 0 ]
@@ -557,7 +596,8 @@ teardown() {
 
 @test "session=next declaration does not affect event= dispatch matching" {
     export MOCK_ISSUE_LIST='[{"number": 603}]'
-    export MOCK_ISSUE_BODY_603='- [ ] Next-session skill self-update observed <!-- verify-type: observation event=auto-run session=next -->'
+    export MOCK_ISSUE_BODY_603='## Post-merge
+- [ ] Next-session skill self-update observed <!-- verify-type: observation event=auto-run session=next -->'
 
     run bash "$SCRIPT" --event auto-run
     [ "$status" -eq 0 ]
@@ -567,7 +607,8 @@ teardown() {
 
 @test "event filter: unknown event emits warning and falls back" {
     export MOCK_ISSUE_LIST='[{"number": 403}]'
-    export MOCK_ISSUE_BODY_403='- [ ] /review skill creates review after execution <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_403='## Post-merge
+- [ ] /review skill creates review after execution <!-- verify-type: opportunistic -->'
 
     # Merge stderr into stdout so the warning is captured in $output
     run bash "$SCRIPT" --event unknown-event-xyz /review 2>&1
@@ -581,7 +622,8 @@ teardown() {
 
 @test "fact gate: token match in condition text includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 800}]'
-    export MOCK_ISSUE_BODY_800='- [ ] /verify skill checks pr route candidates <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_800='## Post-merge
+- [ ] /verify skill checks pr route candidates <!-- verify-type: opportunistic -->'
     echo '{"session_id":"s1","issues":[{"number":1,"fact_tokens":["pr route"]}]}' > "$BATS_TEST_TMPDIR/facts.json"
 
     run bash "$SCRIPT" /verify --facts "$BATS_TEST_TMPDIR/facts.json"
@@ -592,7 +634,8 @@ teardown() {
 
 @test "fact gate: token mismatch excludes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 801}]'
-    export MOCK_ISSUE_BODY_801='- [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_801='## Post-merge
+- [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
     echo '{"session_id":"s1","issues":[{"number":1,"fact_tokens":["pr route"]}]}' > "$BATS_TEST_TMPDIR/facts.json"
 
     run bash "$SCRIPT" /verify --facts "$BATS_TEST_TMPDIR/facts.json"
@@ -602,7 +645,8 @@ teardown() {
 
 @test "fact gate: --facts omitted matches unconditionally (backward compatible)" {
     export MOCK_ISSUE_LIST='[{"number": 802}]'
-    export MOCK_ISSUE_BODY_802='- [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_802='## Post-merge
+- [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /verify
     [ "$status" -eq 0 ]
@@ -612,7 +656,8 @@ teardown() {
 
 @test "fact gate: nonexistent --facts path disables gate with a warning" {
     export MOCK_ISSUE_LIST='[{"number": 803}]'
-    export MOCK_ISSUE_BODY_803='- [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_803='## Post-merge
+- [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
 
     run bash "$SCRIPT" /verify --facts "$BATS_TEST_TMPDIR/nonexistent-facts.json" 2>&1
     [ "$status" -eq 0 ]
@@ -623,11 +668,37 @@ teardown() {
 
 @test "fact gate: ignored in event mode (--event) -- --facts-file/when= remain the only event-mode gates" {
     export MOCK_ISSUE_LIST='[{"number": 804}]'
-    export MOCK_ISSUE_BODY_804='- [ ] pr route observed <!-- verify-type: observation event=auto-run -->'
+    export MOCK_ISSUE_BODY_804='## Post-merge
+- [ ] pr route observed <!-- verify-type: observation event=auto-run -->'
     echo '{"session_id":"s1","issues":[{"number":1,"fact_tokens":["token-not-in-condition"]}]}' > "$BATS_TEST_TMPDIR/facts.json"
 
     run bash "$SCRIPT" --event auto-run --facts "$BATS_TEST_TMPDIR/facts.json"
     [ "$status" -eq 0 ]
     echo "$output" | jq -e 'length == 1' > /dev/null
     echo "$output" | jq -e '.[0].number == 804' > /dev/null
+}
+
+@test "population: gh issue list is called with --state all, not --state closed (issue #1242)" {
+    export MOCK_ISSUE_LIST="[]"
+    run bash "$SCRIPT" /issue
+    [ "$status" -eq 0 ]
+    args_joined="$(tr '\n' ' ' < "$MOCK_DIR/gh-list-args.txt")"
+    [[ "$args_joined" == *"--state all"* ]]
+    [[ "$args_joined" != *"--state closed"* ]]
+}
+
+@test "post-merge scope: a sample condition line outside the Post-merge section is excluded (issue #1242)" {
+    export MOCK_ISSUE_LIST='[{"number": 900}]'
+    export MOCK_ISSUE_BODY_900='## Some Other Section
+
+```
+- [ ] /issue skill creates Issue after execution (example only) <!-- verify-type: opportunistic -->
+```
+
+## Post-merge
+No pending conditions.'
+
+    run bash "$SCRIPT" /issue
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
 }

--- a/tests/scan-pending-ac.bats
+++ b/tests/scan-pending-ac.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/scan-pending-ac.sh's Issue population fetch.
+#
+# Scope: this suite only verifies the `--state all` population fix (Issue
+# #1242). Post-merge section scoping, --facts token filtering, gh-failure
+# fail-open behavior, and --max-candidates truncation are already covered by
+# tests/run-fact-matching.bats and are not duplicated here.
+
+PROJECT_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+SCRIPT="$PROJECT_ROOT/scripts/scan-pending-ac.sh"
+
+setup() {
+    cd "$PROJECT_ROOT"
+
+    export MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+    printf '%s\n' "$@" >> "$MOCK_DIR/gh-list-args.txt"
+    echo "[]"
+    exit 0
+fi
+exit 1
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+@test "population: gh issue list is called with --state all, not --state closed (issue #1242)" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    args_joined="$(tr '\n' ' ' < "$MOCK_DIR/gh-list-args.txt")"
+    [[ "$args_joined" == *"--state all"* ]]
+    [[ "$args_joined" != *"--state closed"* ]]
+}
+
+@test "population: gh issue list is called with the phase/verify label and --json number,body" {
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    args_joined="$(tr '\n' ' ' < "$MOCK_DIR/gh-list-args.txt")"
+    [[ "$args_joined" == *"--label phase/verify"* ]]
+    [[ "$args_joined" == *"--json number,body"* ]]
+}


### PR DESCRIPTION
## Summary
`scripts/opportunistic-search.sh` と `scripts/scan-pending-ac.sh` の Issue 母集団取得を `--state closed` 固定から `--state all` に揃え、OPEN のまま `phase/verify` に留まる Issue (実例: #490, #465) も自動評価パイプラインの対象に含めた。あわせて `opportunistic-search.sh` の本文走査に `scan-pending-ac.sh` 既存の Post-merge セクション境界 awk ロジックを踏襲した scoping を追加し、コードフェンス内のサンプル `- [ ]` 行 (実例: #491) を実 AC と誤認しないようにした。

## Verification (pre-merge)
- `scripts/opportunistic-search.sh` / `scripts/scan-pending-ac.sh` から `--state closed` の記述が消えていること
- `scripts/opportunistic-search.sh` の走査が Post-merge セクションにスコープされていること (rubric 判定)
- `scripts/opportunistic-search.sh` 内に Post-merge 境界ロジックが存在すること
- 母集団拡大の dispatch 件数への影響が Spec Notes に記録されていること (rubric 判定)
- `bats tests/opportunistic-search.bats tests/scan-pending-ac.bats` が PASS すること

## Verification (post-merge)
- 次回 `/audit stats --retention` で #490 / #465 が pending AC の走査対象に含まれ、#491 の偽陽性が Manual Waiting Count から消えていることを確認する

closes #1242
