### PR TITLE
Issue #1105: Split review silent no-op from review-completion-false-negative

### DIFF
--- a/docs/spec/issue-1105-review-silent-no-op-split.md
+++ b/docs/spec/issue-1105-review-silent-no-op-split.md
@@ -82,17 +82,28 @@
 ### Rework
 - N/A — 初回実装でフルスイート bats テスト (1710/1710) が一発 PASS し、手戻りは発生しなかった。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+- Nothing to note — Spec の対応方針と実装 (5 ステップ) は完全に一致していた。Code Retrospective の Design Gaps/Ambiguities で言及されていた「`$?` による失敗判定」は、記述どおりの二重ガードとしては機能しておらず (直前の代入文の終了コードを参照していた)、review フェーズで検出・修正した。Spec の記述自体は「gh 失敗時は従来パターンへフォールバックする」という意図のみで実装詳細までは規定していなかったため、Spec divergence ではなく実装バグとして扱った。
+
+### Recurring issues
+- Nothing to note。
+
+### Acceptance criteria verification difficulty
+- Nothing to note — 7 件の Pre-merge AC (rubric×4, grep×2, github_check×1) はいずれも diff から明確に判定可能で UNCERTAIN は発生しなかった。`ac-tier: preview` 条件も存在しなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- `review-completion-false-negative` 分岐内で `gh pr view --json comments,reviews` によるライブチェックを行い、コメント/レビューともに 0 件のときのみ新パターン `review-silent-no-op` に振り分けた。`gh`/`jq` の失敗時 (非ゼロ終了 or 空出力) は件数が `"0"` と一致しないため、自動的に従来の `review-completion-false-negative` にフォールバックする設計とした。
-- `_phase_retry_hint(phase, number)` を新設し、`silent-no-op` / `review-silent-no-op` の両方の `IMPROVEMENT_HINT` から共通利用することで、review/merge フェーズでの誤案内 (#1255/PR#1269) を同時に解消した。
+- review-light agent (light mode, 4 perspectives 統合) による 1 エージェントレビューで SHOULD 1 件を検出・修正した。`$?` が `gh pr view` ではなく直後の代入文の終了コードを参照する bash の落とし穴で、意図された「gh 失敗時のフォールバック」の exit-code 側ガードが事実上無効化されていた。`_review_gh_status` に明示的に保存する形に修正し、mock で non-zero exit + non-empty stdout を返す回帰テストを追加して修正を検証した。
+- 修正後にフルスイート bats (`--jobs 18 tests/`) を再実行し 1711/1711 PASS を確認 (新規追加した回帰テスト 1 件を含む)。
 
 ### Deferred Items
 - Post-merge AC (`verify-type: manual`): review が silent no-op で終了した実例に対して検出を実行し `review-silent-no-op` として報告されることの確認は未実施 (merge 後に手動確認が必要)。
-- `_review_confirmed_posted` 抑止が発火しなかった未解決事象 (#1255/PR#1269 実測) は本 Issue のスコープ外。証跡不足のため未着手 — 再発時に別途調査 Issue を起票する方針 (Issue 本文の Autonomous Auto-Resolve Log に記録済み)。
+- `_review_confirmed_posted` 抑止が発火しなかった未解決事象 (#1255/PR#1269 実測) は本 Issue のスコープ外のまま。再発時に別途調査 Issue を起票する方針。
 
 ### Notes for Next Phase
-- `github_check "gh pr checks" "Run bats tests"` AC は Step 10 実行時点 (PR 作成前) では UNCERTAIN。PR #1340 の CI 結果が出た後に確認すること。
-- `modules/orchestration-fallbacks.md` の変更が `tests/run-auto-sub.bats` からも参照されている (behavioral change) ため、フルスイート bats (1710 tests, `--jobs 18`) を実行済み。全 PASS。
+- `/merge 1340` 実行時、Pre-merge AC 7 件はすべて `- [x]` 済み。Post-merge AC (manual) の手動確認は merge 後に別途実施すること。
+- review フェーズで追加した修正コミット (`801f6d36`) は PR ブランチに push 済み。push 後の CI (全 11 チェック SUCCESS) も確認済み。

--- a/docs/spec/issue-1105-review-silent-no-op-split.md
+++ b/docs/spec/issue-1105-review-silent-no-op-split.md
@@ -70,3 +70,29 @@
 | saito | MEMBER | first-class | `/issue` フェーズの Issue Retrospective コメント。IMPROVEMENT_HINT のフェーズ別修正を本 Issue のスコープに含めた判断根拠、および `_review_confirmed_posted` 抑止が発火しなかった未解決事象をスコープ外とした判断根拠を記録。内容は Issue 本文の `## Autonomous Auto-Resolve Log` に既に反映済みで、本 Spec に追加のアクションは不要。 | https://github.com/saitoco/wholework/issues/1105#issuecomment-5243312954 |
 
 (このセクションは `append-consumed-comments-section.sh` の安全網が `phase/spec` ラベル付与後のカットオフで再計算し "No new comments" と書いた内容を、`/spec` Step 2 のコメント消化手続き (`phase/issue` ラベル時点カットオフ) の実測に基づき修正したもの)
+
+## Code Retrospective
+
+### Deviations from Design
+- N/A — Implementation Steps 1〜5 を Spec の記述順どおりに実装した。関数名・分岐条件・カタログエントリの節構成・テストケースの内容もすべて Spec の記述と一致している。
+
+### Design Gaps/Ambiguities
+- `gh pr view "$ISSUE_NUMBER" --json comments,reviews` の失敗判定を `$? -eq 0` (終了コード) と `-n "$_review_pr_json"` (出力の非空) の両方でガードした。Spec の対応方針には「`gh` の失敗時は従来パターンへフォールバックする」としか書かれておらず、"失敗" の定義 (非ゼロ終了 vs 空出力) までは明示されていなかったため、両方をガードすることでより保守的な fail-safe とした。
+
+### Rework
+- N/A — 初回実装でフルスイート bats テスト (1710/1710) が一発 PASS し、手戻りは発生しなかった。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- `review-completion-false-negative` 分岐内で `gh pr view --json comments,reviews` によるライブチェックを行い、コメント/レビューともに 0 件のときのみ新パターン `review-silent-no-op` に振り分けた。`gh`/`jq` の失敗時 (非ゼロ終了 or 空出力) は件数が `"0"` と一致しないため、自動的に従来の `review-completion-false-negative` にフォールバックする設計とした。
+- `_phase_retry_hint(phase, number)` を新設し、`silent-no-op` / `review-silent-no-op` の両方の `IMPROVEMENT_HINT` から共通利用することで、review/merge フェーズでの誤案内 (#1255/PR#1269) を同時に解消した。
+
+### Deferred Items
+- Post-merge AC (`verify-type: manual`): review が silent no-op で終了した実例に対して検出を実行し `review-silent-no-op` として報告されることの確認は未実施 (merge 後に手動確認が必要)。
+- `_review_confirmed_posted` 抑止が発火しなかった未解決事象 (#1255/PR#1269 実測) は本 Issue のスコープ外。証跡不足のため未着手 — 再発時に別途調査 Issue を起票する方針 (Issue 本文の Autonomous Auto-Resolve Log に記録済み)。
+
+### Notes for Next Phase
+- `github_check "gh pr checks" "Run bats tests"` AC は Step 10 実行時点 (PR 作成前) では UNCERTAIN。PR #1340 の CI 結果が出た後に確認すること。
+- `modules/orchestration-fallbacks.md` の変更が `tests/run-auto-sub.bats` からも参照されている (behavioral change) ため、フルスイート bats (1710 tests, `--jobs 18`) を実行済み。全 PASS。

--- a/modules/orchestration-fallbacks.md
+++ b/modules/orchestration-fallbacks.md
@@ -216,6 +216,32 @@ Recovery procedure for a named pattern, consumed by the calling skill or used as
 
 ---
 
+## review-silent-no-op
+
+### Symptom
+- `run-review.sh` exits with non-zero and the wrapper log contains `"matches_expected":false` and `"phase":"review"`, and `gh pr view <PR> --json comments,reviews` confirms the PR has zero comments and zero reviews
+- `scripts/detect-wrapper-anomaly.sh` emits pattern: `review-silent-no-op`
+- Likely cause: the forked review session exited (e.g. hit a watchdog silence timeout or a content-filter trigger) before posting any PR comment or review — a genuine no-op, not a marker/heading formatting issue
+
+### Applicable Phases
+- review
+
+### Fallback Steps
+1. Confirm the no-op with `gh pr view <N> --json comments,reviews`: both `comments` and `reviews` should be empty arrays
+2. Re-run `/review <N>` (or `run-review.sh <N>`) to retry the review phase from scratch — there is no partial output to recover or merge
+3. If a second run also produces zero comments/reviews, check the wrapper log for a watchdog silence kill or an API/content-filter error before retrying a third time; escalate to manual review if the same no-op recurs
+4. After a successful retry, re-run `reconcile-phase-state.sh review --pr <N>` to confirm `matches_expected:true`
+
+### Escalation
+- Recovery sub-agent (#316) can be invoked when repeated retries all produce zero comments/reviews with no diagnosable cause in the wrapper log
+
+### Rationale
+- First observed as a mis-classification during Issue #1069 (PR #1077): a genuine silent no-op (zero PR comments/reviews) was reported as `review-completion-false-negative`, which prompted Tier 2 to suggest a marker-addition recovery step that did not apply — the PR had no summary comment to add a marker to
+- Split from `review-completion-false-negative` in #1105: both conditions share the same `matches_expected:false` + `phase:review` reconciler signature, but their recovery differs — `review-completion-false-negative` recovers by locating and marking an existing (but unmarked) summary comment, while `review-silent-no-op` has no comment to recover and instead requires a fresh retry. `scripts/detect-wrapper-anomaly.sh` distinguishes the two via a live `gh pr view --json comments,reviews` count check: both counts `0` routes to `review-silent-no-op`; any other count (or a `gh`/`jq` failure) falls back to `review-completion-false-negative`, preserving prior behavior as a fail-safe
+- IMPROVEMENT_HINT for this pattern is generated via `_phase_retry_hint()`, which also fixed a companion defect (#1255 / PR #1269) where `silent-no-op`-family hints hardcoded `run-code.sh $ISSUE_NUMBER` regardless of phase — for `review`/`merge` phases the wrapper's `$ISSUE_NUMBER` argument actually holds a PR number (see `scripts/run-auto-sub.sh` `run_phase_with_recovery()`), so the old hint named both the wrong script and the wrong number kind
+
+---
+
 ## code-completed-no-pr
 
 ### Symptom

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -117,9 +117,10 @@ elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q "Review Summary" 
 elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q '"phase":"review"' "$LOG_FILE" && ! grep -q '"matches_expected":true' "$LOG_FILE"; then
   # reconcile-first authority: a later matches_expected:true in the same log (post-fallback-review-summary.sh recovery) suppresses this anomaly
   _review_pr_json=$(gh pr view "$ISSUE_NUMBER" --json comments,reviews 2>/dev/null)
+  _review_gh_status=$?
   _review_comment_count=""
   _review_review_count=""
-  if [[ $? -eq 0 && -n "$_review_pr_json" ]]; then
+  if [[ $_review_gh_status -eq 0 && -n "$_review_pr_json" ]]; then
     _review_comment_count=$(echo "$_review_pr_json" | jq -r '.comments | length' 2>/dev/null)
     _review_review_count=$(echo "$_review_pr_json" | jq -r '.reviews | length' 2>/dev/null)
   fi

--- a/scripts/detect-wrapper-anomaly.sh
+++ b/scripts/detect-wrapper-anomaly.sh
@@ -54,6 +54,28 @@ if [[ ! -f "$LOG_FILE" ]]; then
   exit 1
 fi
 
+# _phase_retry_hint: returns a one-line re-run instruction tailored to the phase,
+# since review/merge phases receive a PR number in $number while code phases
+# receive an Issue number (see scripts/run-auto-sub.sh run_phase_with_recovery()).
+_phase_retry_hint() {
+  local phase="$1"
+  local number="$2"
+  case "$phase" in
+    review)
+      echo "Re-run \`run-review.sh $number\` to retry the review phase (argument is a PR number)."
+      ;;
+    merge)
+      echo "Re-run \`run-merge.sh $number\` to retry the merge phase (argument is a PR number)."
+      ;;
+    code*)
+      echo "Re-run \`run-code.sh $number\` to retry the code phase (argument is an Issue number)."
+      ;;
+    *)
+      echo "Re-run the \`$phase\` phase manually (number: $number)."
+      ;;
+  esac
+}
+
 PATTERN_NAME=""
 ANOMALY_DESC=""
 IMPROVEMENT_HINT=""
@@ -94,9 +116,22 @@ elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q "Review Summary" 
   IMPROVEMENT_HINT="Check whether \`run-review.sh\` or the review skill changed the header format of the PR comment. The reconciler expects \`## Review Response Summary\` as defined in \`modules/phase-state.md\`. See \`modules/orchestration-fallbacks.md#reconciler-header-mismatch\` for the full recovery procedure."
 elif grep -q '"matches_expected":false' "$LOG_FILE" && grep -q '"phase":"review"' "$LOG_FILE" && ! grep -q '"matches_expected":true' "$LOG_FILE"; then
   # reconcile-first authority: a later matches_expected:true in the same log (post-fallback-review-summary.sh recovery) suppresses this anomaly
-  PATTERN_NAME="review-completion-false-negative"
-  ANOMALY_DESC="Review phase completion false-negative in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`phase:review\` detected in reconciler output, but no existing fallback header (## Review Response Summary / ## レビュー回答サマリ) was found in wrapper log. Likely caused by LLM omitting the \`<!-- review-summary -->\` marker and using a non-standard heading. Reference: #547."
-  IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#review-completion-false-negative\`: re-run reconcile, check PR comments for summary, add \`<!-- review-summary -->\` marker if present, or re-run /review if absent."
+  _review_pr_json=$(gh pr view "$ISSUE_NUMBER" --json comments,reviews 2>/dev/null)
+  _review_comment_count=""
+  _review_review_count=""
+  if [[ $? -eq 0 && -n "$_review_pr_json" ]]; then
+    _review_comment_count=$(echo "$_review_pr_json" | jq -r '.comments | length' 2>/dev/null)
+    _review_review_count=$(echo "$_review_pr_json" | jq -r '.reviews | length' 2>/dev/null)
+  fi
+  if [[ "$_review_comment_count" == "0" && "$_review_review_count" == "0" ]]; then
+    PATTERN_NAME="review-silent-no-op"
+    ANOMALY_DESC="Review phase silent no-op in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`phase:review\` detected in reconciler output, and \`gh pr view\` confirms zero PR comments and zero reviews. The forked review session likely exited without posting any output. Reference: #1105."
+    IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#review-silent-no-op\`: $(_phase_retry_hint "$PHASE" "$ISSUE_NUMBER")"
+  else
+    PATTERN_NAME="review-completion-false-negative"
+    ANOMALY_DESC="Review phase completion false-negative in phase \`$PHASE\` (exit code $EXIT_CODE): \`matches_expected:false\` and \`phase:review\` detected in reconciler output, but no existing fallback header (## Review Response Summary / ## レビュー回答サマリ) was found in wrapper log. Likely caused by LLM omitting the \`<!-- review-summary -->\` marker and using a non-standard heading. Reference: #547."
+    IMPROVEMENT_HINT="Follow the recovery procedure at \`modules/orchestration-fallbacks.md#review-completion-false-negative\`: re-run reconcile, check PR comments for summary, add \`<!-- review-summary -->\` marker if present, or re-run /review if absent."
+  fi
 elif grep -qiE "APIConnectionError|Request timed out|overloaded_error|529.*[Oo]verload" "$LOG_FILE"; then
   PATTERN_NAME="mid-run-api-error"
   ANOMALY_DESC="API connection error in phase \`$PHASE\` (exit code $EXIT_CODE): API connection/overload pattern detected in wrapper output. The forked session terminated mid-run before phase completion."
@@ -139,7 +174,7 @@ elif [[ "$EXIT_CODE" == "0" ]]; then
       if [[ "$_found_on_origin" == "false" ]]; then
         PATTERN_NAME="silent-no-op"
         ANOMALY_DESC="LLM reported success in phase \`$PHASE\` (exit code 0) but no commit for #$ISSUE_NUMBER found in recent git log. Possible silent no-op: output indicated completion but no code was committed. Reference: #365."
-        IMPROVEMENT_HINT="Re-run \`run-code.sh $ISSUE_NUMBER\` to retry the code phase. If a second run also fails to produce a commit, escalate to manual implementation. See Issue #365 for a known case of this pattern."
+        IMPROVEMENT_HINT="$(_phase_retry_hint "$PHASE" "$ISSUE_NUMBER") If a second run also fails to produce a commit, escalate to manual implementation. See Issue #365 for a known case of this pattern."
       fi
     fi
   fi

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -225,6 +225,52 @@ MOCK
     [[ "$output" == *"### Orchestration Anomalies"* ]]
 }
 
+@test "silent no-op: review phase IMPROVEMENT_HINT names run-review.sh and PR number, not run-code.sh/code phase" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/git" <<'MOCK'
+#!/bin/bash
+# mock git: returns empty output for all subcommands
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/git"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+echo ""
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    echo "実装が完了しました。commit and push も完了しています。" > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 0 --issue 1269 --phase review
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"silent-no-op"* ]]
+    [[ "$output" == *"run-review.sh 1269"* ]]
+    [[ "$output" != *"run-code.sh"* ]]
+    [[ "$output" != *"code phase"* ]]
+}
+
+@test "silent no-op: merge phase IMPROVEMENT_HINT names run-merge.sh and PR number, not run-code.sh/code phase" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/git" <<'MOCK'
+#!/bin/bash
+# mock git: returns empty output for all subcommands
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/git"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+echo "OPEN"
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    echo "実装が完了しました。commit and push も完了しています。" > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 0 --issue 1269 --phase merge
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"silent-no-op"* ]]
+    [[ "$output" == *"run-merge.sh 1269"* ]]
+    [[ "$output" != *"run-code.sh"* ]]
+    [[ "$output" != *"code phase"* ]]
+}
+
 @test "reconciler header mismatch: detects matches_expected false with Review Summary" {
     printf '"matches_expected":false\nreview: Review Summary not found in PR comment\n' > "$LOG_FILE"
     run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 143 --issue 386 --phase review
@@ -451,12 +497,52 @@ MOCK
     [[ "$output" != *"ci-wait-silence-timeout"* ]]
 }
 
-@test "review-completion-false-negative: detects matches_expected false with phase review" {
+@test "review-completion-false-negative: detects matches_expected false with phase review (comments/reviews present)" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+echo '{"comments":[{"body":"some comment"}],"reviews":[]}'
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
     printf '"matches_expected":false\n"phase":"review"\n' > "$LOG_FILE"
-    run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review
     [ "$status" -eq 0 ]
     [[ "$output" == *"review-completion-false-negative"* ]]
+    [[ "$output" != *"review-silent-no-op"* ]]
     [[ "$output" == *"### Orchestration Anomalies"* ]]
+}
+
+@test "review-silent-no-op: detects matches_expected false with phase review and zero comments/reviews" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+echo '{"comments":[],"reviews":[]}'
+exit 0
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    printf '"matches_expected":false\n"phase":"review"\n' > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 1069 --phase review
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"review-silent-no-op"* ]]
+    [[ "$output" != *"review-completion-false-negative"* ]]
+    [[ "$output" == *"### Orchestration Anomalies"* ]]
+    [[ "$output" == *"### Improvement Proposals"* ]]
+    [[ "$output" == *"orchestration-fallbacks.md#review-silent-no-op"* ]]
+}
+
+@test "review-silent-no-op: falls back to review-completion-false-negative when gh pr view fails (fail-safe)" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    printf '"matches_expected":false\n"phase":"review"\n' > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"review-completion-false-negative"* ]]
+    [[ "$output" != *"review-silent-no-op"* ]]
 }
 
 @test "review-completion-false-negative: reconciler-header-mismatch takes priority when Review Summary present" {

--- a/tests/detect-wrapper-anomaly.bats
+++ b/tests/detect-wrapper-anomaly.bats
@@ -545,6 +545,21 @@ MOCK
     [[ "$output" != *"review-silent-no-op"* ]]
 }
 
+@test "review-silent-no-op: falls back to review-completion-false-negative when gh pr view exits non-zero with non-empty stdout (exit-code guard)" {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/gh" <<'MOCK'
+#!/bin/bash
+echo '{"comments":[],"reviews":[]}'
+exit 1
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/gh"
+    printf '"matches_expected":false\n"phase":"review"\n' > "$LOG_FILE"
+    run env PATH="$BATS_TEST_TMPDIR/bin:$PATH" bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"review-completion-false-negative"* ]]
+    [[ "$output" != *"review-silent-no-op"* ]]
+}
+
 @test "review-completion-false-negative: reconciler-header-mismatch takes priority when Review Summary present" {
     printf '"matches_expected":false\n"phase":"review"\nreconcile-phase-state result: Review Summary found\n' > "$LOG_FILE"
     run bash "$SCRIPT" --log "$LOG_FILE" --exit-code 1 --issue 547 --phase review


### PR DESCRIPTION
## Summary
- `scripts/detect-wrapper-anomaly.sh`: added a `_phase_retry_hint(phase, number)` helper (bash 3.2-compatible, `case`-only) that returns a phase-appropriate re-run instruction — `run-code.sh` + Issue number for `code*`, `run-review.sh` / `run-merge.sh` + PR number for `review` / `merge`
- Split the `review-completion-false-negative` branch: it now calls `gh pr view "$ISSUE_NUMBER" --json comments,reviews` and routes to the new `review-silent-no-op` pattern when both comment and review counts are `0`; any other count, or a `gh`/`jq` failure, falls back to the prior `review-completion-false-negative` behavior (fail-safe)
- Fixed the `silent-no-op` branch's `IMPROVEMENT_HINT`, which previously hardcoded `run-code.sh $ISSUE_NUMBER` / "code phase" regardless of the actual phase (#1255 / PR #1269) — now routed through `_phase_retry_hint()`
- Added a `review-silent-no-op` catalog entry to `modules/orchestration-fallbacks.md`, immediately after `review-completion-false-negative`, following the existing 5-section schema (Symptom / Applicable Phases / Fallback Steps / Escalation / Rationale)
- Updated/added `tests/detect-wrapper-anomaly.bats` coverage: negative case for `review-completion-false-negative` (comments/reviews present), positive case for `review-silent-no-op` (zero/zero), fail-safe case (`gh pr view` failure), and phase-specific `IMPROVEMENT_HINT` regression tests for the `silent-no-op` family in `review`/`merge` phases

## Verification (pre-merge)
- `grep "review-silent-no-op" scripts/detect-wrapper-anomaly.sh` — PASS
- `grep "review-silent-no-op" modules/orchestration-fallbacks.md` — PASS
- Full bats suite (`bats --jobs 18 tests/`, behavioral-change full-suite override) — 1710/1710 PASS
- `python3 scripts/validate-skill-syntax.py skills/` — 0 error / 0 warning
- `bash scripts/check-forbidden-expressions.sh` — no violations
- `github_check "gh pr checks" "Run bats tests"` — will resolve once CI runs on this PR

## Verification (post-merge)
- Manual: run detection against a real review silent-no-op example and confirm it reports `review-silent-no-op`

closes #1105
