### PR TITLE
Issue #1285: opportunistic-verify --facts gate reorders instead of excluding candidates

### DIFF
--- a/docs/spec/issue-1285-opportunistic-facts-filter.md
+++ b/docs/spec/issue-1285-opportunistic-facts-filter.md
@@ -83,18 +83,32 @@
 - (code phase) No new comments since last phase.
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec Implementation Step 1 の設計どおり、facts ゲートの `continue` (除外) を除去し、各候補に `_fact_matched` を付与した上でループ完了後に一括で並べ替え+キャップする方式を採用した (逐次除外より、jq の安定ソート非保証を追加順インデックス `_idx` で明示的に補う設計のほうが Spec の要求 (相対順序の保証) に忠実だったため)
-- `FACTS_CANDIDATE_LIMIT=30` は新規測定値ではなく `scan-pending-ac.sh` の `MAX_CANDIDATES` 既定値を踏襲 (Spec Notes 参照)
-- truncation メッセージは `scan-pending-ac.sh` の `Note: truncated ...` 形式を踏襲し、非サイレントな stderr 出力とした
+- レビューで SHOULD 相当の指摘 (`scripts/opportunistic-search.sh:500` の `FACTS_CANDIDATE_LIMIT` 再順序化+キャップ処理が `EVENT_NAME` でガードされておらず、`--event`+`--facts` 同時指定時にヘッダーコメントの「Ignored in event mode」契約に反し得る) を確認・修正した。364行目の既存一致判定と同じ `[ -z "$EVENT_NAME" ]` ガードを追加し、契約とコードを一致させた
+- 修正の妥当性検証のため、35候補のイベントモード母集団で `FACTS_CANDIDATE_LIMIT` (30) を超えてもトランケートされないことを確認する回帰テストを追加した
+- Pre-merge AC 4件は全て PASS と判定 (rubric による `opportunistic-verify.md` の記述確認、grep による `FACTS_CANDIDATE_LIMIT` 実装確認、CI job `Run bats tests` SUCCESS を根拠とした safe mode でのコマンドヒント2件の代替検証)
 
 ### Deferred Items
-- Post-merge observation AC (`session=next` の `/verify` で opportunistic 候補が 0 件になった場合、真に候補なしであることを確認) は未着手 — 次回以降の `/verify` 実行で評価される
-- `scripts/scan-pending-ac.sh` の同型パターン (Spec Notes に記載のスコープ外項目) は本 Issue のスコープ外のまま。別途 Issue化を検討する余地あり
+- Post-merge observation AC (`session=next` の `/verify` で opportunistic 候補が 0 件になった場合、真に候補なしであることを確認) は未着手のまま — 次回以降の `/verify` 実行で評価される (code フェーズから変更なし)
+- `scripts/scan-pending-ac.sh` の同型パターン (Spec Notes に記載のスコープ外項目) は本 Issue のスコープ外のまま (code フェーズから変更なし)
 
 ### Notes for Next Phase
-- Pre-merge AC 4件は全て verify command 実行で PASS 済み、Issue body のチェックボックスも更新済み
-- Spec からの実装乖離なし (Deviations from Design は N/A)
-- `bats tests/opportunistic-search.bats` は全 55 件 PASS (新規テスト2件を含む)
+- レビューは `COMMENT` (MUST issue 0件) で投稿。SHOULD issue 1件はレビューフェーズ内で修正・commit・push 済み (commit a8b70ee9)
+- 修正後の再検証: `python3 scripts/validate-skill-syntax.py skills/` 0 error/warning、`bats tests/opportunistic-search.bats` 全56件 PASS (新規1件を含む)
+- 修正は防御的ガード追加のみで AC/Spec の意味に変更はない (Step 13 ポリシー変更チェックはスキップ)
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Spec と PR diff の間に構造的な乖離はなかった。Implementation Steps 1〜4 の記載順どおりに実装されており、Code Retrospective の "Deviations from Design: N/A" は妥当だった。
+
+### Recurring issues
+
+review-light エージェントが検出した SHOULD issue (`FACTS_CANDIDATE_LIMIT` 再順序化+キャップ処理の `EVENT_NAME` ガード漏れ) は、本 PR 自身が新規に導入したコードの中で、既存の類似ガード (364行目の一致判定) と新規追加箇所 (500行目のキャップ処理) の間で防御条件が非対称になったパターン。同一 PR 内で「同じ条件を複数箇所でガードする必要がある変更」を行う際、一箇所にガードを追加してもう一箇所に追加し忘れるのは再発しうる。今回は現状の呼び出し元では到達不能な潜在バグだったため実害は限定的だが、ヘッダーコメント (ドキュメント) の記述と実装が食い違う形で顕在化した点は、ドキュメント記述をレビューの検証観点として使う (review-spec の documentation consistency perspective) ことの有効性を示す一例。
+
+### Acceptance criteria verification difficulty
+
+4件の Pre-merge AC はいずれも verify command が明確で、機械判定 (rubric / grep / CI job 参照によるコマンドヒント代替検証) で PASS/FAIL を一意に判定できた。UNCERTAIN は発生しなかった。`command` 系 AC 2件 (bats 個別テスト実行・全体実行) は safe mode では直接実行できず CI job `Run bats tests` への参照フォールバックで代替したが、CI ジョブがテストスイート全体を実行する構成であることが前提になっており、AC が指す個別テスト名までは CI ジョブ名からは判別できない (ジョブが SUCCESS であることから包含関係で類推している)。今回は問題にならなかったが、個別テストの粒度で PASS/FAIL を判別する必要がある AC には、コマンドヒントに `-f` フィルタを含める設計自体は妥当だった。

--- a/docs/spec/issue-1285-opportunistic-facts-filter.md
+++ b/docs/spec/issue-1285-opportunistic-facts-filter.md
@@ -66,6 +66,35 @@
 - **(b) 空集合時フォールバックについて**: Issue 本文の対応方針 (b) は、(a) の並べ替え設計を採用したことで構造的に不要になった。並べ替えは常に全候補を出力に残すため (上限キャップを超えない限り)、「フィルタ結果が 0 件になる」状況自体が発生しない
 - **`--context-file` (`keyword=` ゲート) の切り分け**: #400 の実際の Post-merge AC 行を確認したところ `keyword=` 属性を持たないため、`--context-file` ゲートは無条件マッチであり実測の 13→0 に寄与していない。Issue 本文に切り分け結果を追記済み (Notes 参照)
 
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜4 を Spec の記載順どおりに実施した (`FACTS_CANDIDATE_LIMIT=30` 定数の追加、facts ゲートの除外→並べ替え+キャップ変更、`opportunistic-verify.md` の契約説明更新、bats テストのリネーム+新規追加)
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A
+
 ## Consumed Comments
 
 - saito (MEMBER, first-class): Triage AC audit — Pre-merge AC2 (`grep -n "facts" scripts/opportunistic-search.sh` の引数形式不正 + 常時 PASS) と AC3 (`command "bats tests/opportunistic-search.bats"` が直後の AC4 と同一コマンドで区別不能 + 常時 PASS) を指摘し、実装方針確定後の `/spec` での具体化を推奨。本 Spec 作成時に Issue 本文の該当 2 件を修正して対応 (Notes 参照)。https://github.com/saitoco/wholework/issues/1285#issuecomment-5229038068
+- (code phase) No new comments since last phase.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec Implementation Step 1 の設計どおり、facts ゲートの `continue` (除外) を除去し、各候補に `_fact_matched` を付与した上でループ完了後に一括で並べ替え+キャップする方式を採用した (逐次除外より、jq の安定ソート非保証を追加順インデックス `_idx` で明示的に補う設計のほうが Spec の要求 (相対順序の保証) に忠実だったため)
+- `FACTS_CANDIDATE_LIMIT=30` は新規測定値ではなく `scan-pending-ac.sh` の `MAX_CANDIDATES` 既定値を踏襲 (Spec Notes 参照)
+- truncation メッセージは `scan-pending-ac.sh` の `Note: truncated ...` 形式を踏襲し、非サイレントな stderr 出力とした
+
+### Deferred Items
+- Post-merge observation AC (`session=next` の `/verify` で opportunistic 候補が 0 件になった場合、真に候補なしであることを確認) は未着手 — 次回以降の `/verify` 実行で評価される
+- `scripts/scan-pending-ac.sh` の同型パターン (Spec Notes に記載のスコープ外項目) は本 Issue のスコープ外のまま。別途 Issue化を検討する余地あり
+
+### Notes for Next Phase
+- Pre-merge AC 4件は全て verify command 実行で PASS 済み、Issue body のチェックボックスも更新済み
+- Spec からの実装乖離なし (Deviations from Design は N/A)
+- `bats tests/opportunistic-search.bats` は全 55 件 PASS (新規テスト2件を含む)

--- a/modules/opportunistic-verify.md
+++ b/modules/opportunistic-verify.md
@@ -23,7 +23,10 @@ First check for the existence of `${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-se
 
 If the script exists, resolve `--facts` and `--context-file` before calling it:
 
-**Resolve `--facts` (run-fact token pre-filter — narrows the opportunistic-mode candidate set without requiring AC-side attributes):**
+**Resolve `--facts` (run-fact token relevance ordering — reorders the opportunistic-mode candidate set by run-fact relevance without requiring AC-side attributes; matched candidates are prioritized, but unmatched candidates are never dropped solely for lacking a token match):**
+
+- **Ordering, not exclusion**: a candidate whose condition text does not contain any `--facts` token is still included in `opportunistic-search.sh`'s output — it is placed after token-matched candidates, never dropped for the mismatch alone (Issue #1285).
+- **Separate safety valve**: `opportunistic-search.sh` additionally caps the reordered set at a fixed candidate-count limit (`FACTS_CANDIDATE_LIMIT`, applied only when `--facts` is given and valid). This is a population-size safeguard unrelated to token matching, and it prints a non-silent `Note: truncated ...` warning to stderr when it actually drops candidates — token mismatch by itself never triggers this warning.
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/scripts/emit-event.sh"
@@ -46,7 +49,7 @@ Write `.tmp/context-<calling skill's own Issue/PR number>.md` with the Write too
 ${CLAUDE_PLUGIN_ROOT}/scripts/opportunistic-search.sh <skill-name> --context-file .tmp/context-<calling Issue number>.md [--facts .tmp/facts-${AUTO_SESSION_ID}.json]
 ```
 
-- The script fetches closed Issues with the `phase/verify` label and filters by `verify-type: opportunistic` tag, skill name, unchecked conditions, and (when `--facts`/`--context-file` are given) the fact-token and `keyword=` gates
+- The script fetches closed Issues with the `phase/verify` label and filters by `verify-type: opportunistic` tag, skill name, and unchecked conditions; when `--context-file` is given, the `keyword=` gate additionally excludes non-matching candidates; when `--facts` is given, matched candidates are reordered ahead of unmatched ones (never excluded for the mismatch alone) and the reordered set is capped at `FACTS_CANDIDATE_LIMIT`
 - Output is JSON: `[{"number": N, "condition": "condition text"}]` (empty: `[]`)
 - **If output is `[]`**: Output "Opportunistic verification: 0 conditions found, skipping" and exit
 

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -495,9 +495,11 @@ done
 # ahead of unmatched ones (stable within each group via the original array index as the
 # secondary sort key -- jq's sort_by is not guaranteed stable), then apply
 # FACTS_CANDIDATE_LIMIT as a population-size safety valve. Skipped entirely when --facts
-# was not given (FACT_TOKENS_LOWER empty): the pre-#1285 unlimited, unordered output is
-# preserved unchanged in that case.
-if [ -n "$FACT_TOKENS_LOWER" ]; then
+# was not given (FACT_TOKENS_LOWER empty) or in event mode: the pre-#1285 unlimited,
+# unordered output is preserved unchanged in that case. Same [ -z "$EVENT_NAME" ] guard as
+# the matching logic above (line ~364), so --facts is fully ignored in event mode as
+# documented -- both the ordering and the candidate cap.
+if [ -z "$EVENT_NAME" ] && [ -n "$FACT_TOKENS_LOWER" ]; then
     TOTAL_COUNT=$(echo "$RESULTS" | jq 'length')
     RESULTS=$(echo "$RESULTS" | jq -c \
         --argjson limit "$FACTS_CANDIDATE_LIMIT" \

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -53,16 +53,23 @@
 # compatible). See modules/observation-trigger.md § Condition Check Gate
 # (when=).
 #
-# --facts <path>: opportunistic mode (--event omitted) only. Pre-filters matches by
-# run-fact token substring: a matched AC line is only included if its condition text
-# (lowercased, HTML comments and checkbox markup stripped) contains at least one token
-# from --facts <path>'s collect-run-facts.sh JSON (unioned fact_tokens across all
-# issues, same matching logic as scripts/scan-pending-ac.sh's --facts). No AC-side
+# --facts <path>: opportunistic mode (--event omitted) only. Reorders matches by
+# run-fact token relevance instead of excluding them: a matched AC line whose condition
+# text (lowercased, HTML comments and checkbox markup stripped) contains at least one
+# token from --facts <path>'s collect-run-facts.sh JSON (unioned fact_tokens across all
+# issues, same matching logic as scripts/scan-pending-ac.sh's --facts) is placed ahead of
+# non-matching lines in the output; a token mismatch is never, by itself, a reason to drop
+# a candidate that could otherwise be judged this run (Issue #1285). Relative order within
+# each priority group (matched vs. unmatched) follows original discovery order. No AC-side
 # attribute is required. Ignored in event mode (--event) -- event mode uses
 # --facts-file/when= instead. When --facts <path> is omitted, missing, or unparseable,
 # a warning is printed and the gate is disabled (fail-open), the same convention as
 # --context-file/--facts-file above. Distinct from --facts-file <path>, which gates
 # event-mode when=<axis>:<value> clauses against structured run-facts fields.
+#
+# When --facts <path> is given and valid, the full reordered candidate set is additionally
+# capped at FACTS_CANDIDATE_LIMIT entries (a population-size safety valve, unrelated to
+# token matching) -- see FACTS_CANDIDATE_LIMIT below.
 #
 # Output: JSON array [{"number": N, "condition": "condition text"}]
 #         Empty array [] when no matches found
@@ -192,6 +199,12 @@ if [ -n "$FACTS_FILE" ] && [ ! -f "$FACTS_FILE" ]; then
     echo "Warning: --facts-file '${FACTS_FILE}' not found, falling back to lazy run-facts collection" >&2
     FACTS_FILE=""
 fi
+
+# FACTS_CANDIDATE_LIMIT: population-size safety valve applied only when --facts is given
+# and valid (FACT_TOKENS_LOWER non-empty), after reordering. Value (30) follows the
+# existing precedent set by scan-pending-ac.sh's MAX_CANDIDATES default rather than a new
+# measurement -- see docs/spec/issue-1285-opportunistic-facts-filter.md Notes.
+FACTS_CANDIDATE_LIMIT=30
 
 # --facts <path>: resolve the union of fact_tokens (lowercased) from the given
 # collect-run-facts.sh JSON, same logic as scripts/scan-pending-ac.sh's --facts. Missing
@@ -339,11 +352,15 @@ for N in $ISSUE_NUMBERS; do
             | sed 's/^- \[ \] //' \
             | sed 's/ *<!--.*-->//g')
 
-        # Fact-token filter gate (opportunistic mode only, --event unset): skip lines
-        # whose lowercased CONDITION does not contain any --facts token as a substring.
-        # No --facts / empty FACT_TOKENS_LOWER means unconditional match (backward
-        # compatible). Not applied in event mode -- event mode uses --facts-file/when=
-        # instead. See scripts/scan-pending-ac.sh for the same matching approach.
+        # Fact-token relevance tag (opportunistic mode only, --event unset): a line whose
+        # lowercased CONDITION contains at least one --facts token as a substring is tagged
+        # matched, and placed ahead of unmatched lines in the post-loop reorder below --
+        # never excluded solely for the mismatch (Issue #1285: token mismatch is not
+        # evidence the candidate is unjudgeable this run). No --facts / empty
+        # FACT_TOKENS_LOWER, or event mode, means every line is treated as matched (the
+        # reorder below is then a no-op). See scripts/scan-pending-ac.sh for the same
+        # substring-matching approach (used there as a hard filter, not a reorder).
+        FACT_MATCHED=true
         if [ -z "$EVENT_NAME" ] && [ -n "$FACT_TOKENS_LOWER" ]; then
             CONDITION_LOWER=$(echo "$CONDITION" | tr '[:upper:]' '[:lower:]')
             FACT_MATCHED=false
@@ -356,9 +373,6 @@ for N in $ISSUE_NUMBERS; do
                         ;;
                 esac
             done <<< "$FACT_TOKENS_LOWER"
-            if [ "$FACT_MATCHED" = false ]; then
-                continue
-            fi
         fi
 
         # Condition check gate: skip lines whose keyword= attribute does not
@@ -472,8 +486,33 @@ for N in $ISSUE_NUMBERS; do
             fi
         fi
 
-        RESULTS=$(echo "$RESULTS" | jq --argjson n "$N" --arg c "$CONDITION" '. += [{"number": $n, "condition": $c}]')
+        RESULTS=$(echo "$RESULTS" | jq --argjson n "$N" --arg c "$CONDITION" --argjson m "$FACT_MATCHED" \
+            '. += [{"number": $n, "condition": $c, "_fact_matched": $m}]')
     done <<< "$MATCHED"
 done
+
+# Reorder-not-exclude: when --facts was given and valid, move fact-matched candidates
+# ahead of unmatched ones (stable within each group via the original array index as the
+# secondary sort key -- jq's sort_by is not guaranteed stable), then apply
+# FACTS_CANDIDATE_LIMIT as a population-size safety valve. Skipped entirely when --facts
+# was not given (FACT_TOKENS_LOWER empty): the pre-#1285 unlimited, unordered output is
+# preserved unchanged in that case.
+if [ -n "$FACT_TOKENS_LOWER" ]; then
+    TOTAL_COUNT=$(echo "$RESULTS" | jq 'length')
+    RESULTS=$(echo "$RESULTS" | jq -c \
+        --argjson limit "$FACTS_CANDIDATE_LIMIT" \
+        'to_entries
+         | map(.value + {_idx: .key})
+         | sort_by([(if ._fact_matched then 0 else 1 end), ._idx])
+         | .[0:$limit]
+         | map(del(._fact_matched, ._idx))')
+    KEPT_COUNT=$(echo "$RESULTS" | jq 'length')
+    TRUNCATED_COUNT=$((TOTAL_COUNT - KEPT_COUNT))
+    if [ "$TRUNCATED_COUNT" -gt 0 ]; then
+        echo "Note: truncated ${TRUNCATED_COUNT} candidate AC(s) to ${FACTS_CANDIDATE_LIMIT}; deferred to the next run." >&2
+    fi
+else
+    RESULTS=$(echo "$RESULTS" | jq -c 'map(del(._fact_matched))')
+fi
 
 echo "$RESULTS"

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -696,6 +696,23 @@ teardown() {
     echo "$output" | jq -e '.[0].number == 804' > /dev/null
 }
 
+@test "fact gate: FACTS_CANDIDATE_LIMIT cap is also ignored in event mode (no truncation above the limit)" {
+    ISSUE_LIST="[]"
+    for i in $(seq 1 35); do
+        NUM=$((900 + i))
+        ISSUE_LIST=$(echo "$ISSUE_LIST" | jq --argjson n "$NUM" '. + [{"number": $n}]')
+        export "MOCK_ISSUE_BODY_${NUM}=## Post-merge
+- [ ] observed candidate ${NUM} <!-- verify-type: observation event=auto-run -->"
+    done
+    export MOCK_ISSUE_LIST="$ISSUE_LIST"
+    echo '{"session_id":"s1","issues":[{"number":1,"fact_tokens":["token-not-in-condition"]}]}' > "$BATS_TEST_TMPDIR/facts.json"
+
+    run bash "$SCRIPT" --event auto-run --facts "$BATS_TEST_TMPDIR/facts.json"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 35' > /dev/null
+    [[ "$output" != *"Note: truncated"* ]]
+}
+
 @test "population: gh issue list is called with --state all, not --state closed (issue #1242)" {
     export MOCK_ISSUE_LIST="[]"
     run bash "$SCRIPT" /issue

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -632,7 +632,7 @@ teardown() {
     echo "$output" | jq -e '.[0].number == 800' > /dev/null
 }
 
-@test "fact gate: token mismatch excludes the issue" {
+@test "fact gate: token mismatch is deprioritized, not excluded" {
     export MOCK_ISSUE_LIST='[{"number": 801}]'
     export MOCK_ISSUE_BODY_801='## Post-merge
 - [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
@@ -640,7 +640,25 @@ teardown() {
 
     run bash "$SCRIPT" /verify --facts "$BATS_TEST_TMPDIR/facts.json"
     [ "$status" -eq 0 ]
-    [ "$output" = "[]" ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 801' > /dev/null
+}
+
+@test "fact gate: matched candidates ordered before unmatched, none dropped" {
+    export MOCK_ISSUE_LIST='[{"number": 900}, {"number": 901}]'
+    export MOCK_ISSUE_BODY_900='## Post-merge
+- [ ] /verify skill checks unrelated candidates <!-- verify-type: opportunistic -->'
+    export MOCK_ISSUE_BODY_901='## Post-merge
+- [ ] /verify skill checks pr route candidates <!-- verify-type: opportunistic -->'
+    echo '{"session_id":"s1","issues":[{"number":1,"fact_tokens":["pr route"]}]}' > "$BATS_TEST_TMPDIR/facts.json"
+
+    run bash "$SCRIPT" /verify --facts "$BATS_TEST_TMPDIR/facts.json"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 2' > /dev/null
+    # #900 was discovered first (list order) but is token-unmatched; #901 is token-matched
+    # and must be moved ahead of it despite discovery order (reorder-not-exclude contract).
+    echo "$output" | jq -e '.[0].number == 901' > /dev/null
+    echo "$output" | jq -e '.[1].number == 900' > /dev/null
 }
 
 @test "fact gate: --facts omitted matches unconditionally (backward compatible)" {


### PR DESCRIPTION
## Summary
`modules/opportunistic-verify.md` Step 1 が `scripts/opportunistic-search.sh` に渡す `--facts` (run-fact トークン事前フィルタ) は、候補の条件テキストがどの run-fact トークンとも一致しない場合、その候補を候補集合から即座に除外していた。実測ではゲートなしで 13 件あった候補が `--facts` 適用後に 0 件になり、うち #400 は本実行の事実で判定可能だった。フィルタの目的は「LLM 判定コストの削減」であり「除外」ではないため、この挙動は目的に反していた。

本 PR は `--facts` の役割を「除外ゲート」から「優先順位付け (トークン一致を先頭に、不一致を後段に配置) + 上限件数キャップ (`FACTS_CANDIDATE_LIMIT=30`)」に変更し、トークン不一致のみを理由に判定可能な候補が失われないようにする。

- `scripts/opportunistic-search.sh`: `--facts` ゲートを除外から並べ替え+キャップに変更 (bash 3.2+ 互換維持、jq の `sort_by` 非決定性を明示的な追加順インデックスで回避)
- `modules/opportunistic-verify.md`: Step 1 の `--facts` の契約説明を更新 (Ordering-not-exclusion)
- `tests/opportunistic-search.bats`: 既存テストを新挙動に合わせてリネーム・修正し、新規回帰テストを追加

## Verification (pre-merge)
- `modules/opportunistic-verify.md` の `--facts` の記述が、候補を除外するゲートではなく順序付けとして定義されており、トークン不一致だけを理由に候補が失われないことが明記されている
- `scripts/opportunistic-search.sh` に `FACTS_CANDIDATE_LIMIT` が実装されている
- 実測ケース (候補 13 件がトークン不一致で 0 件になる) が再現しないことを検証する bats テストが追加されている
- `bats tests/opportunistic-search.bats` が全 55 件 PASS する

## Verification (post-merge)
- 次回以降の `/verify` で opportunistic 候補が 0 件になった場合、それがトークン不一致ではなく真に候補なしであることを確認する

closes #1285
