### PR TITLE
Issue #1276: #1165 由来の observation AC 16 行を実査し判定不能分を retire

### DIFF
--- a/docs/reports/observation-ac-audit-d3.md
+++ b/docs/reports/observation-ac-audit-d3.md
@@ -84,4 +84,39 @@ Issue #1276 (親 #1270 の sub-issue) の実査記録。#1165 が `verify-type: 
 
 ## 実施記録
 
-<!-- Implementation Step 8 で追記 -->
+### 分類 E (6 行 / 5 Issue) の書き戻し
+
+`#1056` / `#710` (条件1・条件2) / `#513` / `#512` / `#477` の 6 AC 行について、`<!-- verify-type: observation event=auto-run -->` を `<!-- verify-type: manual -->` へ置換した。`#513` / `#512` / `#477` の 3 行は条件文も母集団定義を含む形に書き換えた (`#1056` / `#710` 条件1・条件2 の 3 行は条件文が既に具体的なためタグ差し替えのみ)。書き戻しは `.tmp/issue-body-<N>.md` 経由 (`gh-issue-edit.sh`) で行い、対象 AC 行の HTML コメントと条件文のみを置換し、他の記述は変更していない。
+
+### 分類 B (1 行) の書き戻し
+
+`#465` の post-merge 条件文を、`docs/reports/orchestration-recoveries.md` への記録件数 (1 件以上) を判定根拠として明記する形に書き換えた。`event=auto-run` タグは維持した。
+
+### checkbox 形式検証 (Implementation Step 4)
+
+書き戻した 6 Issue 分の `.tmp/issue-body-<N>.md` (削除前) に対し `scripts/check-ac-checkbox-format.sh` を実行し、全件 `exit=0` (形式違反なし) を確認した。権限拒否は発生しなかったため python3 フォールバックは使用していない。
+
+| Issue | 結果 |
+|---|---|
+| #1056 | exit=0 |
+| #710 | exit=0 |
+| #513 | exit=0 |
+| #512 | exit=0 |
+| #477 | exit=0 |
+| #465 | exit=0 |
+
+### 分類 D (2 行) の retire (Implementation Step 5, 6)
+
+- **#491**: retire 決定コメントを投稿した (https://github.com/saitoco/wholework/issues/491#issuecomment-5228218405)。Issue 本文の `### Post-merge` 節は編集していない。ラベルを `phase/verify` → `phase/done` へ遷移させた。CLOSED のまま。
+- **#490**: retire 決定コメントを投稿した (https://github.com/saitoco/wholework/issues/490#issuecomment-5228218581)。Issue 本文の `### Post-merge` 節は編集していない。ラベルを `phase/verify` → `phase/done` へ遷移させたうえで、`gh api -X PATCH .../issues/490 -f state=closed` により OPEN → CLOSED へ遷移させた (`state_reason: completed` を確認)。
+
+いずれも retire により未チェック post-merge 条件がゼロになったため `phase/done` 遷移が GitHub 上の実状態 (ラベル・close) と一致している。
+
+### opportunistic-search dry-run 確認 (Implementation Step 7)
+
+`scripts/opportunistic-search.sh --event auto-run --dry-run` を実行し (母集団 120 Issue)、以下を Issue 番号単位で確認した:
+
+- **分類 B の #465**: マッチ集合に含まれることを確認した (書き換え後の条件文「`/auto` 実行で silent no-op (exit 0 だが実装なし) が `reconcile-phase-state.sh --check-completion` により検出され 3-tier recovery へ流れた事例が、`docs/reports/orchestration-recoveries.md` に 1 件以上記録されている」がそのまま出力に現れている)。
+- **分類 E の 5 Issue (#1056 / #710 / #513 / #512 / #477)**: いずれもマッチ集合から意図的に外れていることを確認した (`verify-type: manual` への差し戻しにより observation dispatch の母集団から除外された)。
+
+件数差分ではなく個別含有で判定した (#1163 Code Retrospective の指摘に従う)。

--- a/docs/reports/observation-ac-audit-d3.md
+++ b/docs/reports/observation-ac-audit-d3.md
@@ -20,7 +20,7 @@ Issue #1276 (親 #1270 の sub-issue) の実査記録。#1165 が `verify-type: 
 | #961 | `auto-run` | **既に `- [x]` / `phase/done`**。同上 |
 | #484 条件1 | `auto-run` | **既に `- [x]` / `phase/done`**。同上 (同 Issue の条件2 は #1165 が `### Retired Post-merge Conditions` へ退避済みで本 sub-issue の対象外) |
 | #478 条件1 | `auto-run when=mode:batch` | batch run 自身が観測対象。`when=mode:batch` ゲートが batch 実行に絞り込んだうえで、その run の wrapper ログのスキップ警告メッセージで判定できる。blocked Issue を含まない batch では SKIPPED になるが、これは `modules/observation-trigger.md` § Conditions That Cannot Be Pre-Excluded のとおり設計どおりの挙動 |
-| #478 条件2 | `auto-run when=mode:batch` | 同上。checkpoint JSON (`.tmp/auto-checkpoint-*.json`) の `remaining` 配列がスキップされた Issue 番号を保持しているかで判定できる |
+| #478 条件2 | `auto-run when=mode:batch` | 同上。checkpoint JSON (`.tmp/auto-batch-state.json` / `.tmp/auto-batch-state-<BATCH_ID>.json`) の `remaining` 配列がスキップされた Issue 番号を保持しているかで判定できる |
 | #535 | `watchdog-kill` | 「event 固有の観測窓」参照 |
 | #575 | `pr-review-full config=capabilities.workflow when=execution-context:main` | 「event 固有の観測窓」参照 |
 
@@ -50,9 +50,9 @@ Issue #1276 (親 #1270 の sub-issue) の実査記録。#1165 が `verify-type: 
 | Issue / 条件 | 差し戻し理由 | `/verify` 実行時の判定手順 | 条件文の書き換え |
 |---|---|---|---|
 | #1056 | `auto-run` の発火は「`pup` 未インストール環境で `html_check` を含む AC が実行された」ことを保証しない | 本リポジトリで `command -v pup` が不在を返すことを確認 (2026-08-09 実測: 不在) したうえで、`html_check` verify command を 1 件実際に実行し、UNCERTAIN ではなく PASS/FAIL が返ることを確かめる | なし (条件文は具体的) |
-| #710 条件1 | `auto-run` の発火は `/issue` phase が走ったことしか示さず、`Blocked by #N` を body に持つ Issue が起票されたかは保証しない | body に `Blocked by #N` を含む既存 Issue を 1 件選び、`scripts/get-blocked-by.sh <N>` / `gh-graphql.sh` の `blockedByIssues` クエリで relationship が設定済みかを確認する | なし (条件文は具体的) |
+| #710 条件1 | `auto-run` の発火は `/issue` phase が走ったことしか示さず、`Blocked by #N` を body に持つ Issue が起票されたかは保証しない | AC 文が要求するとおり、body に `Blocked by #N` を含む試験 Issue を `/issue` で新規に起票し、`scripts/get-blocked-by.sh <N>` / `gh-graphql.sh` の `blockedByIssues` クエリで relationship が設定されることを確認する (#710 自身が追加した新規作成時の自動 backfill を実際に発火させて検証する — 既存 Issue の確認では条件2 と同じ検証になってしまう) | なし (条件文は具体的) |
 | #710 条件2 | 同上。`/triage` に対応する有効 event 名も存在しない | body-only `Blocked by #N` を持つ既存 Issue に対し `scripts/gh-check-blocking.sh <N>` を実行し、GraphQL 側へ backfill されることを確認する | なし (条件文は具体的) |
-| #513 | 「次の同種 Issue」は内容的性質であり `event=` でも `when=` 3 軸でも表現できない | #513 のマージ (2026-06-09) 以降に作成された Issue のうち間接反映 AC を含むものを `gh issue list` + 本文検索で列挙し、post-merge manual または verify command 型に分類されているかを確認する | あり — 母集団 (「#513 マージ以降に作成された Issue のうち間接反映 AC を含むもの」) を条件文に明記 |
+| #513 | 「次の同種 Issue」は内容的性質であり `event=` でも `when=` の run-context 3 軸 (`route`/`mode`/`recovery-tier`) でも表現できない | #513 のマージ (2026-06-09) 以降に作成された Issue のうち間接反映 AC を含むものを `gh issue list` + 本文検索で列挙し、post-merge manual または verify command 型に分類されているかを確認する | あり — 母集団 (「#513 マージ以降に作成された Issue のうち間接反映 AC を含むもの」) を条件文に明記 |
 | #512 | 「次のユースケース」は内容的性質であり事前排除できない | #512 のマージ (2026-06-09) 以降に作成された `docs/spec/*.md` のうち距離ルールを定義するものを grep で列挙し、「A 以上かつ B 以下」表記が使われているかを確認する | あり — 母集団 (「#512 マージ以降に作成された `docs/spec/*.md` のうち距離ルールを定義するもの」) を条件文に明記 |
 | #477 | 親 #1270 が名指しした実例。「外部 API 統合 Spec」という Spec の内容的性質は event で表現できない (親 Issue の表がそのまま該当) | #477 のマージ (2026-06-14) 以降に作成された `docs/spec/*.md` のうち外部 API を呼ぶ実装を含むものを grep で列挙し、実レスポンスフォーマットと異常コード対処方針が明記されているかを確認する | あり — 母集団 (「#477 マージ以降に作成された `docs/spec/*.md` のうち外部 API 統合を含むもの」) を条件文に明記 |
 
@@ -72,7 +72,7 @@ Issue #1276 (親 #1270 の sub-issue) の実査記録。#1165 が `verify-type: 
 - 観測窓: `/review --full` の完了時。`auto-run` が `/auto` パイプライン全体の完走で開くのに対し、こちらは review フェーズ単体で開く
 - 2 段のゲートが掛かる。`config=capabilities.workflow` は本リポジトリで `true` (`.wholework.yml` の `capabilities: workflow: true`) のため通過する。`when=execution-context:main` は `/review` が main context (ユーザーの直接実行) で走った run にのみ通す
 - `execution-context:main` ゲートは正しい。`skills/review/workflow-guidance.md` は「re-invocation guarantee が無い実行面 (headless `claude -p`、fork 実行された Skill) では Workflow tool を起動せず static Task fan-out へフォールバックする」と定めており、`/auto` 経由の `/review` (= `run-review.sh` の fork context) では Workflow 経路自体が走らない。つまり条件文が要求する「Workflow 経路で完走」は main context でしか成立しない
-- 判定根拠: `/review` Step 14 の完了レポートに `skills/review/workflow-guidance.md` § Completion Report Addition が定める `Workflow mode (capabilities.workflow: true):` 見出しと概算トークン使用量が出力されているか
+- 判定根拠: `/review` Step 14 の完了レポートに `skills/review/workflow-guidance.md` § Cost Transparency が定める `Workflow mode (capabilities.workflow: true):` 見出しと概算トークン使用量が出力されているか
 
 ## #477 の処理
 
@@ -110,11 +110,11 @@ Issue #1276 (親 #1270 の sub-issue) の実査記録。#1165 が `verify-type: 
 - **#491**: retire 決定コメントを投稿した (https://github.com/saitoco/wholework/issues/491#issuecomment-5228218405)。Issue 本文の `### Post-merge` 節は編集していない。ラベルを `phase/verify` → `phase/done` へ遷移させた。CLOSED のまま。
 - **#490**: retire 決定コメントを投稿した (https://github.com/saitoco/wholework/issues/490#issuecomment-5228218581)。Issue 本文の `### Post-merge` 節は編集していない。ラベルを `phase/verify` → `phase/done` へ遷移させたうえで、`gh api -X PATCH .../issues/490 -f state=closed` により OPEN → CLOSED へ遷移させた (`state_reason: completed` を確認)。
 
-いずれも retire により未チェック post-merge 条件がゼロになったため `phase/done` 遷移が GitHub 上の実状態 (ラベル・close) と一致している。
+いずれも AC 行は `- [ ]` のまま (#1166 方式で本文を編集しない) だが、`phase/done` 遷移により `opportunistic-search.sh` / `scan-pending-ac.sh` の母集団 (`--label phase/verify`) から外れ、待ち条件は実質ゼロになった。この `phase/done` 遷移が GitHub 上の実状態 (ラベル・close) と一致している。
 
 ### opportunistic-search dry-run 確認 (Implementation Step 7)
 
-`scripts/opportunistic-search.sh --event auto-run --dry-run` を実行し (母集団 120 Issue)、以下を Issue 番号単位で確認した:
+`scripts/opportunistic-search.sh --event auto-run --dry-run` を実行し (検索母集団 120 Issue。`gh issue list` 段階の値であり、親 #1270 baseline の dispatch 候補 82 Issue / 85 AC 行とは計測段階が異なる)、以下を Issue 番号単位で確認した:
 
 - **分類 B の #465**: マッチ集合に含まれることを確認した (書き換え後の条件文「`/auto` 実行で silent no-op (exit 0 だが実装なし) が `reconcile-phase-state.sh --check-completion` により検出され 3-tier recovery へ流れた事例が、`docs/reports/orchestration-recoveries.md` に 1 件以上記録されている」がそのまま出力に現れている)。
 - **分類 E の 5 Issue (#1056 / #710 / #513 / #512 / #477)**: いずれもマッチ集合から意図的に外れていることを確認した (`verify-type: manual` への差し戻しにより observation dispatch の母集団から除外された)。

--- a/docs/reports/observation-ac-audit-d3.md
+++ b/docs/reports/observation-ac-audit-d3.md
@@ -1,0 +1,87 @@
+# observation AC 実査記録 (#1165 由来 区分 D3)
+
+Issue #1276 (親 #1270 の sub-issue) の実査記録。#1165 が `verify-type: manual` から `verify-type: observation` へ再型付けした **16 AC 行 / 14 Issue** について、「どの event が発火したとき、何を根拠に PASS 判定できるか」を 1 行ずつ実査し、A/B/C/D/E へ分類した。
+
+実査結果: **A 7 行 / B 1 行 / C 0 行 / D 2 行 / E 6 行**。
+
+## 母集団前提の訂正
+
+一次資料 `docs/reports/manual-ac-retype-d3.md` § 「OPEN 2 件 (#490 / #465) は dispatch 母集団に入らない」は、`scripts/opportunistic-search.sh` の母集団取得が `--state closed` 固定であることを根拠にしていたが、**#1242 (commit `5bf85f5f` / PR #1272) により `--state all` へ変更済み**であり、この前提は失効している。実測 (2026-08-09) でも `gh issue list --label phase/verify --state all --search "verify-type: observation in:body"` の母集団 120 件に #490 / #465 がともに含まれることを確認した。本 sub-issue では OPEN 2 件も他と同じ扱いで実査した。
+
+## 実査対象の現況
+
+16 AC 行のうち **3 行 (#1135 / #961 / #484 条件1) は既に `- [x]` かつ所属 Issue が `phase/done` へ到達済み**である。#1165 の再型付け後に実際に PASS 判定されており、「発火時に判定できる」ことが実績で実証されている。これらは分類 A として記録対象に含めるが、Issue 本文もラベルも編集していない。
+
+## 分類 A (7 行) — 維持。判定根拠を記録
+
+| Issue / 条件 | event タグ | 判定根拠 (どの情報源で PASS/FAIL が決まるか) |
+|---|---|---|
+| #1135 | `auto-run when=mode:batch` | **既に `- [x]` / `phase/done`**。再型付け後に実際に PASS 判定されており「発火時に判定できる」ことが実績で実証済み。処理不要 |
+| #961 | `auto-run` | **既に `- [x]` / `phase/done`**。同上 |
+| #484 条件1 | `auto-run` | **既に `- [x]` / `phase/done`**。同上 (同 Issue の条件2 は #1165 が `### Retired Post-merge Conditions` へ退避済みで本 sub-issue の対象外) |
+| #478 条件1 | `auto-run when=mode:batch` | batch run 自身が観測対象。`when=mode:batch` ゲートが batch 実行に絞り込んだうえで、その run の wrapper ログのスキップ警告メッセージで判定できる。blocked Issue を含まない batch では SKIPPED になるが、これは `modules/observation-trigger.md` § Conditions That Cannot Be Pre-Excluded のとおり設計どおりの挙動 |
+| #478 条件2 | `auto-run when=mode:batch` | 同上。checkpoint JSON (`.tmp/auto-checkpoint-*.json`) の `remaining` 配列がスキップされた Issue 番号を保持しているかで判定できる |
+| #535 | `watchdog-kill` | 「event 固有の観測窓」参照 |
+| #575 | `pr-review-full config=capabilities.workflow when=execution-context:main` | 「event 固有の観測窓」参照 |
+
+## 分類 B (1 行) — 条件文を書き換え
+
+| Issue | 現在の条件文 | 書き換え後 | 理由 |
+|---|---|---|---|
+| #465 | `/auto` 実行で silent no-op（exit 0 だが実装なし）が自動検出され、3-tier recovery へ流れることを実運用でモニタする | `/auto` 実行で silent no-op (exit 0 だが実装なし) が `reconcile-phase-state.sh --check-completion` により検出され 3-tier recovery へ流れた事例が、`docs/reports/orchestration-recoveries.md` に 1 件以上記録されている | 観測対象 (silent no-op 検出 → recovery) は `/auto` run 内で発生し `event=auto-run` の観測窓は正しく開くが、「実運用でモニタする」には終端がなく、いつ PASS になるかが一意に決まらない。#1251 の規約に従い判定に必要な情報源 (`orchestration-recoveries.md`) と終端 (1 件以上) を条件文自身に含める。`event=auto-run` は維持 |
+
+## 分類 C (0 行)
+
+該当なし。判定不能と判断した 2 行 (#490 / #491) と差し戻す 6 行のいずれも、`modules/verify-classifier.md` § observation Type が定める 5 つの有効値 (`pr-review-full` / `pr-review-light` / `auto-run` / `watchdog-kill` / `fix-cycle`) のどれに差し替えても観測窓が開かない。特に #710 条件2 が待つ `/triage` 実行に対応する event 名は存在しない。
+
+## 分類 D (2 行) — #1166 方式で retire
+
+| Issue | 条件文 | retire 理由 | retire 後 |
+|---|---|---|---|
+| #491 | `/verify` 実行前に `workflow_dispatch` を促す運用が実際のワークフローで機能することを確認 | 本リポジトリの `.github/workflows/` は `dco.yml` / `kanban-automation.yml` / `test.yml` の 3 件で、いずれも `schedule:` トリガーを持たない (実測)。cron 依存 post-merge AC が本リポジトリに発生しない以上、「`/verify` 前に `workflow_dispatch` で事前トリガーする運用」が機能する場面が原理的に生じない。`modules/verify-patterns.md` §13 のガイドラインは downstream プロジェクト向けであり、upstream からは観測不能。実装の正しさは Pre-merge AC (全件チェック済み) が担保 | `phase/done` へ遷移 (CLOSED のまま) |
+| #490 | 実際の Issue AC で cron 依存条件に注記が付くことを 1 件以上のサンプルで確認 | 同根。cron スケジュールワークフローが存在しない以上、本リポジトリの Issue AC に cron 依存条件が現れず、注記対象のサンプルが原理的に生じない。#490 自身の本文も「#491: workflow_dispatch 推奨ガイドラインとして §13 追加済み（本 Issue の受け入れ条件を実質カバー）」と記録しており、実装の正しさは Pre-merge AC 3 件 (全件チェック済み、`section_contains` による機械検証) が担保 | `phase/done` へ遷移 + **close** |
+
+いずれも #1166 方式: AC 行は編集せず (`### Post-merge` を触らない)、retire 理由を Issue コメントとして投稿し、ラベルを `phase/verify` → `phase/done` へ遷移させる。
+
+## 分類 E (6 行) — `verify-type: manual` へ差し戻し
+
+いずれも「指定 event の発火が、条件文の要求する観測対象をその run 自身の中に生成しない」型である。`auto-run` の発火は `/auto` が完走したことしか保証せず、条件文が要求する**内容的性質を持つ成果物**や**特定環境での実行**は保証しない。一方 `/verify` 実行時に Claude が能動的にコマンドを実行するか蓄積済み成果物を横断検索すれば判定できる。全 6 行が「今すぐ `/verify` で判定できる」側であり、**capability 待ちは 0 行** (`capability=<key>` の併記対象なし)。
+
+| Issue / 条件 | 差し戻し理由 | `/verify` 実行時の判定手順 | 条件文の書き換え |
+|---|---|---|---|
+| #1056 | `auto-run` の発火は「`pup` 未インストール環境で `html_check` を含む AC が実行された」ことを保証しない | 本リポジトリで `command -v pup` が不在を返すことを確認 (2026-08-09 実測: 不在) したうえで、`html_check` verify command を 1 件実際に実行し、UNCERTAIN ではなく PASS/FAIL が返ることを確かめる | なし (条件文は具体的) |
+| #710 条件1 | `auto-run` の発火は `/issue` phase が走ったことしか示さず、`Blocked by #N` を body に持つ Issue が起票されたかは保証しない | body に `Blocked by #N` を含む既存 Issue を 1 件選び、`scripts/get-blocked-by.sh <N>` / `gh-graphql.sh` の `blockedByIssues` クエリで relationship が設定済みかを確認する | なし (条件文は具体的) |
+| #710 条件2 | 同上。`/triage` に対応する有効 event 名も存在しない | body-only `Blocked by #N` を持つ既存 Issue に対し `scripts/gh-check-blocking.sh <N>` を実行し、GraphQL 側へ backfill されることを確認する | なし (条件文は具体的) |
+| #513 | 「次の同種 Issue」は内容的性質であり `event=` でも `when=` 3 軸でも表現できない | #513 のマージ (2026-06-09) 以降に作成された Issue のうち間接反映 AC を含むものを `gh issue list` + 本文検索で列挙し、post-merge manual または verify command 型に分類されているかを確認する | あり — 母集団 (「#513 マージ以降に作成された Issue のうち間接反映 AC を含むもの」) を条件文に明記 |
+| #512 | 「次のユースケース」は内容的性質であり事前排除できない | #512 のマージ (2026-06-09) 以降に作成された `docs/spec/*.md` のうち距離ルールを定義するものを grep で列挙し、「A 以上かつ B 以下」表記が使われているかを確認する | あり — 母集団 (「#512 マージ以降に作成された `docs/spec/*.md` のうち距離ルールを定義するもの」) を条件文に明記 |
+| #477 | 親 #1270 が名指しした実例。「外部 API 統合 Spec」という Spec の内容的性質は event で表現できない (親 Issue の表がそのまま該当) | #477 のマージ (2026-06-14) 以降に作成された `docs/spec/*.md` のうち外部 API を呼ぶ実装を含むものを grep で列挙し、実レスポンスフォーマットと異常コード対処方針が明記されているかを確認する | あり — 母集団 (「#477 マージ以降に作成された `docs/spec/*.md` のうち外部 API 統合を含むもの」) を条件文に明記 |
+
+## event 固有の観測窓 (`watchdog-kill` / `pr-review-full`)
+
+本 sub-issue は 3 つの担当範囲のうち唯一 `auto-run` 以外の event を含む。両者は `auto-run` と観測窓の開き方が異なる。
+
+**#535 (`event=watchdog-kill`, 分類 A)**
+
+- 観測窓: `scripts/claude-watchdog.sh:138-140` の kill handler が `observation-trigger.sh --event watchdog-kill` を呼ぶ時点。`auto-run` が「`/auto` の完走」で開くのに対し、こちらは **`/auto` が完走しなかったとき**にだけ開く。両者は排他に近い関係にある
+- 判定根拠: `docs/reports/orchestration-recoveries.md` の該当エントリ。`### Recovery Applied` に Tier 3 の `recover` plan が `validate-recovery-plan.sh` を通過して適用されたことが記録され、`unsupported op` エラーが記録されていなければ PASS
+- 補強事実: #535 のマージ (2026-06-06) 後、2026-07-02 の `code-pr-external-timeout-kill` エントリ (Issue #875) で Tier 3 が `run_command` ベースの 3 step plan (`git push` → `gh pr create` → `gh-label-transition.sh`) を提出し、validate 通過・適用成功している。ただしこの kill は外部 Bash-tool timeout によるもので `claude-watchdog.sh` の内部 watchdog kill ではないため、`event=watchdog-kill` の発火実績としては数えない。条件文の核心 (`unsupported op` なしに commit→push→PR create で復旧できる) は既に一度実証されている
+- watchdog kill が「PR 作成前」でないタイミングで起きた run では SKIPPED になる。`when=` の `recovery-tier` 軸は run facts JSON (= `/auto` 実行の記述) に対して評価されるため `event=watchdog-kill` では意味を持たず (`modules/observation-trigger.md` § Condition Check Gate (`when=`))、事前排除は行わない
+
+**#575 (`event=pr-review-full config=capabilities.workflow when=execution-context:main`, 分類 A)**
+
+- 観測窓: `/review --full` の完了時。`auto-run` が `/auto` パイプライン全体の完走で開くのに対し、こちらは review フェーズ単体で開く
+- 2 段のゲートが掛かる。`config=capabilities.workflow` は本リポジトリで `true` (`.wholework.yml` の `capabilities: workflow: true`) のため通過する。`when=execution-context:main` は `/review` が main context (ユーザーの直接実行) で走った run にのみ通す
+- `execution-context:main` ゲートは正しい。`skills/review/workflow-guidance.md` は「re-invocation guarantee が無い実行面 (headless `claude -p`、fork 実行された Skill) では Workflow tool を起動せず static Task fan-out へフォールバックする」と定めており、`/auto` 経由の `/review` (= `run-review.sh` の fork context) では Workflow 経路自体が走らない。つまり条件文が要求する「Workflow 経路で完走」は main context でしか成立しない
+- 判定根拠: `/review` Step 14 の完了レポートに `skills/review/workflow-guidance.md` § Completion Report Addition が定める `Workflow mode (capabilities.workflow: true):` 見出しと概算トークン使用量が出力されているか
+
+## #477 の処理
+
+親 Issue #1270 が名指しした実例。分類 E (差し戻し) とし、母集団 (「#477 マージ以降に作成された `docs/spec/*.md` のうち外部 API 統合を含むもの」) を条件文に明記した上で `verify-type: manual` へ差し戻した。詳細は上記「分類 E」表を参照。
+
+## #478 の対象外事項
+
+#478 は本 sub-issue の 2 AC 行 (どちらも分類 A) とは別に、`### Pre-merge (auto-verified)` に未チェックの `github_check "gh run list --workflow=test.yml --commit=$(git rev-parse HEAD) ..."` 行を 1 件持つ。`modules/verify-classifier.md` § 「Why `--commit` is not used」が「`--commit=` を `git rev-parse HEAD` で解決する形は `/verify` 実行時の base branch HEAD を指すため、この Issue 自身の実装を検証できない」と明記している既知の欠陥形である。本 sub-issue のスコープ (post-merge observation AC の実査) 外のため処理せず、事実として注記するに留める。
+
+## 実施記録
+
+<!-- Implementation Step 8 で追記 -->

--- a/docs/spec/issue-1276-observation-ac-audit-d3.md
+++ b/docs/spec/issue-1276-observation-ac-audit-d3.md
@@ -226,24 +226,37 @@ N/A — Spec の Implementation Steps を順序どおり実行した。分類 (A
 
 N/A
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note。review-spec 観点の Perspective 1 (Spec Deviation) はゼロ件で、Spec の Implementation Steps・Changed Files・Key Decisions のすべてが実装 (`docs/reports/observation-ac-audit-d3.md` の内容と 8 Issue への外部操作) と一致していた。
+
+### Recurring issues
+
+review-bug×2 と review-spec が共通して検出した 2 件 (`.tmp/auto-checkpoint-*.json` という実在しないパス、`workflow-guidance.md § Completion Report Addition` という実在しない節名) はいずれも「実装コードから正確な文字列を grep で確認せず記憶・推測で転記した」ことが原因の同型パターンである。しかもこの 2 件は Spec 本文 (`docs/spec/issue-1276-observation-ac-audit-d3.md:69,121`、本 PR の diff 外) からそのまま転記されたもので、Spec フェーズで発生した誤りが code フェーズでの転記を経て観測可能な形 (`/review` が検出できる diff) に現れた。観測対象が「将来 `/verify` が参照する判定根拠」であるレポート特有のリスクとして、パス・セクション名などの具体的な参照を書く際は Read/Grep で実在確認してから記述する、という手順を今後の同種 Issue (実査記録・監査レポート作成) のガイドとして持っておく価値がある。
+
+### Acceptance criteria verification difficulty
+
+Nothing to note。Pre-merge AC 7 件 (rubric 6 + file_exists 1) はすべて safe mode で PASS 判定でき、UNCERTAIN は 0 件だった。verify command 自体の記述にも問題はなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- Spec の分類結果 (A 7 / B 1 / C 0 / D 2 / E 6) をそのまま `docs/reports/observation-ac-audit-d3.md` へ転記し、再判定は行わなかった。
-- 分類 E 6 行 / 分類 B 1 行の Issue 本文書き戻しは `.tmp/issue-body-<N>.md` 経由 (`gh-issue-edit.sh`) で行い、対象 AC 行の HTML コメントと条件文のみを置換した。
-- 分類 D の 2 Issue (#491 / #490) は #1166 方式で retire コメント投稿 + `phase/done` 遷移。#490 はさらに `gh api -X PATCH ... -f state=closed` で close した。
-- `check-ac-checkbox-format.sh` は権限拒否なく実行できた (python3 フォールバックは不要だった)。
+- Step 10 は `--non-interactive` (fork context, re-invocation guarantee なし) のため `capabilities.workflow: true` でも Workflow tool 経路を使わず、`skills/review/workflow-guidance.md` の指示どおり静的 Task fan-out (review-spec + review-bug×2) へフォールバックした。Agent tool を `run_in_background: false` で同一メッセージ内に並列発行した。
+- Step 10 で検出された 6 件 (SHOULD 2 / CONSIDER 4) はすべて `docs/reports/observation-ac-audit-d3.md` 内の参照誤り・表現曖昧性で、MUST は 0 件だった。2 段階検証で全件 PASS (問題確認) と判定されたため、6 件とも修正して commit・push した。
+- Base Branch Conflict Pre-check は `changed in both` 0 件でコンフリクトなし。
 
 ### Deferred Items
 
-- #478 の `### Pre-merge` に残る `github_check ... --commit=$(git rev-parse HEAD)` 形の未チェック AC は本 Issue のスコープ外のまま。記録ファイルへの注記のみ。
-- 分類結果の親 #1270 集約レポート (`docs/reports/observation-ac-audit-summary.md`) への統合は親側の担当。
-- 既に `- [x]` / `phase/done` の 3 行 (#1135 / #961 / #484 条件1) は記録のみで、GitHub 側の操作は行っていない。
+- #478 の `### Pre-merge` に残る `github_check ... --commit=$(git rev-parse HEAD)` 形の未チェック AC は本 Issue のスコープ外のまま (code フェーズから継続)。
+- 分類結果の親 #1270 集約レポート (`docs/reports/observation-ac-audit-summary.md`) への統合は親側の担当 (code フェーズから継続)。
+- `docs/spec/issue-1276-observation-ac-audit-d3.md:69,121` に残る同型の参照誤り (Spec 側、本 PR の diff 外) は修正していない — 本 Issue のスコープは `docs/reports/observation-ac-audit-d3.md` の記録内容であり、Spec 自体の事後訂正は対象外と判断した。
 
 ### Notes for Next Phase
 
-- `/review` は diff がレポートファイル 1 件のみで小さいが、外部操作 (8 Issue の本文編集・コメント投稿・ラベル遷移・1 件の close) の結果は `docs/reports/observation-ac-audit-d3.md` の `## 実施記録` 節と本 Retrospective に記録済み。
-- Pre-merge AC 7 件は本 phase で rubric/file_exists 判定により全件 PASS・チェック済み。`/merge` の pre-merge AC gate は素通りする見込み。
-- 着手時の Issue 状態再確認では spec フェーズからの drift はなかった (Design Gaps/Ambiguities 参照)。
+- `/merge 1295` 実行時、Pre-merge AC 7 件は全件チェック済みのため pre-merge AC gate は素通りする見込み。
+- レビュー修正 commit (`c8a9ae2c`) は PR ブランチへ直接 push 済み。追加の re-review は不要 (MUST 0 件、review-only モードではない通常フロー)。
+- Post-merge AC はこの Issue にはない (効果測定は親 #1270 に集約)。

--- a/docs/spec/issue-1276-observation-ac-audit-d3.md
+++ b/docs/spec/issue-1276-observation-ac-audit-d3.md
@@ -212,26 +212,38 @@ Issue 本文の「担当範囲」表は 16 AC 行を実査対象とするが、�
 - **#1056 の前提 (`pup` 不在) が現在も成立するか**: `command -v pup` で不在を再確認した (2026-08-09)。E の判定手順が `/verify` 実行時にそのまま使える。
 - **`check-ac-checkbox-format.sh` が `/code` から実行できるか**: `skills/code/SKILL.md` の `allowed-tools` に含まれないことを実測確認した。プロジェクトの `.claude/settings.json` 側の許可で通る見込みだが、拒否時は #1165 と同じく `python3` 相当判定へフォールバックする方針を Tool Dependencies に明記し、`skills/code/SKILL.md` の変更はスコープ外とした。
 
+## Code Retrospective
+
+### Deviations from Design
+
+N/A — Spec の Implementation Steps を順序どおり実行した。分類 (A 7 / B 1 / C 0 / D 2 / E 6) の再判定も行っていない。
+
+### Design Gaps/Ambiguities
+
+- Spec Notes for Next Phase の指示どおり、着手時に対象 8 Issue (#1056 / #710 / #513 / #512 / #477 / #465 / #491 / #490) の state・labels を再確認したが、spec フェーズ (2026-08-09) からの drift はなかった (全件 `phase/verify` のまま、E/B 対象行が先に PASS 済みになっている事象は発生しなかった)。observation dispatch の並行進行を懸念した Spec の注意書きは今回は顕在化しなかったが、再確認の手順自体は有効だったため次回以降も踏襲する。
+
+### Rework
+
+N/A
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- 16 AC 行の分類 (A 7 / B 1 / C 0 / D 2 / E 6) は Spec 側で確定済み。`/code` は「実査結果: 16 AC 行の分類」節をそのまま `docs/reports/observation-ac-audit-d3.md` の記録内容として転記すればよく、分類のやり直しは不要。
-- retire は #1166 方式 (AC 行を編集せず retire コメント + `phase/done` 遷移)。#1165 の `### Retired Post-merge Conditions` 退避方式は採らない。
-- 分類 E の 6 行のうち #513 / #512 / #477 の 3 行のみ、タグ差し替えと同じ編集で条件文も書き換える。残り 3 行 (#1056 / #710 条件1 / #710 条件2) はタグ差し替えのみ。
-- #490 は retire 後に `phase/done` 遷移に加えて close する (`gh api -X PATCH ... -f state=closed`)。`gh issue close` は `allowed-tools` に無いが `gh api:*` はある。
+- Spec の分類結果 (A 7 / B 1 / C 0 / D 2 / E 6) をそのまま `docs/reports/observation-ac-audit-d3.md` へ転記し、再判定は行わなかった。
+- 分類 E 6 行 / 分類 B 1 行の Issue 本文書き戻しは `.tmp/issue-body-<N>.md` 経由 (`gh-issue-edit.sh`) で行い、対象 AC 行の HTML コメントと条件文のみを置換した。
+- 分類 D の 2 Issue (#491 / #490) は #1166 方式で retire コメント投稿 + `phase/done` 遷移。#490 はさらに `gh api -X PATCH ... -f state=closed` で close した。
+- `check-ac-checkbox-format.sh` は権限拒否なく実行できた (python3 フォールバックは不要だった)。
 
 ### Deferred Items
 
-- #478 の `### Pre-merge` に残る `github_check ... --commit=$(git rev-parse HEAD)` 形の未チェック AC は本 Issue のスコープ外。記録ファイルへの注記のみ行い、修正はしない。
-- `skills/code/SKILL.md` の `allowed-tools` への `check-ac-checkbox-format.sh` 追加は行わない (拒否時は python3 フォールバック)。
-- 分類結果の親 #1270 集約レポート (`docs/reports/observation-ac-audit-summary.md`) への統合は親側の担当。本 Issue では記録ファイルの作成までを行う。
-- 既に `- [x]` / `phase/done` の 3 行 (#1135 / #961 / #484 条件1) は記録のみで、GitHub 側の操作は一切行わない。
+- #478 の `### Pre-merge` に残る `github_check ... --commit=$(git rev-parse HEAD)` 形の未チェック AC は本 Issue のスコープ外のまま。記録ファイルへの注記のみ。
+- 分類結果の親 #1270 集約レポート (`docs/reports/observation-ac-audit-summary.md`) への統合は親側の担当。
+- 既に `- [x]` / `phase/done` の 3 行 (#1135 / #961 / #484 条件1) は記録のみで、GitHub 側の操作は行っていない。
 
 ### Notes for Next Phase
 
-- 対象 Issue の状態は spec 実行時 (2026-08-09) のスナップショット。`/code` 着手時に再度 `gh issue view` で各 AC 行の checkbox 状態を確認すること — observation dispatch が並行して動いており、E/B 対象行が先に PASS 済みになっている可能性がある。その場合は編集せず記録ファイルに事実を追記する。
-- Issue 本文の書き戻しは `.tmp/issue-body-<N>.md` 経由 (`gh-issue-edit.sh <N> <file>`)。対象行以外を壊さないよう、置換は当該 AC 行の HTML コメントと条件文に限定すること。
-- `opportunistic-search.sh --event auto-run --dry-run` は母集団 120 Issue に対し 1 Issue ずつ `gh issue view` を回すため数分かかる。step 7 の確認は件数差分ではなく Issue 番号の個別含有で判定する。
-- 本 Issue はリポジトリ内変更が記録ファイル 1 件のみで、大半が GitHub 上の外部操作。`/review` が検査できる diff が小さいため、外部操作の結果は記録ファイルの `## 実施記録` 節に残すこと。
+- `/review` は diff がレポートファイル 1 件のみで小さいが、外部操作 (8 Issue の本文編集・コメント投稿・ラベル遷移・1 件の close) の結果は `docs/reports/observation-ac-audit-d3.md` の `## 実施記録` 節と本 Retrospective に記録済み。
+- Pre-merge AC 7 件は本 phase で rubric/file_exists 判定により全件 PASS・チェック済み。`/merge` の pre-merge AC gate は素通りする見込み。
+- 着手時の Issue 状態再確認では spec フェーズからの drift はなかった (Design Gaps/Ambiguities 参照)。


### PR DESCRIPTION
## Summary

#1165 由来の区分 D3 (observation 再型付け 16 AC 行 / 14 Issue) を実査し、A/B/C/D/E へ分類した (A 7 行 / B 1 行 / C 0 行 / D 2 行 / E 6 行)。

- `docs/reports/observation-ac-audit-d3.md` を新規作成し、16 AC 行すべての分類・判定根拠・処理内容を記録
- 分類 E の 6 AC 行 (5 Issue: #1056 / #710 / #513 / #512 / #477) を `verify-type: manual` へ差し戻し (うち #513 / #512 / #477 は条件文も母集団定義を含む形に書き換え)
- 分類 B の 1 AC 行 (#465) の条件文を判定根拠明記の形に書き換え (event=auto-run タグは維持)
- 分類 D の 2 Issue (#491 / #490) へ #1166 方式で retire コメントを投稿し、`phase/verify` → `phase/done` へ遷移 (#490 はさらに close)
- `opportunistic-search.sh --event auto-run --dry-run` で書き換え後の含有/除外を個別確認

リポジトリ内の変更は記録ファイル 1 件のみで、大半は GitHub Issue 本文・コメント・ラベルへの外部操作。

## Verification (pre-merge)

- rubric/file_exists 検証 7 件すべて PASS (docs/reports/observation-ac-audit-d3.md の内容確認)
- bats フルスイート 1637 件 PASS
- `scripts/validate-skill-syntax.py` / `scripts/check-forbidden-expressions.sh` PASS

## Verification (post-merge)

なし (効果測定は親 #1270 に集約)

closes #1276
