### PR TITLE
Issue #1312: get-auto-session-report の silent-window 警告閾値を watchdog の実解決経路に揃える

### DIFF
--- a/docs/spec/issue-1312-align-silent-window-threshold.md
+++ b/docs/spec/issue-1312-align-silent-window-threshold.md
@@ -153,19 +153,30 @@ SILENT_THRESHOLD_ISSUE=$(( ${WATCHDOG_TIMEOUT_ISSUE_DEFAULT:-1200} - SILENT_MARG
 - Behavioral Change Detection (Step 9) により `bats --jobs 18 tests/` のフルスイート実行を行ったところ、`tests/post_merge_check.bats` の 2 件 (`fail: gh issue reopen called when FAIL input given` / `multiple issues: processed sequentially`) が failed した。本変更を `git stash` で除いた状態でも同じ 2 件が同じ `--jobs 18` 条件下で再現し、単独実行 (`bats tests/post_merge_check.bats`) では 10/10 PASS したため、本変更とは無関係な高並列実行時のプリイグジスティング flake と判断した。`test-failure-classify.sh` の分類は `infra`。pr route のため CI 側の検出に委ねる。
 
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Spec の Implementation Steps をそのまま踏襲し、`SILENT_THRESHOLD_*` 4 変数の算出を `load_watchdog_timeout()` の 4 回呼び出しに置き換えた (`command -v` ガード + `-1` センチネルフォールバックを含む)。
-- `tests/audit-auto-session.bats` の既存 silent-window テストへ `WHOLEWORK_CONFIG_PATH=/dev/null` を追加し、この repo 自身の override に依存しない hermetic 実行にした。
-- `tests/get-auto-session-report.bats` の末尾に override 反映 / フォールバックの 2 テストを Spec 記載通り追加した。
+- `/review --light` (REVIEW_DEPTH=light、Issue #1312 の Size に基づく明示指定) で review-light エージェント (Spec 逸脱・エッジケース・セキュリティ・ドキュメント整合性の4観点統合) を1エージェントで実行し、問題は検出されなかった。
+- Pre-merge AC 5件 (rubric×2, grep×2, command×1) をすべて safe mode で検証し、全件 PASS を確認した。command 条件は CI 参照フォールバック (`Run bats tests` ジョブ SUCCESS) 経由で PASS 判定した。
+- Base Branch Conflict Pre-check (`git merge-tree` 3引数形式) で `changed in both` 0件を確認し、main との競合なしと判定した。
 
 ### Deferred Items
-- Post-merge observation AC (`次回 /auto --batch の完走後、spec silent window が at-risk 警告を出さないことを観察する`) は `/verify` フェーズで判定する。
+- Post-merge observation AC (`次回 /auto --batch の完走後、spec silent window が at-risk 警告を出さないことを観察する`) は `/verify` フェーズで判定する (code フェーズの Phase Handoff から引き続き繰越)。
 
 ### Notes for Next Phase
-- `bats --jobs 18 tests/` のフルスイートで `tests/post_merge_check.bats` の 2 件が flake する (本変更と無関係、pre-existing、`--jobs 18` 高並列時のみ再現)。CI や `/review` でこの 2 件が failed した場合、まずこの flake の可能性を疑い、単独実行で再現するか確認すること。
-- 本 Issue の着地により #1301 の post-merge observation AC が初めて判定可能になる。#1301 は `phase/verify` で該当 AC が未チェックのまま残っている。
+- MUST issue はなく、Claude Review Response は "Resolved" 対応なし。`/merge 1319` へ直接進んで問題ない。
+- `bats --jobs 18 tests/` のフルスイートで `tests/post_merge_check.bats` の 2 件が flake する既知事象 (code フェーズの Phase Handoff 記載、本 PR と無関係) は今回の CI 実行では再現しなかった (全ジョブ SUCCESS)。
 
 ## Consumed Comments
 No new comments since last phase.
+
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note. 実装は Spec の Implementation Steps と完全に一致しており、Code Retrospective の "Deviations from Design: N/A" 記載を review 側でも確認した。
+
+### Recurring issues
+- Nothing to note. review-light の4観点いずれにも指摘事項なし。
+
+### Acceptance criteria verification difficulty
+- Nothing to note. Pre-merge AC 5件 (rubric×2, grep×2, command×1) すべてが UNCERTAIN なく PASS に解決した。rubric 条件は Spec の Notes セクションに理由が明記されていたため grader 判定が容易だった。command 条件は CI 参照フォールバックで PASS 判定でき、verify command 自体の不備は見られなかった。

--- a/docs/spec/issue-1312-align-silent-window-threshold.md
+++ b/docs/spec/issue-1312-align-silent-window-threshold.md
@@ -166,3 +166,6 @@ SILENT_THRESHOLD_ISSUE=$(( ${WATCHDOG_TIMEOUT_ISSUE_DEFAULT:-1200} - SILENT_MARG
 ### Notes for Next Phase
 - `bats --jobs 18 tests/` のフルスイートで `tests/post_merge_check.bats` の 2 件が flake する (本変更と無関係、pre-existing、`--jobs 18` 高並列時のみ再現)。CI や `/review` でこの 2 件が failed した場合、まずこの flake の可能性を疑い、単独実行で再現するか確認すること。
 - 本 Issue の着地により #1301 の post-merge observation AC が初めて判定可能になる。#1301 は `phase/verify` で該当 AC が未チェックのまま残っている。
+
+## Consumed Comments
+No new comments since last phase.

--- a/docs/spec/issue-1312-align-silent-window-threshold.md
+++ b/docs/spec/issue-1312-align-silent-window-threshold.md
@@ -138,5 +138,31 @@ SILENT_THRESHOLD_ISSUE=$(( ${WATCHDOG_TIMEOUT_ISSUE_DEFAULT:-1200} - SILENT_MARG
 - **`SILENT_MARGIN=600` の妥当性は本 Issue のスコープ外**: Issue 本文 Notes の判断を踏襲し、固定マージンの是非は変更しない。
 - Issue 本文には元々 CI 検証 AC (`github_check`) を含めていない (route 依存の形式選択は Size 確定後にしか決まらないため) — Size が M/L (pr route) と確定した場合、`/code` フェーズで `github_check` AC の追加要否を再検討する。
 
-## Consumed Comments
-No new comments since last phase.
+## Code Retrospective
+
+### Deviations from Design
+- N/A — 実装は Spec の Implementation Steps 通りに進んだ (`SILENT_THRESHOLD_*` の `load_watchdog_timeout()` 経由化、`tests/audit-auto-session.bats` の hermetic 化、`tests/get-auto-session-report.bats` への 2 テスト追加)。
+
+### Design Gaps/Ambiguities
+- N/A
+
+### Rework
+- N/A
+
+### Notes
+- Behavioral Change Detection (Step 9) により `bats --jobs 18 tests/` のフルスイート実行を行ったところ、`tests/post_merge_check.bats` の 2 件 (`fail: gh issue reopen called when FAIL input given` / `multiple issues: processed sequentially`) が failed した。本変更を `git stash` で除いた状態でも同じ 2 件が同じ `--jobs 18` 条件下で再現し、単独実行 (`bats tests/post_merge_check.bats`) では 10/10 PASS したため、本変更とは無関係な高並列実行時のプリイグジスティング flake と判断した。`test-failure-classify.sh` の分類は `infra`。pr route のため CI 側の検出に委ねる。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Spec の Implementation Steps をそのまま踏襲し、`SILENT_THRESHOLD_*` 4 変数の算出を `load_watchdog_timeout()` の 4 回呼び出しに置き換えた (`command -v` ガード + `-1` センチネルフォールバックを含む)。
+- `tests/audit-auto-session.bats` の既存 silent-window テストへ `WHOLEWORK_CONFIG_PATH=/dev/null` を追加し、この repo 自身の override に依存しない hermetic 実行にした。
+- `tests/get-auto-session-report.bats` の末尾に override 反映 / フォールバックの 2 テストを Spec 記載通り追加した。
+
+### Deferred Items
+- Post-merge observation AC (`次回 /auto --batch の完走後、spec silent window が at-risk 警告を出さないことを観察する`) は `/verify` フェーズで判定する。
+
+### Notes for Next Phase
+- `bats --jobs 18 tests/` のフルスイートで `tests/post_merge_check.bats` の 2 件が flake する (本変更と無関係、pre-existing、`--jobs 18` 高並列時のみ再現)。CI や `/review` でこの 2 件が failed した場合、まずこの flake の可能性を疑い、単独実行で再現するか確認すること。
+- 本 Issue の着地により #1301 の post-merge observation AC が初めて判定可能になる。#1301 は `phase/verify` で該当 AC が未チェックのまま残っている。

--- a/scripts/get-auto-session-report.sh
+++ b/scripts/get-auto-session-report.sh
@@ -23,10 +23,20 @@ SCRIPT_DIR="${WHOLEWORK_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 [[ -f "$SCRIPT_DIR/emit-event.sh" ]] && source "$SCRIPT_DIR/emit-event.sh" || true
 [[ -f "$SCRIPT_DIR/watchdog-defaults.sh" ]] && source "$SCRIPT_DIR/watchdog-defaults.sh" || true
 SILENT_MARGIN=600
-SILENT_THRESHOLD_SPEC=$(( ${WATCHDOG_TIMEOUT_SPEC_DEFAULT:-1800} - SILENT_MARGIN ))
-SILENT_THRESHOLD_CODE=$(( ${WATCHDOG_TIMEOUT_CODE_DEFAULT:-1800} - SILENT_MARGIN ))
-SILENT_THRESHOLD_REVIEW=$(( ${WATCHDOG_TIMEOUT_REVIEW_DEFAULT:-2000} - SILENT_MARGIN ))
-SILENT_THRESHOLD_ISSUE=$(( ${WATCHDOG_TIMEOUT_ISSUE_DEFAULT:-1200} - SILENT_MARGIN ))
+if command -v load_watchdog_timeout >/dev/null 2>&1; then
+  load_watchdog_timeout "$SCRIPT_DIR" "spec";   SILENT_THRESHOLD_SPEC=$(( WATCHDOG_TIMEOUT - SILENT_MARGIN ))
+  load_watchdog_timeout "$SCRIPT_DIR" "code";   SILENT_THRESHOLD_CODE=$(( WATCHDOG_TIMEOUT - SILENT_MARGIN ))
+  load_watchdog_timeout "$SCRIPT_DIR" "review"; SILENT_THRESHOLD_REVIEW=$(( WATCHDOG_TIMEOUT - SILENT_MARGIN ))
+  load_watchdog_timeout "$SCRIPT_DIR" "issue";  SILENT_THRESHOLD_ISSUE=$(( WATCHDOG_TIMEOUT - SILENT_MARGIN ))
+else
+  # watchdog-defaults.sh was not sourced (missing sibling script; guarded at the line above).
+  # Disable the at-risk breakdown via the same "$at_risk_limit > 0" sentinel already used
+  # to exclude the merge phase, instead of duplicating stale default constants.
+  SILENT_THRESHOLD_SPEC=-1
+  SILENT_THRESHOLD_CODE=-1
+  SILENT_THRESHOLD_REVIEW=-1
+  SILENT_THRESHOLD_ISSUE=-1
+fi
 AUTO_EVENTS_LOG="${AUTO_EVENTS_LOG:-.tmp/auto-events.jsonl}"
 
 SESSION_ID=""

--- a/tests/audit-auto-session.bats
+++ b/tests/audit-auto-session.bats
@@ -126,6 +126,7 @@ FIXTURE_EOF
 {"ts":"2026-06-15T10:25:02Z","issue":500,"event":"sub_complete","session_id":"abc-666","exit_code":"0"}
 FIXTURE_EOF
 
+    export WHOLEWORK_CONFIG_PATH=/dev/null
     run bash "$SCRIPT" "abc-666" --metrics-only --no-github
     [ "$status" -eq 0 ]
 

--- a/tests/get-auto-session-report.bats
+++ b/tests/get-auto-session-report.bats
@@ -357,3 +357,40 @@ FIXTURE_EOF
     echo "$output" | grep -q "| #1251 | M/patch |"
     echo "$output" | grep -q "| #1292 | S/pr |"
 }
+
+@test "at-risk threshold honors .wholework.yml phase override: no false positive within headroom" {
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-08-09T10:00:00Z","issue":1301,"event":"sub_start","session_id":"session-1312-override","size":"S"}
+{"ts":"2026-08-09T10:01:00Z","issue":1301,"event":"phase_start","session_id":"session-1312-override","phase":"spec"}
+{"ts":"2026-08-09T10:22:50Z","issue":1301,"event":"max_silent_window","session_id":"session-1312-override","phase":"spec","max_sec":"1310"}
+{"ts":"2026-08-09T10:22:51Z","issue":1301,"event":"phase_complete","session_id":"session-1312-override","phase":"spec"}
+{"ts":"2026-08-09T10:22:52Z","issue":1301,"event":"sub_complete","session_id":"session-1312-override","exit_code":"0"}
+FIXTURE_EOF
+    CONFIG_FIXTURE="$BATS_TEST_TMPDIR/wholework-override.yml"
+    cat > "$CONFIG_FIXTURE" << 'YAML_EOF'
+watchdog-timeout-spec-seconds: 2340
+YAML_EOF
+    export WHOLEWORK_CONFIG_PATH="$CONFIG_FIXTURE"
+
+    run bash "$SCRIPT" "session-1312-override" --metrics-only --no-github
+    [ "$status" -eq 0 ]
+    # override threshold = 2340 - 600 = 1740s; observed 1310s stays under it
+    if echo "$output" | grep -q "within 600s of watchdog limit"; then false; fi
+    echo "$output" | grep -q "Phase silent windows > threshold | 0"
+}
+
+@test "at-risk threshold falls back to phase default when no override is configured" {
+    cat > "$AUTO_EVENTS_LOG" << 'FIXTURE_EOF'
+{"ts":"2026-08-09T10:00:00Z","issue":1301,"event":"sub_start","session_id":"session-1312-default","size":"S"}
+{"ts":"2026-08-09T10:01:00Z","issue":1301,"event":"phase_start","session_id":"session-1312-default","phase":"spec"}
+{"ts":"2026-08-09T10:22:50Z","issue":1301,"event":"max_silent_window","session_id":"session-1312-default","phase":"spec","max_sec":"1310"}
+{"ts":"2026-08-09T10:22:51Z","issue":1301,"event":"phase_complete","session_id":"session-1312-default","phase":"spec"}
+{"ts":"2026-08-09T10:22:52Z","issue":1301,"event":"sub_complete","session_id":"session-1312-default","exit_code":"0"}
+FIXTURE_EOF
+    export WHOLEWORK_CONFIG_PATH=/dev/null
+    run bash "$SCRIPT" "session-1312-default" --metrics-only --no-github
+    [ "$status" -eq 0 ]
+    # default threshold = 1800 - 600 = 1200s; observed 1310s exceeds it
+    echo "$output" | grep -q "within 600s of watchdog limit"
+    echo "$output" | grep -q "Phase silent windows > threshold | 1 (spec:1)"
+}


### PR DESCRIPTION
## Summary
- `scripts/get-auto-session-report.sh` の `SILENT_THRESHOLD_SPEC`/`_CODE`/`_REVIEW`/`_ISSUE` の算出を、`WATCHDOG_TIMEOUT_*_DEFAULT` グローバル変数の直接参照から `load_watchdog_timeout()` 経由 (`.wholework.yml` の phase override を解決) へ変更した。これにより at-risk 警告の閾値算出経路が、実際に watchdog kill を判定する `run-*.sh` 群と同一になる。
- `load_watchdog_timeout` が未定義 (watchdog-defaults.sh が source されない壊れたチェックアウト) の場合は `-1` センチネルで at-risk 判定自体を無効化し、stale なインライン既定値の再導入を避けた。
- `tests/audit-auto-session.bats` の既存 silent-window テストに `WHOLEWORK_CONFIG_PATH=/dev/null` を追加し、この repo 自身の `.wholework.yml` override (`watchdog-timeout-spec-seconds: 2340`) に依存しないよう hermetic 化した。
- `tests/get-auto-session-report.bats` に override 反映 / フォールバックを検証する bats テストを 2 件追加した。

## Verification (pre-merge)
- get-auto-session-report.sh の SILENT_THRESHOLD_* 算出が load_watchdog_timeout() 経由になっている
- get-auto-session-report.sh が load_watchdog_timeout を参照している
- config 解決に失敗する環境でのフォールバック挙動と理由が Spec に記録されている
- phase timeout override フィクスチャで at-risk 判定が override 後の値を基準にする bats テストが追加されている
- `bats tests/get-auto-session-report.bats tests/audit-auto-session.bats` 全件が PASS する

## Verification (post-merge)
- 次回 `/auto --batch` の完走後、`watchdog-timeout-spec-seconds: 2340` に対して余裕のある spec silent window が at-risk 警告を出さないことを観察する

closes #1312
