### PR TITLE
Issue #1293: observation-trigger: keyword= ゲートの非パス様値への部分一致を単語境界マッチに改善

### DIFF
--- a/docs/spec/issue-1293-keyword-gate-cli-flag-fp-fix.md
+++ b/docs/spec/issue-1293-keyword-gate-cli-flag-fp-fix.md
@@ -62,3 +62,29 @@
 
 - saito (MEMBER, first-class) — `/issue 1293 --non-interactive` の Issue Retrospective。Auto-Resolve Log (単語境界マッチが機能しない実機検証結果) を記録。AC 変更なし。https://github.com/saitoco/wholework/issues/1293#issuecomment-5230670606
 - saito (MEMBER, first-class) — Triage AC audit: Pre-merge AC3 の verify command `command "bats tests/opportunistic-search.bats"` が新規カバレッジなしでも常時 PASS するリスクを指摘。`bats --filter` への差し替えを推奨 (本 Spec の Notes・Implementation Step 3 で対応済み)。https://github.com/saitoco/wholework/issues/1293#issuecomment-5230697853
+- `/code 1293 --non-interactive` (code フェーズ): cutoff (`phase/code` ラベル付与時刻 2026-08-09T09:13:45Z) 以降の新規コメントなし。
+
+## Code Retrospective
+
+### Deviations from Design
+- None — Spec の Implementation Steps 1〜3 をそのまま実装した (resolve_filtered_context() への sed -E 式追加とコメント3箇所の更新、observation-trigger.md への段落追加、tests/opportunistic-search.bats への2件のテスト追加)。
+
+### Design Gaps/Ambiguities
+- None — Root Cause 節が却下代替案・採用方針を明確に記録していたため、実装方針で迷う点はなかった。
+
+### Rework
+- None.
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の Implementation Steps をそのまま実装。`resolve_filtered_context()` に2つ目の `sed -E` 式 (`--[A-Za-z0-9-]+=[A-Za-z0-9._-]+`) を追加し、パス様トークン除去と同じキャッシュ済み1回のフィルタリングパスで CLI フラグ構文も除去する構成にした。
+- Behavioral Change Detection がヒット (`tests/check-known-events-firing.bats` が `scripts/opportunistic-search.sh` を直接対応テスト外で参照) したため、`bats --jobs 18 tests/` でフルスイート (1654件) を実行し全件 PASS を確認した。
+
+### Deferred Items
+- Post-merge AC (`event=pr-review-light session=next` の観測) は本 PR の対象外。次回以降 Issue #476 の `/verify` dispatch 時に自然発火を待つ。
+
+### Notes for Next Phase
+- Pre-merge AC 3件は本フェーズ内で verify-executor full mode により PASS 確認済み、Issue #1293 のチェックボックスも更新済み。
+- 追加した2件の bats テスト名には `CLI flag token` という一意な部分文字列を含めてあるため、`bats --filter 'CLI flag token' tests/opportunistic-search.bats` が引き続き有効。

--- a/docs/spec/issue-1293-keyword-gate-cli-flag-fp-fix.md
+++ b/docs/spec/issue-1293-keyword-gate-cli-flag-fp-fix.md
@@ -75,16 +75,27 @@
 ### Rework
 - None.
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — review-light (4観点統合) の判定で Spec と PR diff の間に構造的な乖離は見られなかった。Implementation Steps 1〜3 通りの実装。
+
+### Recurring issues
+- Nothing to note — MUST/SHOULD/CONSIDER の指摘は0件。同種の指摘の繰り返しパターンは見られなかった。
+
+### Acceptance criteria verification difficulty
+- Nothing to note — Pre-merge AC 3件はすべて自動判定 (rubric 2件 PASS、command 1件は CI 参照フォールバック経由で PASS) で UNCERTAIN なく完結した。verify command / rubric 文言のいずれも過不足なく機能した。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の Implementation Steps をそのまま実装。`resolve_filtered_context()` に2つ目の `sed -E` 式 (`--[A-Za-z0-9-]+=[A-Za-z0-9._-]+`) を追加し、パス様トークン除去と同じキャッシュ済み1回のフィルタリングパスで CLI フラグ構文も除去する構成にした。
-- Behavioral Change Detection がヒット (`tests/check-known-events-firing.bats` が `scripts/opportunistic-search.sh` を直接対応テスト外で参照) したため、`bats --jobs 18 tests/` でフルスイート (1654件) を実行し全件 PASS を確認した。
+- Issue Size=M と `--light` 明示指定が整合していたため REVIEW_DEPTH=light を確定し、review-light エージェント1体による4観点統合レビューを実行した。
+- Base Branch Conflict Pre-check (`git merge-tree`) でベースブランチとのコンフリクト (`changed in both`) なしを確認済み。
 
 ### Deferred Items
-- Post-merge AC (`event=pr-review-light session=next` の観測) は本 PR の対象外。次回以降 Issue #476 の `/verify` dispatch 時に自然発火を待つ。
+- Post-merge AC (`event=pr-review-light session=next`) は引き続き次回以降の Issue #476 `/verify` dispatch 時の自然発火待ち。review フェーズでは検証不能 (設計通り継続)。
 
 ### Notes for Next Phase
-- Pre-merge AC 3件は本フェーズ内で verify-executor full mode により PASS 確認済み、Issue #1293 のチェックボックスも更新済み。
-- 追加した2件の bats テスト名には `CLI flag token` という一意な部分文字列を含めてあるため、`bats --filter 'CLI flag token' tests/opportunistic-search.bats` が引き続き有効。
+- MUST issue は0件のため、追加修正なしで `/merge 1314` に進んでよい。
+- CI全11件 SUCCESS、Pre-merge AC3件全て PASS 済み (Issueチェックボックスは code フェーズで既に更新済みのため、review フェーズでの追加更新はなし)。

--- a/modules/observation-trigger.md
+++ b/modules/observation-trigger.md
@@ -202,6 +202,17 @@ path-like tokens (a run of `[A-Za-z0-9._-]` characters containing at least one `
 matching. A word-boundary match (`grep -qiw`) does not fix this: `/` and `.` are non-word
 characters in regex, so `docs/workflow.md` already satisfies `\bworkflow\b`.
 
+**CLI-flag-like token exclusion (Issue #1293)**: the same failure mode recurs for tokens that
+contain no `/` and therefore survive path-like token stripping — e.g. `keyword=workflow` matched
+`` `--workflow=test.yml` `` inside a `github_check "gh run list --workflow=test.yml ..."` verify
+command embedded in a Spec (observed on Issue #476's `event=pr-review-light keyword=workflow` AC,
+re-run #14). A word-boundary match does not fix this either, for the same underlying reason as
+the path-like case: `-` and `=` are also non-word characters in regex, so `--workflow=test.yml`
+already satisfies `\bworkflow\b` (verified with `echo "--workflow=test.yml" | grep -qiw
+"workflow"`, which matches). To avoid this, `opportunistic-search.sh` additionally strips
+CLI-flag-like tokens (`--<flag-name>=<value>`, e.g. `--workflow=test.yml`) from the context
+file's content, in the same cached filtering pass as the path-like token stripping above.
+
 **Arguments table addition (both scripts):**
 
 | Argument | Description |
@@ -211,7 +222,7 @@ characters in regex, so `docs/workflow.md` already satisfies `\bworkflow\b`.
 **Matching specification:**
 
 - Extraction: `keyword=<value>` is read from the AC line via `grep -oE 'keyword=[^ >]+'` (stops at the next space or `-->`).
-- Path-like token stripping: `--context-file`'s content is filtered once per process (cached) via `sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' "$CONTEXT_FILE"` before comparison.
+- Path-like and CLI-flag-like token stripping: `--context-file`'s content is filtered once per process (cached) via `sed -E -e 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' -e 's#--[A-Za-z0-9-]+=[A-Za-z0-9._-]+##g' "$CONTEXT_FILE"` before comparison.
 - Comparison: case-insensitive substring match of `<value>` against the filtered content (`echo "$FILTERED_CONTEXT" | grep -qi -- "$KEYWORD"`).
 - Gate disabled (unconditional match) when: no `keyword=` attribute on the AC line, no `--context-file` given, or the given path does not exist.
 - No semantic/LLM judgment is performed here — this is a lightweight pre-filter; the actual acceptance decision still belongs to `/verify`.

--- a/scripts/opportunistic-search.sh
+++ b/scripts/opportunistic-search.sh
@@ -20,9 +20,10 @@
 # --context-file gates event-mode matches: when a matched AC line carries a
 # `keyword=<text>` attribute and --context-file is given, the Issue is only
 # included if the context file contains that keyword (case-insensitive) after
-# path-like tokens (e.g. docs/workflow.md) are stripped from the context file's
-# content. ACs without `keyword=`, or runs without --context-file, match
-# unconditionally (backward compatible). See modules/observation-trigger.md §
+# path-like tokens (e.g. docs/workflow.md) and CLI-flag-like tokens (e.g.
+# --workflow=test.yml) are stripped from the context file's content. ACs
+# without `keyword=`, or runs without --context-file, match unconditionally
+# (backward compatible). See modules/observation-trigger.md §
 # Condition Check Gate (keyword=).
 #
 # `config=<key>` gates event-mode matches on .wholework.yml validity: when a
@@ -228,11 +229,12 @@ fi
 RUN_FACTS_RESOLVED=false
 RUN_FACTS_JSON=""
 
-# resolve_filtered_context: lazily strip path-like tokens (e.g. docs/workflow.md) from
-# CONTEXT_FILE, once per process. Called on demand by the first keyword=-tagged AC line
-# encountered in the match loop below. Result is cached in FILTERED_CONTEXT (empty when
-# CONTEXT_FILE is unset). This prevents a keyword= value from matching only because it
-# appears as a fragment of an unrelated file path (Issue #1220).
+# resolve_filtered_context: lazily strip path-like tokens (e.g. docs/workflow.md) and
+# CLI-flag-like tokens (e.g. --workflow=test.yml) from CONTEXT_FILE, once per process.
+# Called on demand by the first keyword=-tagged AC line encountered in the match loop
+# below. Result is cached in FILTERED_CONTEXT (empty when CONTEXT_FILE is unset). This
+# prevents a keyword= value from matching only because it appears as a fragment of an
+# unrelated file path (Issue #1220) or CLI flag construct (Issue #1293).
 FILTERED_CONTEXT_RESOLVED=false
 FILTERED_CONTEXT=""
 
@@ -243,7 +245,10 @@ resolve_filtered_context() {
     FILTERED_CONTEXT_RESOLVED=true
 
     if [ -n "$CONTEXT_FILE" ]; then
-        FILTERED_CONTEXT=$(sed -E 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' "$CONTEXT_FILE" 2>/dev/null || true)
+        FILTERED_CONTEXT=$(sed -E \
+            -e 's#[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)+##g' \
+            -e 's#--[A-Za-z0-9-]+=[A-Za-z0-9._-]+##g' \
+            "$CONTEXT_FILE" 2>/dev/null || true)
     fi
 }
 
@@ -376,10 +381,12 @@ for N in $ISSUE_NUMBERS; do
         fi
 
         # Condition check gate: skip lines whose keyword= attribute does not
-        # appear in CONTEXT_FILE once path-like tokens (e.g. docs/workflow.md) are
-        # stripped out. No keyword= attribute or no --context-file means unconditional
-        # match (backward compatible). See modules/observation-trigger.md § Condition
-        # Check Gate (keyword=) — Path-like token exclusion (Issue #1220).
+        # appear in CONTEXT_FILE once path-like tokens (e.g. docs/workflow.md) and
+        # CLI-flag-like tokens (e.g. --workflow=test.yml) are stripped out. No
+        # keyword= attribute or no --context-file means unconditional match
+        # (backward compatible). See modules/observation-trigger.md § Condition
+        # Check Gate (keyword=) — Path-like token exclusion (Issue #1220) and
+        # CLI-flag-like token exclusion (Issue #1293).
         KEYWORD=$(echo "$line" | grep -oE 'keyword=[^ >]+' | sed -e 's/^keyword=//' -e 's/-*$//' || true)
         if [ -n "$KEYWORD" ] && [ -n "$CONTEXT_FILE" ]; then
             resolve_filtered_context

--- a/tests/opportunistic-search.bats
+++ b/tests/opportunistic-search.bats
@@ -324,6 +324,29 @@ teardown() {
     echo "$output" | jq -e '.[0].number == 507' > /dev/null
 }
 
+@test "context gate: keyword found only inside a CLI flag token excludes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 508}]'
+    export MOCK_ISSUE_BODY_508='## Post-merge
+- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
+    echo "gh run list --workflow=test.yml" > "$BATS_TEST_TMPDIR/context-cli-flag-only.md"
+
+    run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-cli-flag-only.md"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "context gate: keyword found in prose text alongside a CLI flag token still includes the issue" {
+    export MOCK_ISSUE_LIST='[{"number": 509}]'
+    export MOCK_ISSUE_BODY_509='## Post-merge
+- [ ] Verify workflow coverage <!-- verify-type: observation event=pr-review-full keyword=workflow -->'
+    printf 'gh run list --workflow=test.yml\nThis PR changes the CI workflow configuration.\n' > "$BATS_TEST_TMPDIR/context-cli-flag-and-prose.md"
+
+    run bash "$SCRIPT" --event pr-review-full --context-file "$BATS_TEST_TMPDIR/context-cli-flag-and-prose.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].number == 509' > /dev/null
+}
+
 @test "config gate: enabled config key includes the issue" {
     export MOCK_ISSUE_LIST='[{"number": 600}]'
     export MOCK_ISSUE_BODY_600='## Post-merge


### PR DESCRIPTION
## Summary
`opportunistic-search.sh` の `resolve_filtered_context()` に、CLI フラグ構文 (`--flag=value`、例: `--workflow=test.yml`) を除去する2つ目の `sed -E` 式を追加。Issue #1220 で対応済みのパス様トークン除外 (`/` を含むトークン) の残存亜種として、非スラッシュ値への `keyword=` ゲート誤マッチを抑制する。

## Verification (pre-merge)
- `modules/observation-trigger.md` § Condition Check Gate (keyword=) に CLI-flag-like token exclusion (Issue #1293) 段落を追加し、Matching specification を更新
- Spec の Root Cause に、単語境界マッチ・構造化マッチの却下理由と採用方針を記録
- `tests/opportunistic-search.bats` に新規 bats テスト2件を追加 (`bats --filter 'CLI flag token' tests/opportunistic-search.bats` で確認)
- フルスイート (`bats --jobs 18 tests/`, 1654件) PASS

## Verification (post-merge)
- 次回以降 Issue #476 の `/verify` が dispatch された際、`--workflow=<file>.yml` のような非スラッシュ CLI フラグ構文への誤発火が再現しないことを観察

closes #1293
