### PR TITLE
Issue #1300: get-auto-session-report: Timeline 表の Size/Route 陳腐化と PR 列の無検証全文検索を修正

### DIFF
--- a/docs/spec/issue-1300-fix-timeline-route-pr-column.md
+++ b/docs/spec/issue-1300-fix-timeline-route-pr-column.md
@@ -112,18 +112,29 @@ N/A — Implementation Steps 1〜5 を Spec の記述通りに実装した。
 ### Rework
 N/A — 手戻りなし。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+N/A — review-light (spec deviation 観点) で乖離なし。`_route` 導出 (`ROUTE_MIX` と同じ `has_pr`/`has_patch` パターン) と `PR` 列の検証付き解決 (`skills/verify/SKILL.md` Step 2 と同方式) はいずれも Spec Implementation Steps の記述通りに実装されていた。
+
+### Recurring issues
+N/A — 同種の issue の複数発生はなし。MUST/SHOULD issue はゼロ、CONSIDER 2件 (コメント欠如・API呼び出し量) はいずれも軽微な提案であり修正は見送った。
+
+### Acceptance criteria verification difficulty
+N/A — 6件の Pre-merge AC (rubric ×3, file_not_contains ×1, grep ×1, command ×1) は全て UNCERTAIN なく機械的に PASS 判定できた。`bats --jobs 18 tests/get-auto-session-report.bats` は 17/17 PASS。verify command の記述と実装の対応も明確だった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `_route` 導出は `ROUTE_MIX` (#1289) と同じ `has_pr`/`has_patch` 判定パターンを Timeline 行生成ループ内に直接インライン展開した (共通関数への抽出はスコープ外、Spec Implementation Step 1 の指示通り)。
-- `PR` 列は `skills/verify/SKILL.md` Step 2 と同じ「候補を最大10件取得 → `gh-extract-issue-from-pr.sh` で実 `closes` 参照を検証 → 一致した最初の候補を採用」方式を採用し、JSON パースは python3 ではなく既存の jq 依存に揃えた。
-- `_size` 表示列 (Timeline 行の `M/`, `S/` 部分) は Spec の判断通り `sub_start.size` のまま変更していない (post-spec 確定値への統一はスコープ外)。
+- `--light` 指定により lightweight integrated review (review-light 1 エージェント、全4観点) を実行し、fan-out レビューは行わなかった。
+- MUST/SHOULD issue が存在しないため `event=COMMENT` でレビューを投稿し、`/merge` への進行をブロックしなかった。
+- CONSIDER 2件 (コメント欠如の可読性提案、候補PR検証ループのAPI呼び出し量) はインラインコメントとして記録した上で、いずれも既存パターンに沿った軽微な提案のため修正を見送った。
 
 ### Deferred Items
-- `_size` 表示自体を post-spec の確定 Size に揃える対応 (Spec Notes に明記のスコープ外事項)。
-- 全 bats スイート並列実行時の `tests/post_merge_check.bats` フレーク — 既存 Issue #1308 で追跡済み、本 Issue からの追加対応なし。
+- CONSIDER: `_has_pr`/`_has_patch` 判定に `ROUTE_MIX` ブロックと同様の説明コメントを追加する提案 (scripts/get-auto-session-report.sh:349) — 任意の可読性向上、修正は見送り。
+- CONSIDER: 候補PR検証ループの API 呼び出し量 (scripts/get-auto-session-report.sh:372) — `skills/verify/SKILL.md` Step 2 と同一パターンのため新規の欠陥ではない。
 
 ### Notes for Next Phase
-- Post-merge AC は `verify-type: observation event=auto-run session=next` — 次回 `/auto --batch` 完走後の L3 retrospective で Timeline 表と Route mix の整合、PR 列の正確性を確認する。
-- `tests/get-auto-session-report.bats` の新規2テストは `NO_GITHUB` の有無を使い分けている (PR列テストは `gh` PATH モックが必要なため `--no-github` なし、route テストは `--no-github` で十分)。
+- `/merge 1311` で問題なく進行可能 (MUST issue ゼロ、CI 全11件 SUCCESS、Pre-merge AC 6件 PASS)。
+- Post-merge AC (`verify-type: observation event=auto-run session=next`) は次回 `/auto --batch` 完走後に `/verify` で確認する。

--- a/docs/spec/issue-1300-fix-timeline-route-pr-column.md
+++ b/docs/spec/issue-1300-fix-timeline-route-pr-column.md
@@ -100,3 +100,30 @@
 ## Consumed Comments
 
 - login: saito / authorAssociation: MEMBER / trust tier: first-class / 内容: `/issue 1300` (non-interactive) 実行時の Autonomous Auto-Resolve Log — AC5 のテスト範囲を降格方向のみから昇格・降格の両方向へ拡張、AC2 の verify command を `case` 文の直接マッピング検出へ変更、Post-merge observation AC に `session=next` を追加。いずれも現在の Issue 本文に既に反映済みであり、本 Spec 作成時点で追加対応は不要と判断した。 / URL: https://github.com/saitoco/wholework/issues/1300#issuecomment-5230385022
+
+## Code Retrospective
+
+### Deviations from Design
+N/A — Implementation Steps 1〜5 を Spec の記述通りに実装した。
+
+### Design Gaps/Ambiguities
+- 全 bats スイート (`bats --jobs 18 tests/`) の1回目実行で `tests/post_merge_check.bats` の `fail: gh issue reopen called when FAIL input given` が1件 FAIL したが、単体実行および2回目の並列実行では PASS した。本 Issue の変更対象 (`scripts/get-auto-session-report.sh` / `tests/get-auto-session-report.bats`) とは無関係な並列実行時フレークであり、既存 Issue #1308 (`tests/post_merge_check.bats: bats --jobs 並列実行時に 2 件 FAIL するフレークを解消`) で追跡済みのため、本 Issue では追加の Follow-up Issue 起票は行わなかった。
+
+### Rework
+N/A — 手戻りなし。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `_route` 導出は `ROUTE_MIX` (#1289) と同じ `has_pr`/`has_patch` 判定パターンを Timeline 行生成ループ内に直接インライン展開した (共通関数への抽出はスコープ外、Spec Implementation Step 1 の指示通り)。
+- `PR` 列は `skills/verify/SKILL.md` Step 2 と同じ「候補を最大10件取得 → `gh-extract-issue-from-pr.sh` で実 `closes` 参照を検証 → 一致した最初の候補を採用」方式を採用し、JSON パースは python3 ではなく既存の jq 依存に揃えた。
+- `_size` 表示列 (Timeline 行の `M/`, `S/` 部分) は Spec の判断通り `sub_start.size` のまま変更していない (post-spec 確定値への統一はスコープ外)。
+
+### Deferred Items
+- `_size` 表示自体を post-spec の確定 Size に揃える対応 (Spec Notes に明記のスコープ外事項)。
+- 全 bats スイート並列実行時の `tests/post_merge_check.bats` フレーク — 既存 Issue #1308 で追跡済み、本 Issue からの追加対応なし。
+
+### Notes for Next Phase
+- Post-merge AC は `verify-type: observation event=auto-run session=next` — 次回 `/auto --batch` 完走後の L3 retrospective で Timeline 表と Route mix の整合、PR 列の正確性を確認する。
+- `tests/get-auto-session-report.bats` の新規2テストは `NO_GITHUB` の有無を使い分けている (PR列テストは `gh` PATH モックが必要なため `--no-github` なし、route テストは `--no-github` で十分)。

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -339,11 +339,15 @@ for _num in $ISSUE_NUMS_FOR_TABLE; do
     end
   ' 2>/dev/null || echo "?")
   _size=$(echo "$_issue_events" | jq -r '[.[] | select(.event == "sub_start") | .size] | first // "?"' 2>/dev/null || echo "?")
-  case "$_size" in
-    XS|S) _route="patch" ;;
-    M|L)  _route="pr" ;;
-    *)    _route="?" ;;
-  esac
+  _has_pr=$(echo "$_issue_events" | jq -r '[.[] | select(.phase == "code-pr")] | length > 0' 2>/dev/null || echo "false")
+  _has_patch=$(echo "$_issue_events" | jq -r '[.[] | select(.phase == "code-patch")] | length > 0' 2>/dev/null || echo "false")
+  if [[ "$_has_pr" == "true" ]]; then
+    _route="pr"
+  elif [[ "$_has_patch" == "true" ]]; then
+    _route="patch"
+  else
+    _route="?"
+  fi
   # Phase breakdown: per-phase duration joined by →
   _phase_breakdown=$(echo "$_issue_events" | jq -r '
     [.[] | select(.event == "phase_start" or .event == "phase_complete")] |
@@ -365,8 +369,14 @@ for _num in $ISSUE_NUMS_FOR_TABLE; do
   # PR lookup
   _pr_col="—"
   if [[ "$NO_GITHUB" == "false" ]]; then
-    _pr_num=$(gh pr list --search "closes #${_num}" --state all --json number --jq '.[0].number // empty' 2>/dev/null || true)
-    [[ -n "$_pr_num" ]] && _pr_col="#${_pr_num}"
+    _candidate_prs=$(gh pr list --search "closes #${_num}" --state all --json number --jq '.[].number' 2>/dev/null | head -10 || true)
+    for _candidate in $_candidate_prs; do
+      _candidate_issue=$("$SCRIPT_DIR/gh-extract-issue-from-pr.sh" "$_candidate" 2>/dev/null | jq -r '.issue_number // empty' 2>/dev/null || true)
+      if [[ "$_candidate_issue" == "$_num" ]]; then
+        _pr_col="#${_candidate}"
+        break
+      fi
+    done
   fi
   # Recovery events for this issue
   _t1_n=$(echo "$_issue_events" | jq '[.[] | select(.event == "recovery" and .tier == "1")] | length' 2>/dev/null || echo 0)

--- a/tests/get-auto-session-report.bats
+++ b/tests/get-auto-session-report.bats
@@ -295,3 +295,65 @@ FIXTURE_EOF
     [ "$status" -eq 0 ]
     echo "$output" | grep -q "Route mix.*patch: 0, pr: 0, xl: 1, unknown: 1"
 }
+
+@test "Timeline PR column: unrelated closes-reference candidate is rejected, column shows —" {
+    # Models the real miss-hit observed in session 23043-1786197225: `gh pr list --search
+    # "closes #1266"` returned PR #1090, but #1090 actually closes #1061 (an unrelated Issue).
+    # The verified-closes-reference resolution must reject the candidate and keep the — default.
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-08-08T14:46:59Z","issue":1266,"event":"sub_start","session_id":"session-prcheck","size":"S"}
+{"ts":"2026-08-08T14:50:00Z","issue":1266,"event":"phase_start","session_id":"session-prcheck","phase":"code-patch"}
+{"ts":"2026-08-08T14:55:00Z","issue":1266,"event":"phase_complete","session_id":"session-prcheck","phase":"code-patch"}
+FIXTURE_EOF
+
+    MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+    mkdir -p "$MOCK_DIR"
+    cat > "$MOCK_DIR/gh" << 'MOCK_EOF'
+#!/bin/bash
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    echo "1090"
+    exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+    echo '{"body":"closes #1061","title":"Issue #1061: unrelated fix","baseRefName":"main"}'
+    exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+    if [[ "$*" == *"body,title"* ]]; then
+        echo '{"body":"","title":"#1266"}'
+    else
+        echo ""
+    fi
+    exit 0
+fi
+exit 0
+MOCK_EOF
+    chmod +x "$MOCK_DIR/gh"
+    export PATH="$MOCK_DIR:$PATH"
+
+    run bash "$SCRIPT" "session-prcheck" --metrics-only
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "| #1266 | S/patch |"
+    row="$(echo "$output" | grep "| #1266 |")"
+    if [[ "$row" == *"#1090"* ]]; then false; fi
+    [[ "$row" == *"| — |"* ]]
+}
+
+@test "Timeline route: Size downgrade and upgrade fixtures report executed-phase route in the row" {
+    # Real-world downgrade/upgrade route mismatches (session 97764-1786198856):
+    # #1251 sub_start'd at Size M but /spec demoted it to S and it ran code-patch;
+    # #1292 sub_start'd at Size S but /spec promoted it to M and it ran code-pr.
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-08-09T10:00:00Z","issue":1251,"event":"sub_start","session_id":"session-sizeflip","size":"M"}
+{"ts":"2026-08-09T10:05:00Z","issue":1251,"event":"phase_start","session_id":"session-sizeflip","phase":"code-patch"}
+{"ts":"2026-08-09T10:28:00Z","issue":1251,"event":"phase_complete","session_id":"session-sizeflip","phase":"code-patch"}
+{"ts":"2026-08-09T11:00:00Z","issue":1292,"event":"sub_start","session_id":"session-sizeflip","size":"S"}
+{"ts":"2026-08-09T11:05:00Z","issue":1292,"event":"phase_start","session_id":"session-sizeflip","phase":"code-pr"}
+{"ts":"2026-08-09T11:23:00Z","issue":1292,"event":"phase_complete","session_id":"session-sizeflip","phase":"code-pr"}
+FIXTURE_EOF
+
+    run bash "$SCRIPT" "session-sizeflip" --metrics-only --no-github
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "| #1251 | M/patch |"
+    echo "$output" | grep -q "| #1292 | S/pr |"
+}


### PR DESCRIPTION
## Summary
- `Size/Route` 列の `_route` 導出を `sub_start` イベントの `size` の `case` マッピングから、`ROUTE_MIX` (#1289) と同じ実行フェーズ (`code-pr`/`code-patch` イベント) 由来の per-issue 導出へ変更
- `PR` 列の解決を、`gh pr list --search` の先頭ヒット無検証採用から、候補 PR の実 `closes` 参照を `gh-extract-issue-from-pr.sh` で検証してから採用する方式へ変更 (`skills/verify/SKILL.md` Step 2 / #1202 と同じ方式)
- `tests/get-auto-session-report.bats` に regression テストを2件追加 (PR列の誤ヒット防止、Size昇格・降格双方向のroute導出)

## Verification (pre-merge)
- Timeline 表の `Size/Route` 列が実行フェーズ (`code-pr`/`code-patch`) に基づく route を報告している
- `case "$_size" in ... esac` 形式のマッピングが Timeline 行生成から除去されている
- `PR` 列が候補 PR の実 `closes` 参照を検証してから採用する方式になっている
- patch route の Issue で `PR` 列が `—` になることを検証する bats テストが追加されている
- Size 昇格・降格の両方向で Timeline 行が実行 route を報告することを検証する bats テストが追加されている
- `bats tests/get-auto-session-report.bats` 全件 PASS (17/17)

## Verification (post-merge)
- 次回 `/auto --batch` の完走後、L3 retrospective の Timeline 表の `Size/Route` 列と `Route mix` の集計が矛盾せず、`PR` 列が各 Issue の実 PR (patch route なら `—`) と一致することを観察する

closes #1300
