### PR TITLE
Issue #1321: Exclude structurally-undecidable candidates from run-fact AC reconciliation

### DIFF
--- a/docs/spec/issue-1321-run-fact-reconciliation-fix.md
+++ b/docs/spec/issue-1321-run-fact-reconciliation-fix.md
@@ -118,17 +118,31 @@
 
 - `scripts/scan-pending-ac.sh` は `tests/scan-pending-ac.bats` からも参照されているため (Spec の Changed Files に記載のない参照)、Step 9 の Behavioral Change Detection により `bats --jobs <N> tests/` のフルスイート実行が確定した。フルスイート 1745 件全 PASS を確認済み (`tests/run-fact-matching.bats` 単体の 35 件 PASS を含む)。
 
+## review retrospective
+
+### Spec vs. implementation divergence patterns
+
+- N/A — review-light の Perspective 1 (Spec 逸脱) で Spec の Implementation Steps 1〜4 と実装の一致を確認済み。構造的な乖離は検出されなかった。
+
+### Recurring issues
+
+- CI `Language Convention check` が FAILURE (MUST) となり `/review` の Step 12 で修正した。根本原因は `scripts/check-language-convention.py` の除外ロジック (フェンス/インラインコード/二重引用符の3種) が (1) 複数行にまたがるインラインコードスパンの行単位バックティック対応判定のずれ、(2) heredoc 内の機能的な日本語キーワードリテラル (二重引用符でもフェンスでもない生テキスト) のいずれにも対応していないこと。今回は `printf '%s\n' "..."` 形式への書き換えと行折り返し位置の調整で回避したが、`scripts/scan-pending-ac.sh`/`modules/run-fact-matching.md` に限らず「AC 条件文が日本語である (`CLAUDE.md` の Issue body 言語規約) ため、マッチング用キーワードデータも日本語で持たざるを得ない」パターンは他の pre-filter 実装でも今後発生しうる。`check-language-convention.py` 自体に (a) 複数行インラインコードスパンの状態追跡、(b) heredoc/配列リテラル形式の機能的データを対象外とする除外ルールを追加する改善の余地がある — 次回同様の FAILURE が発生した場合は `check-language-convention.py` 自体の改善を検討する Issue 起票を優先する。
+
+### Acceptance criteria verification difficulty
+
+- N/A — rubric 3 件・command 1 件とも PR diff / CI 参照から明確に判定でき、UNCERTAIN は発生しなかった。
+
 ## Phase Handoff
-<!-- phase: code -->
+<!-- phase: review -->
 
 ### Key Decisions
-- Rule 1 / Rule 2 の実装対象は Spec のとおり `scripts/scan-pending-ac.sh` のみとし、`modules/run-fact-matching.md` には根拠・リグレッションリスク評価・3 選択肢比較を明文化するに留めた (Step 3 の判定基準 `satisfied`/`not_satisfied`/`ambiguous` や Step 4 の tier gate ロジックには手を入れていない)。
-- Rule 1/Rule 2 とも `--facts` 未指定時は完全に無効化されるガードを維持し、後方互換 (デバッグ用の無フィルタ実行) を壊さないようにした。
+- Step 9 の CI Blocking by default ルールに従い、`Language Convention check` FAILURE を MUST として扱い REQUEST_CHANGES 相当でブロック、Step 12 で修正した (self-review のため実際の投稿イベントは COMMENT フォールバック)。
+- 修正はチェッカーの誤検知を回避する目的の純粋なフォーマット変更 (heredoc → `printf` + 二重引用符、インラインコードスパンの改行位置調整) に限定し、Rule 1/Rule 2 の判定ロジック・キーワード内容には手を入れていない。修正後に `L3_KEYWORDS_LOWER` の出力がバイト同一であることを確認済み。
 
 ### Deferred Items
-- Post-merge AC (「次に run-fact reconciliation が走った session で auto-check が 1 件以上発生するか、または ambiguous 率が実測で低下していることを確認する」) は `session=next` の observation 型のため、次回の `/auto` 実行後の観察に委ねる。
-- `modules/run-fact-matching.md` の Notes で言及されていた `collect-run-facts.sh`/`apply-run-fact-match.sh` へのスキーマ拡張 (L3 retrospective 関連フィールド追加) は、Spec の対処方針で明示的にスコープ外と判断されており、本実装でも着手していない。
+- Post-merge AC (「次に run-fact reconciliation が走った session で auto-check が 1 件以上発生するか、または ambiguous 率が実測で低下していることを確認する」) は `session=next` の observation 型のため、次回の `/auto` 実行後の観察に委ねる (`/code` フェーズから継続、未解消)。
+- `check-language-convention.py` 自体の除外ロジック改善 (複数行インラインコードスパン追跡、heredoc データリテラルの除外) は本 PR のスコープ外 — 再発時に別 Issue での対応を検討 (review retrospective参照)。
 
 ### Notes for Next Phase
-- `/review` は `tests/scan-pending-ac.bats` と `tests/run-fact-matching.bats` の両方が `scan-pending-ac.sh` の直接参照ファイルである点に注意 (前者は Spec の Changed Files に記載がなかった)。
-- Rule 1/Rule 2 のキーワード・スコープ判断根拠は `modules/run-fact-matching.md` の「Ambiguous Breakdown Measurement (Issue #1321)」セクションに集約されている。
+- `/merge` 実行前に CI は全 11 件 SUCCESS (コミット `22b00a7a`) を確認済み。
+- Pre-merge AC は 4/4 PASS、Issue チェックボックスは既にすべて `[x]` (変更不要)。

--- a/docs/spec/issue-1321-run-fact-reconciliation-fix.md
+++ b/docs/spec/issue-1321-run-fact-reconciliation-fix.md
@@ -97,3 +97,37 @@
 ## Consumed Comments
 
 - saito / MEMBER / first-class / `/issue` フェーズの Issue Retrospective コメント。session `83307-1786372673` の追加実測 (27 件全件 ambiguous の内訳分類と pre-filter 改善の示唆) を Background・対応方針へ統合済みであることの記録。本 `/spec` フェーズでの追加アクションは不要 (Issue 本文に統合済みの内容を Root Cause セクションでそのまま活用した) / https://github.com/saitoco/wholework/issues/1321#issuecomment-5248548214
+- `/code` フェーズ (本コミット時点): cutoff (最新 `phase/*` ラベル付与時刻 `2026-08-11T03:35:39Z`) 以降の新規コメントなし。
+
+## Code Retrospective
+
+### Deviations from Design
+
+- N/A — Spec の Implementation Steps 1〜4 をそのままの順序・対象ファイルで実装した。
+
+### Design Gaps/Ambiguities
+
+- N/A — Spec の Root Cause / 対処方針 (Rule 1 スコープ限定の理由、Rule 2 キーワード選定の理由、順序問題 3 選択肢の比較) が実装判断に必要な情報を過不足なく提供していた。
+
+### Rework
+
+- N/A — 手戻りは発生しなかった。
+
+### Test Execution Note
+
+- `scripts/scan-pending-ac.sh` は `tests/scan-pending-ac.bats` からも参照されているため (Spec の Changed Files に記載のない参照)、Step 9 の Behavioral Change Detection により `bats --jobs <N> tests/` のフルスイート実行が確定した。フルスイート 1745 件全 PASS を確認済み (`tests/run-fact-matching.bats` 単体の 35 件 PASS を含む)。
+
+## Phase Handoff
+<!-- phase: code -->
+
+### Key Decisions
+- Rule 1 / Rule 2 の実装対象は Spec のとおり `scripts/scan-pending-ac.sh` のみとし、`modules/run-fact-matching.md` には根拠・リグレッションリスク評価・3 選択肢比較を明文化するに留めた (Step 3 の判定基準 `satisfied`/`not_satisfied`/`ambiguous` や Step 4 の tier gate ロジックには手を入れていない)。
+- Rule 1/Rule 2 とも `--facts` 未指定時は完全に無効化されるガードを維持し、後方互換 (デバッグ用の無フィルタ実行) を壊さないようにした。
+
+### Deferred Items
+- Post-merge AC (「次に run-fact reconciliation が走った session で auto-check が 1 件以上発生するか、または ambiguous 率が実測で低下していることを確認する」) は `session=next` の observation 型のため、次回の `/auto` 実行後の観察に委ねる。
+- `modules/run-fact-matching.md` の Notes で言及されていた `collect-run-facts.sh`/`apply-run-fact-match.sh` へのスキーマ拡張 (L3 retrospective 関連フィールド追加) は、Spec の対処方針で明示的にスコープ外と判断されており、本実装でも着手していない。
+
+### Notes for Next Phase
+- `/review` は `tests/scan-pending-ac.bats` と `tests/run-fact-matching.bats` の両方が `scan-pending-ac.sh` の直接参照ファイルである点に注意 (前者は Spec の Changed Files に記載がなかった)。
+- Rule 1/Rule 2 のキーワード・スコープ判断根拠は `modules/run-fact-matching.md` の「Ambiguous Breakdown Measurement (Issue #1321)」セクションに集約されている。

--- a/docs/spec/issue-1321-run-fact-reconciliation-fix.md
+++ b/docs/spec/issue-1321-run-fact-reconciliation-fix.md
@@ -98,6 +98,7 @@
 
 - saito / MEMBER / first-class / `/issue` フェーズの Issue Retrospective コメント。session `83307-1786372673` の追加実測 (27 件全件 ambiguous の内訳分類と pre-filter 改善の示唆) を Background・対応方針へ統合済みであることの記録。本 `/spec` フェーズでの追加アクションは不要 (Issue 本文に統合済みの内容を Root Cause セクションでそのまま活用した) / https://github.com/saitoco/wholework/issues/1321#issuecomment-5248548214
 - `/code` フェーズ (本コミット時点): cutoff (最新 `phase/*` ラベル付与時刻 `2026-08-11T03:35:39Z`) 以降の新規コメントなし。
+- `/review` フェーズ (本コミット時点): cutoff (最新 `phase/*` ラベル付与時刻 `2026-08-11T03:41:58Z`) 以降の新規コメントなし (Issue/PR とも)。
 
 ## Code Retrospective
 

--- a/modules/run-fact-matching.md
+++ b/modules/run-fact-matching.md
@@ -158,11 +158,11 @@ only ever mark `ambiguous`, before the rubric judgment step runs):
   prose, and the sampling above confirmed no facts-JSON-representable signal exists for
   them when the target Issue wasn't processed this run.
 - **Rule 2 (ordering-problem fix, see below)**: a candidate whose condition text
-  contains an L3/session-retrospective reference keyword (case-insensitive: `L3
-  retrospective`, `L3 レトロスペクティブ`, `L3 セッションレトロスペクティブ`,
-  `session.md`, `セッションレトロスペクティブ`, `session retrospective`) is excluded.
-  Bare `L3` was rejected as a token — it false-positives on unrelated prose like
-  `autonomy: L3`.
+  contains an L3/session-retrospective reference keyword (case-insensitive:
+  `L3 retrospective`, `L3 レトロスペクティブ`, `L3 セッションレトロスペクティブ`,
+  `session.md`, `セッションレトロスペクティブ`, `session retrospective`) is
+  excluded. Bare `L3` was rejected as a token — it false-positives on unrelated
+  prose like `autonomy: L3`.
 
 ### Ordering Problem: L3 Retrospective-Referencing AC
 

--- a/modules/run-fact-matching.md
+++ b/modules/run-fact-matching.md
@@ -110,6 +110,89 @@ condition matchable — a bare phase name is no longer part of the vocabulary an
 the pre-filter. Referencing the phase's wrapper script name (e.g. "`run-code.sh` 実行後") also
 works but is a less natural way to write AC prose than referencing the phase's concrete outcome.
 
+## Ambiguous Breakdown Measurement (Issue #1321)
+
+5 consecutive sessions (2026-08-06–2026-08-10, 147 candidates total) recorded zero
+`auto-check` — every candidate resolved `ambiguous`. Only one session
+(`83307-1786372673`, 2026-08-10, `/auto --batch 1308 1265`, N=27) recorded a
+per-fail-safe-condition breakdown at the time this was investigated:
+
+| Fail-safe condition (Processing Steps Step 3) | Count | Share |
+|---|---|---|
+| Condition's premise event did not occur in this run | **15** | **56%** |
+| Condition text has no representation in the facts JSON | 8 | 30% |
+| Conjunction — only some sub-conditions backed by facts | 4 | 15% |
+
+Sampling 3 of the 15 dominant-category candidates against their source Issues (#1200
+ac7, #807 ac7, #783 ac11) found a common structural pattern: all three targeted Issues
+that this session's run never touched (#1265/#1308), were tagged `verify-type:
+observation`/`opportunistic`, and used a generic event name (`event=auto-run` /
+`event=code-run`) meaning "some future `/auto` run" rather than a specific anomaly.
+Because `collect-run-facts.sh`'s facts JSON is entirely per-issue-keyed
+(`route`/`phases`/`anomalies`/`recovery_tiers`/...), **an Issue absent from
+`facts.issues[]` has zero representable facts** — the rubric in Step 3 can only ever
+return `ambiguous` for it, never `satisfied`. The pre-#1321 `scan-pending-ac.sh --facts`
+pre-filter only checked whether *some* Issue's `fact_tokens` substring-matched the
+condition text; it never checked whether the *candidate's own* Issue was one this run
+actually processed.
+
+**Regression-risk evaluation**: across the 5 measured sessions (147 candidates, 0
+`auto-check`), no case exists where excluding this class of candidate would have
+prevented a `satisfied` verdict that was actually reached — there is no successful case
+to break.
+
+### Candidate Pre-filter Exclusion Rules (`scan-pending-ac.sh --facts`)
+
+Two exclusion rules run inside `scripts/scan-pending-ac.sh`'s candidate loop, active
+only when `--facts` is given (they filter out candidates that Step 3's rubric could
+only ever mark `ambiguous`, before the rubric judgment step runs):
+
+- **Rule 1 (dominant-factor fix)**: a candidate whose `verify_type` is `observation` or
+  `opportunistic`, and whose Issue number is absent from the facts file's
+  `issues[].number` array, is excluded. Scope is deliberately limited to these two
+  verify-types: `manual`/`auto` AC sometimes assert a general, Issue-independent claim
+  about Wholework's own behavior (e.g. `#1212 ac5` — "`/verify`'s CI check matches
+  `headSha` before judging", true regardless of which Issue's run is observed), where
+  mechanical exclusion by Issue-absence would risk losing a rare but real judgment
+  opportunity. `observation`/`opportunistic` AC are inherently "wait for a future event"
+  prose, and the sampling above confirmed no facts-JSON-representable signal exists for
+  them when the target Issue wasn't processed this run.
+- **Rule 2 (ordering-problem fix, see below)**: a candidate whose condition text
+  contains an L3/session-retrospective reference keyword (case-insensitive: `L3
+  retrospective`, `L3 レトロスペクティブ`, `L3 セッションレトロスペクティブ`,
+  `session.md`, `セッションレトロスペクティブ`, `session retrospective`) is excluded.
+  Bare `L3` was rejected as a token — it false-positives on unrelated prose like
+  `autonomy: L3`.
+
+### Ordering Problem: L3 Retrospective-Referencing AC
+
+`skills/auto/SKILL.md` runs run-fact AC reconciliation (single-issue and batch routes
+alike) **before** L3 auto-retrospective generation. A candidate AC whose own condition
+text observes the L3 retrospective (e.g. "does the L3 retrospective record X") is
+therefore judged before the artifact it references exists — session `97764-1786198856`
+recorded 3 such candidates (#1307, #1300, #1289), all structurally undecidable at
+judgment time.
+
+Three options were considered for this ordering problem; **exclusion (Rule 2 above)**
+was adopted:
+
+- **Re-run reconciliation after L3 generation** — rejected: `collect-run-facts.sh`'s
+  facts JSON schema (`session_id`/`mode`/`number`/`size`/`route`/`pr`/`pr_state`/
+  `phases`/`anomalies`/`recovery_tiers`/`fact_tokens`) has no field representing L3
+  retrospective content or its notable-judgment result. Re-running the same judgment
+  step against the same schema would not change the outcome — the schema, not the
+  ordering, is the actual constraint. Adding such a field is schema-extension work
+  outside this fix's scope (measurement + dominant-factor fix + ordering-problem
+  disposition).
+- **Carry the candidate forward to the next run** — rejected: this is what the
+  pre-#1321 design already does by construction (`scan-pending-ac.sh` recomputes
+  candidates fresh every run), and the Background's carryover growth (11→37 candidates
+  across the 5 measured sessions) shows this "carry forward" behavior does not resolve
+  the underlying undecidability — it only accumulates.
+- **Exclude from the candidate set** — adopted: stops the same undecidable candidate
+  from re-entering rubric judgment (and re-generating `advisory` noise) on every run,
+  at minimal cost, without requiring a facts-schema change.
+
 ## Processing Steps
 
 1. Run `${CLAUDE_PLUGIN_ROOT}/scripts/collect-run-facts.sh` (with `--session

--- a/scripts/scan-pending-ac.sh
+++ b/scripts/scan-pending-ac.sh
@@ -124,15 +124,14 @@ if [ -n "$FACTS_PATH" ]; then
 fi
 
 # Rule 2 keyword list (case-insensitive substring match against condition text).
-L3_KEYWORDS_LOWER=$(cat <<'EOF' | tr '[:upper:]' '[:lower:]'
-l3 retrospective
-l3 レトロスペクティブ
-l3 セッションレトロスペクティブ
-session.md
-セッションレトロスペクティブ
-session retrospective
-EOF
-)
+L3_KEYWORDS_LOWER=$(printf '%s\n' \
+  "l3 retrospective" \
+  "l3 レトロスペクティブ" \
+  "l3 セッションレトロスペクティブ" \
+  "session.md" \
+  "セッションレトロスペクティブ" \
+  "session retrospective" \
+  | tr '[:upper:]' '[:lower:]')
 
 ISSUES_JSON=$(gh issue list --label "phase/verify" --state all --json number,body --limit "$LIMIT" 2>/dev/null) || {
   echo "[]"

--- a/scripts/scan-pending-ac.sh
+++ b/scripts/scan-pending-ac.sh
@@ -18,6 +18,21 @@
 # --max-candidates <N>: truncate the candidate list to this size (default 30).
 #   Truncation is never silent: a stderr Note reports how many were dropped.
 #
+# --facts exclusion rules (only active when --facts is given; see
+# modules/run-fact-matching.md "Candidate Pre-filter Exclusion Rules" for the
+# rationale and regression-risk evaluation):
+#   Rule 1: a candidate whose verify_type is "observation" or "opportunistic"
+#     is excluded when its Issue number is not present in the facts file's
+#     `issues[].number` array — per-issue facts (route/phases/anomalies/...)
+#     cannot exist for an Issue the current run never touched, so such a
+#     candidate is structurally undecidable (always "ambiguous").
+#   Rule 2: a candidate whose condition text contains an L3/session
+#     retrospective reference keyword (case-insensitive; see
+#     L3_KEYWORDS_LOWER below) is excluded — the facts JSON has no field
+#     representing L3 retrospective content, and reconciliation runs before
+#     L3 retrospective generation in skills/auto/SKILL.md, so this class of
+#     candidate is also structurally undecidable.
+#
 # Global 1-based checkbox index: counted over every `^- \[[ xX]\]` line in the
 # full Issue body (same convention as scripts/gh-issue-edit.sh --checkbox and
 # scripts/check-pre-merge-ac.sh), so returned ac_index values are directly
@@ -92,6 +107,7 @@ if ! echo "$MAX_CANDIDATES" | grep -qE '^[0-9]+$'; then
 fi
 
 FACT_TOKENS_LOWER=""
+FACTS_ISSUE_NUMBERS=""
 if [ -n "$FACTS_PATH" ]; then
   if [ ! -f "$FACTS_PATH" ]; then
     echo "Error: --facts file not found: $FACTS_PATH" >&2
@@ -101,7 +117,22 @@ if [ -n "$FACTS_PATH" ]; then
     echo "Error: failed to parse --facts file: $FACTS_PATH" >&2
     exit 1
   }
+  FACTS_ISSUE_NUMBERS=$(jq -r '[.issues[].number] | unique | .[]' "$FACTS_PATH" 2>/dev/null) || {
+    echo "Error: failed to parse --facts file: $FACTS_PATH" >&2
+    exit 1
+  }
 fi
+
+# Rule 2 keyword list (case-insensitive substring match against condition text).
+L3_KEYWORDS_LOWER=$(cat <<'EOF' | tr '[:upper:]' '[:lower:]'
+l3 retrospective
+l3 レトロスペクティブ
+l3 セッションレトロスペクティブ
+session.md
+セッションレトロスペクティブ
+session retrospective
+EOF
+)
 
 ISSUES_JSON=$(gh issue list --label "phase/verify" --state all --json number,body --limit "$LIMIT" 2>/dev/null) || {
   echo "[]"
@@ -167,8 +198,9 @@ while IFS= read -r issue_obj; do
   while IFS=$'\t' read -r ac_idx vtype cond_text; do
     [ -z "$ac_idx" ] && continue
 
+    TEXT_LOWER=$(printf '%s' "$cond_text" | tr '[:upper:]' '[:lower:]')
+
     if [ -n "$FACT_TOKENS_LOWER" ]; then
-      TEXT_LOWER=$(printf '%s' "$cond_text" | tr '[:upper:]' '[:lower:]')
       MATCHED=false
       while IFS= read -r tok; do
         [ -z "$tok" ] && continue
@@ -180,6 +212,41 @@ while IFS= read -r issue_obj; do
         esac
       done <<< "$FACT_TOKENS_LOWER"
       if [ "$MATCHED" = false ]; then
+        continue
+      fi
+    fi
+
+    if [ -n "$FACTS_PATH" ]; then
+      # Rule 1: observation/opportunistic candidates whose Issue is absent
+      # from this run's facts.issues[].number are structurally undecidable.
+      if [ "$vtype" = "observation" ] || [ "$vtype" = "opportunistic" ]; then
+        ISSUE_IN_FACTS=false
+        while IFS= read -r facts_n; do
+          [ -z "$facts_n" ] && continue
+          if [ "$facts_n" = "$N" ]; then
+            ISSUE_IN_FACTS=true
+            break
+          fi
+        done <<< "$FACTS_ISSUE_NUMBERS"
+        if [ "$ISSUE_IN_FACTS" = false ]; then
+          continue
+        fi
+      fi
+
+      # Rule 2: candidates referencing L3/session retrospective content are
+      # structurally undecidable (no facts JSON field represents them, and
+      # reconciliation runs before L3 retrospective generation).
+      L3_MATCHED=false
+      while IFS= read -r kw; do
+        [ -z "$kw" ] && continue
+        case "$TEXT_LOWER" in
+          *"$kw"*)
+            L3_MATCHED=true
+            break
+            ;;
+        esac
+      done <<< "$L3_KEYWORDS_LOWER"
+      if [ "$L3_MATCHED" = true ]; then
         continue
       fi
     fi

--- a/tests/run-fact-matching.bats
+++ b/tests/run-fact-matching.bats
@@ -386,6 +386,113 @@ MOCK
     [[ "$condition" == *"pr route"* ]]
 }
 
+@test "scan-pending-ac: Rule 1 excludes observation candidate whose issue is absent from facts.issues" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number": 1200, "body": "### Post-merge\n\n- [ ] <!-- verify-type: observation event=auto-run --> observation condition mentioning pr route\n"}]
+JSON
+  exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    FACTS_FILE="$BATS_TEST_TMPDIR/facts.json"
+    echo '{"session_id":"s1","issues":[{"number":1265,"fact_tokens":["pr route"]}]}' > "$FACTS_FILE"
+
+    run bash "$SCAN_SCRIPT" --facts "$FACTS_FILE"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq 'length')
+    [ "$count" = "0" ]
+}
+
+@test "scan-pending-ac: Rule 1 keeps observation candidate whose issue is present in facts.issues" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number": 1265, "body": "### Post-merge\n\n- [ ] <!-- verify-type: observation event=auto-run --> observation condition mentioning pr route\n"}]
+JSON
+  exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    FACTS_FILE="$BATS_TEST_TMPDIR/facts.json"
+    echo '{"session_id":"s1","issues":[{"number":1265,"fact_tokens":["pr route"]}]}' > "$FACTS_FILE"
+
+    run bash "$SCAN_SCRIPT" --facts "$FACTS_FILE"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq 'length')
+    [ "$count" = "1" ]
+}
+
+@test "scan-pending-ac: Rule 1 does not exclude manual candidate whose issue is absent from facts.issues" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number": 1212, "body": "### Post-merge\n\n- [ ] manual condition mentioning pr route\n"}]
+JSON
+  exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    FACTS_FILE="$BATS_TEST_TMPDIR/facts.json"
+    echo '{"session_id":"s1","issues":[{"number":1265,"fact_tokens":["pr route"]}]}' > "$FACTS_FILE"
+
+    run bash "$SCAN_SCRIPT" --facts "$FACTS_FILE"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq 'length')
+    [ "$count" = "1" ]
+}
+
+@test "scan-pending-ac: Rule 2 excludes candidate referencing L3 retrospective" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number": 1307, "body": "### Post-merge\n\n- [ ] pr route: does the L3 retrospective record this outcome\n"}]
+JSON
+  exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    FACTS_FILE="$BATS_TEST_TMPDIR/facts.json"
+    echo '{"session_id":"s1","issues":[{"number":1307,"fact_tokens":["pr route"]}]}' > "$FACTS_FILE"
+
+    run bash "$SCAN_SCRIPT" --facts "$FACTS_FILE"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq 'length')
+    [ "$count" = "0" ]
+}
+
+@test "scan-pending-ac: Rule 1/Rule 2 are inactive without --facts" {
+    cat > "$MOCK_DIR/gh" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "issue" && "$2" == "list" ]]; then
+  cat <<'JSON'
+[{"number": 1307, "body": "### Post-merge\n\n- [ ] <!-- verify-type: observation event=auto-run --> does the L3 retrospective record this outcome\n"}]
+JSON
+  exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$MOCK_DIR/gh"
+
+    run bash "$SCAN_SCRIPT"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq 'length')
+    [ "$count" = "1" ]
+}
+
 @test "scan-pending-ac: gh failure fails open with empty array" {
     cat > "$MOCK_DIR/gh" <<'MOCK'
 #!/bin/bash


### PR DESCRIPTION
## Summary

`/auto` の run-fact AC reconciliation (`modules/run-fact-matching.md`) が 5 session 連続・通算 147 件で候補全件を `ambiguous` と判定し、`auto-check` が一度も発生していない問題への対処。

- `ambiguous` 判定を fail-safe 条件別に集計 (`modules/run-fact-matching.md` § Ambiguous Breakdown Measurement)。支配的要因は「候補の前提事象が本 run で発生していない」ケース (15/27, 56%)
- `scripts/scan-pending-ac.sh` の `--facts` 指定時の候補フィルタに 2 種類の除外ルールを追加
  - Rule 1: `verify_type` が `observation`/`opportunistic` かつ対象 Issue が facts.issues[].number に不在の候補を除外
  - Rule 2: L3/session retrospective 参照キーワードを含む候補を除外 (順序問題への対処)
- `modules/run-fact-matching.md` に根拠・リグレッションリスク評価・順序問題の 3 選択肢比較を明文化
- `tests/run-fact-matching.bats` に Rule 1/Rule 2 の bats テストケースを追加

## Verification (pre-merge)

- `ambiguous` の内訳が条件別に集計・記録されている (`modules/run-fact-matching.md` § Ambiguous Breakdown Measurement)
- 支配要因への対処 (`scan-pending-ac.sh` Rule 1/Rule 2) が実装され、根拠が明文化されている
- 順序問題の扱い (除外を採用) が `modules/run-fact-matching.md` § Ordering Problem に明文化されている
- `bats tests/run-fact-matching.bats` PASS (35/35)。フルスイート `bats --jobs 18 tests/` も PASS (1745/1745, `scan-pending-ac.sh` を参照する `tests/scan-pending-ac.bats` を含む behavioral change 検知によりフル実行)

## Verification (post-merge)

- 次に run-fact reconciliation が走った session で、`auto-check` が 1 件以上発生するか、または `ambiguous` 率が実測で低下していることを確認する (observation, session=next)

closes #1321
