### PR TITLE
Issue #1275: verify: #1164 由来の observation AC 12 行を実査し判定不能分を retire

### DIFF
--- a/docs/reports/observation-ac-audit-d2.md
+++ b/docs/reports/observation-ac-audit-d2.md
@@ -1,0 +1,146 @@
+# observation AC 実査記録: D2 (#1164 由来, #1275)
+
+親 Issue #1270 の sub-issue #1275 の実査記録。#1164 が区分 D2 (実行シナリオ型) として `verify-type: manual` から `verify-type: observation event=auto-run` へ再型付けした **12 AC 行 / 11 Issue** (#1109 #1106 #1101 #1097 #1031 #954 #529 #515 #511 #486 #446) を対象に、親 #1270 の判定基準 (A/B/C/D/E) に従い 1 行ずつ「どの event が発火したとき何を根拠に PASS 判定できるか」を実査した。
+
+## 分類サマリ
+
+| 分類 | 件数 | 対象 Issue |
+|---|---|---|
+| A (判定可能・維持) | 5 | #1109 #1106 #1101 #1097 #529 |
+| B (条件文の書き換え) | 0 | — |
+| C (event の差し替え) | 0 | — |
+| D (判定不能・retire) | 0 | — |
+| E (`manual` へ差し戻し) | 7 | #1031 #954 #515 #511 #486 #446×2 |
+| **合計** | **12** | — |
+
+D が 0 件のため、#1166 方式の retire コメント投稿・`phase/done` 遷移は本 Issue では発生しない。E はすべて「今すぐ `/verify` (manual) で判定できる」区分であり、capability 待ち (`capability=<key>`) に該当するものはない — 7 件とも装備不足ではなく、(a) `/auto` 非対話モードでの構造的制約 (Step 12a fan-out の無条件 skip)、(b) 統計的・定性的トレンド判断で単発 event 発火では信号を持たない、(c) 特定内容の Issue/PR が発生しない限り観測窓が開かない、のいずれかが理由である。
+
+## 分類基準 (親 #1270 より継承)
+
+| 分類 | 基準 |
+|---|---|
+| A | 指定 event の発火時に、条件文が要求する観測対象が実行事実・リポジトリ状態・GitHub 状態のいずれかから判定できる |
+| B | 観測対象は存在するが条件文が曖昧/母集団定義を欠く → 書き換え |
+| C | 判定可能だが event 選択が誤り → 差し替え |
+| D | どの有効 event でも観測窓が開かず、`/verify` 実行時にも判定不能 → retire (#1166 方式) |
+| E | event では観測窓が開かないが `/verify` 実行時に Claude が実際に操作・確認すれば判定できる → `manual` へ差し戻し |
+
+## A: 判定可能 (5 行、維持)
+
+いずれも「AC 行は編集せず維持」。以下は各行の判定根拠 (どの情報源を見れば PASS/FAIL/SKIPPED が決まるか)。
+
+### #1109 — observation AC の event 発火後 `/verify` 実行で checkbox 更新・`phase/done` 遷移を確認
+
+- **条件文**: 「observation AC を持つ Issue に対して event 発火後に `/verify` を実行し、条件が満たされている場合に checkbox が更新され `phase/done` へ遷移することを確認する」
+- **判定根拠**: この条件は observation dispatch 機構自体の動作確認であり、observation AC を持つ Issue 群 (baseline 母集団 82 Issue) に対して `auto-run` が発火するたびに繰り返し観測機会が生じる。`.tmp/auto-events.jsonl` の `phase=verify` イベント (`session_id` で dispatch と対応付け) と、dispatch 対象 Issue の GitHub 上のラベル/checkbox 状態を突き合わせることで、observation dispatch 起点の `/verify` 実行が実際に checkbox 更新・`phase/done` 遷移まで到達したかを判定できる。#1109 自身の修正 (`/verify` の event 発火済み分岐、`modules/verify-executor.md` の記述更新) が本条件の評価手段そのものを定義しているため、循環参照ではなく自己整合的に判定可能
+- **現状**: まだ「observation dispatch 起点の `/verify` 実行が checkbox を更新した」明確な実例は本実査時点で確認できていないため SKIPPED のまま。発火頻度が高いため今後の観測機会は多い
+
+### #1106 — 自己 PR への `/auto` pr route 実行で merge precondition 警告が出ないことを確認
+
+- **条件文**: 「自己 PR に `/auto` の pr route を実行し、merge precondition の警告が出ずに進行することを確認する」
+- **判定根拠**: wholework は単一アカウントによる自己ホスト運用が前提であり、pr route を通る `/auto` 実行は**ほぼ全件が自己 PR** に該当する。`scripts/reconcile-phase-state.sh` の merge precondition 診断出力 (`review-summary` marker の有無、`reviewDecision`) が直接の判定材料になる
+- **既存実例**: 2026-08-04 の `/auto 1150` (PR #1151、自己 PR・pr route) で `matches_expected: true` を確認済み — `docs/reports/manual-ac-retype-d2.md` に記録あり。頻度・実例とも十分でありA判定が妥当
+
+### #1101 — ベースブランチとの同一行 conflict が MUST 指摘として検出されることを確認
+
+- **条件文**: 「ベースブランチ側と同一行を変更する PR を実際にレビューし、conflict が MUST 指摘として検出されることを確認する」
+- **判定根拠**: #1101 の Background に記録の通り、`modules/verify-executor.md` の `html_check` 行だけでも #424/#1056/#1074/#1069 の 4 件が編集しており、SSoT 文書での同一行 conflict は本リポジトリで実際に繰り返し発生している既知パターン。`/review` が投稿する PR コメント (merge-tree conflict の MUST 指摘) を event 発火時点の直近レビュー結果から確認できる
+- **現状**: SKIPPED のまま (直近で該当 conflict が発生していない)。再発性が確認されている既知パターンのため今後の観測機会は見込める
+
+### #1097 — Size L PR の `--full` review で silent no-op が発生しないことを確認
+
+- **条件文**: 「Size L の PR に対して `run-review.sh <PR> --full` を実行し、silent no-op 検出が発生せず review 自身の Response Summary が投稿されることを確認する」
+- **判定根拠**: Size L の PR は一定頻度で発生し、`--full` review はその都度実行される。`run-review.sh` の exit code と PR コメント (Response Summary の投稿有無) が直接の判定材料
+- **既存実例**: 2026-08-04 の `/auto 1150` (PR #1151、Size L・`--full`・exit 0 + Summary 投稿済み) で確認済み — `docs/reports/manual-ac-retype-d2.md` に記録あり
+
+### #529 — spec phase 後の Size 変化で route/review 深度が自動選択されることを確認
+
+- **条件文**: 「spec phase で Size が変化する Issue に `/auto N` を実行し、変化後の Size に応じた review 深度・route が自動選択されることを実運用で確認する」
+- **判定根拠**: spec phase での Size 変化 (M→L 等) は稀ではあるが実運用で一定数発生する。`.tmp/auto-events.jsonl` の Step 2 (dispatch 時 Size) と spec phase 後の `--no-cache` 再取得 Size を比較し、それに応じた route/review 深度選択を確認できる
+- **既存実例**: 派生元 #501 (`/auto` 実行で spec phase が M→L に Size 再評価し、review 深度の手動切替が必要だった実例) が本条件の直接の動機であり、機構は実装済み
+
+## E: `manual` へ差し戻し (7 行)
+
+いずれも Issue 本文の `<!-- verify-type: observation event=auto-run -->` を `<!-- verify-type: manual -->` に書き換えた (AC 行の条件文自体は変更していない)。
+
+### #1031 — `/issue` Step 12a subagent の pane 残留防止 (目視確認)
+
+- **条件文**: 「実際に `/issue` を XL Issue に対して実行し、Step 12a → 12b → 12c 完了時点で FleetView / pane に subagent が残らないことを目視確認」
+- **差し戻し理由**: Step 12a の並列 subagent fan-out は、非対話モードでは "High-Stakes Decision" として無条件 skip される (`modules/ambiguity-detector.md`)。`auto-run` を含む 5 つの有効 event 値はいずれも `/auto`・`/review`・`claude-watchdog.sh`・fix-cycle という**非対話実行由来**の emitter であるため、これら 5 event のいずれが発火しても Step 12a が実際に fan-out する瞬間には到達しない。つまり event 発火では観測窓が原理的に開かない
+- **`/verify` 実行時に何をすれば判定できるか**: 対話モードで人間が直接 `/issue` を XL Issue に対して実行し、Step 12a→12c 完了直後に `ListAgents` で subagent の残留 (idle 状態) を確認する、または目視で FleetView / pane を確認する。これは Claude/人間が実際に操作すれば判定できるため D ではなく E とした
+
+### #954 — `/issue` L/XL 並列 subagent の結果配信 (SendMessage/Write フォールバック)
+
+- **条件文**: 「実際に Size=XL の Issue で `/issue` を実行し、3 エージェントの調査結果が手動介入なしに回収できることを確認する」
+- **差し戻し理由**: #1031 と同型の構造的制約 — Step 12a の fan-out が非対話モードで無条件 skip されるため、5 つの有効 event 値のいずれでも観測窓が開かない
+- **`/verify` 実行時に何をすれば判定できるか**: 対話モードで人間が Size=XL の Issue に対し `/issue` を実行し、3 エージェント (`issue-scope`/`issue-risk`/`issue-precedent`) の調査結果が `SendMessage` 経由 (または `Write` フォールバック経由) で手動介入なしに回収できたかを Spec の記載内容から確認する
+
+### #515 — `/verify` の tool call parse 失敗頻度の定性的改善確認
+
+- **条件文**: 「実プロジェクトで `/verify N` を複数回実行し、`The model's tool call could not be parsed` の発生頻度が改善していることを定性的に確認」
+- **差し戻し理由**: `docs/reports/manual-ac-retype-d2.md` が再型付け時点で既に指摘済みの通り、「頻度が改善」は単発の event 発火では判定しづらい定性的・統計的な問いであり、発生頻度を追跡する専用の計測基盤が本リポジトリに存在しない。`auto-run` は「1 回の実行が起きた」という事実しか伝えず、複数回にわたる頻度比較のトレンド情報を持たないため、event 発火では観測窓が開かない
+- **`/verify` 実行時に何をすれば判定できるか**: `/verify` 実行時に Claude が直近セッションでの `tool call could not be parsed` エラー遭遇頻度を rubric 相当の定性的判断で確認する。再型付け当初の設計意図 (「`/verify` 再チェック時の LLM 判断に委ねる」) とも整合する
+
+### #511 — MCP smoke test ブロック時の SKIPPED 記録確認
+
+- **条件文**: 「実機 external connector を使う Issue を `/auto` 非対話モードで実行し、MCP smoke 呼び出しがブロックされたケースで SKIPPED が記録され run が中断しないことを確認する」
+- **差し戻し理由**: Smoke Test 機構自体は本リポジトリの `/code` に実装済みだが、条件の発火には「将来のある Issue が `## Smoke Test` + `mcp_call` を Spec に持ち、かつ非対話モードで実際にブロックされる」という特定内容の Issue が存在することが前提となる。`auto-run` はこの内容依存の前提と無関係に発火するため、大半の発火で観測窓が開かない (#446/#486 と同型の「特定内容の Issue/PR 依存」パターン)
+- **`/verify` 実行時に何をすれば判定できるか**: `## Smoke Test` + `mcp_call` を持つ Issue が実際に `/code` 非対話モードで処理された際、Code Retrospective・completion message に SKIPPED 記録があるかを個別に確認する
+
+### #486 — 削除系 PR レビューでの FALSE POSITIVE 防止確認
+
+- **条件文**: 「削除系 PR (`file_not_exists` / `file_not_contains` AC を含む PR) を実際にレビューし、FALSE POSITIVE が発生しないことを確認する」
+- **差し戻し理由**: 親 #1270 が名指しした実例。「該当タイプの PR が発生しない限り観測窓が開かない」(親 Issue 本文より) — `auto-run` は削除系 PR の有無と無関係に発火するため、大半の発火で SKIPPED になる
+- **`/verify` 実行時に何をすれば判定できるか**: 削除系 AC (`file_not_exists`/`file_not_contains`) を含む PR が実際にレビューされた際、そのレビュー結果 (PR コメント) を確認して FALSE POSITIVE の有無を判定する
+
+### #446 条件1/条件2 — 新規 verify command 提案 Issue での adapter pattern 確認 step 動作確認 (`/issue` / `/spec`)
+
+- **条件文 (条件1)**: 「サンプル Issue (新 verify command 提案) で `/issue` 実行し、既存 adapter pattern 確認 step が機能することを手動確認」
+- **条件文 (条件2)**: 「同様に `/spec` 実行で確認」
+- **差し戻し理由**: 親 #1270 が名指しした実例。(1) `/auto` は `/issue` を毎回実行しない (unlabeled Issue の triage 時のみ)、(2) 実行されても「新規 verify command 提案」という Issue 内容の前提が別途必要 (親 Issue 本文より)。加えて、adapter pattern 確認 step が「機能した」ことを示す機械的に検索可能な証跡 (`auto-events.jsonl` 等) が存在しないため、event 発火時点で判定材料を得る手段がない
+- **`/verify` 実行時に何をすれば判定できるか**: 新規 verify command を提案する実 Issue が `/issue`/`/spec` で実際に処理された際、そのセッション記録 (Spec の Codebase Investigation セクション、adapter-resolver.md 参照の有無) を確認して既存 adapter pattern 確認 step が機能したかを判定する
+
+## D: 判定不能 (0 行)
+
+該当なし。12 行のうち「event でも `/verify` 実行時でも原理的に判定不能」に該当するものはなかった — E に分類した 7 行はいずれも `/verify` (manual) 実行時に Claude または人間が実際に操作・確認すれば判定可能であり、#1166 方式の retire は発生しない。
+
+## E の内訳: 即判定可能 / 装備待ちの区別
+
+7 行すべてが「今すぐ `/verify` (manual) で判定できる」に該当し、`capability=<key>` を要する装備待ちの行はない。
+
+| Issue | 装備待ちか | 理由 |
+|---|---|---|
+| #1031 | 否 | `ListAgents` (標準ツール) と対話モードでの直接実行で判定可能 |
+| #954 | 否 | Spec 記載内容の確認で判定可能 |
+| #515 | 否 | rubric 相当の定性的判断で判定可能 |
+| #511 | 否 | Code Retrospective / completion message の確認で判定可能 |
+| #486 | 否 | PR コメントの確認で判定可能 |
+| #446 条件1/条件2 | 否 | セッション記録の確認で判定可能 |
+
+## #446 / #486 の分類・処理内容 (親 Issue が名指しした実例)
+
+親 #1270 は「D と決め打ちしない」として #446 (条件1・条件2) と #486 を明示的に E 候補として本 sub-issue に配分した。実査の結果、いずれも E (`manual` へ差し戻し) と判定し、Issue 本文の該当行を書き換えた。詳細は上記「E: `manual` へ差し戻し」節の #446/#486 各項を参照。
+
+## D2 対象行以外の Post-merge 構成 (処理への影響確認)
+
+`docs/spec/issue-1275-observation-ac-audit-d2.md` Notes に記録の通り、#529 は D2 対象行以外に `verify-type: auto` の条件が既に `[x]` チェック済み、#511 は D2 対象行以外に `verify-type: opportunistic` の未チェック条件 (`## Smoke Test` セクションに関する条件) が別途残る。いずれも本 Issue では D (retire) が発生しなかったため `phase/done` 遷移判断は不要であり、この構成差異は処理結果に影響しない。
+
+## 検証: opportunistic-search.sh dry-run によるマッチ集合確認
+
+`scripts/opportunistic-search.sh --event auto-run --dry-run` (read-only) を編集前後で実行し、機械的に突合した。
+
+- **編集前**: 85 AC 行がマッチ (baseline と一致)。対象 12 行 (#1109 #1106 #1101 #1097 #1031 #954 #529 #515 #511 #486 #446×2) は全件マッチ集合に含まれることを確認
+- **編集後**: A 判定の 5 行 (#1109 #1106 #1101 #1097 #529) は引き続きマッチ集合に含まれることを確認。E 判定の 7 行 (#1031 #954 #515 #511 #486 #446×2) はいずれもマッチ集合から意図通り除外されたことを確認
+- **総マッチ数の変化**: 85→75 (10 減)。E 判定 7 行の除外により本来は 7 減の想定だが、差分は 10 だった。個別突合の結果、7 行の除外に加えて #861 / #769 / #859 の 3 行が編集前後で変動していたことを確認した。これらは本 Issue の編集対象外であり、実査期間中に他セッションで行われた並行活動 (別 Issue のチェックボックス更新等) による変動と考えられる。`docs/reports/manual-ac-retype-d2.md` の先例 (「件数差分の厳密一致より目視突合を正とする」) に倣い、対象 12 行それぞれの個別突合結果 (上記) を正としてマッチ集合確認の根拠とする
+
+## 集約レポートへの統合について
+
+本レポートの分類結果 (A 5 / B 0 / C 0 / D 0 / E 7) を `docs/reports/observation-ac-audit-summary.md` の集約テーブルへ統合するのは親 #1270 自身の責務であり、本 Issue のスコープ外。
+
+## Related
+
+- **#1270** — 親 Issue。実査全体の判定基準・実行順序制約の出典
+- **#1274 / #1276** — 由来単位で並列実行される他 sub-issue (由来: #1163 区分 A / #1165 区分 D3)
+- **#1164** — 区分 D2 として本 12 行を `verify-type: observation event=auto-run` へ再型付けした Issue。`docs/reports/manual-ac-retype-d2.md` が一次資料
+- **#1166** — D (retire) 方式の出典 (本 Issue では該当なし)
+- **#1278** — E の `capability=<key>` 内訳の引き継ぎ先 (本 Issue では該当なし、7 行とも即判定可能)

--- a/docs/spec/issue-1275-observation-ac-audit-d2.md
+++ b/docs/spec/issue-1275-observation-ac-audit-d2.md
@@ -59,3 +59,35 @@
 ## Consumed Comments
 
 - saito / MEMBER / first-class / triage フェーズの Issue Retrospective (Size=M の判断根拠、Background 表の対象 Issue 件数 13→11 修正の auto-resolve 記録、AC/Post-merge への変更なし) / https://github.com/saitoco/wholework/issues/1275#issuecomment-5226504642
+
+## Code Retrospective
+
+### Deviations from Design
+
+- なし。Implementation Steps に記載された手順 (1 行ずつ実査 → D は #1166 方式で retire → B/C は条件文書き換え → E は `manual` へ差し戻し → 記録ファイル作成) をそのまま実行した。分類結果が D 0 件・B/C 0 件・E 7 件・A 5 件になったこと自体は Spec が事前に決めていた配分ではなく実査の結果であり、手順からの逸脱ではない
+
+### Design Gaps/Ambiguities
+
+- **A と E の境界線が親 Issue #1270 の判定基準には明示されていなかった**: 親の「D と E の切り分け」表は D (event 判定不可・`/verify` 判定不可) と E (event 判定不可・`/verify` 判定可) の区別のみを定義しており、A (event 判定可) と E (event 判定不可) を分ける基準は「指定 event の発火時に…判定できる」という定性的な記述に留まっていた。実査では「条件が要求する前提が本リポジトリの通常運用で一定の頻度・既知パターンとして発生し、かつその発生を裏付ける機械可読な証跡 (`auto-events.jsonl`・PR コメント・`reconcile-phase-state.sh` 診断出力等) が存在するか」を実務上の判定軸として採用した (例: #1106/#1097/#529 は既存実例あり → A、#446/#486/#511 は内容依存の前提が成立したことを示す機械可読な証跡が構造的に存在しない → E)。この軸は #1270 や #1251 (AC 記述規約) に明文化されていないため、後続の分類作業 (他 sub-issue や将来の同種実査) で異なる粒度の判断がなされる可能性がある。判定軸そのものを `docs/reports/observation-ac-audit-d2.md` の各 E 項目に「差し戻し理由」として記録することで、後続実査者が同じ軸を参照できるようにした
+- **#1031/#954 (`/issue` Step 12a 関連) は「非対話モードでの構造的 skip」という #1164 の再型付け時点での既知の留意点が、D2 実査時点で改めて D/E 判定の決め手になった**: `docs/reports/manual-ac-retype-d2.md` は再型付け時点で既にこの留意点を記録していたが、「対象外にはせず `auto-run` を付与する」という判断だった。今回の実査で `ListAgents` 等の対話モード限定の確認手段が存在することから D ではなく E と判定した。将来的に `/issue` の非対話モード制約が変わった場合はこの判定も再検討が必要
+
+### Rework
+
+- なし。分類 → 実行 → 記録ファイル作成の一連の作業を手戻りなく完了した
+- Step 9 のテスト実行で、docs のみの新規ファイル追加 (既存ファイル変更なし) にもかかわらず Behavioral Change Detection の「新規ファイルのみ追加なら narrow scope で可」の判定を先に確認せず `bats --jobs 18 tests/` のフルスイートを先行実行してしまい、10 分の Bash ツール上限を超えてバックグラウンドへ移行した。`modules/execution-context.md` の「通知待ちでターンを終えない」原則に従い通知を待たずに進行し、`scripts/check-forbidden-expressions.sh` (対象ファイルに関連する軽量チェック) の実行に切り替えて Step 9 を完了させた。次回同種の docs-only 変更では、フルスイート起動前に Behavioral Change Detection の「新規ファイルのみ」判定を先に確認すること
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- 12 AC 行を A (5) / D (0) / E (7) に分類した。A と E の境界は「条件の前提が本リポジトリで既知の頻度で発生し、機械可読な証跡が存在するか」を実務上の判定軸として採用した (詳細は Code Retrospective 参照)
+- D が 0 件だったため #1166 方式の retire・`phase/done` 遷移は本 Issue では発生しなかった
+- E 判定 7 行 (#1031 #954 #515 #511 #486 #446×2) は全件「即判定可能」であり `capability=<key>` を要する装備待ちには該当しない
+
+### Deferred Items
+- `docs/reports/observation-ac-audit-d2.md` の分類結果 (A 5 / B 0 / C 0 / D 0 / E 7) の集約レポート (`observation-ac-audit-summary.md`) への統合は親 #1270 の責務として本 Issue のスコープ外のまま
+- #1275 の実査で採用した A/E 境界の判定軸 (前掲) は #1270 や #1251 に明文化されていない。他 sub-issue (#1274/#1276) や将来の同種実査が異なる粒度で判断する可能性があり、必要なら親 #1270 側で軸の明文化を検討する余地がある
+
+### Notes for Next Phase
+- `/review` は本 PR が GitHub Issue の本文編集・コメント投稿 (6 Issue: #1031 #954 #515 #511 #486 #446) を伴う点に留意すること — リポジトリファイルの diff は `docs/reports/observation-ac-audit-d2.md` の追加 1 件のみだが、実質的な変更はそれら 6 Issue の本文にも及んでいる
+- `docs/reports/observation-ac-audit-d2.md` の「検証」節に記載の通り、dry-run 前後比較で対象外の #861 / #769 / #859 も変動していた (他セッションの並行活動によるものと推定)。レビュー時にこの差分が本 PR の変更によるものと誤認しないよう注意

--- a/docs/spec/issue-1275-observation-ac-audit-d2.md
+++ b/docs/spec/issue-1275-observation-ac-audit-d2.md
@@ -77,17 +77,33 @@
 - Step 9 のテスト実行で、docs のみの新規ファイル追加 (既存ファイル変更なし) にもかかわらず Behavioral Change Detection の「新規ファイルのみ追加なら narrow scope で可」の判定を先に確認せず `bats --jobs 18 tests/` のフルスイートを先行実行してしまい、10 分の Bash ツール上限を超えてバックグラウンドへ移行した。`modules/execution-context.md` の「通知待ちでターンを終えない」原則に従い通知を待たずに進行し、`scripts/check-forbidden-expressions.sh` (対象ファイルに関連する軽量チェック) の実行に切り替えて Step 9 を完了させた。次回同種の docs-only 変更では、フルスイート起動前に Behavioral Change Detection の「新規ファイルのみ」判定を先に確認すること
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- 12 AC 行を A (5) / D (0) / E (7) に分類した。A と E の境界は「条件の前提が本リポジトリで既知の頻度で発生し、機械可読な証跡が存在するか」を実務上の判定軸として採用した (詳細は Code Retrospective 参照)
-- D が 0 件だったため #1166 方式の retire・`phase/done` 遷移は本 Issue では発生しなかった
-- E 判定 7 行 (#1031 #954 #515 #511 #486 #446×2) は全件「即判定可能」であり `capability=<key>` を要する装備待ちには該当しない
+- Pre-merge AC 6 件すべてを PASS 判定した。うち D=0 に関する 2 件 (#1166 方式 retire / `phase/done` 遷移) は「該当なしのため vacuously satisfied」として PASS とした
+- レポート `docs/reports/observation-ac-audit-d2.md` の記載内容 (対象 6 Issue の `verify-type: manual` 書き換え、対象 6 Issue が `phase/verify` 維持) を `gh issue view` で個別に GitHub 実状態と突合し、一致を確認した
+- review-light エージェント (4 観点統合) で MUST/SHOULD/CONSIDER 相当の指摘は 0 件。修正作業 (Step 12) は発生しなかった
+- CI 全 11 ジョブ SUCCESS、base branch とのコンフリクトなし (`git merge-tree` 0 件) を確認した
 
 ### Deferred Items
 - `docs/reports/observation-ac-audit-d2.md` の分類結果 (A 5 / B 0 / C 0 / D 0 / E 7) の集約レポート (`observation-ac-audit-summary.md`) への統合は親 #1270 の責務として本 Issue のスコープ外のまま
-- #1275 の実査で採用した A/E 境界の判定軸 (前掲) は #1270 や #1251 に明文化されていない。他 sub-issue (#1274/#1276) や将来の同種実査が異なる粒度で判断する可能性があり、必要なら親 #1270 側で軸の明文化を検討する余地がある
+- #1275 の実査で採用した A/E 境界の判定軸は #1270 や #1251 に明文化されていない。他 sub-issue (#1274/#1276) や将来の同種実査が異なる粒度で判断する可能性があり、必要なら親 #1270 側で軸の明文化を検討する余地がある
 
 ### Notes for Next Phase
-- `/review` は本 PR が GitHub Issue の本文編集・コメント投稿 (6 Issue: #1031 #954 #515 #511 #486 #446) を伴う点に留意すること — リポジトリファイルの diff は `docs/reports/observation-ac-audit-d2.md` の追加 1 件のみだが、実質的な変更はそれら 6 Issue の本文にも及んでいる
-- `docs/reports/observation-ac-audit-d2.md` の「検証」節に記載の通り、dry-run 前後比較で対象外の #861 / #769 / #859 も変動していた (他セッションの並行活動によるものと推定)。レビュー時にこの差分が本 PR の変更によるものと誤認しないよう注意
+- `/merge` 実行時、対象 6 Issue (#1031 #954 #515 #511 #486 #446) の本文編集は PR マージとは独立して既に GitHub 上に反映済みである — リポジトリファイルの diff は `docs/reports/observation-ac-audit-d2.md` の追加 1 件のみだが、実質的な変更はそれら 6 Issue の本文にも及んでいる点に留意
+- `docs/reports/observation-ac-audit-d2.md` の「検証」節に記載の通り、dry-run 前後比較で対象外の #861 / #769 / #859 も変動していた (他セッションの並行活動によるものと推定)。`/review` で再実行した dry-run でも同様の変動 (75→74) を確認済みであり、本 PR の変更によるものではない
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+なし。Implementation Steps の手順とレポート内容 (`docs/reports/observation-ac-audit-d2.md`) は一致しており、review-light の 4 観点チェックでも spec 逸脱の指摘はなかった。
+
+### Recurring issues
+
+なし。review-bug 相当の指摘は 0 件で、他 PR と共通する再発パターンは観測されなかった。
+
+### Acceptance criteria verification difficulty
+
+- 6 件の Pre-merge 条件のうち 5 件が `rubric` 型であり、いずれも「レポートファイルへの記載」だけでなく「対象 6 Issue (#1031 #954 #515 #511 #486 #446) の GitHub 本文が実際に書き換わっているか」という、リポジトリ diff からは見えない外部状態の確認を要した。今回は `/review` 側で該当 Issue 本文を個別に `gh issue view` で突合し、レポートの記載内容と実際の GitHub 状態が一致することを確認した。verify command 自体には Issue 本文の書き換え結果を検証する仕組みがなく、rubric の目視確認に依存している点は、この種の「レポート作成 + 外部 Issue 編集」を伴う Issue 全般に共通する構造であり、verify command の記述を強化する余地があるとすれば「対象 Issue 本文に指定 marker が存在すること」を機械的にチェックする verify command 型 (例: 複数 Issue の `<!-- verify-type: ... -->` 一括確認) の追加が考えられるが、今回のスコープ外として記録に留める。
+- 分類 D=0 だった条件 (Pre-merge 4/5) は「該当なしのため vacuously satisfied」という判定になった。条件文自体は「D 分類の AC 行が...」という前提付きの書き方であり、D=0 の場合にどう判定すべきかは条件文から自明ではなかった。今回は「レポートに D=0 の旨が明記されていること」を根拠に PASS としたが、こうした「件数 0 なら自動的に満たされる」条件は #1251 (AC 記述規約) 側で明示的な扱い方 (例: 該当なしの場合の判定ルール) を定義する余地がある。


### PR DESCRIPTION
## Summary

- 親 Issue #1270 の sub-issue。#1164 (区分 D2) が `verify-type: manual` から `verify-type: observation event=auto-run` へ再型付けした 12 AC 行 / 11 Issue (#1109 #1106 #1101 #1097 #1031 #954 #529 #515 #511 #486 #446) を、「どの event が発火したとき何を根拠に PASS 判定できるか」の観点で 1 行ずつ実査した
- 分類結果: A (判定可能・維持) 5 行 / D (判定不能・retire) 0 行 / E (`manual` へ差し戻し) 7 行
- E 判定の 7 行 (#1031 #954 #515 #511 #486 #446×2) について、対象 Issue 本文の該当 AC 行を `<!-- verify-type: observation event=auto-run -->` から `<!-- verify-type: manual -->` へ書き換えた (条件文自体は変更なし)
- 分類・判断根拠を `docs/reports/observation-ac-audit-d2.md` に記録した

## Verification (pre-merge)

- `docs/reports/observation-ac-audit-d2.md` に 12 AC 行すべての分類と判断根拠を Issue 単位・AC 行単位で記載
- `file_exists "docs/reports/observation-ac-audit-d2.md"` を満たす
- 親 Issue が名指しした #446 / #486 の分類結果・処理内容を記載
- 分類 D は 0 件のため retire は発生せず、その旨をレポートに明記
- 分類 D の retire による `phase/done` 遷移も同様に 0 件、レポートに明記
- E へ差し戻した 7 行について `opportunistic-search.sh --event auto-run --dry-run` で編集前後のマッチ集合を確認し、意図通り除外されたことをレポートに記録

## Verification (post-merge)

なし (効果測定は親 #1270 に集約)

closes #1275
