### PR TITLE
Issue #1304: pipe を伴わない否定アサーション 28 件を解消

### DIFF
--- a/docs/reports/bats-negation-assertion-audit.md
+++ b/docs/reports/bats-negation-assertion-audit.md
@@ -1,13 +1,16 @@
-# bats Negation Assertion Audit (Issue #1292)
+# bats Negation Assertion Audit (Issues #1292, #1304)
 
 ## Purpose
 
-Inventory all `! cmd | grep ...` negation assertions in `tests/*.bats` and classify each as
+Inventory all `!`-prefixed negation assertions in `tests/*.bats` — piped (`! cmd | grep ...`),
+non-piped (`! grep -q pattern file`), and bare (`! cmd`, no `grep` at all) — and classify each as
 defective (non-final statement — silently defeated under `set -e`, see
 `modules/test-runner.md` § "bats Negation Assertion Pitfall") or safe (true final statement of
-its `@test` function). This audit is the Spec-phase investigation input for Issue #1292; the
-defective entries were rewritten to the `if cmd | grep -q pattern; then false; fi` form in the
-same Issue.
+its `@test` function). Issue #1292 covered the piped form (9 defective entries fixed). Issue
+#1304 covered the two remaining forms — non-piped + `grep` (26 defective) and bare `!` (2
+defective) — closing the pipe-scoped gap `modules/test-runner.md` left in #1292 (see `## Scope —
+the pipe is irrelevant` there). All defective entries across both Issues were rewritten to the
+`if cmd; then false; fi` form in their respective implementation commits.
 
 ## Search Command and Scope
 
@@ -81,30 +84,210 @@ These lines are each the true final statement of their enclosing `@test` functio
 evaluates the function's own return value directly — no `set -e` non-final-statement exception
 applies, and no rewrite is needed.
 
+## Non-Piped Form Audit (Issue #1304)
+
+### Search Command and Scope
+
+```bash
+grep -rnE '^\s*!\s*.*grep' tests/*.bats | grep -vE '\|\s*grep'
+```
+
+**Measurement scope** (`modules/measurement-scope.md`): 2026-08-09, `HEAD=f4d8fe6d`, scoped to
+`tests/*.bats` directly (non-recursive glob; #1292 confirmed via `find tests -mindepth 2 -name
+"*.bats"` that no `.bats` files exist in subdirectories, so there is no coverage gap).
+
+### Summary
+
+**76 matches total, across 21 files** — 26 defective, 50 safe. (#1292's `## Out of Scope` recorded
+this as "roughly 30 files" — a visual estimate; the actual measured file count is 21. The match
+count of 76 was accurate.)
+
+| Classification | Count |
+|---|---|
+| Defective (non-final statement, required fix) | 26 |
+| Safe (true final statement, no change) | 50 |
+
+### Defective (non-final statement) — 26 entries, fixed in this Issue
+
+| File:Line | Original form | Remediation |
+|---|---|---|
+| `tests/ci-failure-classifier.bats:30` | `! grep -q "The runner has received a shutdown signal" "$VERIFY_SKILL"` | Rewritten to `if ...; then false; fi` |
+| `tests/ci-failure-classifier.bats:35` | `! grep -q "The runner has received a shutdown signal" "$VERIFY_EXECUTOR"` | Rewritten to `if ...; then false; fi` |
+| `tests/gh-graphql.bats:69` | `! grep -q "repo view" "$GH_CALL_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/gh-graphql.bats:240` | `! grep -q "api graphql" "$GH_CALL_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/gh-graphql.bats:242` | `! grep -q "repo view" "$GH_CALL_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/gh-graphql.bats:286` | `! grep -q "repo view" "$GH_CALL_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/gh-graphql.bats:333` | `! grep -q "api graphql" "$GH_CALL_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/observation-trigger.bats:76` | `! grep -q "issue comment" "$BATS_TEST_TMPDIR/gh-calls.log"` (inside `if ... fi`) | Restructured to `if [ -f ... ] && grep -q ...; then false; fi` (only entry not a 1-line replacement — the enclosing `if` guard is folded into the condition) |
+| `tests/observation-trigger.bats:198` | `! grep -q "issue comment" "$BATS_TEST_TMPDIR/gh-calls.log"` | Rewritten to `if ...; then false; fi` |
+| `tests/opportunistic-search.bats:513` | `! grep -q -- "--session\|--facts-file" "$MOCK_DIR/collect-run-facts-args.txt"` | Rewritten to `if ...; then false; fi` |
+| `tests/orchestration-fallbacks.bats:92` | `! grep -q '^## ci-flake-retry' "$CATALOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/retro-proposals.bats:149` | `! grep -q "/Users/" "$GH_CALLS_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/run-code.bats:470` | `! grep -q "phase_start" "$EMIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/run-issue.bats:306` | `! grep -q "phase_start" "$EMIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/run-issue.bats:339` | `! grep -q "wrapper_exit" "$EMIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/run-merge.bats:757` | `! grep -q "phase_start" "$EMIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/run-review.bats:776` | `! grep -q "phase_start" "$EMIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/run-spec.bats:393` | `! grep -q "phase_start" "$EMIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/run-spec.bats:428` | `! grep -q "wrapper_exit" "$EMIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/worktree-merge-push.bats:212` | `! grep -q -- "-C ${WORKTREE_PATH} rebase origin/main" "$GIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/worktree-merge-push.bats:313` | `! grep -q "merge test-branch --ff-only" "$GIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/worktree-merge-push.bats:387` | `! grep -q "merge test-branch --ff-only" "$GIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/worktree-merge-push.bats:388` | `! grep -qE "^rebase " "$GIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/worktree-merge-push.bats:465` | `! grep -qE "^rebase origin/main" "$GIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/worktree-merge-push.bats:623` | `! grep -q "rebase origin/main" "$GIT_LOG"` | Rewritten to `if ...; then false; fi` |
+| `tests/worktree-merge-push.bats:624` | `! grep -qE "\-C .+ rebase" "$GIT_LOG"` | Rewritten to `if ...; then false; fi` |
+
+All existing grep flags and pattern strings were preserved unchanged — only the negation/branch
+structure was rewritten (the observation-trigger.bats:76 restructure above is the sole exception,
+and it too preserves the original `grep` flags and pattern verbatim).
+
+### Safe (true final statement) — 50 entries, no change
+
+| File:Line |
+|---|
+| `tests/append-consumed-comments-section.bats:248` |
+| `tests/auto-recovery.bats:143` |
+| `tests/claude-watchdog.bats:118` |
+| `tests/claude-watchdog.bats:133` |
+| `tests/observation-trigger.bats:127` |
+| `tests/observation-trigger.bats:141` |
+| `tests/observation-trigger.bats:155` |
+| `tests/observation-trigger.bats:175` |
+| `tests/orchestration-fallbacks.bats:93` |
+| `tests/post-fallback-review-summary.bats:42` |
+| `tests/post-fallback-review-summary.bats:113` |
+| `tests/post-fallback-review-summary.bats:165` |
+| `tests/retro-proposals.bats:142` |
+| `tests/run-auto-sub.bats:585` |
+| `tests/run-auto-sub.bats:883` |
+| `tests/run-auto-sub.bats:1325` |
+| `tests/run-auto-sub.bats:1374` |
+| `tests/run-auto-sub.bats:1413` |
+| `tests/run-auto-sub.bats:1527` |
+| `tests/run-auto-sub.bats:1725` |
+| `tests/run-auto-sub.bats:1988` |
+| `tests/run-auto-sub.bats:2220` |
+| `tests/run-code.bats:400` |
+| `tests/run-code.bats:471` |
+| `tests/run-issue.bats:236` |
+| `tests/run-issue.bats:307` |
+| `tests/run-issue.bats:340` |
+| `tests/run-merge.bats:328` |
+| `tests/run-merge.bats:415` |
+| `tests/run-merge.bats:729` |
+| `tests/run-merge.bats:758` |
+| `tests/run-review.bats:563` |
+| `tests/run-review.bats:748` |
+| `tests/run-review.bats:777` |
+| `tests/run-spec.bats:206` |
+| `tests/run-spec.bats:283` |
+| `tests/run-spec.bats:394` |
+| `tests/run-spec.bats:429` |
+| `tests/spawn-recovery-subagent.bats:142` |
+| `tests/verify-executor.bats:24` |
+| `tests/verify-executor.bats:37` |
+| `tests/verify-executor.bats:57` |
+| `tests/verify.bats:128` |
+| `tests/wait-ci-checks.bats:368` |
+| `tests/worktree-merge-push.bats:132` |
+| `tests/worktree-merge-push.bats:162` |
+| `tests/worktree-merge-push.bats:258` |
+| `tests/worktree-merge-push.bats:355` |
+| `tests/worktree-merge-push.bats:389` |
+| `tests/worktree-merge-push.bats:670` |
+
+These lines are each the true final statement of their enclosing `@test` function — no rewrite is
+needed.
+
+## Bare Negation Audit (Issue #1304)
+
+### Search Command and Scope
+
+```bash
+grep -rnE '^\s*!\s' tests/*.bats | grep -v grep
+```
+
+Same measurement scope as the Non-Piped Form Audit above (2026-08-09, `HEAD=f4d8fe6d`).
+
+### Summary
+
+**2 matches total, across 1 file** — 2 defective, 0 safe.
+
+| File:Line | Original form | Remediation |
+|---|---|---|
+| `tests/reclaim-stale-worktrees.bats:136` | `! git -C "$MAIN_REPO" branch -d worktree-code+pr-1149 2>/dev/null` | Rewritten to `if ...; then false; fi` |
+| `tests/reclaim-stale-worktrees.bats:159` | `! git -C "$MAIN_REPO" branch -d worktree-code+issue-5000 2>/dev/null` | Rewritten to `if ...; then false; fi` |
+
+Both entries immediately follow a `# sanity: plain -d must fail` comment (an explicit, intentional
+assertion — not a case of deliberately-allowed failure) and are non-final statements within their
+`@test` function, making them defective by the same criterion as the piped and non-piped forms
+above. The preceding comment was left unchanged.
+
 ## Out of Scope
 
-Two related patterns are subject to the same `set -e` non-final-statement exception rule
-documented in `modules/test-runner.md`, but Issue #1292 explicitly scopes its target pattern to
-the `! cmd | grep -q ...` piped form, so neither is covered by this audit's search command or
-remediation:
+Issue #1292 explicitly scoped its target pattern to the `! cmd | grep -q ...` piped form, leaving
+two related patterns — subject to the same `set -e` non-final-statement exception rule documented
+in `modules/test-runner.md` — outside that audit's search command and remediation:
 
 - **Bare `!` negations without any `grep`** (e.g. `tests/reclaim-stale-worktrees.bats:136,159`
   `! git branch -d ... 2>/dev/null`).
 - **`! grep -q pattern file` without a pipe** (grep reading a file directly, rather than via a
-  piped `echo`/command output). A broader scan (`grep -rnE '^\s*!\s*.*grep' tests/*.bats | grep
-  -vE '\|\s*grep'`) found 76 candidate lines across roughly 30 files as of this audit (2026-08-09)
-  that share the identical exit-status-excluded-from-`set -e` mechanism but were not counted or
-  classified here — this figure is a raw grep count, not a per-line final/non-final
-  classification, so the actual defective subset is unconfirmed. Examples observed to be
-  non-final (and therefore currently detection-power-zero) during a spot check include
-  `tests/run-code.bats:470`, `tests/run-issue.bats:306`, and `tests/gh-graphql.bats:69`.
+  piped `echo`/command output).
 
-Both categories are noted here for reference only; scoping and remediation are left to a
-follow-up Issue rather than this one.
+Issue #1304 closed both gaps: see `## Non-Piped Form Audit (Issue #1304)` (76 candidates, 26
+defective) and `## Bare Negation Audit (Issue #1304)` (2 candidates, 2 defective) above. Combined
+with #1292's piped-form audit, the full breakdown of every `tests/*.bats` leading-`!` negation is
+now accounted for (counts below are measured pre-remediation for each Issue's own scope — the
+piped-form column reflects the 12 matches remaining after #1292's 9 defective entries were already
+rewritten, since a rewritten entry no longer matches the `!`-prefixed search pattern):
+
+| Category | Count | Defective | Safe |
+|---|---|---|---|
+| Piped (`! cmd \| grep ...`) | 12 | 0 (9 fixed in #1292, no longer match this pattern) | 12 |
+| Non-piped + grep (`! grep -q pattern file`) | 76 | 26 | 50 |
+| Bare (`! cmd`, no grep) | 2 | 2 | 0 |
+| **Total** | **90** | **28** | **62** |
+
+Every category above has now been audited and remediated. There is no remaining out-of-scope
+category — this section is retained (heading only) as a historical record of #1292's original
+scope boundary and the two gaps #1304 subsequently closed.
 
 ## Remediation Record
+
+### Issue #1292 (piped form)
 
 All 9 defective entries were rewritten to the `if cmd | grep -q pattern; then false; fi` form in
 this Issue's implementation commit. The 12 safe entries were left unchanged. Post-remediation,
 `bats tests/` was re-run to confirm the rewritten assertions preserve existing pass/fail
 behavior (see Issue #1292 Code Retrospective for the run result).
+
+### Issue #1304 (non-piped and bare forms)
+
+All 28 defective entries — 26 from `## Non-Piped Form Audit (Issue #1304)` and 2 from
+`## Bare Negation Audit (Issue #1304)` — were rewritten to the `if cmd; then false; fi` form (or,
+for `tests/observation-trigger.bats:76`, the equivalent `if ... && cmd; then false; fi` structural
+form, the only entry that isn't a 1-line replacement) in this Issue's implementation commit. The
+50 non-piped safe entries and the 12 piped safe entries were left unchanged. Existing `grep`
+flags and pattern strings were preserved verbatim throughout — only the negation/branch structure
+changed. Per-file remediation:
+
+| File | Lines rewritten |
+|---|---|
+| `tests/ci-failure-classifier.bats` | 30, 35 |
+| `tests/gh-graphql.bats` | 69, 240, 242, 286, 333 |
+| `tests/observation-trigger.bats` | 76, 198 |
+| `tests/opportunistic-search.bats` | 513 |
+| `tests/orchestration-fallbacks.bats` | 92 |
+| `tests/retro-proposals.bats` | 149 |
+| `tests/run-code.bats` | 470 |
+| `tests/run-issue.bats` | 306, 339 |
+| `tests/run-merge.bats` | 757 |
+| `tests/run-review.bats` | 776 |
+| `tests/run-spec.bats` | 393, 428 |
+| `tests/worktree-merge-push.bats` | 212, 313, 387, 388, 465, 623, 624 |
+| `tests/reclaim-stale-worktrees.bats` | 136, 159 (bare form) |
+
+Post-remediation, `bats --jobs <N> tests/` was re-run to confirm the newly-activated assertions
+pass (see Issue #1304 Code Retrospective for the run result and handling of any assertions that
+were found to have been masking a real defect).

--- a/docs/spec/issue-1304-nonpipe-negation-audit.md
+++ b/docs/spec/issue-1304-nonpipe-negation-audit.md
@@ -230,23 +230,40 @@ Implementation Step 1 の対象。`->` の右は当該行の直後に続く文 (
 - **`section_not_contains` は見出し不一致で UNCERTAIN を返す**という仕様を踏まえ、「両カテゴリが解消済みなら `## Out of Scope` 節ごと削除する」案を棄却した。見出しを残して本文のみ書き換える制約を Implementation Step 5 に明記済み。
 - **書き換えが潜在的失敗を露出させるリスク**は Spec フェーズでは解消できない (被検証ファイルが実行時生成の `$EMIT_LOG` 等のため静的判定不可)。#1292 は 9 件の書き換え後も全件 PASS だったが 28 件では保証がないため、Implementation Step 6 に「元の `!` 形式へ戻すことを禁じ、真因側を修正するか前提誤りとして訂正し `## Remediation Record` に記録する」という対処手順を明記して `/code` へ引き渡した。
 
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Implementation Steps 1–6 were followed as written; the defective inventory (26 entries) and bare-negation set (2 entries) from the Spec's Notes were used verbatim with no re-classification.
+
+### Design Gaps/Ambiguities
+
+- **AC5's verify command (`command "bats tests/"`) cannot complete within `modules/verify-executor.md`'s fixed 60-second `command` timeout for a suite this size.** Measured: `bats --jobs 18 tests/` (parallel, 1642 tests) completes in well under 2 minutes; `bats tests/` (serial, the literal form AC5 specifies) did not finish even within the Bash tool's 600-second ceiling and was auto-backgrounded. This means AC5 will return UNCERTAIN via verify-executor at both `/code` Step 10 and `/verify`, regardless of implementation correctness — a systemic gap in the `command` verify type for large-suite full-run assertions, not something introduced by this Issue. Filed as follow-up #1310 (not fixed here — redesigning verify-executor's timeout model is out of this Issue's scope). Step 10 checked AC1–4, 6, 7 (all PASS) and left AC5 unchecked with this UNCERTAIN classification recorded.
+- The Spec's Implementation Step 6 anticipated that *rewritten* assertions might expose a previously-hidden real defect (detection-power-zero → activated). In practice, none of the 28 rewritten assertions failed. The only 2 FAILs surfaced by the full-suite run were in `tests/post_merge_check.bats` — a file untouched by this Issue — and were confirmed (via serial re-run, isolated `--jobs` re-run, and a re-run against unmodified `main`) to be a pre-existing flake specific to parallel execution, unrelated to any of this Issue's 28 rewrites. Filed as follow-up #1308.
+
+### Rework
+
+- N/A — no rework was required; all 28 rewrites were 1-line replacements (per Spec Notes) except the pre-identified `tests/observation-trigger.bats:76` structural exception, which matched the Spec's prescribed 3-line form exactly on first attempt.
+
 ## Phase Handoff
-<!-- phase: spec -->
+<!-- phase: code -->
 
 ### Key Decisions
 
-- 非 pipe + grep 形式 76 件を Spec フェーズで機械分類し、**defective 26 / safe 50** を確定した。`/code` は再分類せず Notes § defective インベントリ (26 件) をそのまま実装対象として使うこと。safe 50 件は AC4 により変更禁止。
-- Issue 本文が委任していた「裸の `!` 否定」は実測 2 件・両方 defective であったため本 Issue に編入した (合計 28 件)。これにより `tests/*.bats` の先頭 `!` 否定 90 件が全件棚卸し済みになる。
-- AC1 の常時 PASS 欠陥を `section_not_contains ... "Both categories are noted here for reference only"` へ差し替え、AC6 (`26 defective`) と AC7 (`regardless of whether a pipe is present`) を新設した。3 件とも実装が書く逐語文字列に依存するため、Implementation Steps 3 と 5 の文字列指定を逐語で守ること。
+- 28 件の書き換えは Spec の defective インベントリ (26 件) と個別対応 (`tests/observation-trigger.bats:76`) をそのまま踏襲し、再分類は行わなかった。safe 62 件 (piped 12 + non-piped 50) はすべて未変更。
+- `docs/reports/bats-negation-assertion-audit.md` に `## Non-Piped Form Audit (Issue #1304)` / `## Bare Negation Audit (Issue #1304)` を新設し、`## Out of Scope` は見出しを残したまま「両カテゴリとも解消済み」の記述に書き換えた。`## Remediation Record` に #1304 分をファイル別の行番号一覧として追記済み。
+- AC5 (`command "bats tests/"`) は Step 10 で PASS/FAIL 判定できず UNCERTAIN のまま未チェックとした。実測で `bats --jobs 18 tests/` は完走 (1640/1642 PASS) するが、AC5 が指定するシリアル形は `verify-executor.md` の 60 秒タイムアウトは疎か Bash ツールの 600 秒上限すら超過する。実装の正しさとは無関係な検証機構側の制約と判断し、follow-up #1310 に切り出した。
 
 ### Deferred Items
 
-- `scripts/check-forbidden-expressions.sh` への機械的検出パターン追加は本 Issue のスコープ外 (Notes § スコープ外に記録)。必要と判断されれば `/verify` の Improvement Proposal として起票。
+- follow-up #1308: `tests/post_merge_check.bats` が `bats --jobs` 並列実行時のみ FAIL するフレーク (未変更の main でも再現、本 Issue の変更とは無関係)。
+- follow-up #1310: `command` verify type の 60 秒固定タイムアウトが、`bats tests/` のような全件スイート実行系 AC を構造的に検証不能にしている問題。
+- `scripts/check-forbidden-expressions.sh` への機械的検出パターン追加は Spec Notes § スコープ外の通り本 Issue のスコープ外のまま。
 - Post-merge AC (次回 bats テストを追加/変更する Issue での観察) は `/verify` に委ねる。
 
 ### Notes for Next Phase
 
-- **28 件はすべて 1 行 → 1 行の置換で行数が変わらない**ため、Notes のインベントリに記載した行番号は書き換え中もずれない。唯一の例外は `tests/observation-trigger.bats:76` (`if ... fi` 内) で、Notes § 個別対応に 3 行構造を保つ書き換え形を明示してある。
-- **`bats --jobs <N> tests/` が新たに RED になる可能性がある**。これは検出力ゼロだったアサーションが有効化された結果であり、元の `!` 形式へ戻す対処は禁止 (Implementation Step 6)。
-- `modules/test-runner.md` への追記は散文のみで `scripts/*.sh` を参照しないため、reader SKILL.md の `allowed-tools` 更新は不要。CI 側でも `scripts/validate-skill-syntax.py` の `validate_modules_scripts_in_allowed_tools()` が裏取りする。
-- `docs/reports/` は `docs/translation-workflow.md` § Exclusions により ja ミラー対象外。監査レポート更新時に `docs/ja/reports/` を作らないこと。
+- Pre-merge AC 7 件中 6 件 (AC1–4, 6, 7) は Step 10 でチェック済み。AC5 のみ UNCERTAIN で未チェック — `/review`/`/verify` で再度同じ理由 (verify-executor の 60 秒タイムアウト) で UNCERTAIN になる見込みであり、これは実装の不備ではない。実質的な確認は `bats --jobs 18 tests/` (1640/1642 PASS) で完了している。
+- `bats --jobs 18 tests/` の残 2 件 FAIL (`tests/post_merge_check.bats:132,181`) は follow-up #1308 で追跡中の無関係な既存フレーク。本 PR のマージ判断に影響しない。
+- `modules/test-runner.md` への追記は散文のみで `scripts/*.sh` を参照しないため、reader SKILL.md の `allowed-tools` 更新は不要 (Spec フェーズの判断どおり)。
+- `docs/reports/` は `docs/translation-workflow.md` § Exclusions により ja ミラー対象外。監査レポート更新時に `docs/ja/reports/` は作成していない。

--- a/docs/spec/issue-1304-nonpipe-negation-audit.md
+++ b/docs/spec/issue-1304-nonpipe-negation-audit.md
@@ -246,24 +246,39 @@ Implementation Step 1 の対象。`->` の右は当該行の直後に続く文 (
 - N/A — no rework was required; all 28 rewrites were 1-line replacements (per Spec Notes) except the pre-identified `tests/observation-trigger.bats:76` structural exception, which matched the Spec's prescribed 3-line form exactly on first attempt.
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
 
-- 28 件の書き換えは Spec の defective インベントリ (26 件) と個別対応 (`tests/observation-trigger.bats:76`) をそのまま踏襲し、再分類は行わなかった。safe 62 件 (piped 12 + non-piped 50) はすべて未変更。
-- `docs/reports/bats-negation-assertion-audit.md` に `## Non-Piped Form Audit (Issue #1304)` / `## Bare Negation Audit (Issue #1304)` を新設し、`## Out of Scope` は見出しを残したまま「両カテゴリとも解消済み」の記述に書き換えた。`## Remediation Record` に #1304 分をファイル別の行番号一覧として追記済み。
-- AC5 (`command "bats tests/"`) は Step 10 で PASS/FAIL 判定できず UNCERTAIN のまま未チェックとした。実測で `bats --jobs 18 tests/` は完走 (1640/1642 PASS) するが、AC5 が指定するシリアル形は `verify-executor.md` の 60 秒タイムアウトは疎か Bash ツールの 600 秒上限すら超過する。実装の正しさとは無関係な検証機構側の制約と判断し、follow-up #1310 に切り出した。
+- Step 8 (safe mode) は AC1, 2, 4, 6, 7 を PASS、AC3 (`command` grep 件数チェック) を UNCERTAIN と判定した。AC3 は CI job との対応付けができず (defective なアサーションは検出力ゼロのため CI success では判定不可)、diff 直接確認で実装充足は独立確認済みだが、safe mode の `command` 型制約によりチェックボックスは `[ ]` のまま据え置いた。AC5 (`bats tests/`) は CI job `Run bats tests` (SUCCESS) を参照し PASS と判定、`[x]` に更新した (`/code` 時点の UNCERTAIN から反転)。
+- Step 10 の review-spec 指摘 5 件 (SHOULD 1 / CONSIDER 4) はすべて MUST 未満。review-bug 指摘 3 件は 2 段階アドバーサリアル検証で全件 REJECT (偽陽性)。MUST 相当の指摘がゼロだったため `event=COMMENT` で投稿。
+- SHOULD 1 件 (`modules/test-runner.md:151` の Correct form 例が pipe 形式のみだった点) のみ Step 12 で修正し、CONSIDER 4 件は今回はスキップ (スコープを絞り、体裁上の指摘に留めた)。
+- `capabilities.workflow: true` が有効だが、`--non-interactive` かつ Workflow ツール自体が再起動保証のない実行サーフェスであるため `skills/review/workflow-guidance.md` の指示通り Workflow path をスキップし、静的 Task fan-out (Agent tool, `run_in_background: false`) にフォールバックした。
 
 ### Deferred Items
 
-- follow-up #1308: `tests/post_merge_check.bats` が `bats --jobs` 並列実行時のみ FAIL するフレーク (未変更の main でも再現、本 Issue の変更とは無関係)。
-- follow-up #1310: `command` verify type の 60 秒固定タイムアウトが、`bats tests/` のような全件スイート実行系 AC を構造的に検証不能にしている問題。
-- `scripts/check-forbidden-expressions.sh` への機械的検出パターン追加は Spec Notes § スコープ外の通り本 Issue のスコープ外のまま。
-- Post-merge AC (次回 bats テストを追加/変更する Issue での観察) は `/verify` に委ねる。
+- follow-up #1308: `tests/post_merge_check.bats` の並列実行時フレーク (本 Issue の変更とは無関係、引き続き未対応)。
+- follow-up #1310: `command` verify type の 60 秒固定タイムアウトによる全件スイート実行系 AC の構造的検証不能問題。
+- AC3 の `command` 型 safe-mode 制約 (タイムアウトとは別の、CI 参照不能パターン) は本 review retrospective に記録。Issue 化は次の `/verify` の集約判断に委ねる。
+- CONSIDER 級のドキュメント一貫性指摘 3 件 (`docs/reports/bats-negation-assertion-audit.md:48,247,253`) は未対応のまま。
 
 ### Notes for Next Phase
 
-- Pre-merge AC 7 件中 6 件 (AC1–4, 6, 7) は Step 10 でチェック済み。AC5 のみ UNCERTAIN で未チェック — `/review`/`/verify` で再度同じ理由 (verify-executor の 60 秒タイムアウト) で UNCERTAIN になる見込みであり、これは実装の不備ではない。実質的な確認は `bats --jobs 18 tests/` (1640/1642 PASS) で完了している。
-- `bats --jobs 18 tests/` の残 2 件 FAIL (`tests/post_merge_check.bats:132,181`) は follow-up #1308 で追跡中の無関係な既存フレーク。本 PR のマージ判断に影響しない。
-- `modules/test-runner.md` への追記は散文のみで `scripts/*.sh` を参照しないため、reader SKILL.md の `allowed-tools` 更新は不要 (Spec フェーズの判断どおり)。
+- `/merge` 前提: MUST issue なし、CI 全 11 job SUCCESS (修正コミット後も再確認済み)、Pre-merge AC は 6/7 が `[x]`、AC3 のみ `[ ]` (UNCERTAIN、実装充足は確認済み)。
+- `/verify` (post-merge) で AC3 を full mode 再検証すれば PASS になる見込み (grep 件数は diff 確認で 0 件と判明済み)。
+- Post-merge 観察条件 (次回 bats テストを追加/変更する Issue での否定アサーション形式の観察) は `/verify` に委ねる。
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+Nothing to note — Implementation Steps 1–6 通り、defective インベントリ 28 件全件を diff で突合し完全一致を確認した (13 ファイル全件サンプル検証済み)。Spec/PR 間の構造的乖離は検出されなかった。
+
+### Recurring issues
+
+`docs/reports/bats-negation-assertion-audit.md` を単一ファイルで #1292/#1304 の 2 Issue にまたがって累積更新する構成が、SHOULD/CONSIDER 級のドキュメント一貫性指摘を複数件 (計 4 件: test-runner.md の Correct form 例が pipe 形式のみだった件、集計表の時点混在に見える表現、"heading only" の記述と実内容の不一致、旧セクションに Issue 番号が付与されていない件) 誘発した。個々の指摘は軽微だが、レポートが Issue をまたいで蓄積される設計そのものが「新旧セクションの記法統一」を継続的な認知負荷として生み続けている。今回は SHOULD 1件のみ修正し CONSIDER 3件は見送ったが、次にこのレポートへ追記する Issue (#1292/#1304 のような "audit を拡張する" 系) が出た場合、追記前に既存セクションとの記法整合 (Issue 番号サフィックスの要否、時点表現の統一) を確認する一手間を Spec フェーズのチェックリストに加えると再発を防げる可能性がある。
+
+### Acceptance criteria verification difficulty
+
+AC3 (`command "test $(grep -c '^\s*! grep -q \"phase_start\"' tests/run-code.bats) -eq 0"`) は `/review` の safe mode で UNCERTAIN となった。AC5 (`command "bats tests/"`) が `/code` Code Retrospective で特定した「`command` 型の 60 秒固定タイムアウトが全件スイート実行系 AC を検証不能にする」問題 (follow-up #1310) とは異なる、もう一つの `command` 型の構造的弱点: AC3 はタイムアウトとは無関係な軽量・決定的なテキストレベルのチェック (grep 件数比較) だが、`command` 型は safe mode で一律 CI reference fallback 頼みとなり、defective なアサーション自体が「検出力ゼロ」(パターンが残っていても CI は SUCCESS のまま) であるためこの AC は原理的に CI 参照でも判定不能だった。実装は diff 確認で充足を独立確認できたが、機構上 UNCERTAIN が確定的に残る。`modules/verify-patterns.md` §9 の "hard-pattern を使うべき条件" (実装が含む正確な文字列を書ける場合) に該当するため、本来 `file_not_contains "tests/run-code.bats" "! grep -q \"phase_start\""` のような safe-mode 対応 (`always_allow`) の verify type で表現できた可能性がある。follow-up #1310 のスコープ (command 型のタイムアウト構造) とは別に、「`command` 型が実は hard-pattern で代替可能なケースを spec 作成時に見分ける」観点を `modules/verify-patterns.md` §9 に追記する価値があるかもしれない (Issue 化は次の `/verify` の集約判断に委ねる)。
 - `docs/reports/` は `docs/translation-workflow.md` § Exclusions により ja ミラー対象外。監査レポート更新時に `docs/ja/reports/` は作成していない。

--- a/modules/test-runner.md
+++ b/modules/test-runner.md
@@ -148,9 +148,10 @@ catch), the negated command's non-zero-turned-zero status does not stop executio
 statements keep running, and the test reports PASS even though the regression it was meant to
 detect actually occurred.
 
-**Correct form**: Wrap the check as `if cmd | grep -q pattern; then false; fi`. This runs an
-explicit (non-negated) `false` in the branch where the pattern is found, which reliably triggers
-`set -e` and fails the test.
+**Correct form**: Wrap the check as `if cmd; then false; fi` — the same shape regardless of
+surface form (`if grep -q pattern file; then false; fi`, `if cmd | grep -q pattern; then false; fi`).
+This runs an explicit (non-negated) `false` in the branch where the pattern is found, which
+reliably triggers `set -e` and fails the test.
 
 **Exception (safe case)**: A `! cmd | grep -q pattern` negation is safe when it is the **true
 final statement** of the `@test` function — bats evaluates the function's own return value

--- a/modules/test-runner.md
+++ b/modules/test-runner.md
@@ -158,3 +158,18 @@ directly, without going through an intervening `set -e` non-final-statement cont
 `tests/collect-recovery-candidates.bats:604-605` (non-final statement — was defective and has
 been fixed to the `if ...; then false; fi` form) against `tests/collect-recovery-candidates.bats:611`
 (true final statement of its `@test` function — unmodified and safe).
+
+#### Scope — the pipe is irrelevant
+
+The same defect holds **regardless of whether a pipe is present**. A negation that reads a file
+directly, with no pipe at all — `! grep -q pattern file` — excludes its exit status from `set -e`
+by the exact same POSIX/bash rule as the piped form (`!` strips the `set -e` trigger from
+whatever command or pipeline it prefixes). A bare `!` in front of any other command (e.g.
+`! git branch -d some-branch 2>/dev/null`) is subject to the identical rule.
+
+Classification therefore never depends on the surface form (piped vs. non-piped vs. bare).
+It depends only on whether the negated line is the **true final statement** of its `@test`
+function — the same criterion as the Exception above. Treat `! cmd`, `! cmd | grep -q pattern`,
+and `! grep -q pattern file` as one and the same pitfall when auditing or writing assertions.
+See `docs/reports/bats-negation-assertion-audit.md` for the full inventory across all surface
+forms.

--- a/tests/ci-failure-classifier.bats
+++ b/tests/ci-failure-classifier.bats
@@ -27,11 +27,11 @@ VERIFY_EXECUTOR="$PROJECT_ROOT/modules/verify-executor.md"
 }
 
 @test "ci-failure-classifier: verify SKILL.md does not duplicate the signature table" {
-    ! grep -q "The runner has received a shutdown signal" "$VERIFY_SKILL"
+    if grep -q "The runner has received a shutdown signal" "$VERIFY_SKILL"; then false; fi
     grep -q "modules/ci-failure-classifier.md" "$VERIFY_SKILL"
 }
 
 @test "ci-failure-classifier: verify-executor.md does not duplicate the signature table" {
-    ! grep -q "The runner has received a shutdown signal" "$VERIFY_EXECUTOR"
+    if grep -q "The runner has received a shutdown signal" "$VERIFY_EXECUTOR"; then false; fi
     grep -q "modules/ci-failure-classifier.md" "$VERIFY_EXECUTOR"
 }

--- a/tests/gh-graphql.bats
+++ b/tests/gh-graphql.bats
@@ -66,7 +66,7 @@ teardown() {
         -F owner=myowner -F repo=myrepo
     [ "$status" -eq 0 ]
     # gh repo view should NOT have been called
-    ! grep -q "repo view" "$GH_CALL_LOG"
+    if grep -q "repo view" "$GH_CALL_LOG"; then false; fi
     # explicit owner/repo should be used
     grep -q "api graphql.*-F owner=myowner" "$GH_CALL_LOG"
     grep -q "api graphql.*-F repo=myrepo" "$GH_CALL_LOG"
@@ -237,9 +237,9 @@ cache_teardown() {
     run bash "$SCRIPT" --cache 'query{viewer{login}}'
     [ "$status" -eq 0 ]
     # gh api graphql should NOT have been called
-    ! grep -q "api graphql" "$GH_CALL_LOG"
+    if grep -q "api graphql" "$GH_CALL_LOG"; then false; fi
     # gh repo view should NOT have been called (repo-info cached)
-    ! grep -q "repo view" "$GH_CALL_LOG"
+    if grep -q "repo view" "$GH_CALL_LOG"; then false; fi
     cache_teardown
 }
 
@@ -283,7 +283,7 @@ cache_teardown() {
     run bash "$SCRIPT" --cache 'query{viewer{login}}'
     [ "$status" -eq 0 ]
     # gh repo view should NOT have been called (repo-info still cached)
-    ! grep -q "repo view" "$GH_CALL_LOG"
+    if grep -q "repo view" "$GH_CALL_LOG"; then false; fi
     # gh api graphql SHOULD have been called (query cache was deleted)
     grep -q "api graphql" "$GH_CALL_LOG"
     cache_teardown
@@ -330,6 +330,6 @@ MOCK
     # Should return filtered result
     [[ "$output" == *"ok"* ]]
     # API should not have been called
-    ! grep -q "api graphql" "$GH_CALL_LOG"
+    if grep -q "api graphql" "$GH_CALL_LOG"; then false; fi
     cache_teardown
 }

--- a/tests/observation-trigger.bats
+++ b/tests/observation-trigger.bats
@@ -72,8 +72,8 @@ teardown() {
     export MOCK_SEARCH_OUTPUT='[{"number": 42, "condition": "watchdog-kill event is observed"}]'
     run bash "$SCRIPT" --event pr-review-full --dry-run
     [ "$status" -eq 0 ]
-    if [ -f "$BATS_TEST_TMPDIR/gh-calls.log" ]; then
-        ! grep -q "issue comment" "$BATS_TEST_TMPDIR/gh-calls.log"
+    if [ -f "$BATS_TEST_TMPDIR/gh-calls.log" ] && grep -q "issue comment" "$BATS_TEST_TMPDIR/gh-calls.log"; then
+        false
     fi
     [ "$output" = "42" ]
 }
@@ -195,7 +195,7 @@ teardown() {
     export MOCK_SEARCH_OUTPUT='[{"number": 42, "condition": "watchdog-kill event is observed"}]'
     run bash "$SCRIPT" --event watchdog-kill
     [ "$status" -eq 0 ]
-    ! grep -q "issue comment" "$BATS_TEST_TMPDIR/gh-calls.log"
+    if grep -q "issue comment" "$BATS_TEST_TMPDIR/gh-calls.log"; then false; fi
     [ "$output" = "42" ]
 }
 

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -510,7 +510,7 @@ teardown() {
     unset WHOLEWORK_SCRIPT_DIR
     [ "$status" -eq 0 ]
     [ -f "$MOCK_DIR/collect-run-facts-args.txt" ]
-    ! grep -q -- "--session\|--facts-file" "$MOCK_DIR/collect-run-facts-args.txt"
+    if grep -q -- "--session\|--facts-file" "$MOCK_DIR/collect-run-facts-args.txt"; then false; fi
     echo "$output" | jq -e 'length == 1' > /dev/null
     echo "$output" | jq -e '.[0].number == 712' > /dev/null
 }

--- a/tests/orchestration-fallbacks.bats
+++ b/tests/orchestration-fallbacks.bats
@@ -89,7 +89,7 @@ ARCHIVE="$PROJECT_ROOT/docs/reports/orchestration-fallbacks-archive.md"
 }
 
 @test "orchestration-fallbacks: archived anchors are absent from live catalog" {
-    ! grep -q '^## ci-flake-retry' "$CATALOG"
+    if grep -q '^## ci-flake-retry' "$CATALOG"; then false; fi
     ! grep -q '^## gh-pr-list-head-glob' "$CATALOG"
 }
 

--- a/tests/reclaim-stale-worktrees.bats
+++ b/tests/reclaim-stale-worktrees.bats
@@ -133,7 +133,7 @@ mock_pr() {
     mock_pr 1149 MERGED "$tip_sha"
 
     # sanity: plain -d must fail (branch not fully merged into main)
-    ! git -C "$MAIN_REPO" branch -d worktree-code+pr-1149 2>/dev/null
+    if git -C "$MAIN_REPO" branch -d worktree-code+pr-1149 2>/dev/null; then false; fi
 
     cd "$MAIN_REPO"
     run "$SCRIPT" --apply
@@ -156,7 +156,7 @@ mock_pr() {
     )
 
     # sanity: plain -d must fail (branch not fully merged into main); issue kind has no -D fallback
-    ! git -C "$MAIN_REPO" branch -d worktree-code+issue-5000 2>/dev/null
+    if git -C "$MAIN_REPO" branch -d worktree-code+issue-5000 2>/dev/null; then false; fi
 
     cd "$MAIN_REPO"
     run "$SCRIPT" --apply

--- a/tests/retro-proposals.bats
+++ b/tests/retro-proposals.bats
@@ -146,7 +146,7 @@ teardown() {
     body="Fix /Users/dev/wholework/modules/retro-proposals.md"
     run perform_routing "owner/repo" "skill-infra" "Fix module" "$body"
     [ "$status" -eq 0 ]
-    ! grep -q "/Users/" "$GH_CALLS_LOG"
+    if grep -q "/Users/" "$GH_CALLS_LOG"; then false; fi
     grep -q "<absolute-path>" "$GH_CALLS_LOG"
 }
 

--- a/tests/run-code.bats
+++ b/tests/run-code.bats
@@ -467,7 +467,7 @@ MOCK
     run bash "$SCRIPT" 123 --pr
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
-    ! grep -q "phase_start" "$EMIT_LOG"
+    if grep -q "phase_start" "$EMIT_LOG"; then false; fi
     ! grep -q "phase_complete" "$EMIT_LOG"
 }
 

--- a/tests/run-issue.bats
+++ b/tests/run-issue.bats
@@ -303,7 +303,7 @@ MOCK
     run bash "$SCRIPT" 123
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
-    ! grep -q "phase_start" "$EMIT_LOG"
+    if grep -q "phase_start" "$EMIT_LOG"; then false; fi
     ! grep -q "phase_complete" "$EMIT_LOG"
 }
 
@@ -336,7 +336,7 @@ MOCK
     run bash "$SCRIPT" 123
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
-    ! grep -q "wrapper_exit" "$EMIT_LOG"
+    if grep -q "wrapper_exit" "$EMIT_LOG"; then false; fi
     ! grep -q "token_usage" "$EMIT_LOG"
 }
 

--- a/tests/run-merge.bats
+++ b/tests/run-merge.bats
@@ -754,7 +754,7 @@ MOCK
     run bash "$SCRIPT" 88
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
-    ! grep -q "phase_start" "$EMIT_LOG"
+    if grep -q "phase_start" "$EMIT_LOG"; then false; fi
     ! grep -q "phase_complete" "$EMIT_LOG"
 }
 

--- a/tests/run-review.bats
+++ b/tests/run-review.bats
@@ -773,7 +773,7 @@ MOCK
     run bash "$SCRIPT" 88
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
-    ! grep -q "phase_start" "$EMIT_LOG"
+    if grep -q "phase_start" "$EMIT_LOG"; then false; fi
     ! grep -q "phase_complete" "$EMIT_LOG"
 }
 

--- a/tests/run-spec.bats
+++ b/tests/run-spec.bats
@@ -390,7 +390,7 @@ MOCK
     run bash "$SCRIPT" 123
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
-    ! grep -q "phase_start" "$EMIT_LOG"
+    if grep -q "phase_start" "$EMIT_LOG"; then false; fi
     ! grep -q "phase_complete" "$EMIT_LOG"
 }
 
@@ -425,7 +425,7 @@ MOCK
     run bash "$SCRIPT" 123
     unset EMIT_PHASE_NAME
     [ "$status" -eq 0 ]
-    ! grep -q "wrapper_exit" "$EMIT_LOG"
+    if grep -q "wrapper_exit" "$EMIT_LOG"; then false; fi
     ! grep -q "token_usage" "$EMIT_LOG"
 }
 

--- a/tests/test-runner.bats
+++ b/tests/test-runner.bats
@@ -61,3 +61,7 @@ TEST_RUNNER="$PROJECT_ROOT/modules/test-runner.md"
     [ "$status" -ne 0 ]
     grep -q -F "bats --jobs <N> tests/" "$TEST_RUNNER"
 }
+
+@test "test-runner: negation pitfall is documented as pipe-independent" {
+    grep -q -F "regardless of whether a pipe is present" "$TEST_RUNNER"
+}

--- a/tests/worktree-merge-push.bats
+++ b/tests/worktree-merge-push.bats
@@ -209,7 +209,7 @@ MOCK
     [ "$status" -eq 0 ]
     [[ "$output" == *"FF merge failed while main is checked out"* ]]
     grep -q -- "-C ${WORKTREE_PATH} rebase main" "$GIT_LOG"
-    ! grep -q -- "-C ${WORKTREE_PATH} rebase origin/main" "$GIT_LOG"
+    if grep -q -- "-C ${WORKTREE_PATH} rebase origin/main" "$GIT_LOG"; then false; fi
     merge_count=$(grep -c "merge test-branch --ff-only" "$GIT_LOG")
     [ "$merge_count" -eq 2 ]
     grep -q "push origin main" "$GIT_LOG"
@@ -310,7 +310,7 @@ MOCK
     grep -q "worktree list --porcelain" "$GIT_LOG"
     grep -q -- "-C ${WORKTREE_PATH} rebase origin/main" "$GIT_LOG"
     grep -q "push origin main" "$GIT_LOG"
-    ! grep -q "merge test-branch --ff-only" "$GIT_LOG"
+    if grep -q "merge test-branch --ff-only" "$GIT_LOG"; then false; fi
     fetch_count=$(grep -c "fetch . test-branch:main" "$GIT_LOG")
     [ "$fetch_count" -eq 2 ]
 }
@@ -384,8 +384,8 @@ MOCK
     run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Cannot locate a worktree"* ]]
-    ! grep -q "merge test-branch --ff-only" "$GIT_LOG"
-    ! grep -qE "^rebase " "$GIT_LOG"
+    if grep -q "merge test-branch --ff-only" "$GIT_LOG"; then false; fi
+    if grep -qE "^rebase " "$GIT_LOG"; then false; fi
     ! grep -q "push" "$GIT_LOG"
 }
 
@@ -462,7 +462,7 @@ MOCK
     run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
     [ "$status" -eq 0 ]
     grep -q -- "-C ${WORKTREE_PATH} rebase origin/main" "$GIT_LOG"
-    ! grep -qE "^rebase origin/main" "$GIT_LOG"
+    if grep -qE "^rebase origin/main" "$GIT_LOG"; then false; fi
     grep -q -- "fetch . +test-branch:main" "$GIT_LOG"
 }
 
@@ -620,8 +620,8 @@ MOCK
     run bash -c "cd '$BATS_TEST_TMPDIR/test-repo' && bash '$SCRIPT' --from test-branch"
     [ "$status" -eq 0 ]
     [[ "$output" == *"is-ancestor=true"* ]]
-    ! grep -q "rebase origin/main" "$GIT_LOG"
-    ! grep -qE "\-C .+ rebase" "$GIT_LOG"
+    if grep -q "rebase origin/main" "$GIT_LOG"; then false; fi
+    if grep -qE "\-C .+ rebase" "$GIT_LOG"; then false; fi
     grep -q "push origin main" "$GIT_LOG"
     fetch_count=$(grep -c "fetch . test-branch:main" "$GIT_LOG")
     [ "$fetch_count" -eq 2 ]


### PR DESCRIPTION
## Summary
- `tests/*.bats` に残っていた **pipe を伴わない否定アサーション** (`! grep -q pattern file` 形式) の defective (非最終文) 26 件、および **grep を伴わない裸の `!` 否定** の defective 2 件、計 28 件を `if cmd; then false; fi` 形式へ書き換え、検出力ゼロだったアサーションを解消した (対象 13 ファイル)。safe (真の最終文) と分類された 62 件は変更していない
- `modules/test-runner.md` の bats Negation Assertion Pitfall に `#### Scope — the pipe is irrelevant` を追加し、この落とし穴が pipe の有無に依存しないことを明記 (#1292 のスコープ限定 → #1304 の見落としの再発防止)。`tests/test-runner.bats` に対応する構造テストを追加
- `docs/reports/bats-negation-assertion-audit.md` を #1292/#1304 両対応に更新 (Non-Piped Form Audit / Bare Negation Audit の新設セクション、Out of Scope の書き換え、Remediation Record の追記)

## Verification (pre-merge)
- `docs/reports/bats-negation-assertion-audit.md` の `## Out of Scope` が本 Issue の棚卸し結果を反映して更新されている
- 非 pipe 形式の defective/safe 分類結果が件数付きで監査レポートに記録されている
- `tests/run-code.bats` の defective 事例 (旧 470 行目) が書き換え済み (grep -c 実測 0 件)
- defective のみが書き換えられ safe は据え置かれている
- `docs/reports/bats-negation-assertion-audit.md` の Non-Piped Form Audit 節に "26 defective" の記載あり
- `modules/test-runner.md` に "regardless of whether a pipe is present" の記載あり
- `bats --jobs 18 tests/`: 1640/1642 PASS。残 2 件 (`tests/post_merge_check.bats:132,181`) は本 PR の変更と無関係な既存フレーク (`--jobs` 並列実行時のみ再現、シリアル実行および未変更の main でも同様に発生することを確認済み)。follow-up #1308 で追跡
- `bats tests/` (serial, verify command 由来の AC) は verify-executor の 60 秒タイムアウトを超過し UNCERTAIN — 実装内容は上記並列実行で確認済み

## Verification (post-merge)
- 次回 bats テストを追加・変更する Issue で、否定アサーションが pipe の有無にかかわらず正しい形式で書かれていることを観察する

closes #1304
