### PR TITLE
Issue #1260: issue/triage: Step 15 AC 監査が自己生成 AC を自動修正してよいかを定義

### DIFF
--- a/docs/spec/issue-1260-step15-ac-audit-policy.md
+++ b/docs/spec/issue-1260-step15-ac-audit-policy.md
@@ -59,3 +59,32 @@ B 案の既知の穴 (Issue 本文): 「Size XS の patch route では `/spec` �
 ## Consumed Comments
 
 - saito / MEMBER / first-class / `/issue` Existing Issue Refinement の Issue Retrospective — AC1 への補助チェック追加理由、Ambiguity Detection の結果 (該当なし、案 A/B/C の決定は `/spec` に意図的に委譲)、事実確認結果、Title drift なし、Blocked-by なしを記録 / https://github.com/saitoco/wholework/issues/1260#issuecomment-5225317179
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Implementation Steps 1・2 をそのまま実施した (段落の挿入位置・内容とも Spec の指定通り)。
+
+### Design Gaps/Ambiguities
+
+- N/A
+
+### Rework
+
+- 実装のやり直しは発生していない。参考記録として: `skills/issue/SKILL.md` が複数テストファイル (`tests/verify-executor.bats` 等、直接対応する `tests/issue.bats` 以外) から参照されているため Behavioral Change Detection が発火し、`bats --jobs 18 tests/` のフルスイート実行が必要になった。実行結果、`tests/post_merge_check.bats` の `fail: gh issue reopen called when FAIL input given` が 1 件 FAIL したが、同ファイル単体実行では PASS することを確認済み。`test-failure-classify.sh` の分類は `infra` (並列実行時のリソース競合によるフレークで、テストコード側の修復対象ではない)。本 Issue の変更 (`skills/issue/SKILL.md` Step 15, `skills/triage/skill-dev-verify-audit.md`) とは無関係と判断し、pr route の既定方針通り CI 側の検知に委ねて未修正のまま継続した。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec Implementation Steps 1・2 をそのまま実施し、`skill-dev-verify-audit.md` § Non-Destructive Audit Behavior に自己生成 AC の扱い (非破壊を維持) と根拠、「Repair handoff for self-generated AC」段落を追加。`skills/issue/SKILL.md` Step 15 に整合段落を挿入した。
+- Pre-merge AC 4件 (rubric x3, section_contains x1) はいずれも実装内容そのままで PASS と判定し、Issue body のチェックボックスを更新した。
+
+### Deferred Items
+- Post-merge AC (`次回 /issue Step 15 が自己生成 AC の不備を検出した際、定めた方針どおりの挙動になることを観察する`, observation type) は次回発火まで未検証のまま。
+- `tests/post_merge_check.bats` の並列実行時フレーク (`fail: gh issue reopen called when FAIL input given`) は本 Issue の変更と無関係と判断し未修正。継続的に発生する場合は別途調査 Issue が必要。
+
+### Notes for Next Phase
+- `/review` は Pre-merge AC 4件が既に `[x]` 済みであることを踏まえ、rubric 判定の妥当性を独立に再確認すること。
+- `/merge` は上記の `tests/post_merge_check.bats` フレークが CI 上でも再現するかを確認し、再現する場合は無関係な既存問題として扱ってよい (本 Issue の diff は `skills/issue/SKILL.md` と `skills/triage/skill-dev-verify-audit.md` のみ)。

--- a/docs/spec/issue-1260-step15-ac-audit-policy.md
+++ b/docs/spec/issue-1260-step15-ac-audit-policy.md
@@ -74,17 +74,31 @@ B 案の既知の穴 (Issue 本文): 「Size XS の patch route では `/spec` �
 
 - 実装のやり直しは発生していない。参考記録として: `skills/issue/SKILL.md` が複数テストファイル (`tests/verify-executor.bats` 等、直接対応する `tests/issue.bats` 以外) から参照されているため Behavioral Change Detection が発火し、`bats --jobs 18 tests/` のフルスイート実行が必要になった。実行結果、`tests/post_merge_check.bats` の `fail: gh issue reopen called when FAIL input given` が 1 件 FAIL したが、同ファイル単体実行では PASS することを確認済み。`test-failure-classify.sh` の分類は `infra` (並列実行時のリソース競合によるフレークで、テストコード側の修復対象ではない)。本 Issue の変更 (`skills/issue/SKILL.md` Step 15, `skills/triage/skill-dev-verify-audit.md`) とは無関係と判断し、pr route の既定方針通り CI 側の検知に委ねて未修正のまま継続した。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — Implementation Steps 1・2 は Spec の指定通りに実施されており、`/review` の独立再検証 (rubric x3, section_contains x1) でも Pre-merge AC 4件全て PASS を再確認した。`/code` の Phase Handoff で依頼された「rubric 判定の妥当性の独立再確認」も完了している。
+
+### Recurring issues
+
+Nothing to note — MUST issue は 0 件。SHOULD issue が 1 件 (`skills/triage/skill-dev-verify-audit.md:254` の Size 列挙が Size S を欠落) 見つかり、修正・push 済み。同種の「Size グループを個別列挙する記述は将来のルーティング変更で陳腐化しやすい」という教訓は、同じ Spec の Notes に既にある一般化した表現 (「次フェーズ (`/spec` または Size XS の場合は `/code`)」) と平仄を取ることで再発を避けられる — 今回は 1 箇所のみで規模化した Issue 起票は不要と判断。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note — rubric 3件・section_contains 1件とも安全モードで確定的に PASS 判定でき、UNCERTAIN は 0 件だった。verify command の記述・対象ファイル指定に不備はなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec Implementation Steps 1・2 をそのまま実施し、`skill-dev-verify-audit.md` § Non-Destructive Audit Behavior に自己生成 AC の扱い (非破壊を維持) と根拠、「Repair handoff for self-generated AC」段落を追加。`skills/issue/SKILL.md` Step 15 に整合段落を挿入した。
-- Pre-merge AC 4件 (rubric x3, section_contains x1) はいずれも実装内容そのままで PASS と判定し、Issue body のチェックボックスを更新した。
+- Pre-merge AC 4件を独立に再検証し、いずれも PASS と再確認した (Issue body のチェックボックスは `/code` により既に `[x]` 済みで変更不要)。
+- `skills/triage/skill-dev-verify-audit.md:254` の Size 列挙から Size S が欠落している SHOULD issue を検出し、修正・commit・push 済み。
 
 ### Deferred Items
 - Post-merge AC (`次回 /issue Step 15 が自己生成 AC の不備を検出した際、定めた方針どおりの挙動になることを観察する`, observation type) は次回発火まで未検証のまま。
-- `tests/post_merge_check.bats` の並列実行時フレーク (`fail: gh issue reopen called when FAIL input given`) は本 Issue の変更と無関係と判断し未修正。継続的に発生する場合は別途調査 Issue が必要。
+- `tests/post_merge_check.bats` の並列実行時フレーク (`fail: gh issue reopen called when FAIL input given`) は本 Issue の変更と無関係と判断し未修正のまま。CI では今回全ジョブ SUCCESS だったため再現しなかった。継続的に発生する場合は別途調査 Issue が必要。
 
 ### Notes for Next Phase
-- `/review` は Pre-merge AC 4件が既に `[x]` 済みであることを踏まえ、rubric 判定の妥当性を独立に再確認すること。
-- `/merge` は上記の `tests/post_merge_check.bats` フレークが CI 上でも再現するかを確認し、再現する場合は無関係な既存問題として扱ってよい (本 Issue の diff は `skills/issue/SKILL.md` と `skills/triage/skill-dev-verify-audit.md` のみ)。
+- `/merge` は MUST issue 0件・CI 全 SUCCESS のためそのまま進めてよい。
+- `tests/post_merge_check.bats` のフレークは本 Issue の diff (`skills/issue/SKILL.md`, `skills/triage/skill-dev-verify-audit.md`) と無関係であり、`/merge` 側での追加対応は不要。

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -624,6 +624,8 @@ Skip this step if the Issue body contains no `<!-- verify: ... -->` patterns.
 
 **Pattern 4 Size/`ALWAYS_PR` sourcing in this context**: read Size with `${CLAUDE_PLUGIN_ROOT}/scripts/get-issue-size.sh $NUMBER` (same call as Step 6); `ALWAYS_PR` is retained from Step 4.
 
+Most AC audited by this step originate from this same execution's Step 9 (Issue body reflection) or Step 12 (sub-issue redistribution) — i.e. self-generated AC. Per `skill-dev-verify-audit.md` § Non-Destructive Audit Behavior, self-generated AC receive the same non-destructive treatment as externally-authored AC: this step never auto-edits the Issue body, even for a small, unambiguous defect. Findings are posted as a comment only; the next phase (`/spec`, or `/code` directly for Size XS) picks them up via the Comment Consumption Procedure.
+
 Note: if Step 2's triage auto-chain already ran in this same session (`triaged` was absent at the start), its own Step 7 already audited the Issue body's pre-refinement ACs — this step's pass is independent and may post a second comment. The overlap is expected and non-blocking; the audit is non-destructive (comment-only).
 
 ---

--- a/skills/triage/skill-dev-verify-audit.md
+++ b/skills/triage/skill-dev-verify-audit.md
@@ -251,7 +251,7 @@ Issue body — both audited AC self-generated within the same `/issue` execution
 defective 自己生成 AC is fixed only once a downstream phase picks up the audit comment.
 This works without any new mechanism: the Comment Consumption Procedure
 (`modules/l0-surfaces.md`) already treats Issue comments as first-class context for
-whichever phase runs next — `/spec` for Size M/L/XL, or `/code` directly for Size XS
+whichever phase runs next — `/spec` for Size S/M/L/XL, or `/code` directly for Size XS
 (whose patch route skips `/spec`). Either phase reads the comment as prompt-equivalent
 input and applies the suggested fix as part of its own work.
 

--- a/skills/triage/skill-dev-verify-audit.md
+++ b/skills/triage/skill-dev-verify-audit.md
@@ -233,6 +233,28 @@ When problems are detected, triage posts a comment to the Issue with the finding
 suggested fixes. The user then decides whether and how to update the Issue body.
 This avoids destructive behavior in cases where `/issue` may regenerate the AC.
 
+**Self-generated AC (自己生成 AC)**: this non-destructive policy applies unconditionally
+even when the audited AC was authored within the same execution that runs this audit —
+e.g. AC produced by `/issue` Existing Issue Refinement's own Step 7 classification,
+Step 9 Issue body reflection, or Step 12 sub-issue redistribution. The audit does not
+distinguish 自己生成 AC from externally-authored AC and does not auto-edit the Issue body
+for either. This determinism is deliberate: defining a boundary for "authored within the
+same execution" is ambiguous when `/triage` Step 2's auto-chain invokes `/issue` — from a
+user's perspective this is a single continuous operation, but from the skill's perspective
+it spans two separate invocations. Making the audit's judgment depend on that ambiguous
+boundary would reintroduce non-deterministic behavior into the very check this rule exists
+to prevent. Observed divergence before this rule was made explicit: Issue #1220 followed
+the non-destructive default (comment-only), while Issue #1221 deviated by auto-editing the
+Issue body — both audited AC self-generated within the same `/issue` execution.
+
+**Repair handoff for self-generated AC**: because the Issue body is never auto-edited, a
+defective 自己生成 AC is fixed only once a downstream phase picks up the audit comment.
+This works without any new mechanism: the Comment Consumption Procedure
+(`modules/l0-surfaces.md`) already treats Issue comments as first-class context for
+whichever phase runs next — `/spec` for Size M/L/XL, or `/code` directly for Size XS
+(whose patch route skips `/spec`). Either phase reads the comment as prompt-equivalent
+input and applies the suggested fix as part of its own work.
+
 **Post the audit comment** only when at least one pattern match is found.
 If no patterns match, skip without posting.
 


### PR DESCRIPTION
## Summary

`/issue` Existing Issue Refinement の Step 15 (AC Verify Command Integrity Audit) が、**同一実行内で自己生成された AC** の不備を検出した際の扱いを定義した。#1220 (非破壊のコメント報告のみ) と #1221 (Issue body を即座に自動修正) で挙動が分かれていた問題を、検討候補 B (一律非破壊を維持し `/spec`/`/code` への引き継ぎを正式化) の採用により解消する。

- `skills/triage/skill-dev-verify-audit.md` § Non-Destructive Audit Behavior に、自己生成 AC も外部由来 AC と同じ非破壊方針の対象であることを明記し、その根拠 (判定の決定性維持、`/triage` Step 2 auto-chain 経由での起源追跡境界の曖昧さ回避) と #1220/#1221 の実測差を記録
- 同セクションに「Repair handoff for self-generated AC」段落を追加し、既存の Comment Consumption Procedure (`modules/l0-surfaces.md`) が次フェーズ (Size M/L/XL は `/spec`、Size XS は `/code`) へのコメント引き継ぎを新規メカニズムなしに提供することを明文化
- `skills/issue/SKILL.md` Step 15 に、Step 9/Step 12 由来の自己生成 AC が上記方針に従うことを明記し、両ファイルの記述が矛盾しないよう整合

## Verification (pre-merge)

- skill-dev-verify-audit.md の Non-Destructive Audit Behavior セクションに自己生成 AC への言及があることを rubric/section_contains で確認
- skills/issue/SKILL.md Step 15 の追記が skill-dev-verify-audit.md の方針と矛盾しないことを rubric で確認
- 採用案 (B) と不採用案 (A/C) の理由、および Size XS 経路への対応が Spec の Notes に記録されていることを rubric で確認
- `bats --jobs 18 tests/` フルスイート実行 (behavioral change 検出により対象化) — `tests/post_merge_check.bats` の1件が並列実行時のみ FAIL するが、単独実行では PASS を確認済み (実装と無関係な既知の並列実行フレーク、詳細は Code Retrospective 参照)
- `python3 scripts/validate-skill-syntax.py skills/` — 0 error / 0 warning
- `bash scripts/check-forbidden-expressions.sh` — 問題なし

## Verification (post-merge)

- 次回 `/issue` Step 15 が自己生成 AC の不備を検出した際、定めた方針どおりの挙動になることを観察する (observation)

closes #1260
