### PR TITLE
Issue #1289: Derive Route mix from executed code-pr/code-patch phase events

### DIFF
--- a/docs/spec/issue-1289-route-mix-post-spec-size.md
+++ b/docs/spec/issue-1289-route-mix-post-spec-size.md
@@ -82,18 +82,26 @@ Acceptance criteria 3 (`operate` route・`xl`・フェーズ未達 Issue の 3 �
 - なし。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Grouped session events by `.issue` and derived `patch`/`pr` from `code-patch`/`code-pr` phase presence rather than the pre-spec `sub_start` size, mirroring `collect-run-facts.sh`'s reference implementation per the Spec's design.
-- Kept `xl` derivation unchanged (`sub_start` size == "XL") since XL parent Issues never reach a `code-pr`/`code-patch` phase of their own.
-- Added a new `unknown` bucket for processed Issues that reach neither `code-pr` nor `code-patch`, matching `collect-run-facts.sh`'s "unknown" precedent rather than folding them into `patch`.
+- Ran `REVIEW_DEPTH=light` (1-agent `review-light`, all 4 aspects) per Issue Size; no Workflow-path fan-out.
+- All 5 Pre-merge ACs re-verified independently via verify-executor semantics (2 rubric, 2 grep, 1 command) — all PASS; posted review as `COMMENT` (no MUST issues).
 
 ### Deferred Items
-- The post-merge observation AC (patch/pr-mixed `/auto --batch` run confirming Route mix matches reality) is deferred to the next such run per its `verify-type: observation session=next` marker — left unchecked.
-- `operate` route has no dedicated bucket (implicitly folded into `patch`, since operate route also emits `code-patch` phase events) — this was an explicit Auto-Resolved Ambiguity Point from `/issue`, not revisited in this phase.
+- The Post-merge observation AC (`verify-type: observation session=next`) remains unchecked, unchanged from the code phase's handoff — still waiting for the next patch/pr-mixed `/auto --batch` run.
 
 ### Notes for Next Phase
-- Historical `docs/sessions/*/session.md` Metrics text (disposable session logs) still shows the old 3-field `patch/pr/xl` format without `unknown` — no update needed there; they are point-in-time snapshots, not living documentation.
-- The full bats suite (1639 tests) was run and passed because `tests/audit-auto-session.bats` also references `scripts/get-auto-session-report.sh`, triggering the Behavioral Change Detection full-suite override — `/review` can treat this as already confirmed pre-merge rather than re-running it.
-- The Issue's own Notes section explicitly deferred adding a `github_check "gh pr checks"` pre-merge CI AC (Size wasn't finalized at Issue-creation time); this PR is on the pr route, so `/review`/`/verify` may add one if desired, but it was not authored here per that deferral.
+- No MUST/SHOULD/CONSIDER issues were raised in review; `/merge 1299` can proceed directly.
+- `bats tests/get-auto-session-report.bats` confirmed 15/15 PASS locally in addition to CI (11/11 checks SUCCESS) — no residual verification risk for `/merge`.
+
+## Review Retrospective
+
+### Spec vs. Implementation Divergence Patterns
+Nothing to note. review-light's Spec-deviation aspect found the implementation followed Implementation Steps 1–3 exactly, including the one documented deviation (an extra `@test` for coverage, already captured in the Code Retrospective) which was not a design divergence.
+
+### Recurring Issues
+Nothing to note. No issue types repeated across this PR's review; 0 findings across all 4 review-light aspects.
+
+### Acceptance Criteria Verification Difficulty
+Nothing to note. All 5 Pre-merge ACs had well-formed verify commands (2 `rubric`, 2 `grep`, 1 `command`) and none required UNCERTAIN fallback or AI-judgment guessing.

--- a/docs/spec/issue-1289-route-mix-post-spec-size.md
+++ b/docs/spec/issue-1289-route-mix-post-spec-size.md
@@ -68,3 +68,32 @@ Acceptance criteria 3 (`operate` route・`xl`・フェーズ未達 Issue の 3 �
 ## Consumed Comments
 
 - saito / MEMBER / first-class / `/issue` フェーズの Issue Retrospective — non-interactive 自動解決ログ (Auto-Resolve Log) の記録。内容は既に Issue 本文の「対応方針 (案)」「Auto-Resolved Ambiguity Points」に反映済みのため、本 Spec への追加指示なし / https://github.com/saitoco/wholework/issues/1289#issuecomment-5228135341
+- 本 `/code` 実行時点で新規コメントなし (cutoff: 直近の `phase/*` ラベル付与時刻 2026-08-08T21:33:24Z)。
+
+## Code Retrospective
+
+### Deviations from Design
+- なし。Implementation Steps 1–3 をそのまま実装した。Implementation Step 2 は 1 件の `@test` 追加を指示していたが、`xl` / `unknown` バケットの分離挙動も個別に固定化する価値があると判断し、2 件目の `@test` (XL sub_start + phase 未到達 Issue の組み合わせ) を追加した。これはアプローチの変更ではなくカバレッジの補強であり、Implementation Steps 自体の更新は不要と判断した。
+
+### Design Gaps/Ambiguities
+- `/code` 開始時点で Issue #1289 のラベルが `phase/ready` を経ずに既に `phase/code` へ遷移済みだった (`reconcile-phase-state.sh --check-precondition` が `matches_expected: false` を報告)。Spec ファイルは存在し内容も完成していたため、前回の `/code` 試行が Step 4 のラベル遷移まで進んだ後に PR 作成前で中断したものと推測される。SKILL.md Step 3 の non-interactive auto-resolve 方針 (`warn-only` で継続) に従い、Spec を正として実装を続行した。
+
+### Rework
+- なし。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Grouped session events by `.issue` and derived `patch`/`pr` from `code-patch`/`code-pr` phase presence rather than the pre-spec `sub_start` size, mirroring `collect-run-facts.sh`'s reference implementation per the Spec's design.
+- Kept `xl` derivation unchanged (`sub_start` size == "XL") since XL parent Issues never reach a `code-pr`/`code-patch` phase of their own.
+- Added a new `unknown` bucket for processed Issues that reach neither `code-pr` nor `code-patch`, matching `collect-run-facts.sh`'s "unknown" precedent rather than folding them into `patch`.
+
+### Deferred Items
+- The post-merge observation AC (patch/pr-mixed `/auto --batch` run confirming Route mix matches reality) is deferred to the next such run per its `verify-type: observation session=next` marker — left unchecked.
+- `operate` route has no dedicated bucket (implicitly folded into `patch`, since operate route also emits `code-patch` phase events) — this was an explicit Auto-Resolved Ambiguity Point from `/issue`, not revisited in this phase.
+
+### Notes for Next Phase
+- Historical `docs/sessions/*/session.md` Metrics text (disposable session logs) still shows the old 3-field `patch/pr/xl` format without `unknown` — no update needed there; they are point-in-time snapshots, not living documentation.
+- The full bats suite (1639 tests) was run and passed because `tests/audit-auto-session.bats` also references `scripts/get-auto-session-report.sh`, triggering the Behavioral Change Detection full-suite override — `/review` can treat this as already confirmed pre-merge rather than re-running it.
+- The Issue's own Notes section explicitly deferred adding a `github_check "gh pr checks"` pre-merge CI AC (Size wasn't finalized at Issue-creation time); this PR is on the pr route, so `/review`/`/verify` may add one if desired, but it was not authored here per that deferral.

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -167,15 +167,27 @@ if [[ "$SESSION_START" != "N/A" && "$SESSION_END" != "N/A" ]]; then
   fi
 fi
 
-# Route mix: count patch (XS/S) vs pr (M/L) from sub_start events
+# Route mix: derive patch/pr/xl/unknown per processed Issue from the actually-executed
+# code-pr / code-patch phase events (post-spec Size reality), not the pre-spec sub_start
+# size — mirrors collect-run-facts.sh's per-issue route derivation. xl is still derived
+# from sub_start size == "XL" (XL parents never reach a code-pr/code-patch phase of their
+# own). Issues with neither phase event fall into unknown, matching collect-run-facts.sh's
+# "unknown" precedent for unresolved route.
 ROUTE_MIX=$(echo "$EVENTS_JSON" | jq -r '
-  [.[] | select(.event == "sub_start")] |
-  {
-    patch: ([.[] | select(.size == "XS" or .size == "S")] | length),
-    pr:    ([.[] | select(.size == "M" or .size == "L")] | length),
-    xl:    ([.[] | select(.size == "XL")] | length)
-  } |
-  "patch: \(.patch), pr: \(.pr), xl: \(.xl)"
+  [.[] | select(.issue != null and .issue > 0 and (.event == "sub_start" or (.event | startswith("phase_"))))]
+  | group_by(.issue)
+  | map({
+      is_xl: (map(select(.event == "sub_start" and .size == "XL")) | length > 0),
+      has_pr: (map(select(.phase == "code-pr")) | length > 0),
+      has_patch: (map(select(.phase == "code-patch")) | length > 0)
+    })
+  | {
+      xl:      (map(select(.is_xl)) | length),
+      pr:      (map(select(.is_xl | not) | select(.has_pr)) | length),
+      patch:   (map(select(.is_xl | not) | select((.has_pr | not) and .has_patch)) | length),
+      unknown: (map(select(.is_xl | not) | select((.has_pr | not) and (.has_patch | not))) | length)
+    } |
+  "patch: \(.patch), pr: \(.pr), xl: \(.xl), unknown: \(.unknown)"
 ' 2>/dev/null || echo "N/A")
 
 # Issues processed (distinct issue numbers with an event indicating actual phase execution)

--- a/tests/get-auto-session-report.bats
+++ b/tests/get-auto-session-report.bats
@@ -261,3 +261,37 @@ FIXTURE_EOF
     echo "$output" | grep -q "Tier 1/2/3 recoveries | 0 / 2 / 3"
     echo "$output" | grep -q "Recovery success rate (tier) | T1: 0 recovered / 0 failed, T2: 1 recovered / 1 failed, T3: 1 recovered / 2 failed"
 }
+
+@test "Route mix: reports the executed code-patch/code-pr phase route, not the pre-spec sub_start size" {
+    # Models session 23043-1786197225 (2026-08-09): #1256 is sub_start'd at Size M but
+    # /spec demotes it to XS and it runs code-patch; #1266 is sub_start'd at Size S and
+    # runs code-patch; #1279 is sub_start'd at Size M and runs code-pr as expected. A
+    # naive sub_start-size read would report "patch: 1, pr: 2"; the executed-phase read
+    # must report "patch: 2, pr: 1".
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-08-08T14:00:17Z","issue":1256,"event":"sub_start","session_id":"session-routemix","size":"M"}
+{"ts":"2026-08-08T14:10:00Z","issue":1256,"event":"phase_start","session_id":"session-routemix","phase":"code-patch"}
+{"ts":"2026-08-08T14:20:00Z","issue":1256,"event":"phase_complete","session_id":"session-routemix","phase":"code-patch"}
+{"ts":"2026-08-08T14:46:59Z","issue":1266,"event":"sub_start","session_id":"session-routemix","size":"S"}
+{"ts":"2026-08-08T14:50:00Z","issue":1266,"event":"phase_start","session_id":"session-routemix","phase":"code-patch"}
+{"ts":"2026-08-08T14:55:00Z","issue":1266,"event":"phase_complete","session_id":"session-routemix","phase":"code-patch"}
+{"ts":"2026-08-08T16:07:42Z","issue":1279,"event":"sub_start","session_id":"session-routemix","size":"M"}
+{"ts":"2026-08-08T16:10:00Z","issue":1279,"event":"phase_start","session_id":"session-routemix","phase":"code-pr"}
+{"ts":"2026-08-08T16:20:00Z","issue":1279,"event":"phase_complete","session_id":"session-routemix","phase":"code-pr"}
+FIXTURE_EOF
+
+    run bash "$SCRIPT" "session-routemix" --metrics-only --no-github
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Route mix.*patch: 2, pr: 1, xl: 0, unknown: 0"
+}
+
+@test "Route mix: XL sub_start and phase-less processed Issue are bucketed separately" {
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-08-08T17:00:00Z","issue":1300,"event":"sub_start","session_id":"session-routemix-xl","size":"XL"}
+{"ts":"2026-08-08T18:00:00Z","issue":1301,"event":"sub_start","session_id":"session-routemix-xl","size":"S"}
+FIXTURE_EOF
+
+    run bash "$SCRIPT" "session-routemix-xl" --metrics-only --no-github
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "Route mix.*patch: 0, pr: 0, xl: 1, unknown: 1"
+}


### PR DESCRIPTION
## Summary
- `scripts/get-auto-session-report.sh` の `Route mix` メトリクスの route 導出元を、`sub_start` イベントの事前 Size ではなく、実際に実行された `code-pr` / `code-patch` phase イベントへ変更 (`collect-run-facts.sh` の参照実装に整合)
- `tests/get-auto-session-report.bats` に、post-spec で Size が降格したケース (実測 session `23043-1786197225` の #1256/#1266/#1279 をモデル化) と XL/未実行 Issue の bucket 分離を検証する `@test` を追加

## Verification (pre-merge)
- `scripts/get-auto-session-report.sh` の `Route mix` が `code-pr` / `code-patch` phase イベントの有無から route を導出している
- `scripts/get-auto-session-report.sh` が `code-patch` を参照している
- `operate` route・`xl`・フェーズ未達 Issue の扱いは Spec の Notes に既に記録済み
- `tests/get-auto-session-report.bats` に `Route mix` を検証する新規 `@test` を追加
- `bats tests/get-auto-session-report.bats` (15 件) と `bats tests/audit-auto-session.bats` (7 件、間接参照ファイル) を含むフルスイート (1639 件) が全件 PASS

## Verification (post-merge)
- patch route と pr route が混在する `/auto --batch` の完走後、L3 retrospective の `Route mix` の内訳が実際の経路構成と一致することを観察する

closes #1289
