### PR TITLE
Issue #1257: Add language convention transcription check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,23 @@ jobs:
       - name: Check for forbidden expressions
         run: bash scripts/check-forbidden-expressions.sh
 
+  language-convention:
+    name: Language Convention check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check language convention
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff "origin/${{ github.base_ref }}...HEAD" -- skills/ modules/ scripts/ | python3 scripts/check-language-convention.py
+          else
+            git diff "HEAD^..HEAD" -- skills/ modules/ scripts/ | python3 scripts/check-language-convention.py
+          fi
+
   macos-shell:
     name: macOS shell compatibility
     runs-on: macos-latest

--- a/docs/ja/structure.md
+++ b/docs/ja/structure.md
@@ -22,7 +22,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # エージェント定義（8 ファイル）
 │   └── <agent-name>.md
-├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（79 ファイル）
+├── scripts/             # スキルとエージェントが使用するユーティリティスクリプト（81 ファイル）
 │   ├── git-hooks/       # Git フックスクリプト（commit-msg DCO 強制）
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -31,11 +31,11 @@ wholework/
 │   │   ├── feature_request.yml  # 機能リクエスト用 Issue Form
 │   │   └── config.yml           # 空白（テンプレートなし）issue を無効化
 │   └── workflows/
-│       ├── test.yml             # CI: bats テスト、スキル構文検証、禁止表現チェック、macOS シェル互換性テスト
+│       ├── test.yml             # CI: bats テスト、スキル構文検証、禁止表現チェック、言語規約チェック、macOS シェル互換性テスト
 │       └── kanban-automation.yml # GitHub Projects ボードでの自動 issue 移動
 ├── examples/            # Wholework 機能のサンプルファイル
 │   └── decomposition/   # /issue --from-decomposition-file 用 decomposition YAML サンプル
-├── tests/               # スクリプトの Bats テストファイル（114 ファイル）
+├── tests/               # スクリプトの Bats テストファイル（116 ファイル）
 │   ├── <script-name>.bats
 │   └── fixtures/        # テスト用フィクスチャファイル
 ├── docs/                # ドキュメントと steering documents
@@ -245,6 +245,7 @@ wholework/
 - `scripts/check-ac-checkbox-format.sh` — Issue 本文の `### Pre-merge` / `### Post-merge` セクション配下でチェックボックス形式でない条件行を検出；`skills/issue/SKILL.md` Step 4 から warn-only で呼び出される
 - `scripts/check-translation-sync.sh` — docs/ja/* と docs/* の翻訳同期状況を確認
 - `scripts/check-forbidden-expressions.sh` — docs/product.md § Terms の deprecated terms を検出
+- `scripts/check-language-convention.py` — unified diff から英語指定パス (skills/, modules/, scripts/) への CJK 文字混入を検出；`language-convention` CI job から呼び出される
 - `scripts/setup-labels.sh` — ワークフロー用 GitHub ラベルを作成
 - `scripts/compute-escalation-level.sh` — phase/verify または Icebox 滞留期間のエスカレーションレベルを計算；`/audit stats --retention` の retire 提案コメントルーティングに使用
 - `scripts/test-skills.sh` — 全スキルテスト実行
@@ -252,7 +253,7 @@ wholework/
 
 ### CI ワークフロー
 
-- `.github/workflows/test.yml` — push/PR 時に bats テスト (`bats --filter-status failed` で並列実行時のみの失敗を非並列再実行し、本物の失敗と切り分ける)、`validate-skill-syntax.py`、禁止表現チェック、macOS シェル互換性テストを実行
+- `.github/workflows/test.yml` — push/PR 時に bats テスト (`bats --filter-status failed` で並列実行時のみの失敗を非並列再実行し、本物の失敗と切り分ける)、`validate-skill-syntax.py`、禁止表現チェック、言語規約チェック、macOS シェル互換性テストを実行
 - `.github/workflows/dco.yml` — 全 PR コミットに対して DCO `Signed-off-by:` を必須化
 - `.github/workflows/kanban-automation.yml` — `phase/*` ラベルイベントで issue をプロジェクトボードのカラムへ自動移動
 

--- a/docs/spec/issue-1257-language-convention-check.md
+++ b/docs/spec/issue-1257-language-convention-check.md
@@ -93,3 +93,32 @@ Implementation Steps 3 に記載の通り、`tests/check-language-convention.bat
 | login | authorAssociation | trust tier | 内容概要 | URL |
 |-------|-------------------|-----------|---------|-----|
 | saito | MEMBER | first-class | Issue Retrospective: Background 事実確認 (訂正なし)、AC2 を「選択した実装成果物への記載」に明確化した Auto-Resolve Log、post-merge observation AC への `session=next` 付与根拠、案 A/B 選択判断は `/spec` フェーズへの委譲を確認 | https://github.com/saitoco/wholework/issues/1257#issuecomment-5227226402 |
+
+## Code Retrospective
+
+### Deviations from Design
+- None. Implementation Steps 1–5 were followed as written.
+
+### Design Gaps/Ambiguities
+- None. Spec's false-positive exclusion logic (fence / inline code / double-quoted string) and its docstring documentation requirement (AC2) were unambiguous and required no interpretation during implementation.
+
+### Rework
+- None.
+
+### Notes
+- `tests/check-language-convention.bats` covers 6 cases (Spec's 3 minimum plus a double-quoted-string false positive, a no-CJK-content case, and a removed-line (`-` prefix) exclusion case) — purely additive coverage, not a deviation from the Spec's Implementation Steps 3 minimum.
+- Behavioral Change Detection (`/code` Step 9) triggered a full parallel bats run (`bats --jobs 18 tests/`, 1626/1626 PASS) instead of narrow scope, because `tests/visual-diff-adapter.bats` references `.github/workflows/test.yml` in a comment (documenting where its Node runtime setup comes from) — an incidental match unrelated to the new `language-convention` job actually added, but the mechanical path-grep check does not distinguish comment references from behavioral dependencies.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Followed Spec's 案 B (script-based CJK diff check) exactly; no implementation-time deviation from the Spec's chosen approach.
+- `check-language-convention.py` uses Python stdlib only (`re`, `sys`), matching the Spec's dependency constraint.
+
+### Deferred Items
+- Post-merge observation AC (`session=next`, `event=auto-run`) is intentionally left unchecked — it verifies itself against a future PR that transcribes Spec Notes rationale into an English-only doc, which cannot happen within this PR.
+
+### Notes for Next Phase
+- All 4 pre-merge AC are `rubric`-type and were graded PASS during `/code` (this session), with checkboxes already updated on the Issue. `/review` should independently re-verify the AC2 docstring-in-implementation-artifact requirement, since it is the AC most prone to Spec-only satisfaction drift.
+- CI job `language-convention` runs on `push` (this PR's own commits) and `pull_request` — confirm the job appears green in PR checks before merge.

--- a/docs/spec/issue-1257-language-convention-check.md
+++ b/docs/spec/issue-1257-language-convention-check.md
@@ -109,16 +109,30 @@ Implementation Steps 3 に記載の通り、`tests/check-language-convention.bat
 - `tests/check-language-convention.bats` covers 6 cases (Spec's 3 minimum plus a double-quoted-string false positive, a no-CJK-content case, and a removed-line (`-` prefix) exclusion case) — purely additive coverage, not a deviation from the Spec's Implementation Steps 3 minimum.
 - Behavioral Change Detection (`/code` Step 9) triggered a full parallel bats run (`bats --jobs 18 tests/`, 1626/1626 PASS) instead of narrow scope, because `tests/visual-diff-adapter.bats` references `.github/workflows/test.yml` in a comment (documenting where its Node runtime setup comes from) — an incidental match unrelated to the new `language-convention` job actually added, but the mechanical path-grep check does not distinguish comment references from behavioral dependencies.
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- No implementation-vs-Spec divergence, but a Spec-level algorithm gap was found: Implementation Steps 1 described fence tracking as counting `` ``` `` occurrences among "追加行" (added lines) only, and `check-language-convention.py` implemented exactly that literal wording. The resulting bug — editing a single line inside an already-existing fenced block (fence delimiters themselves unchanged, hence appearing only as diff context lines) was misclassified as outside the fence — reproduced directly against the script's own docstring example (`skills/verify/SKILL.md`'s `Print advisory` template). The root cause traces to the Spec's algorithm description, not to an implementation shortcut; the Spec itself under-specified how to handle unchanged/context state when the check's *subject* is a diff but its *correctness target* is the resulting file's structure.
+
+### Recurring issues
+- Nothing to note. This is the first Issue in this area (post-#975/#1236 line of fixes) to reach `/review` with a script-level correctness bug; no repeat-of-known-pattern signal.
+
+### Acceptance criteria verification difficulty
+- Nothing to note. All 4 Pre-merge AC are `rubric`-type; each graded cleanly to PASS by both `/code`'s and `/review`'s independent grader passes, with no UNCERTAIN results. The bats suite (converted to 7 cases after the review fix) gave a fast, reliable local reproduction/verification loop for the one MUST finding.
+
+### Improvement proposal (recorded here only; not filed as an Issue per `/verify`-aggregation convention)
+- When a Spec's Implementation Steps describe a diff-scanning algorithm whose correctness target is *post-diff file state* (e.g. "is this added line inside a fence/block/scope in the final file"), the Spec should explicitly call out whether unchanged context lines must also be tracked — not just added lines — to avoid this exact class of bug recurring in future diff-scanning script specs.
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Followed Spec's 案 B (script-based CJK diff check) exactly; no implementation-time deviation from the Spec's chosen approach.
-- `check-language-convention.py` uses Python stdlib only (`re`, `sys`), matching the Spec's dependency constraint.
+- Re-verified all 4 Pre-merge rubric AC independently (not trusting `/code`'s self-graded PASS state at face value), per the prior phase's own handoff note flagging AC2 as most prone to Spec-only satisfaction drift — confirmed all 4 as genuinely PASS against the implementation artifacts.
+- Found and fixed one MUST-severity bug via the review-light agent (Edge Case/Robustness perspective): fence-tracking state only considered added lines, causing false positives when editing inside a pre-existing fenced block. Fixed by also scanning unchanged context lines for fence markers (without checking them for violations), and added a regression bats case.
 
 ### Deferred Items
-- Post-merge observation AC (`session=next`, `event=auto-run`) is intentionally left unchecked — it verifies itself against a future PR that transcribes Spec Notes rationale into an English-only doc, which cannot happen within this PR.
+- Post-merge observation AC (`session=next`, `event=auto-run`) remains unchecked, unchanged from the `/code` phase's assessment — still cannot self-verify within this PR.
 
 ### Notes for Next Phase
-- All 4 pre-merge AC are `rubric`-type and were graded PASS during `/code` (this session), with checkboxes already updated on the Issue. `/review` should independently re-verify the AC2 docstring-in-implementation-artifact requirement, since it is the AC most prone to Spec-only satisfaction drift.
-- CI job `language-convention` runs on `push` (this PR's own commits) and `pull_request` — confirm the job appears green in PR checks before merge.
+- `/merge` can proceed: all 4 Pre-merge AC are PASS, CI is green (11/11, including `Language Convention check` on both the original and fix commits), and the one MUST review finding has been fixed, committed (`Refs:` link to the inline PR comment), and pushed.
+- No policy/AC-text change resulted from the Step 12 fix — the fix corrects the implementation's fence-tracking algorithm to match the AC's/docstring's own stated behavior; it does not change what the AC or verify commands assert.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -29,7 +29,7 @@ wholework/
 │   └── <module-name>.md
 ├── agents/              # Agent definitions (8 files)
 │   └── <agent-name>.md
-├── scripts/             # Utility scripts used by skills and agents (79 files)
+├── scripts/             # Utility scripts used by skills and agents (81 files)
 │   ├── git-hooks/       # Git hook scripts (commit-msg DCO enforcement)
 │   └── <script-name>.{sh,py}
 ├── .github/
@@ -38,11 +38,11 @@ wholework/
 │   │   ├── feature_request.yml  # Feature request Issue Form
 │   │   └── config.yml           # Disables blank (templateless) issues
 │   └── workflows/
-│       ├── test.yml             # CI: bats tests, skill syntax validation, forbidden expressions check, and macOS shell compatibility test
+│       ├── test.yml             # CI: bats tests, skill syntax validation, forbidden expressions check, language convention check, and macOS shell compatibility test
 │       └── kanban-automation.yml # Auto-move issues on GitHub Projects board
 ├── examples/            # Example files for Wholework features
 │   └── decomposition/   # Decomposition YAML samples for /issue --from-decomposition-file
-├── tests/               # Bats test files for scripts (114 files)
+├── tests/               # Bats test files for scripts (116 files)
 │   ├── <script-name>.bats
 │   └── fixtures/        # Test fixture files
 ├── docs/                # Documentation and steering documents
@@ -253,6 +253,7 @@ Key modules:
 - `scripts/check-ac-checkbox-format.sh` — detects non-checkbox condition lines under `### Pre-merge` / `### Post-merge` sections of an Issue body; called warn-only from `skills/issue/SKILL.md` Step 4
 - `scripts/check-translation-sync.sh` — check translation sync status of docs/ja/* against docs/*
 - `scripts/check-forbidden-expressions.sh` — detect deprecated terms from docs/product.md § Terms
+- `scripts/check-language-convention.py` — detect CJK characters transcribed into English-only paths (skills/, modules/, scripts/) from a unified diff; run by the `language-convention` CI job
 - `scripts/setup-labels.sh` — create GitHub labels for workflow
 - `scripts/compute-escalation-level.sh` — compute escalation level for phase/verify or Icebox dwell time; used by `/audit stats --retention` for retire-proposal comment routing
 - `scripts/test-skills.sh` — run all skill tests
@@ -260,7 +261,7 @@ Key modules:
 
 ### CI Workflows
 
-- `.github/workflows/test.yml` — runs bats tests (with a serial re-run of parallel-only failures via `bats --filter-status failed` to distinguish flaky failures from genuine ones), `validate-skill-syntax.py`, forbidden expressions check, and macOS shell compatibility test on push/PR
+- `.github/workflows/test.yml` — runs bats tests (with a serial re-run of parallel-only failures via `bats --filter-status failed` to distinguish flaky failures from genuine ones), `validate-skill-syntax.py`, forbidden expressions check, language convention check, and macOS shell compatibility test on push/PR
 - `.github/workflows/dco.yml` — enforces DCO `Signed-off-by:` on all pull request commits
 - `.github/workflows/kanban-automation.yml` — auto-moves issues to project board columns on `phase/*` label events
 

--- a/scripts/check-language-convention.py
+++ b/scripts/check-language-convention.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Language convention check script
+
+Detects CJK (Japanese) characters accidentally transcribed into English-only
+documents (skills/**/*.md, modules/*.md, scripts/*) from a unified diff.
+
+Reads a unified diff (`git diff` format) from stdin and scans only added
+(`+`-prefixed) lines. The caller is expected to pass a diff already scoped to
+the target paths (e.g. `git diff -- skills/ modules/ scripts/`); this script
+does not filter by path itself.
+
+False positives are excluded for three legitimate CJK usages, per CLAUDE.md's
+"Skill output (terminal): Japanese" convention:
+  (i)   Fenced code blocks containing terminal output templates (e.g. the
+        `Print advisory` template block in skills/verify/SKILL.md) — added
+        lines between a ``` fence-open and fence-close are skipped entirely.
+  (ii)  Inline code spans (`...`) containing Japanese keywords used as data
+        values rather than prose (e.g. the domain classification table's
+        `デザイン` entries in skills/audit/SKILL.md) — the content of inline
+        code spans is stripped before the CJK check.
+  (iii) Double-quoted string literals carrying an output message (e.g. after
+        `Print:` / `Notify user:`) — the content of double-quoted strings is
+        stripped before the CJK check.
+
+Any CJK character remaining in plain prose after these three exclusions is
+treated as a language convention violation.
+
+Uses Python standard library only.
+"""
+
+import re
+import sys
+
+CJK_PATTERN = re.compile(r"[぀-ゟ゠-ヿ一-鿿]")
+INLINE_CODE_PATTERN = re.compile(r"`[^`]*`")
+DOUBLE_QUOTED_PATTERN = re.compile(r'"[^"]*"')
+FENCE_PATTERN = re.compile(r"^\s*```")
+
+
+def find_violations(diff_text):
+    violations = []
+    current_file = None
+    fence_count = 0
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ "):
+            path = line[len("+++ "):].strip()
+            current_file = path[2:] if path.startswith("b/") else path
+            fence_count = 0
+            continue
+
+        if line.startswith("---"):
+            continue
+
+        if not line.startswith("+"):
+            continue
+
+        content = line[1:]
+
+        if FENCE_PATTERN.match(content):
+            fence_count += 1
+            continue
+
+        if fence_count % 2 == 1:
+            continue
+
+        stripped = INLINE_CODE_PATTERN.sub("", content)
+        stripped = DOUBLE_QUOTED_PATTERN.sub("", stripped)
+
+        if CJK_PATTERN.search(stripped):
+            violations.append(f"{current_file}:{content}")
+
+    return violations
+
+
+def main():
+    diff_text = sys.stdin.read()
+    violations = find_violations(diff_text)
+
+    if violations:
+        for violation in violations:
+            print(violation)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-language-convention.py
+++ b/scripts/check-language-convention.py
@@ -5,16 +5,21 @@ Language convention check script
 Detects CJK (Japanese) characters accidentally transcribed into English-only
 documents (skills/**/*.md, modules/*.md, scripts/*) from a unified diff.
 
-Reads a unified diff (`git diff` format) from stdin and scans only added
-(`+`-prefixed) lines. The caller is expected to pass a diff already scoped to
-the target paths (e.g. `git diff -- skills/ modules/ scripts/`); this script
-does not filter by path itself.
+Reads a unified diff (`git diff` format) from stdin and checks added
+(`+`-prefixed) lines for violations. Context lines (unchanged, space-prefixed)
+are also scanned for fence markers — but not for violations — so fence state
+stays correct when a diff edits content inside an already-existing fenced
+block without touching the fence delimiters themselves. The caller is
+expected to pass a diff already scoped to the target paths (e.g.
+`git diff -- skills/ modules/ scripts/`); this script does not filter by path
+itself.
 
 False positives are excluded for three legitimate CJK usages, per CLAUDE.md's
 "Skill output (terminal): Japanese" convention:
   (i)   Fenced code blocks containing terminal output templates (e.g. the
         `Print advisory` template block in skills/verify/SKILL.md) — added
-        lines between a ``` fence-open and fence-close are skipped entirely.
+        lines whose enclosing fence (tracked across both added and unchanged
+        context lines) is open are skipped entirely.
   (ii)  Inline code spans (`...`) containing Japanese keywords used as data
         values rather than prose (e.g. the domain classification table's
         `デザイン` entries in skills/audit/SKILL.md) — the content of inline
@@ -53,13 +58,23 @@ def find_violations(diff_text):
         if line.startswith("---"):
             continue
 
-        if not line.startswith("+"):
+        if line.startswith("-"):
             continue
 
-        content = line[1:]
+        if line.startswith("+"):
+            content = line[1:]
+            is_added = True
+        elif line.startswith(" "):
+            content = line[1:]
+            is_added = False
+        else:
+            continue
 
         if FENCE_PATTERN.match(content):
             fence_count += 1
+            continue
+
+        if not is_added:
             continue
 
         if fence_count % 2 == 1:

--- a/tests/check-language-convention.bats
+++ b/tests/check-language-convention.bats
@@ -32,3 +32,8 @@ SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/check-languag
   run bash -c "printf -- '+++ b/modules/example.md\n@@ -1,1 +0,0 @@\n-転記した内容の rationale をそのまま英語ドキュメントに追加する。\n' | python3 '$SCRIPT'"
   [ "$status" -eq 0 ]
 }
+
+@test "false positive: edit inside a pre-existing fenced block (fence markers unchanged) exits 0" {
+  run bash -c "printf '+++ b/skills/verify/SKILL.md\n@@ -10,7 +10,7 @@\n \`\`\`\n existing english line\n-old english line\n+新しい日本語の行\n \`\`\`\n other line\n' | python3 '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}

--- a/tests/check-language-convention.bats
+++ b/tests/check-language-convention.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/check-language-convention.py"
+
+@test "true positive: plain prose CJK outside fence exits 1" {
+  run bash -c "printf '+++ b/modules/example.md\n@@ -1,0 +1,1 @@\n+転記した内容の rationale をそのまま英語ドキュメントに追加する。\n' | python3 '$SCRIPT'"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"modules/example.md:"* ]]
+}
+
+@test "false positive: CJK inside fenced code block exits 0" {
+  run bash -c "printf '+++ b/skills/verify/SKILL.md\n@@ -1,0 +1,3 @@\n+\`\`\`\n+転記した内容の rationale をそのまま英語ドキュメントに追加する。\n+\`\`\`\n' | python3 '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "false positive: CJK inside inline code span exits 0" {
+  run bash -c "printf '+++ b/skills/audit/SKILL.md\n@@ -1,0 +1,1 @@\n+| \`デザイン\` | design domain keyword |\n' | python3 '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "false positive: CJK inside double-quoted string literal exits 0" {
+  run bash -c "printf '+++ b/skills/verify/SKILL.md\n@@ -1,0 +1,1 @@\n+Print: \"検証が完了しました\"\n' | python3 '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "no violations: diff with no CJK exits 0" {
+  run bash -c "printf '+++ b/scripts/example.sh\n@@ -1,0 +1,1 @@\n+echo \"hello world\"\n' | python3 '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}
+
+@test "removed lines (-) are not scanned" {
+  run bash -c "printf -- '+++ b/modules/example.md\n@@ -1,1 +0,0 @@\n-転記した内容の rationale をそのまま英語ドキュメントに追加する。\n' | python3 '$SCRIPT'"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
英語指定ドキュメント (skills/**/*.md, modules/*.md, scripts/*) への日本語 (CJK) 混入を、unified diff スコープで検出する `scripts/check-language-convention.py` を新規追加し、CI に `language-convention` job として組み込んだ。Spec Notes / Issue 本文の rationale を英語ドキュメントへ転記する際に日本語が混入する事故 (#975, #1236) の再発防止を目的とする。

Spec フェーズで案 A (レビュー観点追加) と案 B (機械的チェック追加) を比較し、案 B を採用した (理由: 案 A は Size XS/S の patch route を構造的に検出できず、2件中1件の再発 (#975) がまさに patch route だったため)。

## Verification (pre-merge)
- 英語指定ドキュメントへの日本語混入を検出する手段が、機械的チェック (`scripts/check-language-convention.py` + CI job) として追加されている
- 正当な日本語 (terminal output テンプレート・インラインコードのキーワード・ダブルクォート文字列メッセージ) を偽陽性としない切り分け基準が、スクリプト本体のモジュール docstring に明記されている
- 案 A/B の比較と選択理由が Spec の `## Notes` に記録されている
- `tests/check-language-convention.bats` で真陽性ケースと偽陽性ケース (フェンス内/インラインコード内/ダブルクォート内) の双方を検証している (全6ケースPASS)

## Verification (post-merge)
- 次回以降、Spec Notes の rationale を英語指定ドキュメントへ転記する変更を含む PR で、日本語混入が検出または未然に防止されることを観察する (observation, session=next)

closes #1257