### PR TITLE
Issue #1292: Document bats negation assertion pitfall in test-runner.md

### DIFF
--- a/docs/reports/bats-negation-assertion-audit.md
+++ b/docs/reports/bats-negation-assertion-audit.md
@@ -83,10 +83,24 @@ applies, and no rewrite is needed.
 
 ## Out of Scope
 
-Bare `!` negations without a `| grep` pipeline (e.g. `tests/reclaim-stale-worktrees.bats:136,159`
-`! git branch -d ... 2>/dev/null`) can be subject to the same `set -e` exception rule, but Issue
-#1292 explicitly scopes its target pattern to `! ... | grep` form. These are noted for reference
-only and are not covered by this audit's remediation.
+Two related patterns are subject to the same `set -e` non-final-statement exception rule
+documented in `modules/test-runner.md`, but Issue #1292 explicitly scopes its target pattern to
+the `! cmd | grep -q ...` piped form, so neither is covered by this audit's search command or
+remediation:
+
+- **Bare `!` negations without any `grep`** (e.g. `tests/reclaim-stale-worktrees.bats:136,159`
+  `! git branch -d ... 2>/dev/null`).
+- **`! grep -q pattern file` without a pipe** (grep reading a file directly, rather than via a
+  piped `echo`/command output). A broader scan (`grep -rnE '^\s*!\s*.*grep' tests/*.bats | grep
+  -vE '\|\s*grep'`) found 76 candidate lines across roughly 30 files as of this audit (2026-08-09)
+  that share the identical exit-status-excluded-from-`set -e` mechanism but were not counted or
+  classified here — this figure is a raw grep count, not a per-line final/non-final
+  classification, so the actual defective subset is unconfirmed. Examples observed to be
+  non-final (and therefore currently detection-power-zero) during a spot check include
+  `tests/run-code.bats:470`, `tests/run-issue.bats:306`, and `tests/gh-graphql.bats:69`.
+
+Both categories are noted here for reference only; scoping and remediation are left to a
+follow-up Issue rather than this one.
 
 ## Remediation Record
 

--- a/docs/reports/bats-negation-assertion-audit.md
+++ b/docs/reports/bats-negation-assertion-audit.md
@@ -1,0 +1,96 @@
+# bats Negation Assertion Audit (Issue #1292)
+
+## Purpose
+
+Inventory all `! cmd | grep ...` negation assertions in `tests/*.bats` and classify each as
+defective (non-final statement — silently defeated under `set -e`, see
+`modules/test-runner.md` § "bats Negation Assertion Pitfall") or safe (true final statement of
+its `@test` function). This audit is the Spec-phase investigation input for Issue #1292; the
+defective entries were rewritten to the `if cmd | grep -q pattern; then false; fi` form in the
+same Issue.
+
+## Search Command and Scope
+
+```bash
+grep -rnE '^\s*!\s*.*\|\s*grep' tests/*.bats
+```
+
+Scope: all `.bats` files directly under `tests/` (116 files as of this audit). Confirmed via
+`find tests -mindepth 2 -name "*.bats"` that no `.bats` files exist in subdirectories, so the
+non-recursive glob `tests/*.bats` has no coverage gap.
+
+## Judgment Criteria
+
+For each matched line, inspect the enclosing `@test "..." { ... }` function body:
+
+- **Defective (non-final statement)**: at least one more statement follows the negation line
+  before the function's closing `}`. Under `set -e`, a negated pipeline's exit status never
+  triggers automatic termination (POSIX/bash semantics for `!`), so if the pattern is found —
+  the exact condition the assertion exists to catch — execution continues past it and the test
+  still reports PASS.
+- **Safe (true final statement)**: the negation line is the last statement before the function's
+  closing `}`. bats evaluates the function's own return value directly, so the negated
+  pipeline's exit status correctly determines pass/fail without an intervening `set -e`
+  non-final-statement context.
+
+## Summary
+
+**21 matches total, across 7 files.**
+
+| Classification | Count |
+|---|---|
+| Defective (non-final statement, required fix) | 9 |
+| Safe (true final statement, no change) | 12 |
+
+## Defective (non-final statement) — 9 entries, fixed in this Issue
+
+| File:Line | Original form | Remediation |
+|---|---|---|
+| `tests/audit-auto-session.bats:66` | `! echo "$output" \| grep -q "Issues processed \| 2"` | Rewritten to `if ...; then false; fi` |
+| `tests/get-auto-session-report.bats:32` | `! echo "$output" \| grep -q "\| #200 \|"` | Rewritten to `if ...; then false; fi` |
+| `tests/get-auto-session-report.bats:70` | `! echo "$output" \| grep -q "\| #501 \|"` | Rewritten to `if ...; then false; fi` |
+| `tests/filter-session-verified-issues.bats:39` | `! echo "$output" \| grep -qx "984"` | Rewritten to `if ...; then false; fi` |
+| `tests/collect-recovery-candidates.bats:376` | `! echo "$output" \| grep -E $'^manual-recovery-review-rerun\t'` | Rewritten to `if ... grep -qE ...; then false; fi` (added `-q`, absent in the original) |
+| `tests/reclaim-stale-worktrees.bats:90` | `! git -C "$MAIN_REPO" worktree list \| grep -q "wt1006"` | Rewritten to `if ...; then false; fi` |
+| `tests/reclaim-stale-worktrees.bats:144` | `! git -C "$MAIN_REPO" worktree list \| grep -q "wt1149"` | Rewritten to `if ...; then false; fi` |
+| `tests/reclaim-stale-worktrees.bats:168` | `! git -C "$MAIN_REPO" worktree list \| grep -q "wt5000"` | Rewritten to `if ...; then false; fi` |
+| `tests/verify.bats:154` | `! step6_section \| grep -q -F "Re-verify even if already checked"` | Rewritten to `if ...; then false; fi` |
+
+Except for `collect-recovery-candidates.bats:376` (missing `-q`, added to match the
+`tests/collect-recovery-candidates.bats:604-605` precedent), all existing grep flags and pattern
+strings were preserved unchanged — only the negation/branch structure was rewritten.
+
+## Safe (true final statement) — 12 entries, no change
+
+| File:Line |
+|---|
+| `tests/audit-auto-session.bats:46` |
+| `tests/audit-auto-session.bats:103` |
+| `tests/get-auto-session-report.bats:71` |
+| `tests/get-auto-session-report.bats:199` |
+| `tests/collect-recovery-candidates.bats:460` |
+| `tests/collect-recovery-candidates.bats:611` |
+| `tests/reclaim-stale-worktrees.bats:91` |
+| `tests/reclaim-stale-worktrees.bats:145` |
+| `tests/reclaim-stale-worktrees.bats:181` |
+| `tests/reclaim-stale-worktrees.bats:206` |
+| `tests/triage-backlog-filter.bats:52` |
+| `tests/triage-backlog-filter.bats:130` |
+
+These lines are each the true final statement of their enclosing `@test` function, so bats
+evaluates the function's own return value directly — no `set -e` non-final-statement exception
+applies, and no rewrite is needed.
+
+## Out of Scope
+
+Bare `!` negations without a `| grep` pipeline (e.g. `tests/reclaim-stale-worktrees.bats:136,159`
+`! git branch -d ... 2>/dev/null`) can be subject to the same `set -e` exception rule, but Issue
+#1292 explicitly scopes its target pattern to `! ... | grep` form. These are noted for reference
+only and are not covered by this audit's remediation.
+
+## Remediation Record
+
+All 9 defective entries were rewritten to the `if cmd | grep -q pattern; then false; fi` form in
+this Issue's implementation commit. The 12 safe entries were left unchanged. Post-remediation,
+`bats tests/` was re-run to confirm the rewritten assertions preserve existing pass/fail
+behavior (see Issue #1292 Code Retrospective for the run result).

--- a/docs/spec/issue-1292-bats-negation-pitfall.md
+++ b/docs/spec/issue-1292-bats-negation-pitfall.md
@@ -86,3 +86,30 @@ tests/audit-auto-session.bats:46,103 / tests/get-auto-session-report.bats:71,199
 | login | authorAssociation | trust tier | intent | URL |
 |---|---|---|---|---|
 | saito | MEMBER | first-class | Issue Retrospective (triage auto-chain): Type=Task, Size=S に確定。AC3 の記録先を「Spec/Issue コメント」→ `docs/reports/bats-negation-assertion-audit.md` に変更した理由 (rubric grader は Spec ファイルと Issue コメントのどちらも読めないため) を記録。Issue 本文にも同内容が反映済み | https://github.com/saitoco/wholework/issues/1292#issuecomment-5228437961 |
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜4 を Spec の記載順どおりに実施した。
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A — Spec フェーズの棚卸し (対象9件・安全12件の分類) がそのまま実装の書き換え対象と一致しており、実装時の再調査・やり直しは発生しなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec 記載の棚卸し結果 (9件書き換え対象・12件安全) をそのまま採用し、実装時の再グレップでも同じ21件・同じ分類であることを確認してから書き換えた。
+- `tests/collect-recovery-candidates.bats:376` のみ既存に `-q` フラグが無かったため、Spec の指示どおり `:604-605` の前例に合わせて `-q` を追加した。他8件は既存の grep フラグ・パターン文字列を変更していない。
+- `bats --jobs 18 tests/` (全1639件) を実行し PASS を確認。既存9件の書き換え後もアサーションの前提条件 (見つかるべきパターンが実際に見つかる/見つからないべきパターンが見つからない) が現状のコードで成立していることを検証した。
+
+### Deferred Items
+- Post-merge AC (次回 bats テストを追加する Issue での観察) は `/verify` 以降の運用に委ねる。
+- `skills/issue/spec-test-guidelines.md` への同内容の追記は Issue 本文 Notes の判断どおり見送った (`modules/test-runner.md` 1箇所で到達範囲は足りるとの Spec の判断を踏襲)。
+
+### Notes for Next Phase
+- 5件の pre-merge AC はすべて `/code` 内で PASS 確認済み (rubric 2件・grep 1件・file_exists 1件・command 1件)。Issue のチェックボックスも `[x]` に更新済み。
+- 変更ファイルは `modules/test-runner.md`、`docs/reports/bats-negation-assertion-audit.md` (新規)、および6件の `tests/*.bats` のみ。SKILL.md やスクリプトへの変更はない。

--- a/docs/spec/issue-1292-bats-negation-pitfall.md
+++ b/docs/spec/issue-1292-bats-negation-pitfall.md
@@ -98,18 +98,34 @@ tests/audit-auto-session.bats:46,103 / tests/get-auto-session-report.bats:71,199
 ### Rework
 - N/A — Spec フェーズの棚卸し (対象9件・安全12件の分類) がそのまま実装の書き換え対象と一致しており、実装時の再調査・やり直しは発生しなかった。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+乖離なし。Implementation Steps 1〜4 の記述と実装内容 (`modules/test-runner.md` の Notes セクション、`docs/reports/bats-negation-assertion-audit.md`、6件の `tests/*.bats` 書き換え) は一致していた。Pre-merge AC 5件はいずれも `/code` 内で PASS 確認済みで、`/review --light` の safe mode 再検証でも同じ結果 (rubric 2件・grep 1件・file_exists 1件・command 1件、全PASS) となった。
+
+### Recurring issues
+
+`docs/reports/bats-negation-assertion-audit.md` の検索コマンド (`grep -rnE '^\s*!\s*.*\|\s*grep' tests/*.bats`) は `! cmd | grep ...` の **pipe 形式のみ**を対象にしているが、`set -e` 下で `!` の終了ステータスが無効化されるという根本原因は pipe の有無に関係なく成立する。review-light の Perspective 1/2 が独立に、pipe を伴わない `! grep -q pattern file` 形式の非最終文アサーションを別途検出した (`grep -rnE '^\s*!\s*.*grep' tests/*.bats | grep -vE '\|\s*grep'` で76件の生候補、`tests/run-code.bats:470` `tests/run-issue.bats:306` `tests/gh-graphql.bats:69` 等で実際に非最終文=検出力ゼロであることを確認)。Issue #1292 の本文は対象パターンを `! cmd | grep -q ...` の pipe 形式に明示的にスコープしていたため、本 Issue の対応としては監査レポートの Out of Scope 節に当該パターンの存在と件数を明記するに留めた (実際の分類・修正は行っていない)。76件という規模は独立の棚卸し・修正作業に値するため、Improvement Proposal として `/verify` での起票検討を推奨する。
+
+### Acceptance criteria verification difficulty
+
+UNCERTAIN は発生しなかった。5件の Pre-merge AC (rubric 2件・grep 1件・file_exists 1件・command 1件) はいずれも判定に迷いなく PASS 確定できた。`command "bats tests/"` は `bats --jobs 18 tests/` で1639件全件 PASS を確認しており、非対話モードでの並列実行 (foreground, timeout 590000ms) も問題なく機能した。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec 記載の棚卸し結果 (9件書き換え対象・12件安全) をそのまま採用し、実装時の再グレップでも同じ21件・同じ分類であることを確認してから書き換えた。
-- `tests/collect-recovery-candidates.bats:376` のみ既存に `-q` フラグが無かったため、Spec の指示どおり `:604-605` の前例に合わせて `-q` を追加した。他8件は既存の grep フラグ・パターン文字列を変更していない。
-- `bats --jobs 18 tests/` (全1639件) を実行し PASS を確認。既存9件の書き換え後もアサーションの前提条件 (見つかるべきパターンが実際に見つかる/見つからないべきパターンが見つからない) が現状のコードで成立していることを検証した。
+- `/review --light` (REVIEW_DEPTH=light, `.wholework.yml` に copilot-review/claude-code-review/coderabbit-review 設定なしのため Step 7 全体スキップ) で review-light エージェントを1体起動し、4観点を統合レビューした。
+- review-light が検出した SHOULD 1件 (監査の検索スコープが pipe 無し `! grep` 形式を捕捉していない) は、既存9件と同じ規模の追加調査・修正 (76件の生候補) を要するため本 PR のスコープには含めず、`docs/reports/bats-negation-assertion-audit.md` の Out of Scope 節に件数・具体例を明記するに留めた。
+- MUST 指摘・CI FAILURE ともに無し。Review は `COMMENT` イベントで投稿された。
 
 ### Deferred Items
 - Post-merge AC (次回 bats テストを追加する Issue での観察) は `/verify` 以降の運用に委ねる。
 - `skills/issue/spec-test-guidelines.md` への同内容の追記は Issue 本文 Notes の判断どおり見送った (`modules/test-runner.md` 1箇所で到達範囲は足りるとの Spec の判断を踏襲)。
+- pipe 無し `! grep -q pattern file` 形式の追加棚卸し・修正 (76件の生候補、review retrospective の Recurring issues に記録) は本 Issue のスコープ外 — `/verify` での Improvement Proposal 起票を推奨。
 
 ### Notes for Next Phase
-- 5件の pre-merge AC はすべて `/code` 内で PASS 確認済み (rubric 2件・grep 1件・file_exists 1件・command 1件)。Issue のチェックボックスも `[x]` に更新済み。
-- 変更ファイルは `modules/test-runner.md`、`docs/reports/bats-negation-assertion-audit.md` (新規)、および6件の `tests/*.bats` のみ。SKILL.md やスクリプトへの変更はない。
+- Pre-merge AC 5件はすべて `/review` 内で PASS 再確認済み (rubric 2件・grep 1件・file_exists 1件・command 1件、UNCERTAIN 0件)。Issue のチェックボックスは既に `[x]` 済みのため変更なし。
+- 変更ファイルは `modules/test-runner.md`、`docs/reports/bats-negation-assertion-audit.md` (新規 + review 対応の追記)、および6件の `tests/*.bats` のみ。SKILL.md やスクリプトへの変更はない。
+- CI 全11ジョブ SUCCESS。`/merge 1303` を実行してよい状態。

--- a/modules/test-runner.md
+++ b/modules/test-runner.md
@@ -134,3 +134,27 @@ await notification) is unaffected by this constraint.
   ```
 - Likely cause: brief analysis of error content
 ```
+
+## Notes
+
+### bats Negation Assertion Pitfall
+
+**Problem**: Writing a negation assertion as `! cmd | grep -q pattern` and placing it as a
+**non-final statement** inside a bats `@test` function silently defeats the assertion under
+`set -e`. Per POSIX/bash semantics, the exit status of a pipeline prefixed with `!` is always
+excluded from triggering `set -e`'s automatic termination, regardless of whether the underlying
+command failed or succeeded. When the pattern is found (the condition the assertion exists to
+catch), the negated command's non-zero-turned-zero status does not stop execution — subsequent
+statements keep running, and the test reports PASS even though the regression it was meant to
+detect actually occurred.
+
+**Correct form**: Wrap the check as `if cmd | grep -q pattern; then false; fi`. This runs an
+explicit (non-negated) `false` in the branch where the pattern is found, which reliably triggers
+`set -e` and fails the test.
+
+**Exception (safe case)**: A `! cmd | grep -q pattern` negation is safe when it is the **true
+final statement** of the `@test` function — bats evaluates the function's own return value
+directly, without going through an intervening `set -e` non-final-statement context. Compare
+`tests/collect-recovery-candidates.bats:604-605` (non-final statement — was defective and has
+been fixed to the `if ...; then false; fi` form) against `tests/collect-recovery-candidates.bats:611`
+(true final statement of its `@test` function — unmodified and safe).

--- a/tests/audit-auto-session.bats
+++ b/tests/audit-auto-session.bats
@@ -63,7 +63,7 @@ FIXTURE_EOF
     # Issue 300 (abc-222) should appear, issue 200 (abc-111) should NOT
     echo "$output" | grep -q "300"
     # Issue 200 belongs to abc-111 and must not be counted
-    ! echo "$output" | grep -q "Issues processed | 2"
+    if echo "$output" | grep -q "Issues processed | 2"; then false; fi
     # Exactly 1 issue processed (from abc-222)
     echo "$output" | grep -q "Issues processed | 1"
 }

--- a/tests/collect-recovery-candidates.bats
+++ b/tests/collect-recovery-candidates.bats
@@ -373,7 +373,7 @@ FIXTURE_EOF
   echo "$output" | grep -E $'^manual-recovery-review-rerun/workflow-wait\t2$'
   # The plain (cause-less) symptom-short key never appears -- every entry in this fixture
   # carries a cause line, so counts are never merged into the bare symptom-short.
-  ! echo "$output" | grep -E $'^manual-recovery-review-rerun\t'
+  if echo "$output" | grep -qE $'^manual-recovery-review-rerun\t'; then false; fi
 
   # threshold=3: merged (4) would clear the bar, but each cause-specific group (2) does not --
   # this proves cause-separation, not merging, is what determines inclusion.

--- a/tests/filter-session-verified-issues.bats
+++ b/tests/filter-session-verified-issues.bats
@@ -36,7 +36,7 @@ FIXTURE_EOF
 
     run bash -c "printf '984\n1009\n1035\n1037\n' | \"$SCRIPT\""
     [ "$status" -eq 0 ]
-    ! echo "$output" | grep -qx "984"
+    if echo "$output" | grep -qx "984"; then false; fi
     echo "$output" | grep -qx "1009"
     echo "$output" | grep -qx "1035"
     echo "$output" | grep -qx "1037"

--- a/tests/get-auto-session-report.bats
+++ b/tests/get-auto-session-report.bats
@@ -29,7 +29,7 @@ FIXTURE_EOF
     echo "$output" | grep -q "^## Metrics"
     echo "$output" | grep -q "Issues processed | 1"
     echo "$output" | grep -q "#100"
-    ! echo "$output" | grep -q "| #200 |"
+    if echo "$output" | grep -q "| #200 |"; then false; fi
     # Required subsections
     echo "$output" | grep -q "### Summary"
     echo "$output" | grep -q "### Phase Activity Summary"
@@ -67,7 +67,7 @@ FIXTURE_EOF
     run bash "$SCRIPT" "session-candidate" --metrics-only --no-github
     [ "$status" -eq 0 ]
     echo "$output" | grep -q "Issues processed | 1"
-    ! echo "$output" | grep -q "| #501 |"
+    if echo "$output" | grep -q "| #501 |"; then false; fi
     ! echo "$output" | grep -q "| #502 |"
 }
 

--- a/tests/reclaim-stale-worktrees.bats
+++ b/tests/reclaim-stale-worktrees.bats
@@ -87,7 +87,7 @@ mock_pr() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"reclaimed (worktree+branch): 1"* ]]
 
-    ! git -C "$MAIN_REPO" worktree list | grep -q "wt1006"
+    if git -C "$MAIN_REPO" worktree list | grep -q "wt1006"; then false; fi
     ! git -C "$MAIN_REPO" branch --list 'worktree-code+issue-1006' | grep -q "worktree-code+issue-1006"
 }
 
@@ -141,7 +141,7 @@ mock_pr() {
     [[ "$output" == *"reclaimed (worktree+branch): 1"* ]]
     [[ "$output" == *"warned (branch tip diverges): 0"* ]]
 
-    ! git -C "$MAIN_REPO" worktree list | grep -q "wt1149"
+    if git -C "$MAIN_REPO" worktree list | grep -q "wt1149"; then false; fi
     ! git -C "$MAIN_REPO" branch --list 'worktree-code+pr-1149' | grep -q "worktree-code+pr-1149"
 }
 
@@ -165,7 +165,7 @@ mock_pr() {
     [[ "$output" == *"warned (branch tip diverges): 1"* ]]
     [[ "$output" != *"reclaimed (worktree+branch): 1"* ]]
 
-    ! git -C "$MAIN_REPO" worktree list | grep -q "wt5000"
+    if git -C "$MAIN_REPO" worktree list | grep -q "wt5000"; then false; fi
     git -C "$MAIN_REPO" branch --list 'worktree-code+issue-5000' | grep -q "worktree-code+issue-5000"
 }
 

--- a/tests/verify.bats
+++ b/tests/verify.bats
@@ -151,7 +151,7 @@ step9_section() {
 }
 
 @test "Step 6 Re-runs description no longer re-verifies already-checked conditions" {
-    ! step6_section | grep -q -F "Re-verify even if already checked"
+    if step6_section | grep -q -F "Re-verify even if already checked"; then false; fi
     step6_section | grep -q -F "skipped by default"
     step6_section | grep -q -F "Only conditions still at \`- [ ]\` are (re-)verified"
 }


### PR DESCRIPTION
## Summary

- `modules/test-runner.md` に新規 `## Notes` セクション (`### bats Negation Assertion Pitfall`) を追加し、`! cmd | grep -q pattern` を bats `@test` の非最終文として書くと `set -e` 下で無効化される落とし穴と、正しい記述形式 (`if cmd | grep -q pattern; then false; fi`) を明文化
- Spec フェーズの棚卸しで判明した検出力ゼロの既存アサーション9件 (6ファイル) を `if ...; then false; fi` 形式へ書き換え
- `docs/reports/bats-negation-assertion-audit.md` を新規作成し、`tests/*.bats` 全116ファイルに対する棚卸し結果 (計21件: 検出力ゼロ9件・安全12件) を検索コマンド・判定基準・是正記録付きで記録

## Verification (pre-merge)

- `modules/test-runner.md` に落とし穴と正しい記述形式が記載されている (rubric)
- `modules/test-runner.md` に `then false` を用いた具体例が示されている (grep)
- `docs/reports/bats-negation-assertion-audit.md` に既存テストの棚卸し結果が記録されている (rubric)
- `docs/reports/bats-negation-assertion-audit.md` が作成されている (file_exists)
- `bats --jobs 18 tests/` — 1639件全件 PASS

## Verification (post-merge)

- 次回 bats テストを追加する Issue で、否定アサーションが正しい形式で書かれていることを観察する (observation)

closes #1292
