### PR TITLE
Issue #1281: Tier 2/3 復旧記録に cause slug を残し原因別の頻度検出を機能させる

### DIFF
--- a/agents/orchestration-recovery.md
+++ b/agents/orchestration-recovery.md
@@ -77,6 +77,7 @@ Output a single JSON object (no markdown fences, no surrounding text) with exact
 ```json
 {
   "action": "<retry|skip|recover|abort>",
+  "cause": "<kebab-case root-cause slug>",
   "rationale": "<one or two sentences explaining the diagnosis and chosen action>",
   "steps": [
     { "op": "run_command", "cmd": "<shell command to execute>" }
@@ -102,6 +103,9 @@ Output a single JSON object (no markdown fences, no surrounding text) with exact
 - Do not include commands that force-push, push directly to main/master, reset hard, close issues, or merge PRs
 - If the appropriate action is `retry` or `skip`, `steps` must be an empty array `[]`
 - If the appropriate action is `abort`, `steps` must be an empty array `[]`
+- `cause` is a kebab-case slug (`^[a-z0-9]+(-[a-z0-9]+)*$`, 40 characters or fewer) naming the **root cause**, not the symptom
+- If the same root cause has occurred before, reuse the existing slug from `docs/reports/orchestration-recoveries.md` (e.g. `background-notification-wait`, `external-kill-during-merge`, `ff-only-merge-base-advanced`, `ci-infra-outage-during-ci-wait`) instead of coining a new one
+- If the root cause cannot be determined, return `unclassified`
 
 **Watchdog-kill-before-PR recovery example (commit→push feature branch→`gh pr create`):**
 
@@ -110,6 +114,7 @@ When the log shows a watchdog kill after implementation was complete but before 
 ```json
 {
   "action": "recover",
+  "cause": "background-notification-wait",
   "rationale": "Watchdog killed run-code.sh after implementation but before commit or PR creation. Recovering by committing uncommitted changes, pushing the feature branch, and creating the PR.",
   "steps": [
     { "op": "run_command", "cmd": "git add -A && git commit -s -m 'feat: implement issue #N (closes #N)\n\nCo-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>'" },
@@ -128,6 +133,7 @@ When the reported blocking symptom is unrelated to the worktree branch itself (e
 ```json
 {
   "action": "recover",
+  "cause": "dirty-guard",
   "rationale": "main has an unrelated dirty-tree blocker (uncommitted L0 log entry) which must be cleared, but worktree-code+issue-N already has unpushed implementation commits and no PR exists yet. Resolving only the dirty tree would leave code-pr phase incomplete, so this plan also pushes the branch and creates the PR.",
   "steps": [
     { "op": "run_command", "cmd": "<step(s) resolving the originally-reported symptom, e.g. committing the unrelated dirty-tree file via the phase's own automated commit path>" },

--- a/docs/reports/orchestration-recoveries.md
+++ b/docs/reports/orchestration-recoveries.md
@@ -51,7 +51,7 @@ This file records cross-Issue recovery events, fallback applications, and diagno
 | Field | Description |
 |-------|-------------|
 | `symptom-short` | Short identifier for the symptom pattern (kebab-case). Frequency grouping key is `symptom-short`, or `symptom-short/cause-slug` when a `cause` line is present in `### Diagnosis` |
-| `cause` | Optional kebab-case root-cause slug in `### Diagnosis` (e.g. `dirty-guard`). Separates occurrences of the same symptom by known root cause during frequency grouping. Written by three paths: Tier 2 (`apply-fallback.sh`, value is the matched symptom anchor), Tier 3 (`spawn-recovery-subagent.sh`, value is the recovery plan's `cause` field, `unclassified` when missing/invalid), and manual recovery (`run-auto-sub.sh --write-manual-recovery --cause`) |
+| `cause` | Kebab-case root-cause slug in `### Diagnosis` (e.g. `dirty-guard`). Optional at read time — pre-#1281 entries lack it. Separates occurrences of the same symptom by known root cause during frequency grouping. Always written by Tier 2 (`apply-fallback.sh`, value is the matched symptom anchor) and Tier 3 (`spawn-recovery-subagent.sh`, value is the recovery plan's `cause` field, `unclassified` when missing/invalid); optional for manual recovery (`run-auto-sub.sh --write-manual-recovery --cause`) |
 | `Source` | Which mechanism detected and handled this recovery event |
 | `Outcome` | `success` = phase completed; `partial` = partial recovery; `failed` = stopped |
 | `Improvement Candidate` | `未起票` = not yet filed; `起票済み #NNN` = filed as Issue #NNN; `N/A` = no action needed |

--- a/docs/reports/orchestration-recoveries.md
+++ b/docs/reports/orchestration-recoveries.md
@@ -51,7 +51,7 @@ This file records cross-Issue recovery events, fallback applications, and diagno
 | Field | Description |
 |-------|-------------|
 | `symptom-short` | Short identifier for the symptom pattern (kebab-case). Frequency grouping key is `symptom-short`, or `symptom-short/cause-slug` when a `cause` line is present in `### Diagnosis` |
-| `cause` | Optional kebab-case root-cause slug in `### Diagnosis` (e.g. `dirty-guard`). Separates occurrences of the same symptom by known root cause during frequency grouping |
+| `cause` | Optional kebab-case root-cause slug in `### Diagnosis` (e.g. `dirty-guard`). Separates occurrences of the same symptom by known root cause during frequency grouping. Written by three paths: Tier 2 (`apply-fallback.sh`, value is the matched symptom anchor), Tier 3 (`spawn-recovery-subagent.sh`, value is the recovery plan's `cause` field, `unclassified` when missing/invalid), and manual recovery (`run-auto-sub.sh --write-manual-recovery --cause`) |
 | `Source` | Which mechanism detected and handled this recovery event |
 | `Outcome` | `success` = phase completed; `partial` = partial recovery; `failed` = stopped |
 | `Improvement Candidate` | `未起票` = not yet filed; `起票済み #NNN` = filed as Issue #NNN; `N/A` = no action needed |

--- a/docs/spec/issue-1281-tier23-cause-slug.md
+++ b/docs/spec/issue-1281-tier23-cause-slug.md
@@ -145,25 +145,38 @@ Changed Files に新規 `scripts/*.sh` は含まれず、`modules/*.md` の変�
 - **`- cause:` 行の検出範囲**: `collect-recovery-candidates.sh` の検出が `### Diagnosis` セクションにスコープされているか不明だったが、パーサ (`:208-221`) を読み、エントリ内の任意の行に対する `^- cause: .+` のベアマッチであることを確認した。配置は書式規約として `### Diagnosis` 先頭に揃える方針で確定
 - **validator を任意キー化しても既存テストが通るか**: `tests/validate-recovery-plan.bats` の 6 フィクスチャがすべて 3 キー構成であることを読んで確認済み。必須キーリストを変更しない限り既存テストは無改変で green
 
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1-9 を Spec記載どおりの順序・内容で実装した。
+
+### Design Gaps/Ambiguities
+- `agents/orchestration-recovery.md` の 2 件目の JSON 例 (Dirty-tree-cleanup-plus-PR-creation, Issue #917) は Spec が cause slug の具体値まで指定していなかった。Constraints の「既出 slug を再利用する」方針に従い、`docs/reports/orchestration-recoveries.md` の Field Definitions で既に例示されている `dirty-guard` を採用した。
+
+### Rework
+- N/A — 手戻りは発生しなかった。
+
+### Test Execution Notes
+- Behavioral change detection (既存ファイル `docs/reports/orchestration-recoveries.md` を直接対応テスト以外からも複数 bats ファイルが参照) によりフルスイート並列実行 (`bats --jobs 18 tests/`) が必要と判定された。2 回実行し、いずれも `tests/post_merge_check.bats` の `fail: gh issue reopen called when FAIL input given` (1〜2 回目とも FAIL) が並列実行時のみ FAIL した (直列実行では 2 回とも 10/10 全 PASS)。本 Issue の変更対象ファイルとは無関係。同一テスト名の並列時 flake は既存 Issue #1231 の Background に既述のため、新規 follow-up Issue は起票せず (実質重複)。本 Issue に関連する `tests/collect-recovery-candidates.bats` / `tests/validate-recovery-plan.bats` / `tests/apply-fallback.bats` / `tests/auto-recovery.bats` / `tests/spawn-recovery-subagent.bats` / `tests/orchestration-recovery.bats` を直列実行し、追加した @test を含む全件 PASS を個別に確認した。
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- Tier 2 と Tier 3 を 1 つの PR で扱う。Issue 本文 Notes が `/spec` に委譲した判断で、受入条件 1-6 が両 Tier をまたぐ 1 セットとして書かれているため分割しない
-- `cause` は `validate-recovery-plan.sh` では任意キー (present-only 検証)、`agents/orchestration-recovery.md` の契約文では必須指示、という非対称構成。validator の検証失敗が「復旧を諦めて stop-and-report」を意味するため、メタデータ欠落で復旧を止めない
-- `cause` が欠落・不正な場合 Tier 3 writer は sentinel `unclassified` を必ず書く。行を省略すると素の `<symptom-short>` に落ち、「cause を出せなかった」と「#1281 以前のエントリ」が区別できなくなる
-- Tier 2 の cause 値はマッチ済み symptom anchor をそのまま使う。`detect_symptom_anchor()` が返す 3 リテラルはいずれも kebab-case 保証済みのため追加サニタイズは不要
+- Implementation Steps 1-9 を Spec記載どおりの順序で実装し、逸脱なし
+- `agents/orchestration-recovery.md` の 2 件目の JSON 例 (Issue #917 由来) の cause 値には、Spec のガイダンス (既出 slug を再利用) に従い `docs/reports/orchestration-recoveries.md` に既に例示されている `dirty-guard` を採用
+- Behavioral change detection の判定に従いフルスイート並列実行 (`bats --jobs 18 tests/`) を実施。並列時のみ `tests/post_merge_check.bats` の 1 テストが flake したが、変更対象ファイルとは無関係かつ既存 Issue #1231 の Background に同一事象の記載があったため、新規 follow-up Issue は起票せず記録のみとした
 
 ### Deferred Items
 
-- 既存エントリへの遡及的な cause 付与 (Issue 本文 Notes でスコープ外と明記)
-- Tier 3 の agent が返す slug が既存 vocabulary を実際に再利用するかの検証は post-merge 観察に委ねる。単発 group-key が増える傾向が見えた場合は、agent プロンプトへ既出 slug 一覧を動的注入する後続 Issue を検討 (Spec の Uncertainty 節)
-- `write_recovery_entry()` 3 経路のエントリ生成共通化 (今回は 2 箇所の追記で足りるため実施しない)
+- 既存エントリへの遡及的な cause 付与 (Issue 本文 Notes でスコープ外と明記、実装でも対応せず)
+- Tier 3 の agent が返す slug が既存 vocabulary を実際に再利用するかの検証は post-merge 観察に委ねる (`session=next`)。単発 group-key が増える傾向が見えた場合は、agent プロンプトへ既出 slug 一覧を動的注入する後続 Issue を検討
+- `write_recovery_entry()` 3 経路のエントリ生成共通化は未実施 (今回は 2 箇所の追記で足りるため)
+- `tests/post_merge_check.bats` の並列実行時 flake の根本原因調査は本 Issue のスコープ外。既存 Issue #1231 が同一事象を Background に記載済み
 
 ### Notes for Next Phase
 
-- `scripts/validate-recovery-plan.sh` の `re` は既存の `import re as _re` がステップ検証ブロック内のローカルスコープにある。`cause` 検証で使うにはファイル冒頭にトップレベル `import re` を追加すること
-- `tests/validate-recovery-plan.bats` の既存 6 フィクスチャは 3 キー構成のまま触らない。必須キーリスト `("action", "rationale", "steps")` を変更すると既存テストが落ちる
-- Implementation Step 9 のテストは Tier 2 の group-key が **出力されないこと** も assert する。これは #1191 の N/A 除外との相互作用を意図的に固定するもので、バグではない (Spec の Notes「実装との矛盾」参照)
-- `tests/collect-recovery-candidates.bats` に `file_contains` 系の verify command を追加する場合、`@test` 名は既存ファイルの実際の命名 (`grep "@test" tests/collect-recovery-candidates.bats`) を確認してから部分文字列を採ること
+- Post-merge AC は `/verify` で次回 Tier 2/3 recovery 発火時の `docs/reports/orchestration-recoveries.md` エントリを観察する。Tier 2 は #1191 の N/A 除外により頻度カウント対象外のため、観察対象は実質 Tier 3 発火時のみ
+- `collect-recovery-candidates.sh --with-tracking` の出力で cause 別 group-key 分離が機能しているかを確認すること
+- `bats --jobs N tests/` を実行する場合、`tests/post_merge_check.bats` の 1 テストが並列実行時のみ flake することがある (直列実行では毎回 PASS)。無関係な FAIL として無視して構わない

--- a/docs/spec/issue-1281-tier23-cause-slug.md
+++ b/docs/spec/issue-1281-tier23-cause-slug.md
@@ -159,24 +159,40 @@ Changed Files に新規 `scripts/*.sh` は含まれず、`modules/*.md` の変�
 ### Test Execution Notes
 - Behavioral change detection (既存ファイル `docs/reports/orchestration-recoveries.md` を直接対応テスト以外からも複数 bats ファイルが参照) によりフルスイート並列実行 (`bats --jobs 18 tests/`) が必要と判定された。2 回実行し、いずれも `tests/post_merge_check.bats` の `fail: gh issue reopen called when FAIL input given` (1〜2 回目とも FAIL) が並列実行時のみ FAIL した (直列実行では 2 回とも 10/10 全 PASS)。本 Issue の変更対象ファイルとは無関係。同一テスト名の並列時 flake は既存 Issue #1231 の Background に既述のため、新規 follow-up Issue は起票せず (実質重複)。本 Issue に関連する `tests/collect-recovery-candidates.bats` / `tests/validate-recovery-plan.bats` / `tests/apply-fallback.bats` / `tests/auto-recovery.bats` / `tests/spawn-recovery-subagent.bats` / `tests/orchestration-recovery.bats` を直列実行し、追加した @test を含む全件 PASS を個別に確認した。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- Spec と実装の構造的な乖離はなし (review-spec agent が Changed Files 10件 + Spec 自身の計 11件がPR変更ファイル一覧と完全一致、Implementation Steps 1-9 の対応も確認済み)。
+- ただし Spec 自体に内部矛盾が1件見つかった: `scripts/validate-recovery-plan.sh` の cause 検証 (Implementation Step 1) は不正値を hard error とする一方、Implementation Step 4 は「空 / キー欠落 / 正規表現に不一致」をすべて `unclassified` に正規化する意図を書いている。実装は両方の指示をそのまま実装した結果、validator が先にゲートするため Step 4 の「不正値→unclassified」分岐が制御フロー上到達不能になった (2件のレビューエージェントが独立に検出、検証で PASS 確認)。/review では validator のセマンティクス変更は本PR自身が追加した固定テスト (`cause: malformed value -> exit 1`) と衝突するため見送り、SHOULD として記録するに留めた。
+
+### Recurring issues
+
+- 「バリデーションを先にゲートする」設計と「不正値も緩やかにフォールバックする」設計が同一 Spec 内で両方指示されるパターンは、今回が初出ではなく一般化できる懸念点。今後 validation + fallback の仕様を書く際は、検証と正規化の実行順序 (正規化してから検証するのか、検証してダメなら丸ごと失敗させるのか) を明示することが望ましい。
+- `!` で否定した grep アサーションが bats の `set -e` 下で非最終文だと無効化される、という bash 特有の落とし穴が今回のPR自身の新規追加コードで再現した (2件のレビューエージェントが独立検出、検証で bash 挙動を実地確認)。同種のパターンが将来また作り込まれる可能性があるため、`if echo ... | grep -qE ...; then false; fi` 形式を bats 記述の標準パターンとして周知する価値がある。
+
+### Acceptance criteria verification difficulty
+
+- Pre-merge の6条件はすべて rubric / grep / command (CI 参照フォールバック) で明確に PASS 判定でき、UNCERTAIN や verify command の不備はなかった。
+- 一方で AC6「cause 分離がテストで保護されている」は verify command が「テストが追加されている」ことのみを機械的に確認するため、テストの実効性 (アサーションが実際に検出力を持つか) までは rubric でも検出できなかった。この種の「テストの存在は確認できるが実効性は確認できない」ギャップは、rubric の文言に「アサーションが実際に regression を検出できる形になっていること」を明示すれば軽減できる可能性がある。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- Implementation Steps 1-9 を Spec記載どおりの順序で実装し、逸脱なし
-- `agents/orchestration-recovery.md` の 2 件目の JSON 例 (Issue #917 由来) の cause 値には、Spec のガイダンス (既出 slug を再利用) に従い `docs/reports/orchestration-recoveries.md` に既に例示されている `dirty-guard` を採用
-- Behavioral change detection の判定に従いフルスイート並列実行 (`bats --jobs 18 tests/`) を実施。並列時のみ `tests/post_merge_check.bats` の 1 テストが flake したが、変更対象ファイルとは無関係かつ既存 Issue #1231 の Background に同一事象の記載があったため、新規 follow-up Issue は起票せず記録のみとした
+- Step 8 の Pre-merge 6条件はすべて PASS (Issue側で既に `[x]` 済みだったものを再検証し確認)。CI 9件も全SUCCESS
+- Step 10 は `.wholework.yml` の `capabilities.workflow: true` により Workflow パスの対象だったが、`--non-interactive` (fork context, 再実行保証なし) のため `workflow-guidance.md` の指示に従い静的 Task fan-out (review-spec + review-bug×2) にフォールバック
+- review-bug×2 が独立に検出した4件の指摘 (うち2件は両エージェントで完全に重複) を Opus 検証サブエージェントで全件 PASS (問題確認) と判定。review-spec の7件は無検証で直接統合 (仕様どおり)
+- SHOULD 5件・CONSIDER 4件のうち7件を修正しコミット (7コミット、各コミットに元の指摘への `Refs:` リンクを付与)。`scripts/validate-recovery-plan.sh` の hard-fail 挙動変更と `agents/orchestration-recovery.md` の例示 slug 差し替えの2件は、PR自身が追加した固定テストとの衝突、および主観的判断が必要という理由でスキップし SHOULD/CONSIDER として記録に留めた
 
 ### Deferred Items
 
-- 既存エントリへの遡及的な cause 付与 (Issue 本文 Notes でスコープ外と明記、実装でも対応せず)
-- Tier 3 の agent が返す slug が既存 vocabulary を実際に再利用するかの検証は post-merge 観察に委ねる (`session=next`)。単発 group-key が増える傾向が見えた場合は、agent プロンプトへ既出 slug 一覧を動的注入する後続 Issue を検討
-- `write_recovery_entry()` 3 経路のエントリ生成共通化は未実施 (今回は 2 箇所の追記で足りるため)
-- `tests/post_merge_check.bats` の並列実行時 flake の根本原因調査は本 Issue のスコープ外。既存 Issue #1231 が同一事象を Background に記載済み
+- `scripts/validate-recovery-plan.sh` の cause 不正値ハードフェイル問題 (SHOULD、PR #1290 review コメント参照) — validator のセマンティクスを緩めるか、`spawn-recovery-subagent.sh` 側で validate 呼び出し前に正規化するかは著者判断の follow-up に委ねる
+- `agents/orchestration-recovery.md` の2件目JSON例のcause値 `dirty-guard` が根本原因命名規約と噛み合わない点 (CONSIDER) — 例示slugの差し替えは主観的判断のため見送り
+- Post-merge AC (Tier 2/3 recovery 発火時のログ観察、`session=next`) は code フェーズの Deferred Items を引き継ぎ、review フェーズでは新規の変更なし
 
 ### Notes for Next Phase
 
-- Post-merge AC は `/verify` で次回 Tier 2/3 recovery 発火時の `docs/reports/orchestration-recoveries.md` エントリを観察する。Tier 2 は #1191 の N/A 除外により頻度カウント対象外のため、観察対象は実質 Tier 3 発火時のみ
-- `collect-recovery-candidates.sh --with-tracking` の出力で cause 別 group-key 分離が機能しているかを確認すること
-- `bats --jobs N tests/` を実行する場合、`tests/post_merge_check.bats` の 1 テストが並列実行時のみ flake することがある (直列実行では毎回 PASS)。無関係な FAIL として無視して構わない
+- `/merge` 実行前に、本 review フェーズで追加した7件の修正コミットがCI green であることを確認すること (ローカルで bats 72/72 PASS, validate-skill-syntax PASS, forbidden-expressions PASS を確認済みだが、push後のCI結果は未観測)
+- Post-merge AC の観察対象は code フェーズの Notes for Next Phase を参照 (Tier 3 recovery 発火時の `docs/reports/orchestration-recoveries.md` エントリと `collect-recovery-candidates.sh --with-tracking` の group-key 分離)

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -638,6 +638,8 @@ When `run-auto-sub.sh` runs the Tier 2 path (`apply-fallback.sh` succeeds), the 
 
 When `apply-fallback.sh` matches a known symptom anchor but the handler itself fails (`exit 2`, distinct from the anchor-not-matched `exit 1`), `run_phase_with_recovery()` emits `recovery tier=2 result=failed` before falling through to Tier 3 — no `orchestration-recoveries.md` entry is written for this case, since `write_recovery_entry()` is only called from a handler's success branch.
 
+As of #1281, `write_recovery_entry()` writes the matched symptom anchor as the entry's `### Diagnosis` leading `- cause: <slug>` line. This groups Tier 2 entries by anchor for `collect-recovery-candidates.sh`'s frequency counting, though Tier 2 entries are excluded from that counting regardless, per the `#1191` `Improvement Candidate: N/A` exclusion rule (`scripts/collect-recovery-candidates.sh`).
+
 ### Manual path: recoveries.md + manual_intervention event
 
 When the parent session performs a manual recovery (e.g., `worktree-merge-push.sh` re-run, `gh pr create` manual call, or `run-*.sh` re-execution), there is no automatic bash path to write the recovery record. The operator must explicitly call — this is itself a standalone Bash tool call subject to the same pointer file regeneration discipline as `/auto` Step 1's `run-*.sh` calls (the PGID pointer from an earlier Bash call is not visible here), so regenerate it in the same call before invoking the subcommand (Issue #1075):
@@ -658,3 +660,5 @@ See also: `modules/orchestration-fallbacks.md#manual-recovery-spec-write`
 When `run-auto-sub.sh` runs the Tier 3 path (`spawn-recovery-subagent.sh` succeeds), the recovery record is written to `docs/reports/orchestration-recoveries.md`; the bash block in `run_phase_with_recovery()` commits and pushes that file immediately. As of #1181, `run-auto-sub.sh` no longer additionally writes a per-Issue Spec-side paper trail (`_write_tier3_recovery_to_spec()` was removed) — `docs/reports/orchestration-recoveries.md` is the sole recording path for Tier 3, same as Tier 2.
 
 When `spawn-recovery-subagent.sh` itself fails (any non-zero exit reached after the Tier 3 call — `action=abort`, an invalid recovery plan, or a `claude -p` failure), `run_phase_with_recovery()` emits `recovery tier=3 result=failed action=<action>` (reading `action` from the leftover `.tmp/recovery-plan-<issue>-<phase>.json` when present, `unknown` otherwise) before propagating the original exit code. No `orchestration-recoveries.md` entry is written for this case — `write_recovery_entry()` inside `spawn-recovery-subagent.sh` is only called from the `retry`/`skip`/`recover` success branches, never from `abort`.
+
+As of #1281, `write_recovery_entry()` writes the recovery plan's `cause` field as the entry's `### Diagnosis` leading `- cause: <slug>` line, normalizing a missing, non-string, or non-kebab-case value to `unclassified`.

--- a/scripts/apply-fallback.sh
+++ b/scripts/apply-fallback.sh
@@ -182,6 +182,7 @@ entry = (
     f"- Wrapper: run-{phase}.sh\n"
     f"- Log tail: \"{log_tail}\"\n\n"
     f"### Diagnosis\n"
+    f"- cause: {anchor}\n"
     f"- Symptom anchor `{anchor}` matched in wrapper log (modules/orchestration-fallbacks.md#{anchor})\n\n"
     f"### Recovery Applied\n"
     f"- action={action}\n\n"

--- a/scripts/collect-recovery-candidates.sh
+++ b/scripts/collect-recovery-candidates.sh
@@ -5,11 +5,13 @@
 #
 # group-key (Issue #1123): normally the H2 header's symptom-short (e.g.
 # "manual-recovery-review-rerun"). When an entry's "### Diagnosis" body has a
-# "- cause: <slug>" line (written by run-auto-sub.sh --write-manual-recovery --cause),
+# "- cause: <slug>" line (written by run-auto-sub.sh --write-manual-recovery --cause,
+# by apply-fallback.sh's Tier 2 writer, and by spawn-recovery-subagent.sh's Tier 3
+# writer -- see docs/reports/orchestration-recoveries.md Field Definitions, Issue #1281),
 # the group key becomes "<symptom-short>/<cause-slug>" instead, so that same-symptom
 # events with a different root cause are counted (and duplicate-checked) separately
-# rather than merged. Entries without a cause line keep the plain symptom-short key
-# (backward compatible with the existing 4 recoveries-log entries).
+# rather than merged. Entries without a cause line (pre-#1281 entries) keep the plain
+# symptom-short key.
 #
 # Exclusion (Issue #1152): judged per entry, not per group-key, so a resolved symptom
 # and a genuine post-fix recurrence of the same group-key can be told apart.

--- a/scripts/spawn-recovery-subagent.sh
+++ b/scripts/spawn-recovery-subagent.sh
@@ -220,9 +220,13 @@ write_recovery_entry() {
     return 0
   fi
 
-  local log_tail_line rationale steps_count steps_summary timestamp
+  local log_tail_line rationale cause steps_count steps_summary timestamp
   log_tail_line=$(tail -1 "$LOG_FILE" 2>/dev/null || true)
   rationale=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('rationale','(none)'))" "$PLAN_FILE" 2>/dev/null || echo "(none)")
+  cause=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('cause',''))" "$PLAN_FILE" 2>/dev/null || echo "")
+  if [[ -z "$cause" ]] || [[ ! "$cause" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    cause="unclassified"
+  fi
   steps_count=$(python3 -c "import json,sys; print(len(json.load(open(sys.argv[1])).get('steps',[])))" "$PLAN_FILE" 2>/dev/null || echo "0")
   timestamp=$(date -u '+%Y-%m-%d %H:%M UTC')
 
@@ -239,6 +243,7 @@ write_recovery_entry() {
   WRE_EXIT_CODE="$EXIT_CODE_PARAM" \
   WRE_LOG_TAIL="$log_tail_line" \
   WRE_RATIONALE="$rationale" \
+  WRE_CAUSE="$cause" \
   WRE_STEPS_SUMMARY="$steps_summary" \
   WRE_ACTION="$action" \
   python3 - <<'PYEOF' || return 0
@@ -251,6 +256,7 @@ issue = os.environ['WRE_ISSUE']
 exit_code = os.environ['WRE_EXIT_CODE']
 log_tail = os.environ['WRE_LOG_TAIL']
 rationale = os.environ['WRE_RATIONALE']
+cause = os.environ['WRE_CAUSE']
 steps_summary = os.environ['WRE_STEPS_SUMMARY']
 action = os.environ['WRE_ACTION']
 
@@ -262,6 +268,7 @@ entry = (
     f"- Wrapper: run-{phase}.sh, exit code: {exit_code}\n"
     f"- Log tail: \"{log_tail}\"\n\n"
     f"### Diagnosis\n"
+    f"- cause: {cause}\n"
     f"- {rationale}\n\n"
     f"### Recovery Applied\n"
     f"- action={action}\n"

--- a/scripts/spawn-recovery-subagent.sh
+++ b/scripts/spawn-recovery-subagent.sh
@@ -224,7 +224,7 @@ write_recovery_entry() {
   log_tail_line=$(tail -1 "$LOG_FILE" 2>/dev/null || true)
   rationale=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('rationale','(none)'))" "$PLAN_FILE" 2>/dev/null || echo "(none)")
   cause=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('cause',''))" "$PLAN_FILE" 2>/dev/null || echo "")
-  if [[ -z "$cause" ]] || [[ ! "$cause" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  if [[ -z "$cause" ]] || [[ ${#cause} -gt 40 ]] || [[ ! "$cause" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
     cause="unclassified"
   fi
   steps_count=$(python3 -c "import json,sys; print(len(json.load(open(sys.argv[1])).get('steps',[])))" "$PLAN_FILE" 2>/dev/null || echo "0")

--- a/scripts/validate-recovery-plan.sh
+++ b/scripts/validate-recovery-plan.sh
@@ -16,6 +16,7 @@ fi
 python3 - <<'PYEOF' "$JSON_INPUT"
 import sys
 import json
+import re
 
 raw = sys.argv[1]
 
@@ -71,6 +72,17 @@ else:
             for pattern in forbidden_cmd_patterns:
                 if _re.search(pattern, cmd_value):
                     errors.append(f"steps[{i}] run_command contains forbidden pattern in cmd='{step.get('cmd')}'")
+
+# optional cause slug
+if "cause" in plan:
+    cause_value = plan["cause"]
+    if not isinstance(cause_value, str):
+        errors.append("'cause' must be a string")
+    else:
+        if not re.fullmatch(r"[a-z0-9]+(-[a-z0-9]+)*", cause_value):
+            errors.append(f"'cause' must be a kebab-case slug (^[a-z0-9]+(-[a-z0-9]+)*$); got '{cause_value}'")
+        if len(cause_value) > 40:
+            errors.append(f"'cause' exceeds 40 characters (length {len(cause_value)})")
 
 if errors:
     for e in errors:

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -571,7 +571,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Pr
 
    **Source 1 note — XL route only**: As of #1181, `run-auto-sub.sh` no longer writes a per-Issue Spec Auto Retrospective entry for Tier 2 or Tier 3 recovery. Tier 3 records directly into `docs/reports/orchestration-recoveries.md` at recovery time via `spawn-recovery-subagent.sh`'s `write_recovery_entry()` — do not append a duplicate entry here for Tier 3. As of #1098, Tier 2 also records directly into `docs/reports/orchestration-recoveries.md` at recovery time via `apply-fallback.sh`'s own `write_recovery_entry()` (bash-path, mirroring Tier 3) — do not append a duplicate entry here for Tier 2 either. This Source 1 append now applies only to recovery events that reach neither bash-path writer (e.g. a manually-observed anomaly the parent session recorded by hand).
 
-   **Source 2 detection — single-Issue parent session only**: Check if `TIER3_RECOVERY_PHASE` is set (retained in Step 6 after Tier 3 succeeds). If set, use retained `TIER3_RECOVERY_*` variables to build the entry and prepend it. For batch/XL routes, `spawn-recovery-subagent.sh` writes directly to `orchestration-recoveries.md`, so Source 2 here covers only single-Issue parent sessions (M/L/patch). `run-auto-sub.sh` commits and pushes `docs/reports/orchestration-recoveries.md` immediately after Tier 3 success to prevent dirty-file conflicts at `/verify` invocation (see #677).
+   **Source 2 detection — single-Issue parent session only**: Check if `TIER3_RECOVERY_PHASE` is set (retained in Step 6 after Tier 3 succeeds). If set, use retained `TIER3_RECOVERY_*` variables to build the entry and prepend it. Write `TIER3_RECOVERY_CAUSE` as the `### Diagnosis` block's leading `- cause: <slug>` line. For batch/XL routes, `spawn-recovery-subagent.sh` writes directly to `orchestration-recoveries.md`, so Source 2 here covers only single-Issue parent sessions (M/L/patch). `run-auto-sub.sh` commits and pushes `docs/reports/orchestration-recoveries.md` immediately after Tier 3 success to prevent dirty-file conflicts at `/verify` invocation (see #677).
 
    For each applicable source, prepend a new entry block to `docs/reports/orchestration-recoveries.md` (after the header comment line `<!-- Log entries appear below, newest first. -->`). Use the Write/Edit tool. Entry format:
 
@@ -585,6 +585,7 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Pr
    - Log tail: "<last relevant log line>"
 
    ### Diagnosis
+   - cause: <slug>
    - <observed state and root cause>
 
    ### Recovery Applied
@@ -1035,7 +1036,7 @@ Spawn the orchestration-recovery sub-agent via Task to diagnose the unknown fail
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/validate-recovery-plan.sh .tmp/recovery-plan-$NUMBER-$PHASE.json
    ```
-   - Validation checks: JSON parseable, required keys (`action`, `rationale`, `steps`) present, `action` in `{retry, skip, recover, abort}`, `steps` length ≤ 5, no forbidden ops (`force_push`, `reset_hard`, `close_issue`, `merge_pr`, `direct_push_main`)
+   - Validation checks: JSON parseable, required keys (`action`, `rationale`, `steps`) present, `action` in `{retry, skip, recover, abort}`, `steps` length ≤ 5, no forbidden ops (`force_push`, `reset_hard`, `close_issue`, `merge_pr`, `direct_push_main`); the optional key `cause`, when present, is validated as a kebab-case slug (`^[a-z0-9]+(-[a-z0-9]+)*$`, 40 characters or fewer) — its absence is not a validation failure
    - If validation fails (exit non-zero): fall back to stop-and-report (see below)
 
 5. **Act on recovery plan**:
@@ -1049,6 +1050,7 @@ Spawn the orchestration-recovery sub-agent via Task to diagnose the unknown fail
    - `TIER3_RECOVERY_PHASE=$PHASE`
    - `TIER3_RECOVERY_ACTION=$action` (the action that succeeded)
    - `TIER3_RECOVERY_RATIONALE`: `rationale` field from the recovery plan JSON
+   - `TIER3_RECOVERY_CAUSE`: `cause` field from the recovery plan JSON (`unclassified` when missing or invalid)
    - `TIER3_RECOVERY_STEPS_COUNT`: number of steps in the plan (0 for retry/skip)
    - `TIER3_RECOVERY_EXIT_CODE=$EXIT_CODE`
    - `TIER3_RECOVERY_LOG_TAIL`: last line of `.tmp/wrapper-out-$NUMBER-$PHASE.log`

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -573,6 +573,8 @@ Read `${CLAUDE_PLUGIN_ROOT}/modules/detect-config-markers.md` and follow the "Pr
 
    **Source 2 detection — single-Issue parent session only**: Check if `TIER3_RECOVERY_PHASE` is set (retained in Step 6 after Tier 3 succeeds). If set, use retained `TIER3_RECOVERY_*` variables to build the entry and prepend it. Write `TIER3_RECOVERY_CAUSE` as the `### Diagnosis` block's leading `- cause: <slug>` line. For batch/XL routes, `spawn-recovery-subagent.sh` writes directly to `orchestration-recoveries.md`, so Source 2 here covers only single-Issue parent sessions (M/L/patch). `run-auto-sub.sh` commits and pushes `docs/reports/orchestration-recoveries.md` immediately after Tier 3 success to prevent dirty-file conflicts at `/verify` invocation (see #677).
 
+   **Source 1/3 cause value**: the `- cause: <slug>` line in the Entry format below is optional per `docs/reports/orchestration-recoveries.md`'s Field Definitions. For Source 1 and Source 3 (no `TIER3_RECOVERY_CAUSE` available), write a kebab-case root-cause slug reusing an existing one from the log when the root cause is known, write `unclassified` when it is not, or omit the line entirely — never leave the literal `<slug>` placeholder.
+
    For each applicable source, prepend a new entry block to `docs/reports/orchestration-recoveries.md` (after the header comment line `<!-- Log entries appear below, newest first. -->`). Use the Write/Edit tool. Entry format:
 
    ```markdown

--- a/tests/apply-fallback.bats
+++ b/tests/apply-fallback.bats
@@ -326,6 +326,7 @@ REPORT_EOF
     [[ "$report_content" == *"- Issue #555, phase: code"* ]]
     [[ "$report_content" != *"- Issue #99, phase: code"* ]]
     [[ "$report_content" == *"- Source: fallback-catalog"* ]]
+    [[ "$report_content" == *"- cause: dco-signoff-missing-autofix"* ]]
     [[ "$report_content" == *"- N/A (resolved by known catalog)"* ]]
 
     # New entry must be prepended (appear before the pre-existing entry)

--- a/tests/auto-recovery.bats
+++ b/tests/auto-recovery.bats
@@ -143,6 +143,24 @@ MOCK
     ! grep -q "recovery-sub-agent" "$REPORT_FILE"
 }
 
+@test "auto-recovery: plan with cause writes '- cause: <slug>' to report" {
+    make_claude_mock '{"action":"retry","cause":"background-notification-wait","rationale":"transient failure","steps":[]}'
+    cd "$BATS_TEST_TMPDIR"
+
+    run bash "$SCRIPT" code 42 --log "$LOG_FILE"
+    [ "$status" -eq 0 ]
+    grep -q -- "- cause: background-notification-wait" "$REPORT_FILE"
+}
+
+@test "auto-recovery: plan without cause writes '- cause: unclassified' to report" {
+    make_claude_mock '{"action":"retry","rationale":"transient failure","steps":[]}'
+    cd "$BATS_TEST_TMPDIR"
+
+    run bash "$SCRIPT" code 42 --log "$LOG_FILE"
+    [ "$status" -eq 0 ]
+    grep -q -- "- cause: unclassified" "$REPORT_FILE"
+}
+
 @test "auto-recovery: missing report file skips write gracefully" {
     make_claude_mock '{"action":"skip","rationale":"already done","steps":[]}'
     cat > "$MOCK_DIR/reconcile-phase-state.sh" <<'MOCK'

--- a/tests/collect-recovery-candidates.bats
+++ b/tests/collect-recovery-candidates.bats
@@ -547,3 +547,66 @@ FIXTURE_EOF
   [ "$status" -eq 0 ]
   echo "$output" | grep -E $'^wrapper-retry-on-kill\t3$'
 }
+
+@test "Tier 2/Tier 3 cause separation: Tier 3 group-keys split by cause, Tier 2 excluded by N/A regardless" {
+  cat > "$RECOVERY_FILE" << 'FIXTURE_EOF'
+## 2026-06-01 10:00 UTC: code-pr-tier3-recovery
+
+### Diagnosis
+- cause: background-notification-wait
+- first background-notification-wait occurrence
+
+### Improvement Candidate
+- 未起票
+
+## 2026-06-02 10:00 UTC: code-pr-tier3-recovery
+
+### Diagnosis
+- cause: background-notification-wait
+- second background-notification-wait occurrence
+
+### Improvement Candidate
+- 未起票
+
+## 2026-06-03 10:00 UTC: code-pr-tier3-recovery
+
+### Diagnosis
+- cause: dirty-guard
+- first dirty-guard occurrence
+
+### Improvement Candidate
+- 未起票
+
+## 2026-06-04 10:00 UTC: code-pr-tier2-recovery
+
+### Diagnosis
+- cause: json-mode-silent-hang
+
+### Improvement Candidate
+- N/A (resolved by known catalog)
+
+## 2026-06-05 10:00 UTC: code-pr-tier2-recovery
+
+### Diagnosis
+- cause: json-mode-silent-hang
+
+### Improvement Candidate
+- N/A (resolved by known catalog)
+
+FIXTURE_EOF
+
+  # threshold=2: the background-notification-wait cause group clears the bar; the bare
+  # symptom-short never appears (every entry carries a cause line); Tier 2 is excluded by
+  # the #1191 N/A rule regardless of cause grouping.
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 2
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -E $'^code-pr-tier3-recovery/background-notification-wait\t2$'
+  ! echo "$output" | grep -E $'^code-pr-tier3-recovery\t'
+  ! echo "$output" | grep -E $'^code-pr-tier2-recovery'
+
+  # threshold=1: the single dirty-guard occurrence now clears the bar too.
+  run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 1
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -E $'^code-pr-tier3-recovery/dirty-guard\t1$'
+  ! echo "$output" | grep -E $'^code-pr-tier2-recovery'
+}

--- a/tests/collect-recovery-candidates.bats
+++ b/tests/collect-recovery-candidates.bats
@@ -601,8 +601,8 @@ FIXTURE_EOF
   run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 2
   [ "$status" -eq 0 ]
   echo "$output" | grep -E $'^code-pr-tier3-recovery/background-notification-wait\t2$'
-  ! echo "$output" | grep -E $'^code-pr-tier3-recovery\t'
-  ! echo "$output" | grep -E $'^code-pr-tier2-recovery'
+  if echo "$output" | grep -qE $'^code-pr-tier3-recovery\t'; then false; fi
+  if echo "$output" | grep -qE $'^code-pr-tier2-recovery'; then false; fi
 
   # threshold=1: the single dirty-guard occurrence now clears the bar too.
   run bash "$SCRIPT" "$RECOVERY_FILE" --threshold 1

--- a/tests/validate-recovery-plan.bats
+++ b/tests/validate-recovery-plan.bats
@@ -36,3 +36,18 @@ SCRIPT="$PROJECT_ROOT/scripts/validate-recovery-plan.sh"
   run bash "$SCRIPT" <<< 'not-valid-json'
   [ "$status" -ne 0 ]
 }
+
+@test "cause: valid kebab-case slug -> exit 0" {
+  run bash "$SCRIPT" <<< '{"action":"skip","cause":"dirty-guard","rationale":"nothing to do","steps":[]}'
+  [ "$status" -eq 0 ]
+}
+
+@test "cause: malformed value (uppercase, spaces) -> exit 1" {
+  run bash "$SCRIPT" <<< '{"action":"skip","cause":"Dirty Guard","rationale":"nothing to do","steps":[]}'
+  [ "$status" -ne 0 ]
+}
+
+@test "cause: key absent -> exit 0 (backward compatible)" {
+  run bash "$SCRIPT" <<< '{"action":"skip","rationale":"nothing to do","steps":[]}'
+  [ "$status" -eq 0 ]
+}

--- a/tests/validate-recovery-plan.bats
+++ b/tests/validate-recovery-plan.bats
@@ -47,6 +47,23 @@ SCRIPT="$PROJECT_ROOT/scripts/validate-recovery-plan.sh"
   [ "$status" -ne 0 ]
 }
 
+@test "cause: 40-char slug (length boundary) -> exit 0" {
+  slug=$(printf 'a%.0s' {1..40})
+  run bash "$SCRIPT" <<< "{\"action\":\"skip\",\"cause\":\"$slug\",\"rationale\":\"nothing to do\",\"steps\":[]}"
+  [ "$status" -eq 0 ]
+}
+
+@test "cause: 41-char slug exceeds length cap -> exit 1" {
+  slug=$(printf 'a%.0s' {1..41})
+  run bash "$SCRIPT" <<< "{\"action\":\"skip\",\"cause\":\"$slug\",\"rationale\":\"nothing to do\",\"steps\":[]}"
+  [ "$status" -ne 0 ]
+}
+
+@test "cause: non-string value -> exit 1" {
+  run bash "$SCRIPT" <<< '{"action":"skip","cause":123,"rationale":"nothing to do","steps":[]}'
+  [ "$status" -ne 0 ]
+}
+
 @test "cause: key absent -> exit 0 (backward compatible)" {
   run bash "$SCRIPT" <<< '{"action":"skip","rationale":"nothing to do","steps":[]}'
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- Tier 2 (`scripts/apply-fallback.sh`) の `write_recovery_entry()` に `### Diagnosis` 先頭行として `- cause: {anchor}` を追加
- Tier 3 (`scripts/spawn-recovery-subagent.sh`) の `write_recovery_entry()` に recovery plan JSON からの `cause` 抽出・kebab-case 検証・`unclassified` フォールバックを追加
- `scripts/validate-recovery-plan.sh` に任意キー `cause` の検証 (string / kebab-case / 40文字以内) を追加。キー欠落は従来どおり許容
- `agents/orchestration-recovery.md` の出力契約に `cause` フィールドを追加 (Constraints に slug 命名規約を明記、既存 JSON 例 2 件を更新)
- `skills/auto/SKILL.md` の LLM 経由 Tier 3 (step 4 validation checks / step 5b `TIER3_RECOVERY_CAUSE` / entry format template) を契約変更に追随
- `docs/reports/orchestration-recoveries.md` の Field Definitions に `cause` の writer 内訳 (Tier 2 / Tier 3 / manual recovery) を追記
- 対応する bats テストを追加 (`validate-recovery-plan.bats` 3件, `apply-fallback.bats` 1件, `auto-recovery.bats` 2件, `collect-recovery-candidates.bats` 1件)

## Verification (pre-merge)
- rubric: apply-fallback.sh の Diagnosis に anchor 由来の cause slug が記録される
- grep: apply-fallback.sh に cause 行の出力がある
- rubric: spawn-recovery-subagent.sh の Diagnosis に cause slug (unclassified フォールバック込み) が記録される
- rubric: agent 出力契約と validator の双方が cause slug に対応 (同一コミットで更新)
- command: `bats tests/collect-recovery-candidates.bats` PASS
- rubric: cause 分離の回帰保護テストが追加されている

## Verification (post-merge)
- 次回 Tier 2 / Tier 3 recovery 発火時、`docs/reports/orchestration-recoveries.md` の当該エントリに `- cause: <slug>` が記録され、`collect-recovery-candidates.sh --with-tracking` で cause 別に分離されることを観察 (`session=next`)

closes #1281